### PR TITLE
chore: release v0.1.0-alpha.1

### DIFF
--- a/crates/shep-cli/CHANGELOG.md
+++ b/crates/shep-cli/CHANGELOG.md
@@ -13,6 +13,319 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.0-alpha.1](https://github.com/TurtIeSocks/shep/releases/tag/shep-v0.1.0-alpha.1) - 2026-08-26
+
+### Added
+
+- *(cli)* shep init writes whichever Flockfile format you point it at
+- *(cli)* shep dogs --available lists the community index
+- *(cli)* parse the dog index, treating every string in it as hostile
+- *(shep)* a Flockfile app with no cwd runs where its Flockfile lives
+- *(core)* refuse reuse_port rather than accepting a knob nothing reads
+- *(shep)* shep init --all is generated from the schema, not from defaults
+- *(shep)* shep init's curated scaffold, and a depth axis for the rest
+- *(shep)* shep init's skeleton, with its tests written first
+- *(shep)* scaffold a starter interpreter mapping on first run
+- *(shep)* opt-in interpreter mapping in shep.toml, plus --interpreter
+- *(lookout)* add the EXIT column to the flock pane, matching the CLI
+- *(shep-cli)* expose exit_cell for lookout's flock pane to reuse
+- *(core,daemon,cli)* carry a sheep's last exit outcome to the operator
+- *(shep)* sheep for the moments with nothing else to look at
+- *(shep)* colour and a face reach the STATUS column
+- *(shep)* carry the style level on Streams
+- *(shep)* a box-drawn table that fits the terminal
+- *(shep)* measure a cell's visible width, not its length
+- *(shep)* one vocabulary for both flock renderings
+- *(shep)* add StyleLevel and the shep style verb
+- *(shep-core)* selectors take globs
+- *(shep)* the lifecycle verbs take several targets
+- *(shep)* `shep start <name>` acts on the sheep the flock already has
+- *(shep)* a sheep started by path runs where you ran `shep start`
+- *(shep-daemon)* a stopped sheep stays in the flock across a daemon restart
+- *(shep)* bare `shep start` runs this directory's Flockfile, or brings a shepherd up
+- *(shep)* `shep flock` falls back to the muster roll instead of refusing
+- *(shep)* show the shepherd's status on the verbs that have nothing else to say
+- *(shep)* `shep ping` reports the shepherd instead of erroring at you
+- *(shep)* teach `shep --help` instead of listing 34 verbs alphabetically
+- *(shep)* add the first-run welcome, and `shep welcome`
+- *(shep)* create the default $SHEP_HOME, refuse a named one that is missing
+- *(lookout)* the actions on screen, five frames, and the docs
+- *(lookout)* the send path's reply, upserting the shepherd's own rows
+- *(lookout)* the action keys and the confirm state machine
+- *(lookout)* the lamb line, DETAIL_ROWS 4 to 5, two frames
+- *(lookout)* Effect::RefreshSelected and the coalesced lamb fetch
+- *(lookout)* FlockSource::send, Sent, Channels, and the reply
+- *(lookout)* show the filter on screen, three frames, and the docs
+- *(lookout)* two input modes and the filter keymap
+- *(lookout)* thread one visible-rows sequence through the cursor
+- *(shep-cli)* shep dev, the isolated foreground development flock
+- *(shep-cli)* the PID-1 init split and the reaper
+- *(shep-cli)* the foreground engine and shep runtime
+- *(shep-cli)* ExitCode::FlockEmpty and the empty-flock watcher
+- *(shep-cli)* shep serve, the verb
+- *(shep-cli)* serve::worker — bind, accept, answer
+- *(shep-cli)* serve::auth — creds file, HMAC-based constant-time check
+- *(shep-cli)* serve::mime and serve::listing — content-type lookup and autoindex HTML
+- *(shep-cli)* serve::path and serve::fs — resolution, containment, refusals
+- *(shep-cli)* move http.rs to the crate root and add write_head
+- *(shep-cli)* turn shep-cli into a library with three thin binaries
+- *(lookout)* add the six remaining gallery scenes, pinned clause by clause
+- *(lookout)* add view/mod.rs's panes_for and wire the bottom stack into draw
+- *(lookout)* add view/detail.rs, the sheep detail pane
+- *(lookout)* add bleats.rs, the feed pane, and wire the heartbeat's host sample
+- *(lookout)* add view/host.rs, the host-usage strip
+- *(lookout)* add source.rs's Local trait and the host sample
+- *(lookout)* add tail.rs, the bounded log reader
+- *(lookout)* move the flock table right for a selection gutter
+- *(lookout)* add a selected sheep to the reducer
+- *(whistle)* add catalogue.rs and docs/whistle/
+- *(whistle)* add mod.rs, the verb and the shep whistle dispatch
+- *(whistle)* add control.rs, the four tools the gate can withhold
+- *(whistle)* add read.rs, the five read-only MCP tools
+- *(whistle)* add facts.rs, schema-carrying payload twins
+- *(whistle)* add shepherd.rs, one connection per tool call
+- *(whistle)* add gate.rs, the [whistle] allow_control gate
+- *(whistle)* add rmcp and schemars, measured against the plan's estimate
+- *(lookout)* add mod.rs, the verb and the UI loop that ties 12a together
+- *(lookout)* add term.rs and input.rs — raw mode, panic hook, keymap
+- *(lookout)* add source.rs and link.rs — subscribe, poll, repair, freeze
+- *(lookout)* render the frames — the point of the whole phase
+- *(lookout)* draw the flock table and the chrome lines
+- *(lookout)* add app.rs, the reducer at the dashboard's core
+- *(lookout)* map the design language's palette onto a terminal
+- *(shep-cli)* add ratatui + crossterm, measured against the plan's estimate
+- *(cli)* scale becomes stock, sendline becomes whisper
+- *(cli)* describe renders each sheep's lamb tree
+- *(daemon)* the shepherd walks a sheep's lamb tree
+- *(core)* Lamb and ProcessInfo::lambs
+- *(cli)* shep set / shep get / shep unset
+- *(core)* shep_core::kv, the file-locked key/value store
+- *(cli)* shep sendline <selector> <line>
+- *(cli)* shep scale <name> <count>
+- *(daemon,cli)* deliver a signal to one sheep, and shep signal
+- *(core)* make ProcessInfo non_exhaustive, add a builder
+- *(cli)* show the bark history
+- *(cli)* bark when the shepherd gives up
+- *(cli)* decide what is worth barking about
+- *(cli)* deliver a bark to a webhook
+- *(cli)* serve the flock's metrics
+- *(cli)* render the flock as prometheus exposition
+- *(cli)* read and write the little HTTP a dog needs
+- *(cli)* give a dog its connection and its own config
+- *(cli)* adopt and rehome a third-party dog
+- *(cli)* enable and disable a dog
+- *(cli)* print the dogs in their own table
+- *(daemon)* let the enabled dogs out at boot
+- *(core)* mark which entries are dogs
+- *(cli)* warn when sudo may have sanitized PATH before install
+- *(cli)* show each sheep's cpu and memory
+- report each sheep's cpu and memory
+- *(cli)* shep startup and unstartup
+- *(cli)* render a systemd unit and a launchd plist
+- *(daemon)* report readiness once the flock is back
+- *(cli)* shep import
+- *(cli)* import only the env an app actually declared
+- *(cli)* collapse pm2 instances into apps
+- *(cli)* read a pm2 dump
+- *(cli)* shep muster
+- *(cli)* shep save
+- *(cli)* add shep trigger
+- *(cli)* shep reload
+- *(cli)* show a flush which files it emptied
+- *(cli)* add `shep flush --daemon` for the shepherd's own logs
+- *(daemon)* make SIGUSR2 reopen every sheep's logs
+- truncate log files with shep flush
+- reopen log files so external rotation works
+- *(daemon)* wire a tracing subscriber so the daemon's diagnostics reach someone
+- *(client)* make EventStream usable without a futures-util dependency
+- *(daemon)* arm and disarm lifecycle extras across the sheep lifecycle
+- *(core)* make the cron worker's sleep bound configurable
+- *(cli)* give notices their own JSON envelope and wire up --quiet
+- *(cli)* daemon shutdown and static shell completions
+- *(core)* report each sheep's resolved log paths on ProcessInfo
+- *(cli)* bleats log following with client-side identity resolution
+- *(cli)* flock, describe, fold, and ping
+- *(cli)* start, stop, restart, and delete
+- *(cli)* foreground daemon subcommand and its detached launcher
+- *(cli)* versioned output envelope with drift-gated table and JSON renderings
+- *(cli)* clap tree, every argument struct, and the exit-code taxonomy
+
+### Fixed
+
+- *(cli)* adopt vetted the candidate against the wrong SHEP_HOME
+- *(cli)* sanitise in the emitters, so the next wire-borne error is safe too
+- *(cli)* the start notice went to two different streams
+- *(cli)* sanitise the one other peer-worded error message
+- *(cli)* say which set the dog-index footer counts count
+- *(cli)* take the invisible-character classes whole
+- *(cli)* bound the status line and header block
+- *(cli)* sanitise header-derived text at the capture seam
+- swapped init arms
+- *(packaging)* ship the license text inside every published tarball
+- *(shep)* gate the two shep style tests that cannot pass on Windows
+- *(shep)* shep restart no longer exits 0 when a sheep cannot come back
+- *(shep)* shep start <name> no longer swallows a spawn failure
+- *(shep)* the serve deadline test races a paused clock, so stop pausing it
+- *(shep)* bleats shows the log before it follows
+- *(shep)* flourish's three functions follow the crate's Windows dead-code convention
+- *(shep)* six pieces of scaffolding that were true when written
+- *(shep)* sanitise a cell's control characters before it is padded
+- *(shep)* every Render impl gets a real PRIORITIES, not the default
+- *(shep)* table_of takes an injected width, not a real-terminal read
+- *(shep)* shep muster's flourish agrees with the table above it
+- *(shep)* dogs and lambs tables never narrowed under a real terminal
+- *(shep)* status_word is a rows_for argument, not Presentation state
+- *(shep)* a refused style write must not rewrite shep.toml
+- *(shep)* set_style_level reports rather than panics on a scalar `style` key
+- *(shep)* `shep style <level>` actually sets the level
+- *(shep)* --style's help is prose, not doc-comment syntax
+- *(shep)* drop the em dash from --quiet's help text
+- *(shep)* visible_width discounts control characters, not just escapes
+- *(shep)* resolve a relative script against the caller's cwd, not the shepherd's
+- *(shep)* gate the home-refusal path to unix so Windows still compiles
+- *(shep)* stop rendering the bin_name note as --help's description
+- close the 7 real-Windows test failures found on `windows`
+- *(shep-cli)* scope the reaped-orphan test to its own grandchild
+- *(deps)* raise three dependency floors that could not build
+- *(lookout)* make the confirm-pin test able to fail
+- *(lookout)* sum the whole flock in the host strip, not the filtered view
+- *(lookout)* stop the action refusal from contradicting the reconnect banner
+- *(lookout)* reseat the cursor when an upsert renames it out of the filter
+- *(lookout)* collapse the Task 5 if-let clippy flagged at the first full gate since it landed
+- *(cli)* say no shepherd is running instead of forwarding ENOENT
+- *(shep-cli)* update the ping fixture for the 0.1.0-alpha.1 bump
+- *(shep-cli)* match the whistle catalogue generator to the renamed crate
+- *(shep-cli)* mask st_mode's file-type bits out of the auth error message
+- *(shep-dev)* make the roll durable when a signal ends the session
+- *(lookout)* three caption/title drifts in the gallery
+- *(shep-cli)* un-break the doc build (found during the phase gate)
+- *(lookout)* stop the bleats feed inventing a sheep when none is selected
+- *(lookout)* guard the bleats feed against a post-freeze read landing
+- *(whistle)* make BleatTail::truncated true for a byte-window cut too
+- *(whistle)* correct the --help claim about what the missing flag defends
+- *(whistle)* un-link mod.rs's cfg(test)-only catalogue reference
+- *(lookout)* stop advertising an x stop that always refuses in 12a
+- *(lookout)* correct two false frame captions, and pin the errored one
+- *(lookout)* reserve a gap column in the status line before the control label
+- *(cli)* lock and narrow the write path for shep.toml
+- *(cli)* stop the daemon inheriting its launcher's descriptors
+- *(dog/bark)* make substitute() a single forward pass
+- *(dog/bark)* refuse cleartext Discord/Slack webhooks at config load
+- *(cli)* enable an adopted dog as the dog it actually is
+- *(cli)* refuse to adopt a dog anyone can rewrite
+- *(daemon)* warn instead of staying silent on inert dog config
+- *(daemon)* reach every writer to a path a reload is sharing
+- close the small findings the log-plane review left open
+- *(daemon)* give the log pump the only claim on the log directory's mode
+- *(cli)* give a reopen room to finish, and let its handler prove it changes nothing
+- *(daemon)* let a reopen that failed say so, instead of acking success
+- *(cli)* stop holding the stderr lock for the daemon's whole life
+- *(workspace)* give path dependencies the versions cargo publish requires
+- *(test)* reap a case's whole flock when it panics, and signal the group
+- *(daemon)* send the graceful stop to the sheep's process group
+- *(cli)* standardise on "the daemon" in error text
+- *(cli)* shep bleats --no-follow reads log files instead of an empty bus
+- *(cli)* make Task 11's non-guarding assertions actually guard
+- *(cli)* close bleats review gaps — Dropped notice, JSON pin, broken pipe, close race
+- *(cli)* address phase3 task7 review findings
+- *(cli)* close output-layer drift gate, table panic, and Windows dead code
+- *(cli)* compiler-checked RpcErrorCode::ALL, $SHEP_HOME/alias coverage, completions without $HOME
+
+### Other
+
+- refresh the release rehearsal, and say where the dog fits
+- *(cli)* two e2e tests left a shepherd running behind them
+- *(cli)* one way to print a notice on each stream
+- the review's three findings on the plumbing refactor
+- *(cli)* From impls for the CLI's source-only error variants
+- *(cli)* fmt lives in Streams, and Streams can fail and note
+- *(cli)* pin what an error and a notice look like on the wire
+- *(cli)* pin the category list against the docs site's
+- rustfmt the shep init e2e test
+- Merge main: pick up the init arm-swap fix
+- methods on `Depth` for better oganization
+- *(shep)* five red tests for shep init, which does not exist yet
+- *(web)* the site was two days stale, and --help had lost every alias
+- *(shep)* pin the missing-node sentence by producing it
+- *(shep)* both init depths build rows through one function
+- log Rin's call that shep should expand ~/ in config paths
+- *(lookout)* the errored caption names what its EXIT column shows
+- *(lookout)* the pinned frames show a real exit, not a column of dashes
+- *(lookout)* regenerate frames.txt/frames.ansi for the EXIT column
+- changelog entries for the crates that actually changed
+- *(shep)* pin the flock listing's drop order column by column
+- *(shep)* pin sheep_flourish's own rules, and both flourish gates
+- *(shep)* add the pipe test spec §5 claimed already existed
+- *(shep)* pin every style level through the real rendering seam
+- *(shep)* a `--home` that is not there is a usage error, not an unreachable daemon
+- *(cli)* point the systemd-analyze check at a binary that exists
+- *(cli)* stop the describe fixture betting on losing a race
+- describe lookout's shipped filter, actions, and lambs, not the gaps
+- *(lookout)* fix the stale bin-only justification for frames' cfg(test)
+- *(lookout)* the Phase 16 sweep and the phase gate
+- *(shep-cli-changelog)* fix rename leftovers, permanent in the shep tarball
+- *(changelog)* head all four shipped CHANGELOGs with 0.1.0-alpha.1
+- catch three more shep-cli-as-package-name misses
+- *(shep)* rename the package from shep-cli to shep
+- *(shep-cli)* drop 40 dead_code attributes that suppress nothing
+- *(shep-cli)* update the crate-root doc for 12b's shipped panes
+- *(reap)* correct three docs claiming init calls set_child_subreaper
+- *(phase15)* close the serve/dev/runtime ledger and update the docs
+- *(shep-core)* say that the non-unix ring and kv locks hold nothing
+- Merge Phase 14: config and packaging
+- *(lookout)* document fit's char-vs-column limitation as v1.1 debt
+- *(lookout)* rewrite comments that describe shipped features as unbuilt
+- *(lookout)* make the pane-sweep test check where panes actually sit
+- *(lookout)* make the frozen-frame host-strip comment true
+- *(shep-cli)* fix the false lookout CHANGELOG entry
+- *(lookout)* reconcile the docs with what Phase 12b shipped
+- *(whistle)* stop filtering blank stdout lines out of the JSON-RPC check
+- *(whistle)* cover the malformed-shep.toml stderr notice
+- *(whistle)* drop dead_code allows that suppress nothing
+- *(whistle)* add CHANGELOG entries for the whole phase
+- *(whistle)* reconcile the ledger, README and CLAUDE.md with the shipped MCP server
+- *(whistle)* add the e2e tier over real stdio
+- *(release)* give every crate the metadata crates.io needs
+- *(lookout)* reconcile the ledger with 12a's shipped shell and flock table
+- *(lookout)* make the panic-hook restore ordering a permanent, headless test
+- *(cli)* the lamb-tree poll rides out an exec, not a sampling tick
+- *(cli)* the kv store end to end, and docs/kv.md
+- *(core,daemon)* make IR-20 true of the tree it governs
+- *(core,daemon,cli)* close the IR-20 rationale gap on six error enums
+- correct the ring claim, reuse_port, and two openat2 comments
+- record what a dog is and what it costs
+- *(dog/bark)* satisfy rustfmt on the discord-http-refused test
+- *(dog/bark)* cover GaveUp's quiet half on both routes
+- *(cli)* drop the tracing dependency that lost its last call site
+- record what a pm2 cutover actually takes
+- *(cli)* pull parse_selector into one shared copy
+- *(cli)* stop claiming a TUI, a file server and container modes ship
+- *(cli)* name the function that fills in DEFAULT_DEADLINE, not a line
+- *(cli)* reopen's failure output can name a sheep the operator did not
+- *(cli)* name the SO_REUSEPORT precondition on reload
+- *(cli)* the selector test covers four verbs, not three
+- *(cli)* name the selector test rather than linking to it
+- close the log plane's uncovered behaviours
+- unstick six enumerations the log plane falsified
+- record the log plane
+- *(cli)* prove an external copytruncate still lands at offset zero
+- correct six claims the flush verb makes about itself
+- *(cli)* correct three false claims, and honour NO_COLOR
+- *(cli)* pin the two log knobs the daemon subcommand exists to honour
+- *(cli)* pin a real RSS breach restarting a real sheep
+- *(cli)* pin a cron occurrence restarting a real sheep on a real clock
+- stop promising work this phase does not deliver
+- *(cli)* end-to-end coverage for watch, readiness and config rejection
+- *(cli)* give the e2e harness timeout headroom over SPAWN_DEADLINE
+- *(cli)* drop internal spec reference from `fold` help text
+- *(cli)* end-to-end tier with autostart, concurrency, and pinned JSON fixtures
+- *(cli)* correct two stale dead-code claims in launch.rs
+- *(cli)* close query verb coverage gaps from task 9 review
+- *(shep-cli)* close lifecycle verb coverage gaps from review
+- *(client)* fold the fakes back into shep-client behind test-support
+- SECURITY.md premises contract + per-crate changelogs (IR-42/45)
+- scaffold cargo workspace (shep-core, shep-daemon, shep-client, shep-cli)
+
 ### Additions
 
 - `shep flock` and `shep describe` gain an `EXIT` column: the exit code, or

--- a/crates/shep-daemon/CHANGELOG.md
+++ b/crates/shep-daemon/CHANGELOG.md
@@ -10,6 +10,269 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.0-alpha.1](https://github.com/TurtIeSocks/shep/releases/tag/shep-daemon-v0.1.0-alpha.1) - 2026-08-26
+
+### Added
+
+- *(daemon)* name the sun_path limit instead of passing ENAMETOOLONG through
+- *(core)* refuse reuse_port rather than accepting a knob nothing reads
+- *(core,daemon,cli)* carry a sheep's last exit outcome to the operator
+- *(shep-daemon)* a stopped sheep stays in the flock across a daemon restart
+- *(cli)* scale becomes stock, sendline becomes whisper
+- *(daemon)* the shepherd walks a sheep's lamb tree
+- *(core)* shep_core::kv, the file-locked key/value store
+- *(cli)* shep sendline <selector> <line>
+- *(daemon)* the supervisor writes a line to a sheep
+- *(daemon)* pipe a sheep's stdin, opt-in per app
+- *(daemon)* the supervisor scales an app
+- *(daemon,cli)* deliver a signal to one sheep, and shep signal
+- *(core,daemon)* forward shepherd-channel traffic onto the bus
+- *(core)* reject an unknown kill_signal when the config is read
+- *(core)* make ProcessInfo non_exhaustive, add a builder
+- *(daemon)* leave a trail when a dog gives up
+- *(daemon)* group a listing by name so a clustered app reads as one
+- *(daemon)* let the enabled dogs out at boot
+- *(daemon)* answer the dog contract
+- *(daemon)* start a dog through the ordinary spawn path
+- keep dogs out of what a wildcard selector sweeps
+- *(core)* mark which entries are dogs
+- report each sheep's cpu and memory
+- *(daemon)* sample every sheep, enforce only where a limit exists
+- *(daemon)* report readiness once the flock is back
+- assemble the flock from the roll on demand
+- *(daemon)* write the muster roll when an operator asks
+- *(core)* bound a custom action with its own timeout
+- *(daemon)* answer a trigger for every sheep it matched
+- *(daemon)* wait for an action's reply, or time out
+- *(core)* put trigger on the wire
+- *(daemon)* let a triggered action carry params
+- *(daemon)* keep a handle on the shepherd channel
+- *(daemon)* bound every reload swap with a deadline of the actor's own
+- *(daemon)* report a reload's progress on the bus
+- *(daemon)* answer the reload verb on the control socket
+- *(daemon)* reload an app one instance at a time
+- *(daemon)* let the stop ladder's cap be the caller's choice
+- *(daemon)* say which entry holds which half of a reload
+- *(daemon)* refuse a log ancestry a root shepherd should not write below
+- *(daemon)* refuse to follow a symlink at a log path
+- *(daemon)* make SIGUSR2 reopen every sheep's logs
+- truncate log files with shep flush
+- reopen log files so external rotation works
+- *(daemon)* give the supervisor a way to reach its log pumps
+- *(core)* let an app open the shepherd channel without a readiness flag
+- *(daemon)* wire a tracing subscriber so the daemon's diagnostics reach someone
+- *(daemon)* arm and disarm lifecycle extras across the sheep lifecycle
+- *(daemon)* watch-triggered restarts with glob filtering and re-check
+- *(daemon)* debounced filesystem watch bridged onto tokio
+- *(daemon)* gate online on readiness for apps that configure it
+- *(daemon)* HTTP, TCP and exec probes over real sockets and processes
+- *(daemon)* liveness probing with a consecutive-failure threshold
+- *(daemon)* polling memory-limit enforcement behind a mechanism-free seam
+- *(daemon)* sample resident memory across a sheep's process tree
+- *(daemon)* cron-scheduled restarts with a wall-clock seam
+- *(core)* report each sheep's resolved log paths on ProcessInfo
+- *(daemon)* daemon boot — readiness pipe, signal handlers, ordered teardown
+- *(daemon)* boot layout — 0700 dirs, pidfile, stale-socket recovery
+- *(daemon)* UDS RPC server — peer-cred auth, handshake, subscriptions
+- *(daemon)* RPC dispatch — verb routing, typed errors, per-call deadlines
+- *(daemon)* muster roll — registry, atomic writes, debounced writer, restore
+- *(daemon)* event bus — topic globs, forwarder task, drop-oldest notices
+- *(daemon)* supervisor actor with sheep-task ownership + deterministic lifecycle tests
+- *(daemon)* kill ladder — message/signal, timeout, SIGKILL tree
+- *(daemon)* tokio runner — process groups, socketpair channel, log capture
+- *(daemon)* spawn assembly — slots, env, interpreter, log paths
+- *(daemon)* restart brain — signal exits never match stop_exit_codes
+- *(daemon)* entry, budget, pinned integer backoff
+- *(daemon)* runner abstraction, shepherd channel types, scripted fake
+
+### Fixed
+
+- *(daemon)* drop the From that let ? pick the wrong BootError
+- *(packaging)* ship the license text inside every published tarball
+- *(daemon)* a respawn that never spawns must not keep the old exit code
+- *(shep-daemon)* widen the coalescing window, and pin the half load cannot break
+- *(shep-daemon)* stop asserting on which batch a write lands in
+- close the 7 real-Windows test failures found on `windows`
+- *(shep-daemon)* log the pump's ancestry-check refusal instead of swallowing it
+- *(shep-daemon)* stop treating a pre-drop straggler batch as a leak
+- *(daemon)* canonicalize the watch root here, not in the backend
+- *(shep-daemon)* silence a clippy lint in the new signalled-shutdown test
+- *(shep-dev)* make the roll durable when a signal ends the session
+- *(daemon)* a scale is refused while an earlier one is still leaving
+- *(daemon)* an abandoned stdin write is dropped, and not_written says what it means
+- *(daemon)* a full stdin queue reports no elapsed time it did not measure
+- *(daemon)* describe's lamb names stop being permanently stale
+- *(daemon)* record a partial scale in the muster roll
+- *(daemon)* stamp custom actions so a late reply cannot answer the wrong wait
+- *(protocol)* stop Response's derived Debug from leaking a dog's TOML section
+- *(daemon)* let a child block on the shepherd channel
+- *(daemon)* log the two skips that drop real work in silence
+- *(daemon)* say on the bus that a reload ended with its drainee already gone
+- *(daemon)* announce a swap only for a replacement that is still serving
+- *(daemon)* reach every writer to a path a reload is sharing
+- *(daemon)* assert the reachability claim the queue-abort rests on
+- *(daemon)* stop a reload swapping against an instance already on its way out
+- *(daemon)* stop the swap gate at the commit, and say what it made redundant
+- *(daemon)* stop an abandoned reload reporting a dying drainee as online
+- *(daemon)* hold an automatic restart off both halves of a reload's swap
+- *(daemon)* end a reload whose replacement outlives the drainee it replaced
+- *(daemon)* stop a reload deleting an app an operator only stopped
+- close the small findings the log-plane review left open
+- *(daemon)* tell a watch rescan apart from an event on the watch root
+- *(daemon)* give the log pump the only claim on the log directory's mode
+- *(daemon)* flush every writer to a path a flush is about to empty
+- *(cli)* give a reopen room to finish, and let its handler prove it changes nothing
+- *(daemon)* let a reopen that failed say so, instead of acking success
+- *(daemon)* end a log pump when its `logs` receiver goes, line or no line
+- *(daemon)* serve the log pump's control channel while it waits for room
+- *(daemon)* close the interest-cache race the log-capture harness still had
+- *(daemon)* ignore a sheep's own logs, and stop docs promising what nobody sees
+- *(daemon)* stop reporting every automatic restart as a user action
+- *(core)* reject the zero-valued knobs that turn loops into hot spins
+- *(test)* reap a case's whole flock when it panics, and signal the group
+- *(daemon)* count cron and watch restarts as automatic, not operator
+- *(daemon)* let a stop or delete override an automatic restart mid-ladder
+- *(core)* reject watch globs that will not compile at config time
+- *(daemon)* close the four ways a lifecycle extra outlives its sheep
+- *(daemon)* restart on a watch rescan, and arm the watch tests that could not fail
+- *(daemon)* make the watch source's tests actually guard what they claim
+- *(daemon)* carry `manually` through a gated app's deferred Online
+- *(daemon)* scope a readiness probe to the assembled spec's env
+- *(daemon)* carry the port in an HTTP probe's Host header
+- *(daemon)* require an HTTP status line before trusting its status code
+- *(daemon)* finish OsProber's redacting Debug non-exhaustively
+- *(daemon)* kill a timed-out exec probe's whole process group
+- *(daemon)* give an exec probe null stdio instead of the daemon's
+- *(daemon)* reject a zero probe interval, and pin the timeout wire
+- *(daemon,core)* harden cron worker per Task 3 review round
+- *(daemon)* send the graceful stop to the sheep's process group
+- *(daemon)* stop an fd-adoption test double-closing another test's descriptor
+- *(daemon)* honour a pending Delete on the duplicate-exit path
+- *(daemon)* rearm shutdown-signal listeners against a swallowed repeat SIGTERM
+- *(daemon)* restore IR-22 by design + flock the pidfile against the double-bind race
+- *(daemon)* honest SAFETY comment, deadline+credentials coverage, roll disclosure
+- *(daemon)* honour pending_delete when a Delete races a Restart
+- *(daemon)* delete-racing-shutdown deregistration; test: supervisor proptest over command/exit interleavings (IR-37)
+- *(daemon)* uid/gid spawn + seed PATH/base env so bare interpreters exec
+- *(daemon)* adopt the ready fd before boot opens anything (IO safety)
+- *(daemon)* create runtime dirs at 0700 instead of chmod-after (TOCTOU)
+- *(daemon)* abort the bus forwarder on every connection-teardown path
+- *(daemon)* resolve broken intra-doc links in server.rs's module doc
+- *(daemon)* restart budget errors at max_restarts, not max_restarts+1 (spec §4)
+- *(daemon)* correct Quick-start doctest, kill-module taxonomy, inline audit
+- *(daemon)* supervisor concurrency — shutdown orphans, kill-path deadlock, stale-timer backoff, overlapping-command reply
+- collapse nested if-let into let-chains (clippy::collapsible_if)
+- *(daemon)* CI portability + fake accessor fixes from review
+
+### Other
+
+- the review's three findings on the plumbing refactor
+- *(daemon)* From impls for the daemon's source-only error variants
+- changelog entries for the crates that actually changed
+- *(shep-daemon)* stop asserting coalescing against a shared CI runner
+- *(docs.rs)* make shep-core's schema feature visible on docs.rs
+- *(changelog)* head all four shipped CHANGELOGs with 0.1.0-alpha.1
+- *(release)* give every crate the metadata crates.io needs
+- *(core,daemon)* move shepherd channel message types to shep-core
+- *(core,daemon)* make IR-20 true of the tree it governs
+- *(core,daemon,cli)* close the IR-20 rationale gap on six error enums
+- correct the ring claim, reuse_port, and two openat2 comments
+- *(daemon)* narrow the inner-loop skip to a real slow module
+- *(daemon)* say what an answering socket actually proves
+- *(daemon)* wait out a crashed daemon's socket before rebooting
+- record what a custom action is and is not
+- *(daemon)* reconcile the changelog for Phase 7's trigger work
+- *(daemon)* ask for the channel the writer-task case needs
+- prove a trigger reaches a real child and comes back
+- *(cli)* stop claiming a TUI, a file server and container modes ship
+- *(daemon)* name ReloadState's variants for the role, not the phase
+- *(daemon)* expect over bare indexing in handle_reload
+- *(daemon)* name Reloading in track_spawned's arm list
+- graceful_timeout, not both timeouts, was the option with no reader
+- *(daemon)* the Stopping test section describes what it now guards
+- *(daemon)* pin that the muster roll never counts a reload's drainee
+- *(daemon)* reconcile the reopen entry with the reach it shipped with
+- *(daemon)* tighten the ReloadState paragraph the pid removal left behind
+- *(daemon)* call the uncommitted-swap helper instead of re-deriving it
+- *(daemon)* drop the write-only pid off ReloadState::Draining
+- record what reload does and does not promise
+- *(changelog)* say what a reload costs on each platform
+- *(daemon)* record every pid an event names, not only the ones a reply does
+- prove what a reload does to a live connection
+- *(daemon)* pin the arming order a reload depends on
+- *(daemon)* drive a drainee's liveness failure through the real probe chain
+- *(daemon)* drop task-relative phrasing from shipped comments
+- *(daemon)* stop guard 4 claiming a second rejection that never runs
+- *(daemon)* watch for the event the drainee-report bug actually emits
+- *(daemon)* scope the swap-gate release note to what it actually does
+- *(daemon)* note in the release notes which instances a reload skips
+- *(daemon)* say what holding off a cron or watch trigger actually costs
+- *(daemon)* say the swap gate keys on the phase, not the marker
+- *(daemon)* let the second-reload-refused case see the damage it names
+- *(daemon)* import AppConfig instead of naming it in full at one call site
+- *(daemon)* split the two arguments stacked on one rpc error arm
+- *(daemon)* name the shutdown-mid-reload asymmetry instead of folding it away
+- *(daemon)* make abort_reload's reachability claim a check
+- *(daemon)* give the shutdown-refuses-a-reload case something to observe
+- *(daemon)* make the stop-mid-reload case actually order-dependent
+- *(daemon)* pin the guards a reload's drainee must never pass
+- *(security)* correct the log-file claim and record the log-path posture
+- close the log plane's uncovered behaviours
+- unstick six enumerations the log plane falsified
+- correct two claims the log plane makes that are false
+- *(daemon)* pin the respawn that re-points a slot at its new log pump
+- record the log plane
+- correct six claims the flush verb makes about itself
+- *(daemon)* correct three claims the log seam makes, and cover what it hands on
+- *(cli)* correct three false claims, and honour NO_COLOR
+- *(changelog)* record the shep-daemon visibility narrowing
+- *(daemon)* narrow the crate's public surface to its real consumers
+- *(daemon)* pin the rescan producer and four watch/cron behaviours
+- *(daemon)* pin InstanceExtras' redacting Debug
+- *(daemon)* pin handle_ready_result's shutdown guard
+- *(changelog)* record the three rejections and two fixes just landed
+- *(changelog)* correct nine claims, and mark the phase 4 plan complete
+- stop promising work this phase does not deliver
+- *(daemon)* correct what a DST fall-back does to a cron occurrence
+- *(changelog)* record the Phase 4 lifecycle subsystems and config keys
+- *(daemon)* make the lifecycle-extra module headers decision guides
+- *(daemon)* pin the budget reset a restart of a stopped sheep performs
+- *(daemon)* pin the budget reset an operator's restart performs
+- *(daemon)* property and boundary coverage for the lifecycle extras
+- *(daemon)* account for the transition the disarm checklist left out
+- *(daemon)* cover the three lifecycle-extra behaviours nothing was pinning
+- *(daemon)* say where disarm is really called from, and narrow Command
+- *(daemon)* cover the lifecycle-extra behaviour nothing was pinning
+- *(daemon)* say what the rescan bypass is actually keyed on
+- *(comments)* make phase-created comments self-contained
+- *(daemon)* stop the boot race test fabricating a live "stale" socket
+- *(daemon)* unbreak the private-items doc build
+- *(daemon)* prove the shepherd channel's ready message reaches the gate
+- *(daemon)* say why readiness doesn't floor its probe interval
+- *(daemon)* correct what a cleared `ready_tx` means
+- *(daemon)* note what exit 127 stops meaning without the shell
+- *(daemon)* assert the bytes an HTTP probe puts on the wire
+- *(daemon)* accept either failure from an unroutable TCP address
+- *(daemon)* the polling enforcer is no longer a later addition
+- *(daemon)* pin four unguarded limits-loop behaviors, hoist per-tick tree index
+- *(daemon)* fix broken intra-doc links to the cfg-gated fake module
+- *(daemon)* guard tree_rss's parent-pid decision against real-OS regression
+- *(daemon)* drop task-relative phrasing from moved testing.rs comments
+- *(daemon)* move mod testing out of lib.rs into its own file
+- *(daemon)* drop task-relative phrasing from Cargo.toml comments
+- *(daemon)* make write_pidfile test-only
+- *(daemon)* correct two unsafe-surface claims left stale by Decision 1
+- correct stale unsafe-surface counts across docs and plan
+- *(daemon)* plane taxonomy, canonical security writeup, inline audit
+- *(daemon)* end-to-end tier — real socket, real children, muster round trip
+- *(daemon)* make the bare-interpreter test actually gate PATH seeding
+- *(daemon)* pin ready-fd adoption ordering; correct unsafe-surface docs
+- *(daemon)* crate mini-guide + inline audit
+- *(daemon)* fix rustdoc intra-links that reddened the docs CI job
+- *(daemon)* commit proptest regression seed for brain budget invariant
+- SECURITY.md premises contract + per-crate changelogs (IR-42/45)
+- scaffold cargo workspace (shep-core, shep-daemon, shep-client, shep-cli)
+
 ### Additions
 
 - Record every sheep's last exit outcome and carry it on `ProcessInfo`. The


### PR DESCRIPTION



## 🤖 New release

* `shep-core`: 0.1.0-alpha.1
* `shep-daemon`: 0.1.0-alpha.1
* `shep-client`: 0.1.0-alpha.1
* `shep`: 0.1.0-alpha.1

<details><summary><i><b>Changelog</b></i></summary><p>

## `shep-core`

<blockquote>

## [0.1.0-alpha.1] - 2026-08-16

### Additions

- Add `DaemonConfig::load_layered` and `DaemonOverrides` — a third
  `file < SHEP_* env < flags` layer over the `file < env` `load` already did.
  `load` keeps its exact signature and semantics; `load_layered` validates
  exactly once, after all three layers are merged, so a good override can
  rescue a `shep.toml` whose own value is below the floor. `DaemonOverrides`
  is `#[non_exhaustive]` with a consuming-self builder, because it grows a
  field every time the hidden `daemon` subcommand grows a flag.
- Add `config::parse_daemon_bool` — the shared `1|0|true|false` grammar
  `SHEP_LOG_JSON` and `--log-json` both parse through, so the two never drift
  apart into different boolean spellings.
- Add a non-default `schema` feature: `JsonSchema` for the Flockfile
  document, `AppConfig`, `ProbeConfig`, `ProbeKind`, `MemSize`, `UpDuration`,
  and `config::flockfile_schema_json`, which renders the document schema as
  pretty-printed JSON. Off by default; `shep-cli` turns it on. The schema
  describes the deserializer, not the `normalize` step — `kill_signal` is an
  unconstrained string in the schema even though `normalize` narrows it to
  five signal names afterward.
- Accept and ignore `$schema` at the Flockfile top level — a JSON/JSON5
  editor's own convention for pointing at a schema file, read by
  `RawFlockfile` and discarded. Does not touch `AppConfig`, which is on the
  wire; `PROTOCOL_VERSION` is unaffected.
- Add `signals::OperatorSignal`, the nine signals `shep signal` may name;
  `Request::Signal` / `Response::Signalled` / `SignalReply` / `SignalOutcome`.
- Add `Request::Scale` / `Response::Scaled` — set an app's instance count,
  the stocking rate; the CLI verb is `shep stock` (alias `scale`).
- Add `AppConfig::stdin` (default `false`) — pipe a sheep's stdin so `shep
  whisper` (alias `sendline`) can reach it; `Request::SendLine` /
  `Response::SentLine` / `LineReply` / `LineOutcome`.
- Add `Lamb` and `ProcessInfo::lambs` — a sheep's process-tree members,
  populated by `Describe` only. `None` means the reply did not walk for them,
  never that there are none.
- Add `kv` — the file-locked key/value store at `$SHEP_HOME/kv.json` (spec
  §5), and `ShepPaths::kv`.
- Add `BusEvent::Channel` and the `channel.ready` / `channel.metric` /
  `channel.action_reply` topics (spec §6).
- Add `protocol::ProcessInfoBuilder`.
- Add `config::KillSignal`, the four-signal grammar `kill_signal` accepts.
- Add `barks` module: `Bark`, `SinkOutcome`, `append`, `read`, and
  `DEFAULT_MAX_BYTES` — the `barks.jsonl` ring both the bark dog (a rule
  fired) and the shepherd itself (an enabled dog gave up) append to, and
  `shep barks` will read. One JSON object per line, because a
  line-delimited format is the one shape where a writer dying mid-append
  costs the reader one record rather than the file. `append` keeps the
  ring under a byte cap by evicting whole lines oldest-first, rewriting
  the survivors plus the new record to a sibling temp file and `rename`ing
  it over the original — the same atomic-replace shape
  `shep-daemon::snapshot::write_atomic` uses, so an interrupted rewrite
  never leaves a truncated line behind. A single record bigger than the
  whole cap is written anyway, over cap, rather than dropped — the
  alternative silently loses the alert that was too interesting to fit.
  `read` is the forgiving half: a line that will not parse — a partial
  write from a dead writer, or a record from a future shep — costs that
  one record, not the whole history, because this file is read during an
  incident and refusing it over one bad line is the wrong failure mode.
  Lives in shep-core, not shep-daemon, because it has two writers in two
  different processes and neither is the other's crate; one implementation
  of the cap keeps them from evicting differently. `Bark`'s `Debug` is
  derived, not redacted: it carries a rule name, a subject and a message,
  all shep's own prose, and `SinkOutcome` names a sink by its
  `[dog.bark.sinks]` config key, never by its webhook URL or token — the
  file itself is still created owner-only (unix `0600`) as a matter of
  posture, not because it holds a secret today.

- Add `ProcessSelector::is_exact`, which answers whether a selector names one
  entry the caller already knew of — by its name or its id — rather than
  sweeping whatever matches. `Regex` and `Fold` are wildcards by this
  measure even when the pattern is a literal that can only ever match one
  name: what the split turns on is whether the operator named the thing, not
  how many things the selector reaches. The daemon uses it to keep a dog out
  of what `all` and a `/regex/` sweep touch while leaving `shep restart bark`
  able to reach it.

- Add `DaemonSection::adopted_dogs`, a `BTreeMap<String, PathBuf>` recording
  where each adopted dog's binary lives, keyed by dog name (`shep adopt`
  writes an entry; `shep rehome` removes it). A name in `enabled_dogs` with
  no entry here is a built-in dog — an argv branch of the shep binary
  itself — and that presence-or-absence is the whole of the distinction.
  The path deliberately lives in `[daemon.adopted_dogs]` rather than as a
  shep-owned key inside `[dog.<name>]`: that table is the dog's own opaque
  configuration, parsed by the dog and not by shep, and a shep-owned key
  planted inside it would collide with a third-party dog's own schema.
  `PathBuf`, not `String`: unlike `DogSource::Adopted`'s wire form, this
  value never crosses the wire — it is read straight off `shep.toml` and
  handed to a spawn, which is a path, not serialized text.
- Add `Request::DogConfig`, `Request::EnableDog`, `Request::DisableDog`, and
  `Response::DogSection`, `Response::DogStarted` — the wire verbs a dog and an
  operator use to fetch a dog's config, start one, and stop one. Additive
  under `#[non_exhaustive]` on the same terms as `Reopen` above —
  `PROTOCOL_VERSION` stays **1**, and an older daemon fails to decode the verb
  rather than answering it.

  `DogConfig` carries a `name: String`, not a `SelectorSpec`: a dog's name is
  a config key, selecting one `[dog.<name>]` table and one `enabled_dogs`
  entry, not a set of processes, so a selector here would invite `shep enable
  all`, which has no meaning. `DogSection` answers with the section rendered
  back to TOML text rather than a typed structure — a config value the daemon
  never has reason to parse for the dog, and a third-party dog stays bound to
  the shape of its own section rather than to shep's config model, file
  discovery, or layering rules. That text is wrapped in `DogSectionToml`, a
  `#[serde(transparent)]` newtype over `String` whose `Debug` prints a byte
  count instead of the section: a `[dog.<name>]` table is where a webhook
  credential lives, and keeping it off the process table is the whole reason
  the section travels over the socket rather than through the child's
  environment. A derived `Debug` would have handed it back on the first
  `tracing::debug!` of a reply. The newtype is transparent to serde, so the
  wire bytes are those of a bare string and the pinned fixtures are unchanged;
  it `Deref`s to `str` for reading. `EnableDog` carries the same `name` plus a
  `DogSource` naming where the dog's binary comes from, and answers
  `DogStarted(ProcessInfo)` — a bare `ProcessInfo`, not a `Vec`, the only
  `Response` variant shaped that way: enabling starts exactly one dog, and a
  one-element list would invite a reader to wonder when it holds two.
  `DisableDog` answers the existing `Response::Deleted(Vec<u32>)` rather than
  a variant of its own: disabling deregisters exactly as `Delete` does, so
  this is the same fact and not a coincidence of shape.
- Add `ProcessInfo::dog` and `DogSource`, marking which flock entries are
  dogs (the daemon's own supervised utility processes — metrics, bark) rather
  than sheep, and naming where a marked one came from: `BuiltIn` for an argv
  branch of the shep binary itself, `Adopted { path }` for an operator's own
  binary run at the daemon's own trust level. `DogSource` is
  `#[non_exhaustive]`, so a future source needs no protocol bump, and `path`
  is a `String` rather than a `PathBuf` for the reason `ProcessInfo::out_file`
  is one: serde's `PathBuf` impl refuses a non-UTF-8 path outright, aborting
  the whole reply rather than degrading the one odd field. Additive under
  `#[non_exhaustive]` and an `Option` field, so `PROTOCOL_VERSION` stays
  **1** on the same terms as `out_file`/`cpu_percent` before it: a daemon
  built before dogs existed sends no `dog` key at all, and a current client
  decodes that as `None`.

  `None` deliberately covers both "this entry is a sheep" and "this peer
  predates the field" without needing to tell them apart, unlike
  `cpu_percent`'s three enumerated cases — a stale `cpu_percent` reading
  would be a claim about resource use, and there is no equivalent claim a
  missing `dog` marker could get wrong: a daemon that predates dogs truly has
  none, so "not a dog" is the correct answer under either reading.

- Add `ProcessInfo::cpu_percent` and `ProcessInfo::memory_bytes`, a sheep's
  live resource use as the daemon read it while answering. CPU is a
  percentage of one core over the window since the daemon's last periodic
  sample, memory a resident set size in bytes; both are summed over the
  sheep's whole process tree, so a sheep that forks lambs is reported as what
  it actually costs the machine. Both are `Option`, and all three of the
  cases that make one `None` render as unknown rather than as zero: the sheep
  is not running, it has been up for less than one sampling window and so has
  no honest CPU figure yet, or the peer daemon predates the fields.
  `PROTOCOL_VERSION` stays 1 for the reason `out_file`/`err_file` left it at
  1 — the fields are additive, they decode to `None` from pre-existing bytes
  (pinned by a committed byte fixture), and a peer that predates them ignores
  them.

- Add `ProbeTarget`, parsing a probe's `target` once, at config time, into the
  form its kind promises: `http://host[:port][/path]` for `Http` (port
  defaults to 80, path to `/`), `host:port` for `Tcp`, and any non-empty
  command line for `Exec`. Both authority-bearing kinds share one split, so a
  bracketed IPv6 host such as `[::1]` is accepted on either and carried with
  its brackets stripped. `https://` targets are rejected with their own error
  variant — the HTTP prober is a hand-rolled client with no TLS, and a probe
  that silently failed every poll would look exactly like a down app.
  `normalize` now validates `readiness_probe` and `liveness_probe` targets
  (discarding the parsed value; the daemon re-parses when it arms the probe),
  rejects an explicit `failure_threshold == 0`, and rejects `watch = true`
  with no `cwd`. A zero threshold is unhealthy before the first poll ever
  runs. For `watch`, there is no directory to watch, and defaulting to the
  daemon's own cwd risks recursively watching the whole filesystem under a
  systemd unit with no `WorkingDirectory=`.
- Reject the zero-valued knobs that turn a loop into a hot spin, each with
  its own error variant naming the app: `liveness_probe.interval` below one
  second (`IntervalBelowMinimum`), `max_memory` of `0` (`ZeroMaxMemory`),
  and `watch_delay` of `0` (`ZeroWatchDelay`). A sub-second liveness
  interval was previously clamped in silence, which the neighbouring
  `max_cron_sleep` knob already refused to do on the grounds that a clamp
  announces itself only in a log file nobody reads. A zero `watch_delay`
  reaches the debouncer, whose tick is `delay / 4`, and pegs a core per
  watched app. A zero `max_memory` is a ceiling every process exceeds, so
  the sheep restarts every poll forever. A `readiness_probe.interval` below
  the floor is still accepted: that poll is bounded by `listen_timeout`, so
  it cannot spin.
- Add `CronSchedule`, validating `cron_restart` against croner's dialect and
  resolving `cron_timezone` against the IANA database, replacing the
  5-token-count stopgap. Accepts the seven vixie `@nickname` shorthands,
  expanded to five-field patterns before croner ever sees them: `@yearly`
  and `@annually` -> `0 0 1 1 *`, `@monthly` -> `0 0 1 * *`, `@weekly` ->
  `0 0 * * 0`, `@daily` and `@midnight` -> `0 0 * * *`, `@hourly` ->
  `0 * * * *`.
- Add the `[daemon] max_cron_sleep` key: the longest a cron worker sleeps
  before re-deriving its next occurrence, which bounds how far a cron restart
  can drift after a laptop suspend or an NTP step. Defaults to 60s when unset,
  and `SHEP_MAX_CRON_SLEEP` overrides the file value. Values below one second
  are **rejected** rather than clamped — below that the loop stops scheduling
  and starts spinning, and a clamp would announce itself only in a detached
  daemon's log file. Mind the duration grammar, which is `UpDuration`'s and
  counts **milliseconds** when no unit is given: `max_cron_sleep = "60"` is
  sixty milliseconds and fails the floor, while `"60s"` is the minute most
  people mean.
- Add wire protocol v1 types — `Request`, `Response`, `Envelope`, `Reply`,
  `RpcError`, `Hello`/`HelloAck`, `BusEvent` — with pinned insta snapshots of
  their serialized form.
- Add `Request::Reopen` and `Response::Reopened`, asking a daemon to reopen
  the log files of every matched sheep after an external rotator has renamed
  them. Both enums are `#[non_exhaustive]` and no existing variant changes,
  so `PROTOCOL_VERSION` stays **1**: the committed v1 byte fixtures still
  deserialize. A new *variant* buys no graceful answer from an older daemon,
  though, and this one does not either: `Request` is internally tagged
  (`#[serde(tag = "kind")]`) with no `#[serde(other)]` catch-all, so a daemon
  whose `Request` predates the variant fails to decode the frame at all and
  ends the connection. The `Internal` wildcard in the daemon's dispatch fires
  only where its own `shep-core` already knows the variant — which, for a
  shipped daemon, means it implements it too. (The additive-*field* reasoning
  under `ProcessInfo::out_file` below is sound and simply does not extend to
  variants.) `Reopened` carries `ProcessInfo`s like `Stopped` and `Restarted`
  do — every matched sheep, including any that was not running and so had
  nothing to reopen.
- Add `Request::Flush` and `Response::Flushed`, asking a daemon to empty the
  log files of every matched sheep. Additive under `#[non_exhaustive]` on the
  same terms as `Reopen` above — `PROTOCOL_VERSION` stays **1**, and an older
  daemon fails to decode the verb rather than answering it. `Flush`
  carries a `SelectorSpec` with no default anywhere in the stack — the verb
  destroys log data, so the operator names its target. `Flushed` carries one
  `ProcessInfo` per matched SHEEP, not one per file emptied: several sheep
  can share a log path (`merge_logs`, or an explicit `out_file` on a
  multi-instance app) and the daemon truncates each distinct path once, but
  the selector names sheep and so does the answer.
- Add `Request::Reload` and `Response::Reloading`, asking a daemon to replace
  each matched sheep with a fresh instance of the same app, one instance of an
  app at a time. Additive under `#[non_exhaustive]` on the same terms as
  `Reopen` above — `PROTOCOL_VERSION` stays **1**, and an older daemon fails
  to decode the verb rather than answering it. `Reload` carries a
  `SelectorSpec` with no default anywhere in the stack, matching
  `stop`/`restart`/`delete`: the verb replaces running processes, so the
  operator names its target.

  `Reloading` is named for what it is. It is an **acceptance**, and the only
  reply in the enum carrying a flock listing that names one rather than
  finished work — `ShuttingDown` is an acceptance too and carries nothing.
  The reason is timing: one instance costs a
  readiness wait plus a drain in the worst case, so a clustered app outlasts
  any deadline a client is allowed to ask for, and a reply that waited would
  time out while the reload it asked for went on running. It carries the
  matched sheep as they stood when the reload was accepted — including any
  with nothing to replace, which are the no-op successes they look like — and
  the swaps themselves report on the bus.
- Add `ProcessEventKind::Reload`, `Reloaded` and `ReloadAbandoned`
  (`process.reload`, `process.reloaded`, `process.reload_abandoned`), the
  three ways a reload reports itself. `Reload` names the instance being
  replaced, `Reloaded` the replacement once the instance it drained is gone,
  and `ReloadAbandoned` whichever instance the abandonment left holding the
  slot — the one the reload gave up on replacing, still the app's live one, or
  the replacement itself where that is what went down. **A subscriber built
  before these variants cannot
  decode the frames and drops them**, and unlike a new `Request` variant that
  is not something it opted into: every topic here is `process.<something>`,
  which the `process.*` glob already matches. Accepted rather than worked
  around, because a reload's reply is an acceptance and the bus is therefore
  the only place its outcome is reported at all; reusing `Start`/`Stop` and
  leaving subscribers to infer a reload from a doubled name would make the
  outcome unreadable to a new client as well as an old one.
- Add `Request::Trigger` and `Response::Triggered`, asking a daemon to send a
  named action to every matched sheep over its shepherd channel and report
  what each app says back (`shep trigger <target> <action> [params]`).
  Additive under `#[non_exhaustive]` on the same terms as `Reopen` above —
  `PROTOCOL_VERSION` stays **1**, and an older daemon fails to decode the
  verb rather than answering it. `Trigger` carries a `SelectorSpec` with no
  default anywhere in the stack, matching `stop`/`restart`/`reload`/`delete`/
  `flush`. `action` is a free-form `String` the daemon never parses or
  validates, and `params` an `Option<String>` matching the shepherd channel's
  own `action` message.

  `Triggered` carries `Vec<ActionReply>`, not `Vec<ProcessInfo>`: a reply
  body has nowhere to live on `ProcessInfo`, and `EmptiedFile`
  (`shep-cli`'s own non-`ProcessInfo` row) is the precedent for a row built
  for what one verb needs rather than reused from the flock-listing shape.
  Each `ActionReply` carries the sheep's id and name plus a new
  `#[non_exhaustive]` `ActionOutcome`: `Replied { body }` when the app
  answered, `NoChannel` when the daemon had no shepherd channel to deliver
  over, `Skipped` for a reload drainee, or `TimedOut` when nothing came back
  before the app's action timeout. Per-row rather than a whole-request
  refusal, matching `Reopen`/`Flush`'s own precedent: spec §9's selector
  grammar (`all`, `/regex/`, `fold:`) makes a mixed flock the normal case,
  and a channel-less sheep in that mix should not cost every other sheep its
  answer.
- Add `Request::Muster` and `Response::Mustered`, asking a daemon to assemble
  the flock from the muster roll on disk (`shep muster`). Additive under
  `#[non_exhaustive]` on the same terms as `SaveRoll` below — `PROTOCOL_VERSION`
  stays **1**, and an older daemon fails to decode the verb rather than
  answering it. `Muster` carries no fields for the reason `SaveRoll` carries
  none: the roll describes a whole flock, so there is nothing to select.
  `Mustered` carries the same `Vec<ProcessInfo>` `Flock` does, and reports
  every sheep of every app the roll restored rather than only the ones that
  call spawned — assembling a flock that is already assembled starts nothing,
  and an empty listing there would be indistinguishable from an empty roll,
  which is the one outcome the reply exists to tell apart.
- Add `Request::SaveRoll` and `Response::RollSaved`, asking a daemon to write
  the muster roll now, bypassing the snapshot writer's debounce
  (`shep save`). Additive under `#[non_exhaustive]` on the same terms as
  `Reopen` above — `PROTOCOL_VERSION` stays **1**, and an older daemon fails
  to decode the verb rather than answering it. `SaveRoll` carries no fields:
  unlike `Stop`/`Restart`/`Trigger` and the rest, there is no flock to
  select — the roll always records the whole flock. `RollSaved` is the only
  struct-shaped `Response` variant, carrying the roll's absolute path (a
  `String`, not a `PathBuf`, for the reason `ProcessInfo::out_file`'s own
  comment gives) and how many apps it recorded (`apps: u32`, matching
  `SavedApp::instances_running`'s width in shep-daemon's `snapshot.rs`).
- Add `MemSize` and `UpDuration` config value newtypes, parsing the strict
  Flockfile grammars `^\d+(G|M|K)?$` and `^\d+(h|m|s)?$`.
- Add `ProcStatus` with stable wire strings for the process lifecycle states.
- Add `ShepPaths` to resolve the `$SHEP_HOME` runtime directory layout.
- Add `AppConfig` with the v1 Flockfile field set, plus `normalize` and
  `normalize_all`, which produce a proof-token `ResolvedApp`.
- Add `AppConfig::channel`, opening the shepherd channel on fd 3 for an app
  on its own rather than only as a side effect of `wait_ready` or
  `shutdown_with_message`. Defaults to `false`: a socketpair plus two pump
  tasks per sheep is real cost against spec §14.11's single-digit-MB
  idle-RSS goal, so the channel now opens only when something asks for one.
  `wait_ready` and `shutdown_with_message` keep opening it on their own,
  unaffected by the new field.
- Add `AppConfig::action_timeout`, how long a triggered action gets to answer
  before its row becomes `ActionOutcome::TimedOut`. Defaults to 3s, replacing
  the flock-wide constant the daemon used before this field existed, with the
  same value and the same reasoning: comfortably under the 5s an RPC caller
  gets by default, so the honest `TimedOut` row still reaches a caller who set
  no deadline of its own. `normalize` rejects a value at or above 58s — 2s
  under the daemon's own hard ceiling on any deadline a caller could ever be
  given, `MAX_DEADLINE_MS` — because past that line no caller, however long a
  deadline it asks for, could ever be given room to wait it out; a value
  merely above the 5s *default* is accepted, on the understanding that
  satisfying it is the caller's to arrange with a wider deadline of its own
  (`Client::request_with_deadline`, the way `shep logs -f` already asks for
  `LOG_PLANE_DEADLINE` rather than the client's default).
- Add `Flockfile` discovery (`discover`) and TOML/YAML/JSON/JSON5 parsing.
- Add `DaemonConfig`, parsing `shep.toml` with `SHEP_*` env-variable
  layering.
- Add `ProcessSelector` parsing and matching (`all`, id, name, `/regex/`,
  `fold:<name>`).
- Add the length-delimited JSON wire codec (`codec`, `encode_frame`,
  `decode_frame`) with a 16 MiB frame cap (`MAX_FRAME_BYTES`).
- Add `SelectorSpec` <-> `ProcessSelector` wire bridges (`TryFrom`/`From`) so
  selectors travel over RPC.
- Add `ProcessInfo::out_file` and `ProcessInfo::err_file`, the daemon's
  resolved log paths for a sheep. Readers can no longer derive these: an
  explicit `out_file`/`err_file` in an app's config may point anywhere, so
  guessing the `logs/<name>-<instance>-out.log` convention silently finds
  nothing for such a sheep. Both are `Option<String>` — a string because
  every other path on this wire is one and because serde refuses a non-UTF-8
  `PathBuf` outright, failing the whole reply rather than one field; optional
  because this addition does not bump `PROTOCOL_VERSION`, so a daemon
  predating the fields still connects and sends replies without them, where
  `None` means "peer too old to say", never "this sheep has no log file".
  `PROTOCOL_VERSION` stays 1: the fields are additive, they decode to `None`
  from pre-existing bytes (pinned by a committed byte fixture), and a peer
  that predates them ignores them.
- Add `[daemon] log_level`, overridable by `SHEP_LOG_LEVEL`, deciding how
  much of the daemon's own diagnostics is rendered. Its type is the new
  `LogLevel` — `off`, `error`, `warn`, `info`, `debug`, `trace`, lowercase
  and nothing else — and the default is `warn`, which is where the daemon's
  warn-and-continue arms live: a watch it could not arm, a cron pattern it
  could not parse, a memory ceiling a process tree crossed. `debug` fires
  per dropped restart and per child metric sample, so it is a firehose on a
  busy flock rather than a slightly noisier log. A name outside the six is a
  startup error (`DaemonConfigError::Toml` from the file,
  `DaemonConfigError::BadEnvValue` from the environment), never a silent
  fallback to the default. `DaemonSection` gains the field, so a struct
  literal naming every field must name this one too; `..Default::default()`
  is unaffected.
- `protocol::channel` — the shepherd channel's `ChildMessage`/`ShepherdMessage`
  shapes, moved here from shep-daemon so a bus event can carry one.
- Add `config::WhistleSection` and `DaemonConfig::whistle` — the `[whistle]`
  section, one key (`allow_control`, default `false`) gating whether `shep
  whistle`'s four control tools are offered. Lives in `shep.toml` and
  nowhere else: no flag, no `SHEP_*` variable, because the config file is
  what an operator can audit and `shep whistle`'s launcher writes its own
  argv. `Debug` is derived, not redacted (IR-41) — one boolean, no secret.

### Fixes

- `normalize` refuses a `kill_signal` shep cannot send instead of leaving the
  daemon to substitute SIGTERM at every stop.
- Give the workspace's path dependencies (`shep-core`, `shep-daemon`,
  `shep-client`) a version alongside their `path`, which `cargo publish`
  requires — it strips `path` from a dependency at publish time and refuses
  to publish anything left with no version to put there. One cosmetic side
  effect for this crate specifically: its `[target.'cfg(any())'.dependencies]`
  floor-pin block (see that block's own comment) publishes as real manifest
  entries, so crates.io and docs.rs list all six of `annotate-snippets`,
  `anstyle`, `encoding_rs_io`, `pest`, `quote` and `syn` as dependencies of
  `shep-core`, even though `cfg(any())` never matches and not one of them
  ever builds into it. `shep-daemon` and `shep-cli` publish the same way, for
  the two and the one floor pin their own blocks carry.
- Reject a `watch_options` or `ignore_watch` pattern globset will not compile,
  with `NormalizeError::InvalidWatchGlob`, naming the sheep, which of the two
  lists the pattern came from, the pattern as written and globset's reason.
  `normalize` compiles every pattern through globset — the engine the daemon's
  own watch filter uses — and checks both lists whether or not `watch` is on.
  Previously a pattern such as `"["` was accepted, the sheep came up `online`,
  and the watch it configured simply did not exist.
- Reject JSON5 documents nested past depth 64 instead of stack-overflowing
  (an uncatchable `SIGABRT`) on deeply nested or malicious `Flockfile` input.
- Make the JSON5 depth guard comment-aware: `//` and `/* */` comments
  containing a quote character no longer desync the guard's string-tracking
  and disable it for the rest of the document.
- Stop `DaemonConfig`'s `Debug` implementation from leaking `[dog.*]` table
  values (e.g. webhook URLs); it now prints only the table count.

### Changes

- `config::DaemonConfig` is `#[non_exhaustive]`. Outside shep-core it can no
  longer be built with a struct literal or `..Default::default()`. **A
  breaking change for any out-of-tree struct-literal construction.** It is
  for field growth — `DaemonConfig` gains a section roughly every phase — not
  for validation: the type is not a proof token and does not become one,
  fields stay `pub`, and holding one does not prove it was validated. The
  escape hatch if that ever needs to change is a public `validate`, not
  private fields.
- `protocol::ProcessInfo` is `#[non_exhaustive]` — construct it with
  `ProcessInfo::builder`. Fields remain `pub`; reading and assigning are
  unchanged. A future field is no longer a breaking change for downstream
  crates.
- `ProcessInfo` no longer derives `Eq`. `cpu_percent` is an `f32` and floats
  are only partially ordered, so the derive could not survive the field.
  `PartialEq` stays, which is everything `assert_eq!` and a `==` comparison
  need; what stops compiling downstream is a `HashSet<ProcessInfo>`, a
  `BTreeSet` of them, or a type that derives `Eq` and holds one. Nothing in
  this workspace does any of the three.

- `cron_restart` validation moves in both directions. Tighter: patterns the
  stopgap accepted purely on token count (e.g. `99 99 99 99 99`) now fail
  with croner's own reason, and croner's `L`, `W`, `#` and `?` extensions are
  newly rejected with the offending character named — six-field and
  seconds-bearing patterns were already rejected by the token count and stay
  rejected, but the error now says why instead of "not a 5-field pattern",
  and `@reboot` is rejected with a message about what it means rather than
  about field counts. Looser: `0 0 * JUL WED` and `0 0 * * MON-FRI` keep
  working, and the seven vixie nicknames above are now accepted where the
  token-count stopgap rejected them. `NormalizeError::InvalidCron` becomes a
  struct variant (`{ pattern, reason }`) instead of a bare tuple, and gains a
  sibling `InvalidTimezone { name }` for a `cron_timezone` that is not an
  IANA zone — validated even when `cron_restart` is absent.
- `DaemonConfigError` gains a `BelowMinimum { key, value, min }` variant, for
  the `max_cron_sleep` floor above. This is filed as a change rather than an
  addition because the enum carries no `#[non_exhaustive]`: any downstream
  `match` over it stops compiling until it handles the new variant.
- `encode_frame` now returns `Bytes` instead of `BytesMut`: it takes
  ownership of the serialized `Vec`'s buffer instead of copying it.
- Swap the YAML backend from `serde_yml` to `serde-saphyr` (pure-Rust
  parser), keeping the crate's `forbid(unsafe_code)` guarantee.
- Rename `ConfigError` -> `NormalizeError`, matching the per-construction-site
  naming convention used by the crate's other error enums.
- Rewrite `AppConfig::reuse_port`'s doc. It previously read "Bind listen
  sockets with SO_REUSEPORT", first person, as though shep does the
  binding — it doesn't. The child binds after `exec`, and a socket option
  has to be set before `bind()` by the process that binds, so `reuse_port
  = true` has only ever meant the operator asserting that the app sets the
  option itself (Node ≥22's `reusePort`, Go's `Control` hook, nginx's
  `reuseport`); shep's contribution is permission for the old and new
  instance to overlap during reload, not the mechanism. The doc now also
  names the failure mode: an app that does not set the option gets
  `EADDRINUSE` at the replacement spawn on every reload, undetectable in
  advance, and `SO_REUSEADDR` — which far more frameworks set by default —
  is not sufficient. No behavior changed; the field's meaning was always
  this, only the doc claimed otherwise.
- Wire fixtures now pin every `SelectorSpec` variant, every
  `ProcessEventKind`, and every `Response` tag. No wire string changed —
  this closes coverage, not behaviour.
- `FlockfileError`, `DaemonConfigError` and `BarkError` are `#[non_exhaustive]`.
  Match on them with a wildcard arm.
- `SelectorError`, `ParseMemSizeError`, `ParseUpDurationError` and `WireError`
  are `#[non_exhaustive]`. Match on them with a wildcard arm.
</blockquote>

## `shep-daemon`

<blockquote>

## [0.1.0-alpha.1](https://github.com/TurtIeSocks/shep/releases/tag/shep-daemon-v0.1.0-alpha.1) - 2026-08-26

### Added

- *(daemon)* name the sun_path limit instead of passing ENAMETOOLONG through
- *(core)* refuse reuse_port rather than accepting a knob nothing reads
- *(core,daemon,cli)* carry a sheep's last exit outcome to the operator
- *(shep-daemon)* a stopped sheep stays in the flock across a daemon restart
- *(cli)* scale becomes stock, sendline becomes whisper
- *(daemon)* the shepherd walks a sheep's lamb tree
- *(core)* shep_core::kv, the file-locked key/value store
- *(cli)* shep sendline <selector> <line>
- *(daemon)* the supervisor writes a line to a sheep
- *(daemon)* pipe a sheep's stdin, opt-in per app
- *(daemon)* the supervisor scales an app
- *(daemon,cli)* deliver a signal to one sheep, and shep signal
- *(core,daemon)* forward shepherd-channel traffic onto the bus
- *(core)* reject an unknown kill_signal when the config is read
- *(core)* make ProcessInfo non_exhaustive, add a builder
- *(daemon)* leave a trail when a dog gives up
- *(daemon)* group a listing by name so a clustered app reads as one
- *(daemon)* let the enabled dogs out at boot
- *(daemon)* answer the dog contract
- *(daemon)* start a dog through the ordinary spawn path
- keep dogs out of what a wildcard selector sweeps
- *(core)* mark which entries are dogs
- report each sheep's cpu and memory
- *(daemon)* sample every sheep, enforce only where a limit exists
- *(daemon)* report readiness once the flock is back
- assemble the flock from the roll on demand
- *(daemon)* write the muster roll when an operator asks
- *(core)* bound a custom action with its own timeout
- *(daemon)* answer a trigger for every sheep it matched
- *(daemon)* wait for an action's reply, or time out
- *(core)* put trigger on the wire
- *(daemon)* let a triggered action carry params
- *(daemon)* keep a handle on the shepherd channel
- *(daemon)* bound every reload swap with a deadline of the actor's own
- *(daemon)* report a reload's progress on the bus
- *(daemon)* answer the reload verb on the control socket
- *(daemon)* reload an app one instance at a time
- *(daemon)* let the stop ladder's cap be the caller's choice
- *(daemon)* say which entry holds which half of a reload
- *(daemon)* refuse a log ancestry a root shepherd should not write below
- *(daemon)* refuse to follow a symlink at a log path
- *(daemon)* make SIGUSR2 reopen every sheep's logs
- truncate log files with shep flush
- reopen log files so external rotation works
- *(daemon)* give the supervisor a way to reach its log pumps
- *(core)* let an app open the shepherd channel without a readiness flag
- *(daemon)* wire a tracing subscriber so the daemon's diagnostics reach someone
- *(daemon)* arm and disarm lifecycle extras across the sheep lifecycle
- *(daemon)* watch-triggered restarts with glob filtering and re-check
- *(daemon)* debounced filesystem watch bridged onto tokio
- *(daemon)* gate online on readiness for apps that configure it
- *(daemon)* HTTP, TCP and exec probes over real sockets and processes
- *(daemon)* liveness probing with a consecutive-failure threshold
- *(daemon)* polling memory-limit enforcement behind a mechanism-free seam
- *(daemon)* sample resident memory across a sheep's process tree
- *(daemon)* cron-scheduled restarts with a wall-clock seam
- *(core)* report each sheep's resolved log paths on ProcessInfo
- *(daemon)* daemon boot — readiness pipe, signal handlers, ordered teardown
- *(daemon)* boot layout — 0700 dirs, pidfile, stale-socket recovery
- *(daemon)* UDS RPC server — peer-cred auth, handshake, subscriptions
- *(daemon)* RPC dispatch — verb routing, typed errors, per-call deadlines
- *(daemon)* muster roll — registry, atomic writes, debounced writer, restore
- *(daemon)* event bus — topic globs, forwarder task, drop-oldest notices
- *(daemon)* supervisor actor with sheep-task ownership + deterministic lifecycle tests
- *(daemon)* kill ladder — message/signal, timeout, SIGKILL tree
- *(daemon)* tokio runner — process groups, socketpair channel, log capture
- *(daemon)* spawn assembly — slots, env, interpreter, log paths
- *(daemon)* restart brain — signal exits never match stop_exit_codes
- *(daemon)* entry, budget, pinned integer backoff
- *(daemon)* runner abstraction, shepherd channel types, scripted fake

### Fixed

- *(daemon)* drop the From that let ? pick the wrong BootError
- *(packaging)* ship the license text inside every published tarball
- *(daemon)* a respawn that never spawns must not keep the old exit code
- *(shep-daemon)* widen the coalescing window, and pin the half load cannot break
- *(shep-daemon)* stop asserting on which batch a write lands in
- close the 7 real-Windows test failures found on `windows`
- *(shep-daemon)* log the pump's ancestry-check refusal instead of swallowing it
- *(shep-daemon)* stop treating a pre-drop straggler batch as a leak
- *(daemon)* canonicalize the watch root here, not in the backend
- *(shep-daemon)* silence a clippy lint in the new signalled-shutdown test
- *(shep-dev)* make the roll durable when a signal ends the session
- *(daemon)* a scale is refused while an earlier one is still leaving
- *(daemon)* an abandoned stdin write is dropped, and not_written says what it means
- *(daemon)* a full stdin queue reports no elapsed time it did not measure
- *(daemon)* describe's lamb names stop being permanently stale
- *(daemon)* record a partial scale in the muster roll
- *(daemon)* stamp custom actions so a late reply cannot answer the wrong wait
- *(protocol)* stop Response's derived Debug from leaking a dog's TOML section
- *(daemon)* let a child block on the shepherd channel
- *(daemon)* log the two skips that drop real work in silence
- *(daemon)* say on the bus that a reload ended with its drainee already gone
- *(daemon)* announce a swap only for a replacement that is still serving
- *(daemon)* reach every writer to a path a reload is sharing
- *(daemon)* assert the reachability claim the queue-abort rests on
- *(daemon)* stop a reload swapping against an instance already on its way out
- *(daemon)* stop the swap gate at the commit, and say what it made redundant
- *(daemon)* stop an abandoned reload reporting a dying drainee as online
- *(daemon)* hold an automatic restart off both halves of a reload's swap
- *(daemon)* end a reload whose replacement outlives the drainee it replaced
- *(daemon)* stop a reload deleting an app an operator only stopped
- close the small findings the log-plane review left open
- *(daemon)* tell a watch rescan apart from an event on the watch root
- *(daemon)* give the log pump the only claim on the log directory's mode
- *(daemon)* flush every writer to a path a flush is about to empty
- *(cli)* give a reopen room to finish, and let its handler prove it changes nothing
- *(daemon)* let a reopen that failed say so, instead of acking success
- *(daemon)* end a log pump when its `logs` receiver goes, line or no line
- *(daemon)* serve the log pump's control channel while it waits for room
- *(daemon)* close the interest-cache race the log-capture harness still had
- *(daemon)* ignore a sheep's own logs, and stop docs promising what nobody sees
- *(daemon)* stop reporting every automatic restart as a user action
- *(core)* reject the zero-valued knobs that turn loops into hot spins
- *(test)* reap a case's whole flock when it panics, and signal the group
- *(daemon)* count cron and watch restarts as automatic, not operator
- *(daemon)* let a stop or delete override an automatic restart mid-ladder
- *(core)* reject watch globs that will not compile at config time
- *(daemon)* close the four ways a lifecycle extra outlives its sheep
- *(daemon)* restart on a watch rescan, and arm the watch tests that could not fail
- *(daemon)* make the watch source's tests actually guard what they claim
- *(daemon)* carry `manually` through a gated app's deferred Online
- *(daemon)* scope a readiness probe to the assembled spec's env
- *(daemon)* carry the port in an HTTP probe's Host header
- *(daemon)* require an HTTP status line before trusting its status code
- *(daemon)* finish OsProber's redacting Debug non-exhaustively
- *(daemon)* kill a timed-out exec probe's whole process group
- *(daemon)* give an exec probe null stdio instead of the daemon's
- *(daemon)* reject a zero probe interval, and pin the timeout wire
- *(daemon,core)* harden cron worker per Task 3 review round
- *(daemon)* send the graceful stop to the sheep's process group
- *(daemon)* stop an fd-adoption test double-closing another test's descriptor
- *(daemon)* honour a pending Delete on the duplicate-exit path
- *(daemon)* rearm shutdown-signal listeners against a swallowed repeat SIGTERM
- *(daemon)* restore IR-22 by design + flock the pidfile against the double-bind race
- *(daemon)* honest SAFETY comment, deadline+credentials coverage, roll disclosure
- *(daemon)* honour pending_delete when a Delete races a Restart
- *(daemon)* delete-racing-shutdown deregistration; test: supervisor proptest over command/exit interleavings (IR-37)
- *(daemon)* uid/gid spawn + seed PATH/base env so bare interpreters exec
- *(daemon)* adopt the ready fd before boot opens anything (IO safety)
- *(daemon)* create runtime dirs at 0700 instead of chmod-after (TOCTOU)
- *(daemon)* abort the bus forwarder on every connection-teardown path
- *(daemon)* resolve broken intra-doc links in server.rs's module doc
- *(daemon)* restart budget errors at max_restarts, not max_restarts+1 (spec §4)
- *(daemon)* correct Quick-start doctest, kill-module taxonomy, inline audit
- *(daemon)* supervisor concurrency — shutdown orphans, kill-path deadlock, stale-timer backoff, overlapping-command reply
- collapse nested if-let into let-chains (clippy::collapsible_if)
- *(daemon)* CI portability + fake accessor fixes from review

### Other

- the review's three findings on the plumbing refactor
- *(daemon)* From impls for the daemon's source-only error variants
- changelog entries for the crates that actually changed
- *(shep-daemon)* stop asserting coalescing against a shared CI runner
- *(docs.rs)* make shep-core's schema feature visible on docs.rs
- *(changelog)* head all four shipped CHANGELOGs with 0.1.0-alpha.1
- *(release)* give every crate the metadata crates.io needs
- *(core,daemon)* move shepherd channel message types to shep-core
- *(core,daemon)* make IR-20 true of the tree it governs
- *(core,daemon,cli)* close the IR-20 rationale gap on six error enums
- correct the ring claim, reuse_port, and two openat2 comments
- *(daemon)* narrow the inner-loop skip to a real slow module
- *(daemon)* say what an answering socket actually proves
- *(daemon)* wait out a crashed daemon's socket before rebooting
- record what a custom action is and is not
- *(daemon)* reconcile the changelog for Phase 7's trigger work
- *(daemon)* ask for the channel the writer-task case needs
- prove a trigger reaches a real child and comes back
- *(cli)* stop claiming a TUI, a file server and container modes ship
- *(daemon)* name ReloadState's variants for the role, not the phase
- *(daemon)* expect over bare indexing in handle_reload
- *(daemon)* name Reloading in track_spawned's arm list
- graceful_timeout, not both timeouts, was the option with no reader
- *(daemon)* the Stopping test section describes what it now guards
- *(daemon)* pin that the muster roll never counts a reload's drainee
- *(daemon)* reconcile the reopen entry with the reach it shipped with
- *(daemon)* tighten the ReloadState paragraph the pid removal left behind
- *(daemon)* call the uncommitted-swap helper instead of re-deriving it
- *(daemon)* drop the write-only pid off ReloadState::Draining
- record what reload does and does not promise
- *(changelog)* say what a reload costs on each platform
- *(daemon)* record every pid an event names, not only the ones a reply does
- prove what a reload does to a live connection
- *(daemon)* pin the arming order a reload depends on
- *(daemon)* drive a drainee's liveness failure through the real probe chain
- *(daemon)* drop task-relative phrasing from shipped comments
- *(daemon)* stop guard 4 claiming a second rejection that never runs
- *(daemon)* watch for the event the drainee-report bug actually emits
- *(daemon)* scope the swap-gate release note to what it actually does
- *(daemon)* note in the release notes which instances a reload skips
- *(daemon)* say what holding off a cron or watch trigger actually costs
- *(daemon)* say the swap gate keys on the phase, not the marker
- *(daemon)* let the second-reload-refused case see the damage it names
- *(daemon)* import AppConfig instead of naming it in full at one call site
- *(daemon)* split the two arguments stacked on one rpc error arm
- *(daemon)* name the shutdown-mid-reload asymmetry instead of folding it away
- *(daemon)* make abort_reload's reachability claim a check
- *(daemon)* give the shutdown-refuses-a-reload case something to observe
- *(daemon)* make the stop-mid-reload case actually order-dependent
- *(daemon)* pin the guards a reload's drainee must never pass
- *(security)* correct the log-file claim and record the log-path posture
- close the log plane's uncovered behaviours
- unstick six enumerations the log plane falsified
- correct two claims the log plane makes that are false
- *(daemon)* pin the respawn that re-points a slot at its new log pump
- record the log plane
- correct six claims the flush verb makes about itself
- *(daemon)* correct three claims the log seam makes, and cover what it hands on
- *(cli)* correct three false claims, and honour NO_COLOR
- *(changelog)* record the shep-daemon visibility narrowing
- *(daemon)* narrow the crate's public surface to its real consumers
- *(daemon)* pin the rescan producer and four watch/cron behaviours
- *(daemon)* pin InstanceExtras' redacting Debug
- *(daemon)* pin handle_ready_result's shutdown guard
- *(changelog)* record the three rejections and two fixes just landed
- *(changelog)* correct nine claims, and mark the phase 4 plan complete
- stop promising work this phase does not deliver
- *(daemon)* correct what a DST fall-back does to a cron occurrence
- *(changelog)* record the Phase 4 lifecycle subsystems and config keys
- *(daemon)* make the lifecycle-extra module headers decision guides
- *(daemon)* pin the budget reset a restart of a stopped sheep performs
- *(daemon)* pin the budget reset an operator's restart performs
- *(daemon)* property and boundary coverage for the lifecycle extras
- *(daemon)* account for the transition the disarm checklist left out
- *(daemon)* cover the three lifecycle-extra behaviours nothing was pinning
- *(daemon)* say where disarm is really called from, and narrow Command
- *(daemon)* cover the lifecycle-extra behaviour nothing was pinning
- *(daemon)* say what the rescan bypass is actually keyed on
- *(comments)* make phase-created comments self-contained
- *(daemon)* stop the boot race test fabricating a live "stale" socket
- *(daemon)* unbreak the private-items doc build
- *(daemon)* prove the shepherd channel's ready message reaches the gate
- *(daemon)* say why readiness doesn't floor its probe interval
- *(daemon)* correct what a cleared `ready_tx` means
- *(daemon)* note what exit 127 stops meaning without the shell
- *(daemon)* assert the bytes an HTTP probe puts on the wire
- *(daemon)* accept either failure from an unroutable TCP address
- *(daemon)* the polling enforcer is no longer a later addition
- *(daemon)* pin four unguarded limits-loop behaviors, hoist per-tick tree index
- *(daemon)* fix broken intra-doc links to the cfg-gated fake module
- *(daemon)* guard tree_rss's parent-pid decision against real-OS regression
- *(daemon)* drop task-relative phrasing from moved testing.rs comments
- *(daemon)* move mod testing out of lib.rs into its own file
- *(daemon)* drop task-relative phrasing from Cargo.toml comments
- *(daemon)* make write_pidfile test-only
- *(daemon)* correct two unsafe-surface claims left stale by Decision 1
- correct stale unsafe-surface counts across docs and plan
- *(daemon)* plane taxonomy, canonical security writeup, inline audit
- *(daemon)* end-to-end tier — real socket, real children, muster round trip
- *(daemon)* make the bare-interpreter test actually gate PATH seeding
- *(daemon)* pin ready-fd adoption ordering; correct unsafe-surface docs
- *(daemon)* crate mini-guide + inline audit
- *(daemon)* fix rustdoc intra-links that reddened the docs CI job
- *(daemon)* commit proptest regression seed for brain budget invariant
- SECURITY.md premises contract + per-crate changelogs (IR-42/45)
- scaffold cargo workspace (shep-core, shep-daemon, shep-client, shep-cli)

### Additions

- Record every sheep's last exit outcome and carry it on `ProcessInfo`. The
  supervisor already had it -- it decides restart policy against
  `stop_exit_codes` -- and discarded it, so no operator surface could say why
  a sheep died. Set on every path through `handle_exited`, which is the one
  place a process under a registered id stops existing, and therefore covers
  an operator stop, a delete, a reload's drainee, a crash loop and shutdown
  alike. Cleared when a respawn fails to spawn at all, because nothing exited
  there and a stale code would read as a fresh crash.

### Fixes

- `shep serve`'s connection deadline is a config field rather than a constant
  read at the use site, so its test can wait one out on a real clock. The test
  previously paused the clock and raced tokio's auto-advance against live
  socket IO, failing about one run in three.

### Security and unsafe

- Refuse, under a shepherd running as root, to open a log file whose ancestry
  another local user could redirect — and warn about it, once per path, under
  any other. An ancestor is loose when it is owned by neither the daemon's own
  uid nor root, or when it is a world-writable directory. Ownership is the
  load-bearing half: it catches an intermediate component swapped for a
  symlink, which `O_NOFOLLOW` on the final component structurally cannot see,
  and it catches an ordinary `0755` directory owned by an app's own
  dropped-privilege `user`, which a write-bit test alone waves through. The
  split by uid is deliberate — a loose ancestry is an escalation only for a
  privileged daemon, and a developer logging to `/tmp` as themselves has
  handed nobody anything they could not already do, so refusing there would
  break a legitimate setup to no one's benefit. The sticky bit does not change
  the answer: it restricts unlinking and renaming entries you do not own, not
  creating new ones, and the attack plants a NEW entry at a path shep has not
  created yet. A TOCTOU window remains between the check and the open, and
  there is no portable way to close it while macOS is tier-1. The check costs
  one `lstat(2)` per path component (7.8 µs for a nine-component path,
  measured).
- Open every log file with `O_NOFOLLOW`, in both halves of the log plane:
  the pump's appending handle and the truncating one `shep flush` opens. An
  app's `out_file`/`err_file` are free-form config, so a log path can name a
  pre-existing directory shep neither created nor tightens — and there
  another local user could plant a symlink where the log file was going to
  be, have a root shepherd append the sheep's stdout through it, and have
  `shep flush` empty its target. Dropping privileges with `user`/`group`
  never helped, because log I/O never leaves the daemon, and the peer-cred
  check was never in the path, because the attacker never touches the socket.
  Both opens now fail instead, leaving the symlink and its target alone. The
  guard covers only the FINAL path component: a symlinked parent directory
  still resolves, and closing that needs `openat2(RESOLVE_NO_SYMLINKS)`,
  which is Linux-only and so out of scope while macOS is tier-1. `O_APPEND`
  rides alongside the new flag rather than being replaced by it — losing it
  brings back the sparse hole after every rotation. An operator whose log
  path legitimately IS a symlink is told so in those words, on the failure
  path each verb already has: `ELOOP`'s own wording ("too many levels of
  symbolic links") describes a loop they do not have.

### Additions

- `MemorySampler::identify` (defaulted) and `StatsState::lambs_of` — a
  sheep's parent-pid descendants, walked on demand and carried by `Describe`
  only.
- `Request::SendLine` — one line to a sheep's stdin, per-sheep outcome,
  bounded at two seconds.
- `SpawnSpec::stdin` and `ProcIo::to_stdin` — an opt-in pipe on a sheep's
  stdin, with a per-line acknowledgement.
- `Request::Scale` — set an app's instance count. Scale-up takes the lowest
  free slots, scale-down releases the highest, and the new count is written
  back to the muster roll.
- `RunningProcess::signal_process` (defaulted, so it is additive for an
  out-of-tree implementor) and `Request::Signal` — one signal to one sheep's
  own process, not its group.
- Every shepherd-channel message a sheep writes is forwarded to the bus,
  including an `action-reply` no trigger is waiting for.
- `ShepherdMessage::Action` carries `id`; `ChildMessage::ActionReply`
  accepts an optional `id` echo. Additive — an app that ignores both is
  matched by name and order exactly as before.
- `SHEP_CHANNEL_VERSION` is exported to every child with a channel;
  `channel::CHANNEL_VERSION` is its value.
- Record, in `barks.jsonl`, an enabled dog that exhausts its restart budget —
  the shepherd's own trail for the one alert it cannot deliver itself. It has
  no sinks and no webhook code by design, so a dead bark dog can raise no
  webhook alert about its own death; what it can guarantee is a local record,
  so an operator reading `shep barks` after an outage finds the moment
  alerting stopped rather than a gap they have to infer. Written by a bus
  watcher (`dogs::spawn_dog_watch`), not a branch inside the supervisor —
  supervision stays blind to dog-ness, and this only answers who should see
  an event that already happened. Fires on a dog's `Errored` only, never on
  an `Exit` it survives or a sheep's own `Errored`, which is bark's record to
  write. A lagging watcher logs the drop at `warn!` and does not attempt to
  recover it; polling for what the bus already dropped would be building a
  second bark dog inside the shepherd.

- Start every `[daemon] enabled_dogs` dog when the daemon boots, strictly
  after the muster restore and strictly before the daemon reports itself
  ready. Both halves of that placement are load-bearing: after the restore,
  because a metrics dog started first would answer for an empty flock for
  the whole restore window, and a bark dog would raise a `process.start`
  alert for every sheep the roll brings back; before readiness, because
  `Type=notify` going green is meant to mean the whole daemon — flock and
  dogs alike — is up, the same reasoning that already put the restore
  itself inside that promise.

  A dog that will not start never fails the boot — the flock comes up and
  the daemon serves regardless, with a `warn!` naming the dog. That covers
  a binary this build cannot spawn, a spawn failure the OS reports, AND the
  case `EnableDog`'s own handler already guards: `start_dog` is idempotent
  by name, so a dog enabled under a name a sheep already holds comes back
  `Ok` over the sheep rather than starting anything, and reporting that as
  a success would be a false one, exactly as it would be over the socket.

- Answer the three dog verbs. `DogConfig` hands a dog its own `[dog.<name>]`
  section as TOML text, `EnableDog` starts one, and `DisableDog` stops and
  deregisters it through the same `delete` a sheep goes through — kill
  ladder, graceful timeout, deregistration — rather than a second way to end
  a supervised process.

  A dog's configuration travels over the socket, never in its environment.
  The child inherits `$SHEP_HOME` and nothing else it did not already need in
  order to exec; it connects to the socket that names, handshakes, and asks
  for its section. A bark sink is a webhook URL with a bearer token in it,
  and the environment is readable from the process table on some systems,
  inherited by every child a dog spawns, and captured into crash dumps. The
  reply is opaque text the dog parses rather than a shep type, so a
  third-party dog is bound to the shape of its own section and not to this
  project's config model, file discovery or layering rules — changing any of
  those cannot then break a dog nobody has seen.

  The section is read from disk on every request rather than served from a
  copy taken at boot. One reader can never be stale, and it is what makes
  `shep disable X && shep enable X` pick up an edited section. A missing
  file, or a file with no such section, answers with the empty string: a dog
  with no configuration is the ordinary case, not a fault.

  Enabling a dog under a name a sheep already holds is refused rather than
  answered. Starting one is idempotent by name, so what comes back is
  whatever already holds the name; an unmarked entry means no dog started and
  none can while the name is taken, and reporting it would claim a success
  that never happened.

- Start a dog. `SupervisorHandle::start_dog` registers one through the same
  spawn path a sheep takes, and writes onto its entry where the dog came
  from. The marker rides the entry rather than a registry of its own, which
  is what makes a restart, a memory-limit respawn, a cron occurrence, a
  watch-triggered restart and a reload all keep it without any of them
  knowing dogs exist — a reload reads it off the instance it is replacing,
  and everything else mutates the entry in place. It lands on a dog that
  failed to spawn too: a binary that is not there has to be visible as
  `errored` in the dogs table, not as a sheep nobody started.

  Starting a dog is idempotent by name. `shep enable` runs against a daemon
  that may already have the dog, and a second live process under one name
  would mean two connections, two metrics listeners on one port and two
  copies of every bark; the dog already registered is reported as it stands
  instead. A dog is refused outright once a graceful shutdown has begun, the
  same rule `start`, `restart` and `reload` follow — the shutdown's kill list
  is fixed when it runs, so a child registered after it is one nothing would
  kill.

- Keep a dog out of what a wildcard selector sweeps. `stop all`, `reload all`,
  `delete all`, `describe all` and a `/regex/` or `fold:` sweep now pass every
  dog by, while a selector that names one — `shep restart bark`, or its id —
  still reaches it. `flock` is the deliberate exception: it is the single
  registry both the flock table and the dogs table are rendered from, so
  filtering there would leave the second one with nothing to show.
  A dog is a process an operator installed rather than a member of the flock
  `all` means, and an operator sweeping the flock does not expect to take the
  metrics plumbing down with it. Selection is now answered in one place for
  every verb that resolves a selector against the registry, so the reach of
  `stop`, `reload`, `reopen`, `flush` and `trigger` cannot drift apart; a
  by-product is that a multi-match `stop`/`restart` emits its events in id
  order rather than in whatever order the registry happened to yield.

- Answer `flock` and `describe` with each sheep's live CPU and memory, in the
  two `ProcessInfo` fields shep-core grew for them. The reading is taken when
  the request is served, not read off the last periodic tick, so memory is
  current rather than up to 15 s stale; CPU is the delta since that tick,
  which is what lets a listing report a rate without blocking for a second
  reading of its own. A sheep the daemon has not yet sampled once reports no
  CPU — a percentage invented from a 50 ms window is worse than an empty
  cell.

  Only those two verbs pay for it. The sample is a syscall walk over the
  host's whole process table, measured at 5.77 ms across 883 processes, and
  `start`/`stop`/`restart`/`reload`/`reopen`/`flush` answer with
  `ProcessInfo` rows nobody reads resource use from. It runs on the blocking
  pool rather than on a runtime worker, and a listing whose sample fails
  comes back without the numbers rather than failing outright.

- Name `fake::FIRST_SCRIPTED_PID` (behind `test-fakes`), the pid
  `ScriptedRunner` hands its first spawn. A fixture describing that proc's
  process table can say which pid it means instead of repeating the literal.

- Sample every sheep, and enforce only where a limit exists. The polling loop
  used to run for the ids `max_memory` armed it against and for nobody else,
  so an app that set no ceiling — the ordinary case — was never measured at
  all. Sampling is now its own concern (`limits::stats`): every sheep with a
  pid is watched from the moment it comes online, and a memory ceiling arms
  the enforcer on top of that rather than instead of it. Enforcement itself
  is untouched — same cadence, same self-disarm on breach, same backpressure
  on a full report channel.

  It costs no extra walk of the process table. The polling tick already built
  one index per pass; it now hands that index to the sampler before running
  the enforcement pass, so the 6.5 ms syscall walk still happens once every
  15 s however many sheep are in the flock.

  CPU is the reason the two halves have to share a tick. Resident memory is a
  level and can be read on demand, but the OS reports CPU as a counter, so a
  percentage needs two readings and the wall time between them. The tick
  records one baseline per sheep; an on-demand read subtracts against it and
  writes nothing back, which is what stops two listings a moment apart from
  dividing a near-zero counter delta by a near-zero window. A sheep that came
  online since the last tick has no baseline and reports no CPU at all, which
  is the honest answer for a window nobody has measured yet.

- Report readiness to an init system that supervises the shepherd directly:
  one `READY=1` datagram to whatever `$NOTIFY_SOCKET` names, sent as the
  **last** step of `boot`, after the muster restore has finished and the
  control plane is assembled. New unix-only `notify` module.

  The ordering is the whole feature. A unit that goes green when the process
  execs describes a flock that is not up yet, so a restore that hangs reads
  as a healthy service supervising nothing, and anything ordered after that
  unit starts against apps that do not exist. Reporting last turns the same
  hang into a failed start. This is deliberately the opposite of the
  readiness pipe filed further down, and the two answer different parents:
  that one tells a `shep` process that daemonized this one it may now exit,
  and is written the moment the socket binds so a slow muster cannot make it
  think the boot failed; this one decides when a unit goes green. Both may
  be set, but whichever is supervising, the other is not.

  No new dependency and no unsafe: `std` addresses both shapes systemd can
  hand a service — a filesystem path through `UnixDatagram::send_to`, and an
  `@`-prefixed abstract name through `SocketAddrExt::from_abstract_name` plus
  `UnixDatagram::send_to_addr`, stable since 1.70. Off Linux an `@` address is
  `NotifyError::Unsupported` rather than a path, because there is no abstract
  namespace to reach and writing into a file literally named `@…` would
  succeed while telling nobody anything. An **absent** `$NOTIFY_SOCKET` is
  the ordinary case — every interactive run, the daemon the CLI autostarts
  for itself, and macOS, whose launchd has no readiness protocol at all — and
  it is a silent no-op, never an error.

  A failed send is a `warn!` and the boot continues. The daemon is fully
  functional; what failed is the init system's knowledge of it, which
  systemd's own `TimeoutStartSec` reports honestly. Killing a working
  supervisor over one undeliverable datagram would leave the flock down after
  a reboot instead of merely unannounced.

  `notify` is public because `shep-cli` names `NOTIFY_SOCKET_ENV` — the
  environment read belongs where every `SHEP_*` override is already read, and
  what crosses the crate boundary is the resolved address (see Changes).
- Answer `Request::Muster` on the control socket, over the same restore the
  daemon already runs at boot. `snapshot::muster` is now that one
  implementation: `boot::restore_flock` is a line over it, and the request
  handler calls it and turns the names it hands back into a listing. The
  restore that runs unattended after a reboot is therefore the one an operator
  exercises by hand, rather than a second path nobody has driven. It returns
  names instead of a listing so the boot caller has nothing to report and no
  reason to try.

  An app the flock already has is left where it stands, and is still counted
  as restored. Boot never meets that case, since its flock is empty by
  construction; an operator meets it whenever a muster follows a partial
  restore, or simply runs twice. Starting such an app again is not the no-op
  it looks like — `instance_slots` allocates the lowest FREE slot, so a second
  start of a one-instance app leaves it running two and the next roll records
  the pair. Restarting it would drop live connections over a verb that never
  claimed to be `restart`, and refusing the whole muster over it would break
  the partial-restore case the verb is most useful for. The unit of the rule
  is the app, not the instance count.
- Answer `Request::SaveRoll` on the control socket: the daemon writes the
  muster roll immediately, bypassing the debounce the 