### PR TITLE
adopt ergonomics and shep <dogname> dispatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,8 +166,10 @@ leading `~/` expanded if you don't give an absolute path, and named after
 its own file stem (`shep-` stripped) unless you pass `--name`. It's served
 its own `[dog.<name>]` config over the same socket `shep` itself talks to
 rather than through its environment, so a webhook credential never ends up
-in a process listing or a crash dump. [docs/dogs.md](docs/dogs.md) is the
-guide.
+in a process listing or a crash dump. Once adopted, `shep <name>
+[args...]` runs it directly, passing your own arguments through — built-in
+verbs always win, so a dog can't shadow one. [docs/dogs.md](docs/dogs.md)
+is the guide.
 
 **Coming from pm2.** `shep import` reads a real `dump.pm2` and writes a
 Flockfile. It starts nothing, names every clustered app on stderr because

--- a/README.md
+++ b/README.md
@@ -169,7 +169,8 @@ rather than through its environment, so a webhook credential never shows
 up in a process listing or gets inherited by anything the dog spawns.
 Once adopted, `shep <name>
 [args...]` runs it directly, passing your own arguments through — built-in
-verbs always win, so a dog can't shadow one. [docs/dogs.md](docs/dogs.md)
+verbs and their aliases always win, so a dog can't shadow either.
+[docs/dogs.md](docs/dogs.md)
 is the guide.
 
 **Coming from pm2.** `shep import` reads a real `dump.pm2` and writes a

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ The whole vocabulary, and whether it exists yet.
 | a bark | a webhook alert | `[dog.bark.sinks]` config, `shep barks` | yes |
 | the whistle | the MCP interface agents talk to | `shep whistle` | yes |
 | the lookout | the terminal dashboard | `shep lookout` (alias `dash`) | partly |
-| adopt / rehome | register or drop a third-party dog | `shep adopt <name> <path>` | yes |
+| adopt / rehome | register or drop a third-party dog | `shep adopt <path> [--name <name>]` | yes |
 | that'll do | graceful stop, after the real herding command | `shep thatlldo` | yes |
 | stock | change how many instances of an app run (the stocking rate) | `shep stock <name> <count>` (alias `scale`) | yes |
 | signal | send a signal to one sheep's own process | `shep signal <selector> <signal>` | yes |
@@ -160,11 +160,14 @@ the exact command you should run and exits non-zero.
 **Dogs.** `shep enable metrics` turns on a Prometheus endpoint at
 `127.0.0.1:9615`; `shep enable bark` watches the flock and posts alerts to
 Discord, Slack, or a JSON endpoint you name under `[dog.bark.sinks]`. Both
-ship inside the binary. `shep adopt <name> <path>` runs anyone else's
-binary the same way — vetted once when you adopt it, and served its own
-`[dog.<name>]` config over the same socket `shep` itself talks to rather
-than through its environment, so a webhook credential never ends up in a
-process listing or a crash dump. [docs/dogs.md](docs/dogs.md) is the guide.
+ship inside the binary. `shep adopt <path>` runs anyone else's binary the
+same way — vetted once when you adopt it, found on `$PATH` or with a
+leading `~/` expanded if you don't give an absolute path, and named after
+its own file stem (`shep-` stripped) unless you pass `--name`. It's served
+its own `[dog.<name>]` config over the same socket `shep` itself talks to
+rather than through its environment, so a webhook credential never ends up
+in a process listing or a crash dump. [docs/dogs.md](docs/dogs.md) is the
+guide.
 
 **Coming from pm2.** `shep import` reads a real `dump.pm2` and writes a
 Flockfile. It starts nothing, names every clustered app on stderr because

--- a/README.md
+++ b/README.md
@@ -165,8 +165,9 @@ same way — vetted once when you adopt it, found on `$PATH` or with a
 leading `~/` expanded if you don't give an absolute path, and named after
 its own file stem (`shep-` stripped) unless you pass `--name`. It's served
 its own `[dog.<name>]` config over the same socket `shep` itself talks to
-rather than through its environment, so a webhook credential never ends up
-in a process listing or a crash dump. Once adopted, `shep <name>
+rather than through its environment, so a webhook credential never shows
+up in a process listing or gets inherited by anything the dog spawns.
+Once adopted, `shep <name>
 [args...]` runs it directly, passing your own arguments through — built-in
 verbs always win, so a dog can't shadow one. [docs/dogs.md](docs/dogs.md)
 is the guide.

--- a/crates/shep-cli/src/cli.rs
+++ b/crates/shep-cli/src/cli.rs
@@ -301,8 +301,10 @@ pub enum Commands {
     /// `[daemon] adopted_dogs` and `[daemon] enabled_dogs` in `shep.toml`,
     /// and starts it now if a shepherd is running.
     ///
-    /// Refuses, before touching the config at all, a path that does not
-    /// exist, is not a file, has no execute bit set, or that this kernel
+    /// The path can be given as-is, with a leading `~/`, or as a bare name
+    /// already on `$PATH` (`cargo install` puts one there). Refuses, before
+    /// touching the config at all, a path that resolves to nothing that
+    /// exists, is not a file, has no execute bit set, or that this kernel
     /// will not exec. An adopted dog runs at the shepherd's own trust
     /// level, with no sandboxing beyond it.
     Adopt(AdoptArgs),
@@ -881,13 +883,13 @@ pub struct DogArgs {
 /// built into this binary has no path to vet, so `enable` cannot carry out
 /// what `adopt` does.
 ///
-/// **Argument order is inverted from [`AdoptArgs`]'s own**, and that
-/// inversion is deliberate, not an oversight to fix: pm2's own spelling
-/// puts the path before the name (`--exec <path> <name>`), while `shep
-/// adopt` puts the name first (`adopt <name> <path>`, decision, Rin). Both
-/// arguments are strings, so a reader who assumes the two orders agree
-/// introduces a silent swap that nothing short of a test catches — see
-/// `main.rs`'s `the_hidden_pm2_spelling_reaches_adopt_with_the_arguments_the_right_way_round`.
+/// `name` here is a required positional, unlike [`AdoptArgs`]'s own
+/// (optional, defaulted from the binary's file stem) — pm2's own spelling
+/// carries no such default, and `enable --exec` exists only to keep that
+/// spelling working verbatim, not to gain `adopt`'s newer conveniences. A
+/// reader relying on the two shapes agreeing is a mistake nothing but a
+/// test catches — see `main.rs`'s
+/// `the_hidden_pm2_spelling_reaches_adopt_with_the_arguments_the_right_way_round`.
 #[derive(Debug, clap::Args)]
 pub struct EnableArgs {
     /// The dog's name — the `[dog.<name>]` config key
@@ -900,15 +902,24 @@ pub struct EnableArgs {
 
 /// Arguments to `shep adopt`.
 ///
-/// Positional, name then path (decision, Rin: no `--exec` flag on this
-/// verb) — the reverse order of [`EnableArgs`]'s hidden `--exec` alias; see
-/// that type's own doc for why the inversion is deliberate.
+/// `path` is the one positional; `--name` is optional and defaults to the
+/// binary's file stem with a leading `shep-` stripped, the way `cargo`
+/// strips `cargo-` from its own external subcommands (`shep-log-rotate`
+/// defaults to `log-rotate`). Previously both were required positionals,
+/// name first (`adopt <name> <path>`) — a breaking CLI change, decision
+/// Rin: `shep adopt <path>` alone now works for a binary whose name is
+/// already the name you want, matching `shep start <script>`'s own
+/// optional `--name`.
 #[derive(Debug, clap::Args)]
 pub struct AdoptArgs {
-    /// The dog's name — the `[dog.<name>]` config key
-    pub name: String,
-    /// Path to the dog's binary, vetted before `shep.toml` is touched
+    /// Path to the dog's binary, vetted before `shep.toml` is touched.
+    /// Resolved before vetting: as given, with a leading `~/` expanded, or
+    /// looked up on `$PATH` if it names no directory — first hit wins.
     pub path: PathBuf,
+    /// The dog's name — the `[dog.<name>]` config key. Defaults to the
+    /// binary's file stem with a leading `shep-` stripped.
+    #[arg(long)]
+    pub name: Option<String>,
 }
 
 /// The selector the verbs that take an optional one fall back to.

--- a/crates/shep-cli/src/cli.rs
+++ b/crates/shep-cli/src/cli.rs
@@ -305,8 +305,12 @@ pub enum Commands {
     /// already on `$PATH` (`cargo install` puts one there). Refuses, before
     /// touching the config at all, a path that resolves to nothing that
     /// exists, is not a file, has no execute bit set, or that this kernel
-    /// will not exec. An adopted dog runs at the shepherd's own trust
-    /// level, with no sandboxing beyond it.
+    /// will not exec — and refuses a name that already names a built-in
+    /// verb or alias, since such a dog could never be reached. An adopted
+    /// dog runs at the shepherd's own trust level, with no sandboxing
+    /// beyond it. Once adopted, `shep <name> [args...]` runs it directly,
+    /// passing `args` through untouched — a second invocation mode from
+    /// the one the shepherd itself uses to supervise it.
     Adopt(AdoptArgs),
     /// Forget an adopted dog entirely: stops it if a shepherd is running,
     /// and removes it from `[daemon] enabled_dogs`, `[daemon]

--- a/crates/shep-cli/src/commands/dogs.rs
+++ b/crates/shep-cli/src/commands/dogs.rs
@@ -31,6 +31,7 @@
 //! proportion to the ask; `shep muster` is the one verb that autostarts,
 //! and it says so in its own help text.
 
+use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 
@@ -590,10 +591,18 @@ fn warn_group_writable(streams: &mut Streams<'_>, path: &Path) {
 
 /// `shep adopt <name> <path>`: vets a binary shep has never seen, records
 /// it, and starts it if a shepherd is running.
+///
+/// `args.path` is resolved before vetting ([`resolve_adopt_path`]): as
+/// given, with a leading `~/` expanded, or looked up on `$PATH` if it
+/// names no directory. All three funnel into the same [`vet_binary`] call,
+/// so this changes what `adopt` can FIND, never what it VETS.
 pub async fn adopt(streams: &mut Streams<'_>, paths: &ShepPaths, args: &AdoptArgs) -> ExitCode {
-    let vetted = match vet_binary(&args.path, &paths.home) {
+    let home = std::env::var_os("HOME").map(PathBuf::from);
+    let path_var = std::env::var_os("PATH");
+    let candidate = resolve_adopt_path(&args.path, home.as_deref(), path_var.as_deref());
+    let vetted = match vet_binary(&candidate, &paths.home) {
         Ok(vetted) => vetted,
-        Err(refusal) => return fail_adopt(streams, &args.path, &refusal),
+        Err(refusal) => return fail_adopt(streams, &candidate, &refusal),
     };
     let path = vetted.path;
     for writable in &vetted.group_writable {
@@ -606,6 +615,88 @@ pub async fn adopt(streams: &mut Streams<'_>, paths: &ShepPaths, args: &AdoptArg
     }
     let client = Client::connect(&paths.socket).await.ok();
     adopt_after_config(streams, &args.name, &path, client.as_ref()).await
+}
+
+/// Resolves `raw` -- `shep adopt`'s own path argument -- before it reaches
+/// [`vet_binary`]: (a) as given, (b) with a leading `~/` expanded against
+/// `home`, (c) looked up on `path_var`. First hit wins; if none of the
+/// three finds anything, `raw` comes back unchanged so `vet_binary` reports
+/// the same [`AdoptRefusal::Missing`] it always has.
+///
+/// `home` and `path_var` are taken as parameters, read once by [`adopt`]
+/// from `$HOME`/`$PATH`, rather than read here -- the same reason
+/// [`resolve_paths`](crate::resolve_paths) takes an `env` closure instead
+/// of calling `std::env::var` inline: it keeps this function a pure
+/// function of its inputs, testable with a fabricated home or `$PATH`
+/// without touching the real environment (this crate forbids `unsafe`
+/// code outright, so a test cannot use `std::env::set_var` to do that
+/// either -- it is `unsafe` as of edition 2024).
+///
+/// All three routes funnel into the one [`vet_binary`] call in [`adopt`]
+/// once this returns -- existence, file-ness, the execute bit and the exec
+/// probe are exactly as strict for a `$PATH` hit or a `~/`-expanded one as
+/// for a literal path, so this changes what `adopt` can FIND, never what
+/// it VETS. `cargo install shep-log-rotate` puts the binary on `$PATH`
+/// under its own name; this is what lets `shep adopt shep-log-rotate` find
+/// it there instead of demanding the full install path.
+fn resolve_adopt_path(raw: &Path, home: Option<&Path>, path_var: Option<&OsStr>) -> PathBuf {
+    if raw.exists() {
+        return raw.to_path_buf();
+    }
+    if let Some(expanded) = raw
+        .to_str()
+        .and_then(|value| expand_tilde_candidate(value, home))
+        && expanded.exists()
+    {
+        return expanded;
+    }
+    if let Some(found) = lookup_on_path(raw, path_var) {
+        return found;
+    }
+    raw.to_path_buf()
+}
+
+/// `~/`-expands `value` against `home`, for [`resolve_adopt_path`]'s
+/// second step. `None` for anything
+/// [`shep_core::config::expand_home_tilde`] refuses (another user's home,
+/// or no home to expand against) or that does not start with `~` at all --
+/// either way [`resolve_adopt_path`] moves on to its next step rather than
+/// surfacing a tilde-specific error, since the path might never have been
+/// a tilde path to begin with.
+///
+/// The one piece of tilde-expansion logic in the workspace lives in
+/// shep-core, shared with Flockfile path fields (`normalize::expand_tilde`)
+/// -- this is not a second implementation of it.
+fn expand_tilde_candidate(value: &str, home: Option<&Path>) -> Option<PathBuf> {
+    if !value.starts_with('~') {
+        return None;
+    }
+    shep_core::config::expand_home_tilde(value, home)
+        .ok()
+        .map(PathBuf::from)
+}
+
+/// Looks `name` up on `path_var` (`$PATH`'s own syntax: `:`-separated
+/// directories), the way a shell would -- and only the way a shell would: a
+/// bare name with no directory component of its own (`shep-log-rotate`,
+/// not `./shep-log-rotate` or `/opt/bin/shep-log-rotate`), and only a hit
+/// with an execute bit set for someone, so a same-named non-executable
+/// file earlier on `$PATH` does not block the real binary further down it.
+fn lookup_on_path(name: &Path, path_var: Option<&OsStr>) -> Option<PathBuf> {
+    let is_bare = name
+        .parent()
+        .is_some_and(|parent| parent.as_os_str().is_empty());
+    if !is_bare {
+        return None;
+    }
+    let dirs = path_var?;
+    std::env::split_paths(dirs)
+        .map(|dir| dir.join(name))
+        .find(|candidate| {
+            use std::os::unix::fs::PermissionsExt as _;
+            std::fs::metadata(candidate)
+                .is_ok_and(|meta| meta.is_file() && meta.permissions().mode() & 0o111 != 0)
+        })
 }
 
 /// `adopt`'s daemon half — see [`enable_after_config`]'s own doc for why
@@ -1248,6 +1339,99 @@ mod tests {
             text.contains("next shepherd"),
             "the operator needs to know the dog is not running yet: {text}"
         );
+    }
+
+    /// fails if `resolve_adopt_path` stops trying a literal path first, or
+    /// tries the other two steps when the literal one already exists --
+    /// the base case every other `resolve_adopt_path` test builds on.
+    #[test]
+    fn resolve_adopt_path_prefers_a_literal_path_that_exists() {
+        let dir = tempfile::tempdir().unwrap();
+        let binary = dir.path().join("thing");
+        std::fs::write(&binary, "").unwrap();
+
+        let resolved = resolve_adopt_path(&binary, None, None);
+        assert_eq!(resolved, binary);
+    }
+
+    /// fails if `shep adopt lr '~/.cargo/bin/shep-log-rotate'` stops
+    /// working -- issue 1's second repro. `resolve_adopt_path` must expand
+    /// `~/` against the `home` it is given when the literal path (a
+    /// literal `~` directory, which does not exist) is not there.
+    ///
+    /// Mutation check: reverting the tilde-expansion step (returning
+    /// `raw` unchanged whenever the literal path is missing, skipping
+    /// straight to the `$PATH` lookup) reddens this -- `resolve_adopt_path`
+    /// would return the untouched `~/...` path, which `vet_binary` then
+    /// reports `Missing` for.
+    #[test]
+    fn resolve_adopt_path_expands_a_leading_tilde_against_the_given_home() {
+        let home = tempfile::tempdir().unwrap();
+        let binary_dir = home.path().join(".cargo/bin");
+        std::fs::create_dir_all(&binary_dir).unwrap();
+        let binary = binary_dir.join("shep-log-rotate");
+        std::fs::write(&binary, "").unwrap();
+
+        let raw = Path::new("~/.cargo/bin/shep-log-rotate");
+        let resolved = resolve_adopt_path(raw, Some(home.path()), None);
+        assert_eq!(resolved, binary);
+    }
+
+    /// fails if `shep adopt lr shep-log-rotate` stops working when the
+    /// binary is only on `$PATH` -- issue 1's first repro (`cargo install
+    /// shep-log-rotate` puts it there under its own name).
+    ///
+    /// Mutation check: reverting the `$PATH` step to return `None`
+    /// unconditionally reddens this the same way the tilde mutation above
+    /// reddens its own test.
+    #[test]
+    fn resolve_adopt_path_falls_back_to_a_path_lookup_for_a_bare_name() {
+        let dir = tempfile::tempdir().unwrap();
+        let binary = dir.path().join("shep-log-rotate");
+        std::fs::write(&binary, "").unwrap();
+        let mut mode = std::fs::metadata(&binary).unwrap().permissions();
+        std::os::unix::fs::PermissionsExt::set_mode(&mut mode, 0o755);
+        std::fs::set_permissions(&binary, mode).unwrap();
+        let path_var = std::ffi::OsString::from(dir.path());
+
+        let raw = Path::new("shep-log-rotate");
+        let resolved = resolve_adopt_path(raw, None, Some(&path_var));
+        assert_eq!(resolved, binary);
+    }
+
+    /// fails if a `$PATH` lookup fires for a name that already names a
+    /// directory of its own (`./thing`, `bin/thing`, `/opt/thing`) -- a
+    /// shell never searches `$PATH` for one of those, and neither should
+    /// this: a same-named file elsewhere on `$PATH` would silently adopt
+    /// the wrong binary.
+    #[test]
+    fn resolve_adopt_path_does_not_path_search_a_name_with_a_directory_component() {
+        let path_dir = tempfile::tempdir().unwrap();
+        // A file that WOULD match if `$PATH` were searched -- proving the
+        // guard, not just an absent or non-executable one.
+        let decoy = path_dir.path().join("thing");
+        std::fs::write(&decoy, "").unwrap();
+        let mut mode = std::fs::metadata(&decoy).unwrap().permissions();
+        std::os::unix::fs::PermissionsExt::set_mode(&mut mode, 0o755);
+        std::fs::set_permissions(&decoy, mode).unwrap();
+        let path_var = std::ffi::OsString::from(path_dir.path());
+
+        let raw = Path::new("./thing");
+        let resolved = resolve_adopt_path(raw, None, Some(&path_var));
+        assert_eq!(
+            resolved, raw,
+            "a name with its own directory must never be searched on $PATH"
+        );
+    }
+
+    /// fails if none of the three resolution steps finding nothing stops
+    /// returning `raw` unchanged -- the funnel that keeps a plain missing
+    /// path reporting the same [`AdoptRefusal::Missing`] it always has,
+    /// rather than a resolution-specific error.
+    #[test]
+    fn resolve_adopt_path_returns_raw_unchanged_when_nothing_resolves() {
+        let raw = Path::new("/nonexistent/shep-nothing");
+        assert_eq!(resolve_adopt_path(raw, None, None), raw);
     }
 
     /// fails if `rehome` behaves as `disable` does — the whole difference

--- a/crates/shep-cli/src/commands/dogs.rs
+++ b/crates/shep-cli/src/commands/dogs.rs
@@ -589,13 +589,14 @@ fn warn_group_writable(streams: &mut Streams<'_>, path: &Path) {
     streams.aside(GROUP_WRITABLE_NOTICE, &message);
 }
 
-/// `shep adopt <name> <path>`: vets a binary shep has never seen, records
-/// it, and starts it if a shepherd is running.
+/// `shep adopt <path> [--name <name>]`: vets a binary shep has never seen,
+/// records it, and starts it if a shepherd is running.
 ///
-/// `args.path` is resolved before vetting ([`resolve_adopt_path`]): as
-/// given, with a leading `~/` expanded, or looked up on `$PATH` if it
-/// names no directory. All three funnel into the same [`vet_binary`] call,
-/// so this changes what `adopt` can FIND, never what it VETS.
+/// `args.path` is resolved before vetting ([`resolve_adopt_path`]), and
+/// `args.name` defaults to the resolved binary's file stem
+/// ([`default_dog_name`]) when omitted. Both funnel into the same
+/// [`vet_binary`] call, so a defaulted name is exactly as vetted as a
+/// typed one.
 pub async fn adopt(streams: &mut Streams<'_>, paths: &ShepPaths, args: &AdoptArgs) -> ExitCode {
     let home = std::env::var_os("HOME").map(PathBuf::from);
     let path_var = std::env::var_os("PATH");
@@ -605,16 +606,42 @@ pub async fn adopt(streams: &mut Streams<'_>, paths: &ShepPaths, args: &AdoptArg
         Err(refusal) => return fail_adopt(streams, &candidate, &refusal),
     };
     let path = vetted.path;
+    let name = match &args.name {
+        Some(name) => name.clone(),
+        None => default_dog_name(&candidate),
+    };
     for writable in &vetted.group_writable {
         warn_group_writable(streams, writable);
     }
     if let Err(err) = ShepToml::edit(&paths.daemon_config, |cfg| {
-        cfg.adopt_dog(&args.name, &path);
+        cfg.adopt_dog(&name, &path);
     }) {
         return fail_config(streams, &err);
     }
     let client = Client::connect(&paths.socket).await.ok();
-    adopt_after_config(streams, &args.name, &path, client.as_ref()).await
+    adopt_after_config(streams, &name, &path, client.as_ref()).await
+}
+
+/// The dog name `shep adopt` defaults to when `--name` is omitted: `path`'s
+/// file stem with one leading `shep-` stripped, the way `cargo` strips
+/// `cargo-` from its own external subcommands. `shep-log-rotate` defaults
+/// to `log-rotate`; a binary with no `shep-` prefix keeps its whole stem,
+/// and a binary literally named `shep-` (stem would strip to empty) keeps
+/// its whole stem too, rather than defaulting to an unreachable empty name.
+///
+/// Derived from `path` as resolved (pre-canonicalize), not from
+/// `vet_binary`'s canonicalized return value: a symlink's own name is what
+/// an operator typed and expects to see, not whatever file it happens to
+/// point at.
+fn default_dog_name(path: &Path) -> String {
+    let stem = path
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or_else(|| path.to_str().unwrap_or("dog"));
+    stem.strip_prefix("shep-")
+        .filter(|rest| !rest.is_empty())
+        .unwrap_or(stem)
+        .to_string()
 }
 
 /// Resolves `raw` -- `shep adopt`'s own path argument -- before it reaches
@@ -1216,7 +1243,7 @@ mod tests {
         let mut out = Vec::new();
         let mut err = Vec::new();
         let args = AdoptArgs {
-            name: "otel".to_string(),
+            name: Some("otel".to_string()),
             path: bin.clone(),
         };
         let code = adopt(&mut streams(&mut out, &mut err), &paths, &args).await;
@@ -1243,7 +1270,7 @@ mod tests {
         let mut out = Vec::new();
         let mut err = Vec::new();
         let args = AdoptArgs {
-            name: "otel".to_string(),
+            name: Some("otel".to_string()),
             path: dir.path().join("nope"),
         };
         let code = adopt(&mut streams(&mut out, &mut err), &paths, &args).await;
@@ -1265,7 +1292,7 @@ mod tests {
         let mut out = Vec::new();
         let mut err = Vec::new();
         let args = AdoptArgs {
-            name: "otel".to_string(),
+            name: Some("otel".to_string()),
             path: dir.path().join("nope"),
         };
         let code = adopt(&mut streams(&mut out, &mut err), &paths, &args).await;
@@ -1323,7 +1350,7 @@ mod tests {
         let mut out = Vec::new();
         let mut err = Vec::new();
         let args = AdoptArgs {
-            name: "otel".to_string(),
+            name: Some("otel".to_string()),
             path: binary,
         };
         let code = adopt(&mut streams(&mut out, &mut err), &paths, &args).await;
@@ -1339,6 +1366,57 @@ mod tests {
             text.contains("next shepherd"),
             "the operator needs to know the dog is not running yet: {text}"
         );
+    }
+
+    /// fails if `adopt` stops defaulting the name when `--name` is omitted,
+    /// or defaults it from the whole file name instead of the stripped
+    /// stem: `shep-otel` must default to `otel`, the way `cargo` strips
+    /// `cargo-` from its own external subcommands.
+    ///
+    /// Mutation check: reverting `default_dog_name` to return `stem`
+    /// unstripped reddens this (`shep-otel` recorded verbatim) rather than
+    /// `otel`.
+    #[tokio::test]
+    async fn adopt_with_no_name_flag_defaults_from_the_stripped_stem() {
+        let dir = tempfile::tempdir().unwrap();
+        let paths = ShepPaths::resolve(&|_| None, dir.path());
+        let binary = dir.path().join("shep-otel");
+        std::fs::write(&binary, "#!/bin/sh\nexit 0\n").unwrap();
+        let mut mode = std::fs::metadata(&binary).unwrap().permissions();
+        std::os::unix::fs::PermissionsExt::set_mode(&mut mode, 0o755);
+        std::fs::set_permissions(&binary, mode).unwrap();
+
+        let mut out = Vec::new();
+        let mut err = Vec::new();
+        let args = AdoptArgs {
+            path: binary,
+            name: None,
+        };
+        let code = adopt(&mut streams(&mut out, &mut err), &paths, &args).await;
+
+        assert_eq!(code, ExitCode::Success);
+        let written = std::fs::read_to_string(&paths.daemon_config).unwrap();
+        let cfg = shep_core::config::DaemonConfig::load(Some(&written), &|_| None).unwrap();
+        assert!(
+            cfg.daemon.adopted_dogs.contains_key("otel"),
+            "the defaulted name must be `otel`, not `shep-otel`: {written}"
+        );
+    }
+
+    /// fails if `default_dog_name` stops stripping exactly one leading
+    /// `shep-`, keeps stripping a binary that never had the prefix, or
+    /// leaves a pathological `shep-` binary defaulting to an empty
+    /// (unreachable) name.
+    #[test]
+    fn default_dog_name_strips_one_leading_shep_prefix_and_no_further() {
+        assert_eq!(
+            default_dog_name(Path::new("/opt/bin/shep-log-rotate")),
+            "log-rotate"
+        );
+        assert_eq!(default_dog_name(Path::new("/opt/bin/otel")), "otel");
+        // Stripping the prefix here would leave "", an unreachable name --
+        // the whole stem is kept instead.
+        assert_eq!(default_dog_name(Path::new("/opt/bin/shep-")), "shep-");
     }
 
     /// fails if `resolve_adopt_path` stops trying a literal path first, or

--- a/crates/shep-cli/src/commands/dogs.rs
+++ b/crates/shep-cli/src/commands/dogs.rs
@@ -592,21 +592,27 @@ fn warn_group_writable(streams: &mut Streams<'_>, path: &Path) {
 /// `shep adopt <path> [--name <name>]`: vets a binary shep has never seen,
 /// records it, and starts it if a shepherd is running.
 ///
-/// `args.path` is resolved before vetting ([`resolve_adopt_path`]), and
-/// `args.name` defaults to the resolved binary's file stem
-/// ([`default_dog_name`]) when omitted. Both funnel into the same
-/// [`vet_binary`] call and the same [`collides_with_a_verb`] refusal as an
-/// explicit `--name` would, so a defaulted name is exactly as vetted as a
-/// typed one.
+/// `args.path` is resolved before anything else ([`resolve_adopt_path`]),
+/// and `args.name` defaults to the resolved binary's file stem
+/// ([`default_dog_name`]) when omitted -- a defaulted name goes through the
+/// same [`collides_with_a_verb`] refusal an explicit `--name` would.
+///
+/// **The collision check runs before [`vet_binary`], not after.**
+/// `vet_binary` spawns the candidate to prove this kernel can exec it, so
+/// checking the name first means a refused name never gets that binary run
+/// at all -- a refusal that already ran the thing it refuses is not a
+/// refusal. `default_dog_name` needs only the resolved `candidate`, never
+/// the vetted/canonicalized path, so nothing forces the other order.
 pub async fn adopt(streams: &mut Streams<'_>, paths: &ShepPaths, args: &AdoptArgs) -> ExitCode {
     let home = std::env::var_os("HOME").map(PathBuf::from);
     let path_var = std::env::var_os("PATH");
     let candidate = resolve_adopt_path(&args.path, home.as_deref(), path_var.as_deref());
-    let vetted = match vet_binary(&candidate, &paths.home) {
-        Ok(vetted) => vetted,
-        Err(refusal) => return fail_adopt(streams, &candidate, &refusal),
-    };
-    let path = vetted.path;
+    // Named and checked for a verb collision BEFORE vetting, deliberately:
+    // `vet_binary` below spawns the candidate to prove this kernel can exec
+    // it, and a refusal that runs after that spawn has already run the
+    // thing it refuses. `default_dog_name` only needs the resolved
+    // `candidate`, never the vetted/canonicalized path, so this reorder
+    // costs nothing -- see `a_name_collision_is_refused_before_the_candidate_is_ever_spawned`.
     let name = match &args.name {
         Some(name) => name.clone(),
         None => default_dog_name(&candidate),
@@ -614,6 +620,11 @@ pub async fn adopt(streams: &mut Streams<'_>, paths: &ShepPaths, args: &AdoptArg
     if collides_with_a_verb(&name) {
         return fail_adopt_name_collision(streams, &name);
     }
+    let vetted = match vet_binary(&candidate, &paths.home) {
+        Ok(vetted) => vetted,
+        Err(refusal) => return fail_adopt(streams, &candidate, &refusal),
+    };
+    let path = vetted.path;
     for writable in &vetted.group_writable {
         warn_group_writable(streams, writable);
     }
@@ -1476,6 +1487,54 @@ mod tests {
             !paths.daemon_config.exists(),
             "a name collision must never touch shep.toml: {}",
             paths.daemon_config.display()
+        );
+    }
+
+    /// fails if `adopt` refuses a name collision only after already
+    /// vetting the candidate -- `vet_binary` spawns the binary as part of
+    /// vetting (to prove this kernel can exec it), so a refusal that runs
+    /// after `vet_binary` has already run the thing it refuses. The
+    /// outcome alone (`InvalidConfig`, no `shep.toml` write) is identical
+    /// whichever order runs first -- `adopt_refuses_a_name_that_collides_with_a_built_in_verb`
+    /// above cannot tell them apart -- so this test distinguishes the two
+    /// orders by which REFUSAL REASON reaches the operator instead of by a
+    /// spawn side effect: `args.path` here names nothing on disk, so
+    /// `vet_binary` fails at its very first check (`std::fs::metadata`,
+    /// `AdoptRefusal::Missing`) without ever attempting to spawn anything.
+    /// If the collision check runs first, the operator sees the collision
+    /// message; if `vet_binary` runs first, they see "no file exists at
+    /// that path" instead, for a name that was always going to be refused
+    /// either way. A process-spawn side effect (a marker file a script
+    /// writes) was tried first and dropped: `vet_binary`'s own exec probe
+    /// polls for up to 50ms before falling back to a hard kill, and that
+    /// race was not reliably observable from this test's own harness --
+    /// this path-shaped signal has no timing to race at all.
+    ///
+    /// Mutation check: moving the `collides_with_a_verb` check back to
+    /// after `vet_binary` reddens this -- the reported refusal becomes
+    /// `AdoptRefusal::Missing`'s message instead of the collision one.
+    #[tokio::test]
+    async fn a_name_collision_is_refused_before_vet_binary_ever_runs() {
+        let dir = tempfile::tempdir().unwrap();
+        let paths = ShepPaths::resolve(&|_| None, dir.path());
+
+        let mut out = Vec::new();
+        let mut err = Vec::new();
+        let args = AdoptArgs {
+            path: dir.path().join("nope"),
+            name: Some("stop".to_string()),
+        };
+        let code = adopt(&mut streams(&mut out, &mut err), &paths, &args).await;
+
+        assert_eq!(code, ExitCode::InvalidConfig);
+        let text = String::from_utf8(err).unwrap();
+        assert!(
+            text.contains("already a shep verb or alias"),
+            "the collision must be the reported reason, not vet_binary's own refusal: {text}"
+        );
+        assert!(
+            !text.contains("no file exists at that path"),
+            "vet_binary must never run on a name that was always going to be refused: {text}"
         );
     }
 

--- a/crates/shep-cli/src/commands/dogs.rs
+++ b/crates/shep-cli/src/commands/dogs.rs
@@ -595,7 +595,8 @@ fn warn_group_writable(streams: &mut Streams<'_>, path: &Path) {
 /// `args.path` is resolved before vetting ([`resolve_adopt_path`]), and
 /// `args.name` defaults to the resolved binary's file stem
 /// ([`default_dog_name`]) when omitted. Both funnel into the same
-/// [`vet_binary`] call, so a defaulted name is exactly as vetted as a
+/// [`vet_binary`] call and the same [`collides_with_a_verb`] refusal as an
+/// explicit `--name` would, so a defaulted name is exactly as vetted as a
 /// typed one.
 pub async fn adopt(streams: &mut Streams<'_>, paths: &ShepPaths, args: &AdoptArgs) -> ExitCode {
     let home = std::env::var_os("HOME").map(PathBuf::from);
@@ -610,6 +611,9 @@ pub async fn adopt(streams: &mut Streams<'_>, paths: &ShepPaths, args: &AdoptArg
         Some(name) => name.clone(),
         None => default_dog_name(&candidate),
     };
+    if collides_with_a_verb(&name) {
+        return fail_adopt_name_collision(streams, &name);
+    }
     for writable in &vetted.group_writable {
         warn_group_writable(streams, writable);
     }
@@ -620,28 +624,6 @@ pub async fn adopt(streams: &mut Streams<'_>, paths: &ShepPaths, args: &AdoptArg
     }
     let client = Client::connect(&paths.socket).await.ok();
     adopt_after_config(streams, &name, &path, client.as_ref()).await
-}
-
-/// The dog name `shep adopt` defaults to when `--name` is omitted: `path`'s
-/// file stem with one leading `shep-` stripped, the way `cargo` strips
-/// `cargo-` from its own external subcommands. `shep-log-rotate` defaults
-/// to `log-rotate`; a binary with no `shep-` prefix keeps its whole stem,
-/// and a binary literally named `shep-` (stem would strip to empty) keeps
-/// its whole stem too, rather than defaulting to an unreachable empty name.
-///
-/// Derived from `path` as resolved (pre-canonicalize), not from
-/// `vet_binary`'s canonicalized return value: a symlink's own name is what
-/// an operator typed and expects to see, not whatever file it happens to
-/// point at.
-fn default_dog_name(path: &Path) -> String {
-    let stem = path
-        .file_stem()
-        .and_then(|s| s.to_str())
-        .unwrap_or_else(|| path.to_str().unwrap_or("dog"));
-    stem.strip_prefix("shep-")
-        .filter(|rest| !rest.is_empty())
-        .unwrap_or(stem)
-        .to_string()
 }
 
 /// Resolves `raw` -- `shep adopt`'s own path argument -- before it reaches
@@ -724,6 +706,55 @@ fn lookup_on_path(name: &Path, path_var: Option<&OsStr>) -> Option<PathBuf> {
             std::fs::metadata(candidate)
                 .is_ok_and(|meta| meta.is_file() && meta.permissions().mode() & 0o111 != 0)
         })
+}
+
+/// The dog name `shep adopt` defaults to when `--name` is omitted: `path`'s
+/// file stem with one leading `shep-` stripped, the way `cargo` strips
+/// `cargo-` from its own external subcommands. `shep-log-rotate` defaults
+/// to `log-rotate`; a binary with no `shep-` prefix keeps its whole stem,
+/// and a binary literally named `shep-` (stem would strip to empty) keeps
+/// its whole stem too, rather than defaulting to an unreachable empty name.
+///
+/// Derived from `path` as resolved (pre-canonicalize), not from
+/// `vet_binary`'s canonicalized return value: a symlink's own name is what
+/// an operator typed and expects to see, not whatever file it happens to
+/// point at.
+fn default_dog_name(path: &Path) -> String {
+    let stem = path
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or_else(|| path.to_str().unwrap_or("dog"));
+    stem.strip_prefix("shep-")
+        .filter(|rest| !rest.is_empty())
+        .unwrap_or(stem)
+        .to_string()
+}
+
+/// Whether `name` already names a built-in verb or one of its visible
+/// aliases -- `shep adopt`'s own refusal, since a dog adopted under such a
+/// name could never be reached: `shep <name>` always dispatches to the
+/// built-in verb first (see `lib.rs`'s `dispatch_adopted_dog`).
+///
+/// Reads the name and every alias straight off the real `clap::Command`
+/// tree (`Cli::command()`) rather than a hand-copied list, so a verb added
+/// later is refused automatically instead of silently becoming
+/// unreachable once adopted under it.
+fn collides_with_a_verb(name: &str) -> bool {
+    use clap::CommandFactory as _;
+    crate::cli::Cli::command()
+        .get_subcommands()
+        .any(|sub| sub.get_name() == name || sub.get_all_aliases().any(|alias| alias == name))
+}
+
+/// Renders the refusal for a name `shep adopt` will not accept because it
+/// already names a built-in verb or alias.
+fn fail_adopt_name_collision(streams: &mut Streams<'_>, name: &str) -> ExitCode {
+    let code = ExitCode::InvalidConfig;
+    let message = format!(
+        "`{name}` is already a shep verb or alias, so an adopted dog by that name could never \
+         be reached -- pick another name with --name"
+    );
+    streams.fail(code, &message)
 }
 
 /// `adopt`'s daemon half — see [`enable_after_config`]'s own doc for why
@@ -948,7 +979,7 @@ mod tests {
         );
     }
 
-    /// The defect this test exists for: `shep adopt otel <path>` recorded
+    /// The defect this test exists for: `shep adopt <path> --name otel` recorded
     /// the binary, and the `shep enable otel` after it sent `BuiltIn`
     /// regardless — so the shepherd spawned `shep dog otel`, an argv branch
     /// of this binary, the operator's own binary never ran, and nothing
@@ -1403,20 +1434,49 @@ mod tests {
         );
     }
 
-    /// fails if `default_dog_name` stops stripping exactly one leading
-    /// `shep-`, keeps stripping a binary that never had the prefix, or
-    /// leaves a pathological `shep-` binary defaulting to an empty
-    /// (unreachable) name.
-    #[test]
-    fn default_dog_name_strips_one_leading_shep_prefix_and_no_further() {
-        assert_eq!(
-            default_dog_name(Path::new("/opt/bin/shep-log-rotate")),
-            "log-rotate"
+    /// fails if `adopt` accepts a name that already belongs to a built-in
+    /// verb or alias -- such a dog could never be reached, since
+    /// `dispatch_adopted_dog` (`lib.rs`) only ever runs once clap has
+    /// already failed to match the name against a real subcommand.
+    ///
+    /// Mirrors [`a_refused_adopt_leaves_the_config_untouched`]'s own shape:
+    /// the refusal must happen before `shep.toml` is touched at all, same
+    /// as every other `AdoptRefusal`.
+    ///
+    /// Mutation check: reverting `collides_with_a_verb` to always return
+    /// `false` reddens this (`Success` and a written config instead of
+    /// `InvalidConfig` and an absent one).
+    #[tokio::test]
+    async fn adopt_refuses_a_name_that_collides_with_a_built_in_verb() {
+        let dir = tempfile::tempdir().unwrap();
+        let paths = ShepPaths::resolve(&|_| None, dir.path());
+        let binary = dir.path().join("watchdog");
+        std::fs::write(&binary, "#!/bin/sh\nexit 0\n").unwrap();
+        let mut mode = std::fs::metadata(&binary).unwrap().permissions();
+        std::os::unix::fs::PermissionsExt::set_mode(&mut mode, 0o755);
+        std::fs::set_permissions(&binary, mode).unwrap();
+
+        let mut out = Vec::new();
+        let mut err = Vec::new();
+        // "stop" is a real verb; "ls" is `flock`'s own visible alias. Both
+        // must be refused the same way.
+        for reserved in ["stop", "ls"] {
+            let args = AdoptArgs {
+                path: binary.clone(),
+                name: Some(reserved.to_string()),
+            };
+            let code = adopt(&mut streams(&mut out, &mut err), &paths, &args).await;
+            assert_eq!(
+                code,
+                ExitCode::InvalidConfig,
+                "`{reserved}` must be refused"
+            );
+        }
+        assert!(
+            !paths.daemon_config.exists(),
+            "a name collision must never touch shep.toml: {}",
+            paths.daemon_config.display()
         );
-        assert_eq!(default_dog_name(Path::new("/opt/bin/otel")), "otel");
-        // Stripping the prefix here would leave "", an unreachable name --
-        // the whole stem is kept instead.
-        assert_eq!(default_dog_name(Path::new("/opt/bin/shep-")), "shep-");
     }
 
     /// fails if `resolve_adopt_path` stops trying a literal path first, or
@@ -1432,10 +1492,10 @@ mod tests {
         assert_eq!(resolved, binary);
     }
 
-    /// fails if `shep adopt lr '~/.cargo/bin/shep-log-rotate'` stops
-    /// working -- issue 1's second repro. `resolve_adopt_path` must expand
-    /// `~/` against the `home` it is given when the literal path (a
-    /// literal `~` directory, which does not exist) is not there.
+    /// fails if `shep adopt '~/.cargo/bin/shep-log-rotate'` stops working
+    /// -- issue 1's second repro. `resolve_adopt_path` must expand `~/`
+    /// against the `home` it is given when the literal path (a literal
+    /// `~` directory, which does not exist) is not there.
     ///
     /// Mutation check: reverting the tilde-expansion step (returning
     /// `raw` unchanged whenever the literal path is missing, skipping
@@ -1455,8 +1515,8 @@ mod tests {
         assert_eq!(resolved, binary);
     }
 
-    /// fails if `shep adopt lr shep-log-rotate` stops working when the
-    /// binary is only on `$PATH` -- issue 1's first repro (`cargo install
+    /// fails if `shep adopt shep-log-rotate` stops working when the binary
+    /// is only on `$PATH` -- issue 1's first repro (`cargo install
     /// shep-log-rotate` puts it there under its own name).
     ///
     /// Mutation check: reverting the `$PATH` step to return `None`
@@ -1510,6 +1570,38 @@ mod tests {
     fn resolve_adopt_path_returns_raw_unchanged_when_nothing_resolves() {
         let raw = Path::new("/nonexistent/shep-nothing");
         assert_eq!(resolve_adopt_path(raw, None, None), raw);
+    }
+
+    /// fails if `default_dog_name` stops stripping exactly one leading
+    /// `shep-`, keeps stripping a binary that never had the prefix, or
+    /// leaves a pathological `shep-` binary defaulting to an empty
+    /// (unreachable) name.
+    #[test]
+    fn default_dog_name_strips_one_leading_shep_prefix_and_no_further() {
+        assert_eq!(
+            default_dog_name(Path::new("/opt/bin/shep-log-rotate")),
+            "log-rotate"
+        );
+        assert_eq!(default_dog_name(Path::new("/opt/bin/otel")), "otel");
+        // Stripping the prefix here would leave "", an unreachable name --
+        // the whole stem is kept instead.
+        assert_eq!(default_dog_name(Path::new("/opt/bin/shep-")), "shep-");
+    }
+
+    /// fails if `collides_with_a_verb` misses a real subcommand name, an
+    /// alias of one, or refuses a name that names neither.
+    ///
+    /// Mutation check: reverting `collides_with_a_verb` to always return
+    /// `false` reddens the first two assertions; always `true` reddens the
+    /// third.
+    #[test]
+    fn collides_with_a_verb_covers_names_and_visible_aliases() {
+        assert!(collides_with_a_verb("stop"), "a real verb must collide");
+        assert!(collides_with_a_verb("ls"), "flock's own alias must collide");
+        assert!(
+            !collides_with_a_verb("watchdog"),
+            "an arbitrary name must not collide"
+        );
     }
 
     /// fails if `rehome` behaves as `disable` does — the whole difference

--- a/crates/shep-cli/src/commands/query.rs
+++ b/crates/shep-cli/src/commands/query.rs
@@ -463,15 +463,25 @@ fn install_line(source: &DogSourceKind, package: &str) -> String {
 /// discards its entire `[dog.<name>]` config section. [`DogSourceKind::Manual`]
 /// has no predictable install path to fill in, so its line names the
 /// placeholder literally rather than guessing one.
+///
+/// Always spells `--name` explicitly, even for an entry (like this
+/// project's own `shep-log-rotate`) whose `adopt_as` happens to equal
+/// `package` with `shep-` stripped -- `shep adopt`'s own default would
+/// already get that one right, but the index is user-contributed and
+/// nothing enforces the naming convention on `package`, so a future entry
+/// whose default would NOT match `adopt_as` must not ship a silently wrong
+/// copy-pasteable command.
 fn adopt_line(source: &DogSourceKind, adopt_as: &str, package: &str) -> String {
     match source {
         DogSourceKind::Cargo { .. } | DogSourceKind::CargoGit { .. } => {
-            format!("  $ shep adopt {adopt_as} ~/.cargo/bin/{package}")
+            format!("  $ shep adopt ~/.cargo/bin/{package} --name {adopt_as}")
         }
         DogSourceKind::GoInstall { .. } => {
-            format!("  $ shep adopt {adopt_as} $(go env GOPATH)/bin/{package}")
+            format!("  $ shep adopt $(go env GOPATH)/bin/{package} --name {adopt_as}")
         }
-        DogSourceKind::Manual { .. } => format!("  $ shep adopt {adopt_as} <path to the binary>"),
+        DogSourceKind::Manual { .. } => {
+            format!("  $ shep adopt <path to the binary> --name {adopt_as}")
+        }
     }
 }
 

--- a/crates/shep-cli/src/commands/shep_toml.rs
+++ b/crates/shep-cli/src/commands/shep_toml.rs
@@ -223,8 +223,10 @@ impl ShepToml {
 
     /// Reads `path`, treating a missing file as an empty document.
     ///
-    /// Private, and reached only from [`Self::edit`] with the document's
-    /// lock already held — see that method's own doc.
+    /// Private. Reached two ways: from [`Self::edit`]/[`Self::try_edit`]
+    /// with the document's lock already held for a write, and from
+    /// [`Self::adopted_dog_path_readonly`] with no lock at all, for a
+    /// caller that only ever reads.
     ///
     /// # Errors
     /// - [`ShepTomlError::Io`] — the file exists and could not be read.
@@ -320,6 +322,29 @@ impl ShepToml {
             .get(name)?
             .as_str()
             .map(PathBuf::from)
+    }
+
+    /// [`Self::adopted_dog_path`] without [`Self::edit`]'s write side --
+    /// for a caller that only wants the answer, such as `lib.rs`'s
+    /// `dispatch_adopted_dog`, which runs on every unrecognized verb, most
+    /// of which are typos rather than dog names.
+    ///
+    /// Creates nothing: a missing `$SHEP_HOME` or a missing `path` is an
+    /// ordinary "no such dog" answer ([`Self::open`] already treats a
+    /// missing file as an empty document), never a reason to create
+    /// either. Takes no lock, unlike [`Self::edit`] -- `Self::save`'s
+    /// rename onto `path` is atomic, so a concurrent writer can only ever
+    /// make this read observe the document just before or just after that
+    /// write, never a torn one.
+    ///
+    /// # Errors
+    /// [`ShepTomlError::Io`] if `path` exists and could not be read.
+    /// [`ShepTomlError::Parse`] if `path` exists and is not valid TOML.
+    pub fn adopted_dog_path_readonly(
+        path: &Path,
+        name: &str,
+    ) -> Result<Option<PathBuf>, ShepTomlError> {
+        Ok(Self::open(path)?.adopted_dog_path(name))
     }
 
     /// Forgets `name` entirely: out of `enabled_dogs`, out of

--- a/crates/shep-cli/src/dog_index.rs
+++ b/crates/shep-cli/src/dog_index.rs
@@ -108,8 +108,8 @@ pub struct AvailableDog {
     pub package: String,
     /// The name this dog expects to be adopted under, and the whole reason
     /// the detail view exists. A dog is given no argv and cannot learn its
-    /// own adopted name, so `shep adopt <name> <path>` with the wrong
-    /// `<name>` silently discards its entire `[dog.<name>]` section. An
+    /// own adopted name, so `shep adopt <path> --name <name>` with the
+    /// wrong `<name>` silently discards its entire `[dog.<name>]` section. An
     /// adopt line must be built from this field, never from
     /// [`Self::name`] or [`Self::package`].
     pub adopt_as: String,

--- a/crates/shep-cli/src/lib.rs
+++ b/crates/shep-cli/src/lib.rs
@@ -1140,16 +1140,18 @@ async fn run(cli: Cli, style: style::Presentation) -> ExitCode {
         // `--exec` is the hidden pm2 spelling of `adopt` (`EnableArgs`'
         // own doc) — checked here, not inside `commands::dogs`, so that
         // module's `enable` keeps the simple `&str` signature every other
-        // verb here has, and the argument-order inversion this alias
-        // carries lives at the one seam that has to know about it.
+        // verb here has, and the field mapping this alias needs (`--exec`'s
+        // path becomes `AdoptArgs::path`, `enable`'s own positional `name`
+        // becomes `AdoptArgs::name`) lives at the one seam that has to know
+        // about it.
         Commands::Enable(ref args) => match &args.exec {
             Some(path) => {
                 dogs::adopt(
                     &mut streams,
                     &paths,
                     &AdoptArgs {
-                        name: args.name.clone(),
                         path: path.clone(),
+                        name: Some(args.name.clone()),
                     },
                 )
                 .await
@@ -1741,21 +1743,34 @@ mod tests {
 
     /// The `adopt`/`rehome` sibling of
     /// `enable_and_disable_parse_to_their_own_commands_and_require_a_name`.
-    /// `adopt` needs both positionals; `rehome` shares `DogArgs` with
-    /// `disable`, so it needs only the name.
+    /// `adopt` needs only its one positional, `path` — `name` is an
+    /// optional `--name` flag, matching `shep start <script>`'s own
+    /// optional `--name`. `rehome` shares `DogArgs` with `disable`, so it
+    /// needs only the name.
     #[test]
     fn adopt_and_rehome_parse_to_their_own_commands_and_require_their_arguments() {
         use clap::Parser;
         use cli::Commands;
 
-        let adopted = Cli::try_parse_from(["shep", "adopt", "otel", "/opt/bin/shep-otel"])
-            .unwrap()
-            .command;
+        let adopted =
+            Cli::try_parse_from(["shep", "adopt", "/opt/bin/shep-otel", "--name", "otel"])
+                .unwrap()
+                .command;
         let Commands::Adopt(args) = adopted else {
             panic!("expected adopt")
         };
-        assert_eq!(args.name, "otel");
         assert_eq!(args.path, PathBuf::from("/opt/bin/shep-otel"));
+        assert_eq!(args.name, Some("otel".to_string()));
+
+        // `--name` is optional: a bare path still parses, with no name.
+        let unnamed = Cli::try_parse_from(["shep", "adopt", "/opt/bin/shep-otel"])
+            .unwrap()
+            .command;
+        let Commands::Adopt(args) = unnamed else {
+            panic!("expected adopt")
+        };
+        assert_eq!(args.path, PathBuf::from("/opt/bin/shep-otel"));
+        assert_eq!(args.name, None);
 
         let rehomed = Cli::try_parse_from(["shep", "rehome", "otel"])
             .unwrap()
@@ -1767,11 +1782,7 @@ mod tests {
 
         assert!(
             Cli::try_parse_from(["shep", "adopt"]).is_err(),
-            "`shep adopt` with neither name nor path must be a usage error"
-        );
-        assert!(
-            Cli::try_parse_from(["shep", "adopt", "otel"]).is_err(),
-            "`shep adopt otel` with no path must be a usage error"
+            "`shep adopt` with no path must be a usage error"
         );
         assert!(
             Cli::try_parse_from(["shep", "rehome"]).is_err(),
@@ -1780,11 +1791,11 @@ mod tests {
     }
 
     /// fails if `enable --exec` routes to `enable` (which would try to run
-    /// a built-in dog named after a path), and fails if the argument order
-    /// is read as `adopt`'s. The two orders are inverted
-    /// (`EnableArgs`'/`AdoptArgs`' own docs), and a swap here is silent:
-    /// both arguments are strings, so nothing but a pinned assertion on
-    /// which field holds which value would catch one crossing the other.
+    /// a built-in dog named after a path), and fails if `--exec`'s value
+    /// and `enable`'s own positional `name` land in the wrong fields once
+    /// `main`'s dispatch turns them into an `AdoptArgs`. Both are strings,
+    /// so a swap here is silent — nothing but a pinned assertion on which
+    /// field holds which value would catch one crossing the other.
     #[test]
     fn the_hidden_pm2_spelling_reaches_adopt_with_the_arguments_the_right_way_round() {
         use clap::Parser;

--- a/crates/shep-cli/src/lib.rs
+++ b/crates/shep-cli/src/lib.rs
@@ -57,6 +57,8 @@ mod whistle;
 
 use std::ffi::OsString;
 use std::io::{IsTerminal, Write};
+#[cfg(unix)]
+use std::path::Path;
 use std::path::PathBuf;
 
 use clap::Parser;
@@ -186,6 +188,17 @@ fn run_argv(argv: Vec<OsString>) -> std::process::ExitCode {
     // all. Holding the result lets those two be answered before clap has its
     // say. Ok invocations are unaffected.
     let parsed = Cli::try_parse_from(argv.clone());
+    // Before clap ever gets to render its own "unrecognized subcommand"
+    // error, check whether the token it could not place names an adopted
+    // dog. Sync, and cheap for the overwhelming majority of invocations
+    // that parse cleanly (`Ok` short-circuits `if let Err` immediately) —
+    // see `dispatch_adopted_dog`'s own doc for the whole contract.
+    #[cfg(unix)]
+    if let Err(ref err) = parsed
+        && let Some(code) = dispatch_adopted_dog(&argv, err)
+    {
+        return code;
+    }
     let runtime = match tokio::runtime::Builder::new_multi_thread()
         .enable_all()
         .build()
@@ -245,6 +258,143 @@ fn run_argv(argv: Vec<OsString>) -> std::process::ExitCode {
         output::terminal_width(),
     );
     std::process::ExitCode::from(runtime.block_on(run(cli, style)) as u8)
+}
+
+/// Before clap's own "unrecognized subcommand" error (suggestions and
+/// all), checks whether the token it could not place names an adopted
+/// dog — `shep <dogname> [args...]` runs it directly, git/cargo's own
+/// external-subcommand precedent (`git foo` runs `git-foo`).
+///
+/// Resolved against **adopted dogs only**, never a `$PATH` scan: the
+/// operator explicitly ran `shep adopt` for these, and `commands::dogs`'
+/// own vetting already ran once, at adopt time. A `$PATH` scan would let
+/// any stray binary on the machine become a shep verb.
+///
+/// **Built-in verbs always win, structurally, not by a check here.** This
+/// only ever runs once clap has already failed to match `token` against
+/// every real subcommand and alias, so a dog named `stop` can never
+/// shadow `shep stop` — and `shep adopt` itself refuses to register a name
+/// that collides with one (`commands::dogs::collides_with_a_verb`), since
+/// such a dog could never be reached anyway.
+///
+/// `None` for every case that should still reach clap's own error: a
+/// parse failure that is not `InvalidSubcommand`, a `$SHEP_HOME` this
+/// process cannot resolve, or a name `shep.toml` has never heard of. None
+/// of those earn a special message — the token just was not an adopted
+/// dog, and clap's ordinary unknown-verb error, suggestions included, is
+/// exactly right for that.
+///
+/// The explicit `err.kind()` check below is not redundant with the
+/// `ContextKind::InvalidSubcommand` match just under it, even though
+/// nothing in this crate's own test suite can tell the two apart: clap
+/// also attaches that same context to an `ErrorKind::ArgumentConflict`
+/// (`clap_builder::error::subcommand_conflict`), but only when a command
+/// sets `args_conflicts_with_subcommands` — [`cli::Cli`] never does, so
+/// that producer is unreachable through this binary's own parse tree
+/// today. The check stays anyway, documented rather than deleted: relying
+/// on an unset builder option to keep two error shapes from colliding is
+/// exactly the kind of coupling that breaks silently the day someone
+/// upstream of this function sets it for an unrelated reason.
+#[cfg(unix)]
+fn dispatch_adopted_dog(argv: &[OsString], err: &clap::Error) -> Option<std::process::ExitCode> {
+    if err.kind() != clap::error::ErrorKind::InvalidSubcommand {
+        return None;
+    }
+    let name = match err.get(clap::error::ContextKind::InvalidSubcommand) {
+        Some(clap::error::ContextValue::String(name)) => name.as_str(),
+        _ => return None,
+    };
+    // The token's own position in the raw argv, not clap's — clap's error
+    // carries the name but not where it sat, and everything after it is
+    // this dog's own argv, passed through untouched.
+    let index = argv.iter().position(|arg| arg.to_str() == Some(name))?;
+    let global = GlobalArgs {
+        home: home_before(&argv[1..index]),
+        format: Format::Table,
+        quiet: false,
+        style: None,
+    };
+    let paths = resolve_paths(&global).ok()?;
+    let path = ShepToml::edit(&paths.daemon_config, |cfg| cfg.adopted_dog_path(name))
+        .ok()
+        .flatten()?;
+    let dog_argv = argv[index + 1..].to_vec();
+    Some(run_adopted_dog(&path, &paths.home, &dog_argv))
+}
+
+/// Scans `prefix` — the argv tokens before the one clap could not place —
+/// for `--home`, in either `--home value` or `--home=value` form. The only
+/// global flag [`resolve_paths`] reads, and the only one
+/// [`dispatch_adopted_dog`] needs reconstructed: the rest of `GlobalArgs`
+/// (`--format`, `--quiet`, `--style`) governs only how this crate renders
+/// its own output, never which binary `shep.toml` names for a dog.
+///
+/// Falls back to `$SHEP_HOME` from the environment when `prefix` names no
+/// `--home` — reproducing by hand the fallback clap's own `env =
+/// "SHEP_HOME"` attribute gives `GlobalArgs::home` on a parse that
+/// succeeds, for the one parse that did not.
+///
+/// `#[cfg(unix)]` for the same reason [`dispatch_adopted_dog`] (its only
+/// caller) is: nothing here is unix-specific, but leaving it uncompiled on
+/// Windows rather than merely unreachable keeps the Windows tier's own
+/// `cargo check` gate free of one more dead-code warning for a function
+/// with no caller there at all.
+#[cfg(unix)]
+fn home_before(prefix: &[OsString]) -> Option<PathBuf> {
+    let mut tokens = prefix.iter();
+    while let Some(arg) = tokens.next() {
+        if let Some(value) = arg.to_str().and_then(|s| s.strip_prefix("--home=")) {
+            return Some(PathBuf::from(value));
+        }
+        if arg == "--home" {
+            return tokens.next().map(PathBuf::from);
+        }
+    }
+    std::env::var_os("SHEP_HOME").map(PathBuf::from)
+}
+
+/// Runs `path` — an adopted dog's binary — the way an operator invoking it
+/// by name expects: `extra_args` passed through exactly as typed,
+/// `$SHEP_HOME` the one environment variable it needs to find the
+/// shepherd, stdio inherited so an interactive dog behaves like any other
+/// program run directly from a shell.
+///
+/// **A second invocation mode, deliberately distinct from the supervised
+/// one.** A dog the shepherd starts gets no argv and this same one env
+/// entry (`shep_daemon::dogs::dog_app`'s own doc — that contract is
+/// unchanged by this function existing); a dog an operator names on the
+/// command line gets whatever they typed after it, because passing
+/// arguments through is the entire reason to invoke it this way instead
+/// of through `shep enable`.
+///
+/// Exit code mirrors shell convention via [`dog_exit_code`]: the child's
+/// own code, or `128 + signal` if it died by one — the same reading
+/// `commands::reap::classify` gives a reaped supervisor.
+#[cfg(unix)]
+fn run_adopted_dog(path: &Path, home: &Path, extra_args: &[OsString]) -> std::process::ExitCode {
+    let status = std::process::Command::new(path)
+        .args(extra_args)
+        .env("SHEP_HOME", home)
+        .status();
+    match status {
+        Ok(status) => std::process::ExitCode::from(dog_exit_code(status)),
+        Err(err) => {
+            eprintln!("shep: could not run adopted dog {}: {err}", path.display());
+            std::process::ExitCode::from(ExitCode::Failure as u8)
+        }
+    }
+}
+
+/// `status`'s own exit code, or `128 + signal` if it died by one — the
+/// shell convention `commands::reap::classify` already reads a reaped
+/// supervisor's status by.
+#[cfg(unix)]
+fn dog_exit_code(status: std::process::ExitStatus) -> u8 {
+    use std::os::unix::process::ExitStatusExt as _;
+    match status.code() {
+        Some(code) => code as u8,
+        None => (128 + status.signal().unwrap_or(0)) as u8,
+    }
 }
 
 /// Prints the one-line shepherd status to stderr, for an invocation clap
@@ -1531,6 +1681,143 @@ mod tests {
         assert!(
             !named.exists(),
             "a refused path must be left on disk exactly as it was found"
+        );
+    }
+
+    /// fails if `home_before` stops reading `--home value` -- the common
+    /// form, and the one every existing invocation in this file's own
+    /// argv-construction tests already uses.
+    #[cfg(unix)]
+    #[test]
+    fn home_before_reads_a_separate_value_argument() {
+        let prefix = [OsString::from("--home"), OsString::from("/tmp/x")];
+        assert_eq!(home_before(&prefix), Some(PathBuf::from("/tmp/x")));
+    }
+
+    /// fails if `home_before` stops reading the `--home=value` form clap
+    /// itself also accepts.
+    #[cfg(unix)]
+    #[test]
+    fn home_before_reads_an_equals_form() {
+        let prefix = [OsString::from("--home=/tmp/y")];
+        assert_eq!(home_before(&prefix), Some(PathBuf::from("/tmp/y")));
+    }
+
+    /// fails if `home_before` only ever checks the first token instead of
+    /// scanning the whole prefix -- `--home` can follow other global flags
+    /// in a real invocation (`shep --format json --home /tmp/z mydog`).
+    #[cfg(unix)]
+    #[test]
+    fn home_before_skips_unrelated_tokens_before_finding_home() {
+        let prefix = [
+            OsString::from("--format"),
+            OsString::from("json"),
+            OsString::from("--home"),
+            OsString::from("/tmp/z"),
+        ];
+        assert_eq!(home_before(&prefix), Some(PathBuf::from("/tmp/z")));
+    }
+
+    /// fails if `dog_exit_code` stops reading a normal exit's own code.
+    #[cfg(unix)]
+    #[test]
+    fn dog_exit_code_reads_a_normal_exit_status() {
+        use std::os::unix::process::ExitStatusExt as _;
+        let status = std::process::ExitStatus::from_raw(7 << 8);
+        assert_eq!(dog_exit_code(status), 7);
+    }
+
+    /// fails if `dog_exit_code` stops applying the `128 + signal` shell
+    /// convention `commands::reap::classify` already reads a reaped
+    /// supervisor's status by.
+    #[cfg(unix)]
+    #[test]
+    fn dog_exit_code_reads_128_plus_signal_for_a_signalled_status() {
+        use std::os::unix::process::ExitStatusExt as _;
+        let status = std::process::ExitStatus::from_raw(9); // SIGKILL, no WIFEXITED bit
+        assert_eq!(dog_exit_code(status), 128 + 9);
+    }
+
+    /// fails if `dispatch_adopted_dog` starts trying to look up a dog for
+    /// any parse failure at all, not only an unrecognized-subcommand one --
+    /// a missing required argument (`shep adopt` with no path) must reach
+    /// clap's own usage error exactly as it always has.
+    ///
+    /// Does not, on its own, mutation-cover the explicit `err.kind()`
+    /// check inside `dispatch_adopted_dog`: a `MissingRequiredArgument`
+    /// carries no `ContextKind::InvalidSubcommand` value either, so the
+    /// context-match just below that check already returns `None` here
+    /// with or without it. That check's own doc names the narrower case
+    /// (an `ArgumentConflict` clap does not produce anywhere in this
+    /// binary's own command tree) it guards against instead.
+    #[cfg(unix)]
+    #[test]
+    fn dispatch_adopted_dog_is_none_for_a_parse_error_that_is_not_invalid_subcommand() {
+        let argv: Vec<OsString> = ["shep", "adopt"].into_iter().map(OsString::from).collect();
+        let err = Cli::try_parse_from(&argv).unwrap_err();
+        assert_ne!(err.kind(), clap::error::ErrorKind::InvalidSubcommand);
+        assert!(dispatch_adopted_dog(&argv, &err).is_none());
+    }
+
+    /// fails if `dispatch_adopted_dog` invents a dog for a name
+    /// `shep.toml` has never heard of -- this must fall through to clap's
+    /// own unknown-verb error (suggestions included), not a silent,
+    /// unrelated failure.
+    #[cfg(unix)]
+    #[test]
+    fn dispatch_adopted_dog_is_none_for_a_name_shep_toml_has_never_heard_of() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = dir.path().join(".shep");
+        std::fs::create_dir_all(&home).unwrap();
+        let argv: Vec<OsString> = ["shep", "--home"]
+            .into_iter()
+            .map(OsString::from)
+            .chain([home.into_os_string(), OsString::from("nosuchdog")])
+            .collect();
+        let err = Cli::try_parse_from(&argv).unwrap_err();
+        assert_eq!(err.kind(), clap::error::ErrorKind::InvalidSubcommand);
+        assert!(dispatch_adopted_dog(&argv, &err).is_none());
+    }
+
+    /// fails if `dispatch_adopted_dog` stops finding a dog `shep.toml`
+    /// really does have registered, once clap has already failed to parse
+    /// its name as a subcommand -- the fast-tier half of issue 3's
+    /// dispatch; `cli_e2e.rs`'s own case drives the real compiled binary
+    /// end to end and pins the argv/`SHEP_HOME` contract this test does
+    /// not reach (`std::process::ExitCode` carries no way to inspect the
+    /// value it wraps, so this only asserts that a real spawn-and-wait
+    /// happened, not which code it returned).
+    #[cfg(unix)]
+    #[test]
+    fn dispatch_adopted_dog_finds_a_dog_shep_toml_really_has() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = dir.path().join(".shep");
+        std::fs::create_dir_all(&home).unwrap();
+        let script = dir.path().join("mydog.sh");
+        std::fs::write(&script, "#!/bin/sh\nexit 0\n").unwrap();
+        let mut mode = std::fs::metadata(&script).unwrap().permissions();
+        std::os::unix::fs::PermissionsExt::set_mode(&mut mode, 0o755);
+        std::fs::set_permissions(&script, mode).unwrap();
+        ShepToml::edit(&home.join("shep.toml"), |cfg| {
+            cfg.adopt_dog("mydog", &script);
+        })
+        .unwrap();
+
+        let argv: Vec<OsString> = ["shep", "--home"]
+            .into_iter()
+            .map(OsString::from)
+            .chain([
+                home.into_os_string(),
+                OsString::from("mydog"),
+                OsString::from("koji"),
+            ])
+            .collect();
+        let err = Cli::try_parse_from(&argv).unwrap_err();
+        assert_eq!(err.kind(), clap::error::ErrorKind::InvalidSubcommand);
+
+        assert!(
+            dispatch_adopted_dog(&argv, &err).is_some(),
+            "an adopted dog must dispatch instead of falling through to clap's own error"
         );
     }
 

--- a/crates/shep-cli/src/lib.rs
+++ b/crates/shep-cli/src/lib.rs
@@ -315,7 +315,12 @@ fn dispatch_adopted_dog(argv: &[OsString], err: &clap::Error) -> Option<std::pro
         style: None,
     };
     let paths = resolve_paths(&global).ok()?;
-    let path = ShepToml::edit(&paths.daemon_config, |cfg| cfg.adopted_dog_path(name))
+    // `_readonly`, not `ShepToml::edit`: this runs on every unrecognized
+    // verb, most of which are typos rather than dog names, and `edit`
+    // saves unconditionally even when its closure only reads -- a lookup
+    // that finds nothing would still create `$SHEP_HOME` and write a
+    // `shep.toml` as a side effect of failing.
+    let path = ShepToml::adopted_dog_path_readonly(&paths.daemon_config, name)
         .ok()
         .flatten()?;
     let dog_argv = argv[index + 1..].to_vec();
@@ -1777,6 +1782,47 @@ mod tests {
         let err = Cli::try_parse_from(&argv).unwrap_err();
         assert_eq!(err.kind(), clap::error::ErrorKind::InvalidSubcommand);
         assert!(dispatch_adopted_dog(&argv, &err).is_none());
+    }
+
+    /// fails if `dispatch_adopted_dog`'s lookup creates anything on a
+    /// plain "no such dog" answer. CodeRabbit's finding on PR #4, verified
+    /// against the real code before fixing: `ShepToml::edit` calls
+    /// `open_locked`, which calls `create_home_dir` unconditionally, and
+    /// `edit` itself calls `doc.save()` unconditionally even when its
+    /// closure only read. Routing this lookup through `edit` meant a
+    /// plain typo like `shep flcok`, on a machine with no `$SHEP_HOME`
+    /// yet, created the directory and wrote an empty `shep.toml` as a
+    /// side effect of failing to find a dog. A read that fails should
+    /// leave the filesystem exactly as it found it.
+    ///
+    /// `home` here is never pre-created, unlike this file's other two
+    /// `dispatch_adopted_dog` tests just above and below -- the point of
+    /// this one is exactly that absence.
+    ///
+    /// Mutation check: routing the lookup in `dispatch_adopted_dog` back
+    /// through `ShepToml::edit` reddens this -- both `home` and
+    /// `home.join("shep.toml")` come to exist.
+    #[cfg(unix)]
+    #[test]
+    fn dispatch_adopted_dog_creates_nothing_for_a_missing_shep_home() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = dir.path().join(".shep");
+        assert!(!home.exists(), "test setup must start with no $SHEP_HOME");
+
+        let argv: Vec<OsString> = ["shep", "--home"]
+            .into_iter()
+            .map(OsString::from)
+            .chain([home.clone().into_os_string(), OsString::from("nosuchdog")])
+            .collect();
+        let err = Cli::try_parse_from(&argv).unwrap_err();
+        assert_eq!(err.kind(), clap::error::ErrorKind::InvalidSubcommand);
+
+        assert!(dispatch_adopted_dog(&argv, &err).is_none());
+        assert!(
+            !home.exists(),
+            "a failed dog lookup must never create $SHEP_HOME: {}",
+            home.display()
+        );
     }
 
     /// fails if `dispatch_adopted_dog` stops finding a dog `shep.toml`

--- a/crates/shep-cli/src/output/rows.rs
+++ b/crates/shep-cli/src/output/rows.rs
@@ -563,7 +563,7 @@ impl Render for DogDisabledRow {
     const PRIORITIES: &'static [u8] = &[0, 7, 6, 0];
 }
 
-/// `shep adopt <name> <path>`: what the config edit and, if a shepherd is
+/// `shep adopt <path> [--name <name>]`: what the config edit and, if a shepherd is
 /// running, the resulting `EnableDog` RPC actually did.
 ///
 /// Constructed by `commands/dogs.rs`'s `adopt`. [`Self::source`] is always

--- a/crates/shep-cli/tests/cli_e2e.rs
+++ b/crates/shep-cli/tests/cli_e2e.rs
@@ -5877,3 +5877,68 @@ fn piped_table_output_at_the_default_style_carries_no_box_or_escape() {
 
     graceful_kill(dir.path());
 }
+
+// --- Issue 1: `shep adopt` finds a bare $PATH name and expands `~/` ------
+
+/// Issue 1's first repro, verbatim: `cargo install shep-log-rotate` puts
+/// the binary on `$PATH` under its own name, and `shep adopt` used to be
+/// unable to find it there at all.
+#[test]
+fn shep_adopt_finds_a_binary_on_path_by_bare_name() {
+    let home = TempDir::new().unwrap();
+    let bin_dir = TempDir::new().unwrap();
+    let binary = write_script(&bin_dir, "shep-log-rotate", "#!/bin/sh\nexit 0\n");
+
+    let output = Command::cargo_bin("shep")
+        .unwrap()
+        .env("PATH", bin_dir.path())
+        .arg("--home")
+        .arg(home.path())
+        .arg("adopt")
+        .arg("lr")
+        .arg("shep-log-rotate")
+        .timeout(CMD_TIMEOUT)
+        .output()
+        .unwrap();
+
+    assert_success(&output);
+    let written = std::fs::read_to_string(home.path().join("shep.toml")).unwrap();
+    assert!(
+        written.contains(&binary.display().to_string()),
+        "the $PATH hit must be the recorded binary: {written}"
+    );
+}
+
+/// Issue 1's second repro, verbatim: a literal `~/` path, which worked in
+/// a Flockfile (2026-08-19) but not at `shep adopt` until now.
+#[test]
+fn shep_adopt_expands_a_leading_tilde_path() {
+    let shep_home = TempDir::new().unwrap();
+    let fake_user_home = TempDir::new().unwrap();
+    let bin_dir = fake_user_home.path().join(".cargo/bin");
+    std::fs::create_dir_all(&bin_dir).unwrap();
+    let binary = bin_dir.join("shep-log-rotate");
+    std::fs::write(&binary, "#!/bin/sh\nexit 0\n").unwrap();
+    let mut mode = std::fs::metadata(&binary).unwrap().permissions();
+    mode.set_mode(0o755);
+    std::fs::set_permissions(&binary, mode).unwrap();
+
+    let output = Command::cargo_bin("shep")
+        .unwrap()
+        .env("HOME", fake_user_home.path())
+        .arg("--home")
+        .arg(shep_home.path())
+        .arg("adopt")
+        .arg("lr")
+        .arg("~/.cargo/bin/shep-log-rotate")
+        .timeout(CMD_TIMEOUT)
+        .output()
+        .unwrap();
+
+    assert_success(&output);
+    let written = std::fs::read_to_string(shep_home.path().join("shep.toml")).unwrap();
+    assert!(
+        written.contains(&binary.display().to_string()),
+        "the ~/-expanded binary must be the one recorded: {written}"
+    );
+}

--- a/crates/shep-cli/tests/cli_e2e.rs
+++ b/crates/shep-cli/tests/cli_e2e.rs
@@ -5142,11 +5142,11 @@ fn available_dogs_detail_view_uses_adopt_as_never_name() {
         "install command: {stdout}"
     );
     assert!(
-        stdout.contains("$ shep adopt log-rotate ~/.cargo/bin/shep-log-rotate"),
+        stdout.contains("$ shep adopt ~/.cargo/bin/shep-log-rotate --name log-rotate"),
         "adopt command must use adopt_as (log-rotate), not name (Spot): {stdout}"
     );
     assert!(
-        !stdout.contains("adopt Spot"),
+        !stdout.contains("--name Spot"),
         "adopt command must never use the display name: {stdout}"
     );
 }
@@ -5895,8 +5895,9 @@ fn shep_adopt_finds_a_binary_on_path_by_bare_name() {
         .arg("--home")
         .arg(home.path())
         .arg("adopt")
-        .arg("lr")
         .arg("shep-log-rotate")
+        .arg("--name")
+        .arg("lr")
         .timeout(CMD_TIMEOUT)
         .output()
         .unwrap();
@@ -5929,8 +5930,9 @@ fn shep_adopt_expands_a_leading_tilde_path() {
         .arg("--home")
         .arg(shep_home.path())
         .arg("adopt")
-        .arg("lr")
         .arg("~/.cargo/bin/shep-log-rotate")
+        .arg("--name")
+        .arg("lr")
         .timeout(CMD_TIMEOUT)
         .output()
         .unwrap();

--- a/crates/shep-cli/tests/cli_e2e.rs
+++ b/crates/shep-cli/tests/cli_e2e.rs
@@ -5878,7 +5878,7 @@ fn piped_table_output_at_the_default_style_carries_no_box_or_escape() {
     graceful_kill(dir.path());
 }
 
-// --- Issue 1: `shep adopt` finds a bare $PATH name and expands `~/` ------
+// --- Issue 1/2/3: adopt ergonomics and `shep <dogname>` dispatch ---------
 
 /// Issue 1's first repro, verbatim: `cargo install shep-log-rotate` puts
 /// the binary on `$PATH` under its own name, and `shep adopt` used to be
@@ -5942,5 +5942,141 @@ fn shep_adopt_expands_a_leading_tilde_path() {
     assert!(
         written.contains(&binary.display().to_string()),
         "the ~/-expanded binary must be the one recorded: {written}"
+    );
+}
+/// Writes a script that records its own argv and `$SHEP_HOME` into `marker`
+/// (inside `dir`), prints a distinctive stdout line, and exits `code` --
+/// the fixture [`an_adopted_dog_runs_directly_with_its_own_argv_and_shep_home`]
+/// and [`a_built_in_verb_always_wins_over_a_same_named_adopted_dog`] both
+/// build on.
+fn write_marker_script(dir: &TempDir, marker: &Path, code: u8) -> PathBuf {
+    write_script(
+        dir,
+        "dog.sh",
+        &format!(
+            "#!/bin/sh\necho \"argv:$*\" > \"{marker}\"\necho \"home:$SHEP_HOME\" >> \"{marker}\"\necho from-the-dog\nexit {code}\n",
+            marker = marker.display(),
+        ),
+    )
+}
+
+/// `shep <dogname> [args...]` (issue 3): once a dog is adopted, invoking
+/// its name directly runs it -- with the operator's own argv passed
+/// through untouched and `$SHEP_HOME` set, the "operator-invoked" contract
+/// that is deliberately distinct from the supervised one (no argv, that
+/// same one env entry) a shepherd-started dog gets.
+///
+/// The dispatch call itself carries no `--home` flag at all -- `$SHEP_HOME`
+/// is set through the environment instead, exercising `home_before`'s
+/// fallback to the real environment alongside its `--home`-flag form,
+/// which the lib-tier `home_before_*` tests already cover directly.
+///
+/// Mutation check: reverting `lib.rs`'s `dispatch_adopted_dog` to always
+/// return `None` reddens this immediately -- clap's own "unrecognized
+/// subcommand" error and exit code 2 instead of the dog's own exit code 7.
+#[test]
+fn an_adopted_dog_runs_directly_with_its_own_argv_and_shep_home() {
+    let home = TempDir::new().unwrap();
+    let marker = home.path().join("marker.txt");
+    let script = write_marker_script(&home, &marker, 7);
+
+    let adopted = shep(home.path())
+        .arg("adopt")
+        .arg(&script)
+        .arg("--name")
+        .arg("deploy")
+        .output()
+        .unwrap();
+    assert_success(&adopted);
+
+    let ran = Command::cargo_bin("shep")
+        .unwrap()
+        .env("SHEP_HOME", home.path())
+        .arg("deploy")
+        .arg("koji")
+        .arg("--flag")
+        .timeout(CMD_TIMEOUT)
+        .output()
+        .unwrap();
+
+    assert_eq!(
+        ran.status.code(),
+        Some(7),
+        "the dog's own exit code must pass through: {ran:?}"
+    );
+    assert!(
+        String::from_utf8_lossy(&ran.stdout).contains("from-the-dog"),
+        "stdio must be inherited, not captured away: {ran:?}"
+    );
+    let recorded = std::fs::read_to_string(&marker).unwrap();
+    assert!(
+        recorded.contains("argv:koji --flag"),
+        "argv must reach the dog exactly as typed: {recorded}"
+    );
+    assert!(
+        recorded.contains(&format!("home:{}", home.path().display())),
+        "SHEP_HOME must reach the dog's own environment: {recorded}"
+    );
+}
+
+/// Built-in verbs always win, structurally (issue 3): a `[daemon]
+/// adopted_dogs` entry named `stop` -- written directly, bypassing `shep
+/// adopt`'s own refusal of the name, the way a hand-edited `shep.toml`
+/// could -- must never shadow the real `shep stop`. `dispatch_adopted_dog`
+/// only ever runs once clap has already failed to match a token against a
+/// real subcommand, so `stop` never reaches it at all.
+///
+/// `shep stop all` against a `$SHEP_HOME` with no shepherd running exits
+/// `DaemonUnreachable` (5) -- `commands::lifecycle::stop` goes through
+/// `connect_client`, which does not autostart -- so that exit code, and the
+/// marker file never appearing, are both proof the built-in ran (or at
+/// least was the one dispatch attempted) rather than the dog's script.
+#[test]
+fn a_built_in_verb_always_wins_over_a_same_named_adopted_dog() {
+    let home = TempDir::new().unwrap();
+    let marker = home.path().join("marker.txt");
+    let script = write_marker_script(&home, &marker, 0);
+    std::fs::write(
+        home.path().join("shep.toml"),
+        format!(
+            "[daemon]\nadopted_dogs = {{ stop = \"{}\" }}\nenabled_dogs = [\"stop\"]\n",
+            script.display()
+        ),
+    )
+    .unwrap();
+
+    let output = shep(home.path()).arg("stop").arg("all").output().unwrap();
+
+    assert_eq!(
+        output.status.code(),
+        Some(5),
+        "must be the built-in `stop`'s own DaemonUnreachable, not the dog's exit 0: {output:?}"
+    );
+    assert!(
+        !marker.exists(),
+        "the adopted dog's script must never have run"
+    );
+}
+
+/// An unrecognized verb with no matching adopted dog stays an ordinary
+/// unknown-verb error, suggestions included -- `dispatch_adopted_dog`
+/// finding nothing must fall all the way through to clap's own rendering,
+/// not a silent or different failure. No dog is adopted at all here, and
+/// `$SHEP_HOME` does not even exist yet.
+#[test]
+fn an_unknown_verb_with_no_matching_dog_keeps_claps_own_suggestion() {
+    let home = TempDir::new().unwrap();
+
+    let output = shep(home.path()).arg("flcok").output().unwrap();
+
+    assert_eq!(output.status.code(), Some(2), "clap's own usage exit code");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("unrecognized subcommand"),
+        "clap's own wording must survive untouched: {stderr}"
+    );
+    assert!(
+        stderr.contains("flock"),
+        "clap's own did-you-mean must still suggest the real verb: {stderr}"
     );
 }

--- a/crates/shep-core/src/config/mod.rs
+++ b/crates/shep-core/src/config/mod.rs
@@ -18,7 +18,9 @@ pub use flockfile::{FlockFormat, Flockfile, FlockfileError, discover};
 #[cfg(feature = "schema")]
 pub use flockfile::{flockfile_schema_json, flockfile_schema_string};
 pub use kill_signal::KillSignal;
-pub use normalize::{NormalizeError, ResolvedApp, normalize, normalize_all};
+pub use normalize::{
+    NormalizeError, ResolvedApp, TildeError, expand_home_tilde, normalize, normalize_all,
+};
 pub use probe::{ProbeTarget, ProbeTargetError};
 #[cfg(feature = "schema")]
 pub use scaffold::{CURATED, Depth, Scaffold, ScaffoldError};

--- a/crates/shep-core/src/config/normalize.rs
+++ b/crates/shep-core/src/config/normalize.rs
@@ -103,6 +103,12 @@ impl ResolvedApp {
 /// A path that does not start with `~` is returned untouched, so this is a
 /// no-op for every absolute and relative path anyone already has.
 ///
+/// Thin wrapper over [`expand_home_tilde`], the one piece of tilde-expansion
+/// logic in the workspace: this attaches the sheep name and field
+/// [`NormalizeError`] carries, so a Flockfile refusal names the line to
+/// edit. A caller with no such context — `shep-cli`'s own `shep adopt`,
+/// resolving a bare CLI argument — calls [`expand_home_tilde`] directly.
+///
 /// # Errors
 /// - [`NormalizeError::TildeUser`] if the path names another user's home.
 /// - [`NormalizeError::NoHomeForTilde`] if `~/` is used and `home` is `None`.
@@ -112,22 +118,74 @@ fn expand_tilde(
     name: &str,
     field: &'static str,
 ) -> Result<String, NormalizeError> {
+    expand_home_tilde(value, home).map_err(|err| match err {
+        TildeError::OtherUser => NormalizeError::TildeUser {
+            name: name.to_string(),
+            field,
+            value: value.to_string(),
+        },
+        TildeError::NoHome => NormalizeError::NoHomeForTilde {
+            name: name.to_string(),
+            field,
+        },
+    })
+}
+
+/// Why [`expand_home_tilde`] refused a value — the two failure modes with
+/// no per-field context attached, for a caller that has none to give.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TildeError {
+    /// The value names another user's home (`~user/...`). Refused rather
+    /// than resolved: answering it means a passwd lookup, and under a
+    /// systemd unit the answer depends on who the process runs as rather
+    /// than on who wrote the value.
+    OtherUser,
+    /// The value begins `~/` and no home directory could be determined.
+    NoHome,
+}
+
+impl fmt::Display for TildeError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::OtherUser => write!(
+                f,
+                "shep expands only `~/` (your own home); another user's home needs a \
+                 passwd lookup whose answer depends on who the process runs as"
+            ),
+            Self::NoHome => write!(f, "begins with `~/` but no home directory could be found"),
+        }
+    }
+}
+
+impl core::error::Error for TildeError {}
+
+/// Expands a leading `~/` in `value` against `home` — the one piece of
+/// tilde-expansion logic in the workspace, shared by `expand_tilde` above
+/// (Flockfile path fields, private to this module) and `shep-cli`'s own
+/// `shep adopt` (its `<path>` argument). Adopt's own CLI path used to run
+/// without this entirely, which is why `~/.cargo/bin/whatever` worked in
+/// a Flockfile and not at `shep adopt`.
+///
+/// Deliberately narrow, matching `expand_tilde`'s own doc: `~/` only.
+/// `~user/...` is refused (a passwd lookup, whose answer depends on who
+/// the process runs as) and `$VAR` is never expanded, here or anywhere.
+///
+/// A value that does not start with `~` is returned unchanged, so this is
+/// a no-op for every absolute and relative path anyone already has.
+///
+/// # Errors
+/// - [`TildeError::OtherUser`] if the value names another user's home.
+/// - [`TildeError::NoHome`] if `~/` is used and `home` is `None`.
+pub fn expand_home_tilde(value: &str, home: Option<&Path>) -> Result<String, TildeError> {
     let Some(rest) = value.strip_prefix('~') else {
         return Ok(value.to_string());
     };
     // `~` alone, or `~/...`. Anything else after the tilde names a user.
     if !(rest.is_empty() || rest.starts_with('/')) {
-        return Err(NormalizeError::TildeUser {
-            name: name.to_string(),
-            field,
-            value: value.to_string(),
-        });
+        return Err(TildeError::OtherUser);
     }
     let Some(home) = home else {
-        return Err(NormalizeError::NoHomeForTilde {
-            name: name.to_string(),
-            field,
-        });
+        return Err(TildeError::NoHome);
     };
     // `join` would discard `home` for a rest that still looks absolute, so
     // the separator is trimmed and the two halves are concatenated instead.
@@ -764,6 +822,34 @@ mod tests {
         assert!(
             matches!(err, NormalizeError::NoHomeForTilde { .. }),
             "{err:?}"
+        );
+    }
+
+    /// Pins [`expand_home_tilde`]'s own public contract directly, apart
+    /// from [`expand_tilde`]'s wrapping of it into a [`NormalizeError`]:
+    /// `shep-cli`'s own `shep adopt` calls this function directly (it has
+    /// no app name or field to attach), so its behavior needs its own
+    /// coverage independent of whatever `AppConfig`-shaped test drives it
+    /// above.
+    #[test]
+    fn expand_home_tilde_covers_its_four_documented_cases() {
+        let home = Path::new("/home/rin");
+        assert_eq!(
+            expand_home_tilde("~/bin/dog", Some(home)).unwrap(),
+            home.join("bin/dog").to_string_lossy()
+        );
+        assert_eq!(
+            expand_home_tilde("/opt/bin/dog", Some(home)).unwrap(),
+            "/opt/bin/dog",
+            "a value with no leading ~ is returned unchanged"
+        );
+        assert_eq!(
+            expand_home_tilde("~/bin/dog", None).unwrap_err(),
+            TildeError::NoHome
+        );
+        assert_eq!(
+            expand_home_tilde("~deploy/bin/dog", Some(home)).unwrap_err(),
+            TildeError::OtherUser
         );
     }
 

--- a/docs/dogs.md
+++ b/docs/dogs.md
@@ -223,8 +223,8 @@ Once adopted, `shep <name> [args...]` runs the dog directly — the same
 one the shepherd itself uses: a dog the shepherd starts gets no argv and
 one environment variable (`$SHEP_HOME`, below); a dog you name on the
 command line gets whatever you typed after it, passed straight through,
-plus that same `$SHEP_HOME`. A built-in verb always wins over a
-same-named dog.
+plus that same `$SHEP_HOME`. A built-in verb or alias always wins over
+a same-named dog.
 
 `rehome <name>` is `disable`'s counterpart for a third-party dog: it stops
 it if running and forgets the registration in `shep.toml` entirely, rather

--- a/docs/dogs.md
+++ b/docs/dogs.md
@@ -188,13 +188,20 @@ through an advisory file lock, never truncated in place.
 
 ## Writing your own
 
-Third-party extension is `shep adopt <name> <path>`:
+Third-party extension is `shep adopt <path> [--name <name>]`:
 
 ```
-shep adopt watchdog ./bin/my-watchdog
+shep adopt ./bin/my-watchdog --name watchdog
 shep enable watchdog
 shep rehome watchdog
 ```
+
+`--name` is optional. Leave it off and the dog is named after its own
+file stem with a leading `shep-` stripped, the way `cargo` strips
+`cargo-` from its own external subcommands — `shep adopt
+~/.cargo/bin/shep-log-rotate` alone names itself `log-rotate`. The path
+itself can be given as-is, with a leading `~/`, or as a bare name already
+on `$PATH` (which is where `cargo install`/`go install` put it).
 
 `adopt` vets the binary once, at the moment you run it — not again at
 every later boot or every `enable`. It refuses a path that does not

--- a/docs/dogs.md
+++ b/docs/dogs.md
@@ -206,14 +206,25 @@ on `$PATH` (which is where `cargo install`/`go install` put it).
 `adopt` vets the binary once, at the moment you run it — not again at
 every later boot or every `enable`. It refuses a path that does not
 exist, is not a file, has no execute bit for anyone, or is world-writable
-(the binary itself or its containing directory), and it warns rather than
-refuses on a merely group-writable one. Passing all of that, it actually
-spawns the binary with no arguments and kills it immediately, because the
-only honest way to know whether this kernel can exec a file is to ask
-this kernel. What gets recorded in `shep.toml` is the canonicalized,
-absolute path — never whatever relative path you typed — because the
-daemon may resolve it again after a reboot from a different working
-directory than the one `adopt` ran from.
+(the binary itself or its containing directory); it also refuses a name
+that already belongs to a built-in verb or alias, since a dog by that
+name could never be reached. It warns rather than refuses on a merely
+group-writable path. Passing all of that, it actually spawns the binary
+with no arguments and kills it immediately, because the only honest way
+to know whether this kernel can exec a file is to ask this kernel. What
+gets recorded in `shep.toml` is the canonicalized, absolute path — never
+whatever relative path you typed — because the daemon may resolve it
+again after a reboot from a different working directory than the one
+`adopt` ran from.
+
+Once adopted, `shep <name> [args...]` runs the dog directly — the same
+`git foo` runs `git-foo` precedent, resolved against adopted dogs only
+(never a `$PATH` scan). It's a second invocation mode, distinct from the
+one the shepherd itself uses: a dog the shepherd starts gets no argv and
+one environment variable (`$SHEP_HOME`, below); a dog you name on the
+command line gets whatever you typed after it, passed straight through,
+plus that same `$SHEP_HOME`. A built-in verb always wins over a
+same-named dog.
 
 `rehome <name>` is `disable`'s counterpart for a third-party dog: it stops
 it if running and forgets the registration in `shep.toml` entirely, rather

--- a/web/src/data/cli-reference.generated.txt
+++ b/web/src/data/cli-reference.generated.txt
@@ -791,8 +791,11 @@ Vet a binary shep has never seen and register it as a dog: writes `[daemon] adop
 
 The path can be given as-is, with a leading `~/`, or as a bare name already on `$PATH` (`cargo
 install` puts one there). Refuses, before touching the config at all, a path that resolves to
-nothing that exists, is not a file, has no execute bit set, or that this kernel will not exec. An
-adopted dog runs at the shepherd's own trust level, with no sandboxing beyond it.
+nothing that exists, is not a file, has no execute bit set, or that this kernel will not exec — and
+refuses a name that already names a built-in verb or alias, since such a dog could never be reached.
+An adopted dog runs at the shepherd's own trust level, with no sandboxing beyond it. Once adopted,
+`shep <name> [args...]` runs it directly, passing `args` through untouched — a second invocation
+mode from the one the shepherd itself uses to supervise it.
 
 Usage: shep adopt [OPTIONS] <PATH>
 

--- a/web/src/data/cli-reference.generated.txt
+++ b/web/src/data/cli-reference.generated.txt
@@ -789,18 +789,18 @@ Options:
 Vet a binary shep has never seen and register it as a dog: writes `[daemon] adopted_dogs` and
 `[daemon] enabled_dogs` in `shep.toml`, and starts it now if a shepherd is running.
 
-Refuses, before touching the config at all, a path that does not exist, is not a file, has no
-execute bit set, or that this kernel will not exec. An adopted dog runs at the shepherd's own trust
-level, with no sandboxing beyond it.
+The path can be given as-is, with a leading `~/`, or as a bare name already on `$PATH` (`cargo
+install` puts one there). Refuses, before touching the config at all, a path that resolves to
+nothing that exists, is not a file, has no execute bit set, or that this kernel will not exec. An
+adopted dog runs at the shepherd's own trust level, with no sandboxing beyond it.
 
-Usage: shep adopt [OPTIONS] <NAME> <PATH>
+Usage: shep adopt [OPTIONS] <PATH>
 
 Arguments:
-  <NAME>
-          The dog's name — the `[dog.<name>]` config key
-
   <PATH>
-          Path to the dog's binary, vetted before `shep.toml` is touched
+          Path to the dog's binary, vetted before `shep.toml` is touched. Resolved before vetting:
+          as given, with a leading `~/` expanded, or looked up on `$PATH` if it names no directory —
+          first hit wins
 
 Options:
       --format <FORMAT>
@@ -811,6 +811,10 @@ Options:
           - json:  A versioned JSON envelope, one object per invocation
           
           [default: table]
+
+      --name <NAME>
+          The dog's name — the `[dog.<name>]` config key. Defaults to the binary's file stem with a
+          leading `shep-` stripped
 
   -q, --quiet
           Suppress non-essential output

--- a/web/src/pages/docs/community-dogs.astro
+++ b/web/src/pages/docs/community-dogs.astro
@@ -45,11 +45,11 @@ function adoptLine(dog: Dog): string {
   switch (dog.source.kind) {
     case "cargo":
     case "cargo-git":
-      return `$ shep adopt ${dog.adopt_as} ~/.cargo/bin/${dog.package}`;
+      return `$ shep adopt ~/.cargo/bin/${dog.package} --name ${dog.adopt_as}`;
     case "go-install":
-      return `$ shep adopt ${dog.adopt_as} $(go env GOPATH)/bin/${dog.package}`;
+      return `$ shep adopt $(go env GOPATH)/bin/${dog.package} --name ${dog.adopt_as}`;
     case "manual":
-      return `$ shep adopt ${dog.adopt_as} <path to the binary>`;
+      return `$ shep adopt <path to the binary> --name ${dog.adopt_as}`;
   }
 }
 ---
@@ -67,8 +67,8 @@ function adoptLine(dog: Dog): string {
       <code>metrics</code> and <code>bark</code> ship inside the{" "}
       <code>shep</code> binary. Everything below is a dog someone outside
       this project wrote and adopted the same way, with{" "}
-      <code>shep adopt &lt;name&gt; &lt;path&gt;</code>, pointed at a binary
-      you didn't have to write yourself.
+      <code>shep adopt &lt;path&gt;</code>, pointed at a binary you didn't
+      have to write yourself.
     </p>
 
     <p>

--- a/web/src/pages/docs/dogs.astro
+++ b/web/src/pages/docs/dogs.astro
@@ -270,7 +270,7 @@ watchdog  adopted  true      stopped`}</CodeBlock>
       the shepherd's own: a supervised dog gets no argv and one environment
       variable; a dog you name on the command line gets whatever you typed
       after it, plus that same <code>$SHEP_HOME</code>. A built-in verb
-      always wins over a same-named dog.
+      or alias always wins over a same-named dog.
     </p>
     <p>
       What gets recorded in <code>shep.toml</code> is the canonicalized,

--- a/web/src/pages/docs/dogs.astro
+++ b/web/src/pages/docs/dogs.astro
@@ -241,9 +241,11 @@ sinks = ["oncall"]`}</CodeBlock>
         <code>cargo-</code> from its own external subcommands. Vets the
         binary once, at adopt time: refusing a path that doesn't resolve to
         anything that exists, isn't a file, has no execute bit, or is
-        world-writable, then actually spawns it with no arguments and kills
-        it immediately, because the only honest way to know whether this
-        kernel can exec a file is to ask this kernel.
+        world-writable, and refusing a name that already belongs to a
+        built-in verb or alias, since such a dog could never be reached.
+        Passing all of that, it actually spawns the binary with no
+        arguments and kills it immediately, because the only honest way to
+        know whether this kernel can exec a file is to ask this kernel.
       </p>
     </VerbSignature>
     <VerbSignature verb="rehome" usage="shep rehome <name>">
@@ -260,6 +262,16 @@ watchdog  adopted  true      online
 $ shep rehome watchdog
 NAME      SOURCE   SHEPHERD  STATUS
 watchdog  adopted  true      stopped`}</CodeBlock>
+    <p>
+      Once adopted, <code>shep watchdog [args...]</code> runs it directly —
+      git and cargo's own precedent (<code>git foo</code> runs{" "}
+      <code>git-foo</code>), resolved against adopted dogs only, never a{" "}
+      <code>$PATH</code> scan. It's a second invocation mode, distinct from
+      the shepherd's own: a supervised dog gets no argv and one environment
+      variable; a dog you name on the command line gets whatever you typed
+      after it, plus that same <code>$SHEP_HOME</code>. A built-in verb
+      always wins over a same-named dog.
+    </p>
     <p>
       What gets recorded in <code>shep.toml</code> is the canonicalized,
       absolute path (never whatever relative path you typed) because the

--- a/web/src/pages/docs/dogs.astro
+++ b/web/src/pages/docs/dogs.astro
@@ -231,13 +231,19 @@ sinks = ["oncall"]`}</CodeBlock>
     </p>
 
     <h2>Writing your own</h2>
-    <VerbSignature verb="adopt" usage="shep adopt <name> <path>">
+    <VerbSignature verb="adopt" usage="shep adopt <path> [--name <name>]">
       <p>
-        Third-party extension. Vets the binary once, at adopt time:
-        refusing a path that doesn't exist, isn't a file, has no execute
-        bit, or is world-writable, then actually spawns it with no
-        arguments and kills it immediately, because the only honest way to
-        know whether this kernel can exec a file is to ask this kernel.
+        Third-party extension. The path can be given as-is, with a leading{" "}
+        <code>~/</code>, or as a bare name already on <code>$PATH</code>{" "}
+        (where <code>cargo install</code> puts one). <code>--name</code> is
+        optional and defaults to the binary's file stem with a leading{" "}
+        <code>shep-</code> stripped, the way <code>cargo</code> strips{" "}
+        <code>cargo-</code> from its own external subcommands. Vets the
+        binary once, at adopt time: refusing a path that doesn't resolve to
+        anything that exists, isn't a file, has no execute bit, or is
+        world-writable, then actually spawns it with no arguments and kills
+        it immediately, because the only honest way to know whether this
+        kernel can exec a file is to ask this kernel.
       </p>
     </VerbSignature>
     <VerbSignature verb="rehome" usage="shep rehome <name>">
@@ -247,7 +253,7 @@ sinks = ["oncall"]`}</CodeBlock>
         leaving it disabled-but-known.
       </p>
     </VerbSignature>
-    <CodeBlock>{`$ shep adopt watchdog ./bin/my-watchdog
+    <CodeBlock>{`$ shep adopt ./bin/my-watchdog --name watchdog
 NAME      SOURCE   SHEPHERD  STATUS
 watchdog  adopted  true      online
 


### PR DESCRIPTION
- `shep adopt` resolves `~/` and a bare `$PATH` name before vetting, so `shep adopt shep-log-rotate` (from `cargo install`) and `shep adopt '~/.cargo/bin/shep-log-rotate'` both work now
- `shep adopt` takes `<path> [--name <name>]` instead of `<name> <path>`. Breaking change, no compat shim, the two shapes can't be parsed unambiguously together. Name defaults to the binary's file stem with `shep-` stripped
- adopted dogs are runnable directly now, `shep <name> [args...]` dispatches to them, git/cargo style. Resolved against adopted dogs only, never a `$PATH` scan, and built-in verbs always win
- `shep adopt` refuses a name that already belongs to a built-in verb or alias, since that dog could never be reached

Three commits, one per fix. Tests are per-commit, plus e2e against the real binary.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Simplified dog adoption syntax with an optional `--name`.
  * Resolve executables from explicit paths, `~/` paths, or `$PATH`.
  * Automatically derive names from executable filenames.
  * Invoke adopted dogs directly with forwarded arguments and environment settings.
  * Preserve built-in command precedence and reject conflicting adoption names.

* **Documentation**
  * Updated CLI, web, and dog adoption documentation with the new workflow and examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->