### PR TITLE
dogs.json object wrapper, community-dogs card redesign

### DIFF
--- a/crates/shep-cli/src/cli.rs
+++ b/crates/shep-cli/src/cli.rs
@@ -1154,7 +1154,39 @@ fn duration_flag(value: &str) -> Result<shep_core::values::UpDuration, String> {
 
 #[cfg(test)]
 mod tests {
+    use std::path::{Path, PathBuf};
+
     use super::*;
+
+    /// `web/`, three directories above this file, only when it actually
+    /// exists.
+    ///
+    /// Same helper, and the same reasoning, as
+    /// `dog_index::tests::workspace_web_dir` -- see that one for why this
+    /// has to be a runtime check rather than `include_str!`. Duplicated
+    /// rather than shared: two call sites and six lines each did not earn a
+    /// crate-wide test-support module.
+    fn workspace_web_dir() -> Option<PathBuf> {
+        let dir = Path::new(concat!(env!("CARGO_MANIFEST_DIR"), "/../../web"));
+        dir.is_dir().then(|| dir.to_path_buf())
+    }
+
+    /// Reads `web/{relative}`, or `None` outside the workspace checkout
+    /// (see [`workspace_web_dir`]).
+    ///
+    /// `web/` present but `relative` missing is real drift inside the
+    /// checkout, not a published-crate build, and panics accordingly.
+    ///
+    /// # Panics
+    /// Inside the workspace, if `relative` cannot be read.
+    fn read_workspace_web_file(relative: &str) -> Option<String> {
+        let dir = workspace_web_dir()?;
+        Some(
+            std::fs::read_to_string(dir.join(relative)).unwrap_or_else(|err| {
+                panic!("web/{relative} exists in the workspace but could not be read: {err}")
+            }),
+        )
+    }
 
     #[test]
     fn the_command_tree_parses_and_is_internally_consistent() {
@@ -1172,14 +1204,19 @@ mod tests {
     /// 2026-08-23 when `init` did the same.
     ///
     /// `help` is clap's own subcommand and the one deliberate omission.
+    ///
+    /// Skips outside the workspace checkout -- see
+    /// [`read_workspace_web_file`].
     #[test]
     fn every_visible_verb_reaches_the_docs_site_generator() {
         use clap::CommandFactory;
 
-        const GENERATOR: &str = include_str!("../../../web/scripts/generate-cli-reference.sh");
+        let Some(generator) = read_workspace_web_file("scripts/generate-cli-reference.sh") else {
+            return;
+        };
         const NOT_DOCUMENTED: &[&str] = &["help"];
 
-        let (_, rest) = GENERATOR
+        let (_, rest) = generator
             .split_once("VERBS=(")
             .expect("the generator declares a VERBS array");
         let (block, _) = rest.split_once(')').expect("the VERBS array closes");

--- a/crates/shep-cli/src/dog_index.rs
+++ b/crates/shep-cli/src/dog_index.rs
@@ -48,6 +48,24 @@
 //! ([`Index::skipped`]). One bad row must not blank the listing, and the
 //! skip must not be silent either.
 //!
+//! ## The wrapper, and why the document is not just the array
+//!
+//! The document is a JSON object, `{"$schema": ..., "version": 1, "dogs":
+//! [...]}`, not a bare top-level array of entries the way `shep` 0.1.0 read
+//! it. `$schema` is what gives a contributor's editor completion when they
+//! add a row; a bare array can never carry that, or anything else beside
+//! itself. `version` is what lets a future, incompatible reshape of this
+//! wrapper announce itself instead of quietly parsing wrong: a `version`
+//! this build does not recognise is [`IndexError::UnsupportedVersion`],
+//! refused with a message that says to upgrade `shep`, not a parse error.
+//! **This is a breaking change against shep 0.1.0**, which reads the old
+//! bare-array shape and nothing else; there is no dual-format fallback,
+//! because the docs site publishes one index for every shep that asks, and
+//! 0.1.0 is hours old.
+//!
+//! Only the wrapper is new. Every entry inside `dogs` still validates
+//! exactly as it always did -- the rest of this doc, unchanged below.
+//!
 //! ## Errors and the URL
 //!
 //! None of [`IndexError`]'s variants but [`IndexError::InsecureUrl`] names
@@ -81,6 +99,13 @@ pub const INDEX_URL_ENV: &str = "SHEP_DOG_INDEX";
 /// naming anything else is skipped rather than shown, because a category
 /// shep does not know is a category shep cannot file or explain.
 const CATEGORIES: [&str; 6] = ["logs", "metrics", "alerts", "health", "deploy", "other"];
+
+/// The only `version` this build's [`parse_index`] accepts. Bump this, and
+/// the docs site's published `dogs.json`, together, the day the wrapper's
+/// own shape needs to change in a way an old `shep` could not read safely
+/// -- an entry's own shape is free to grow independently, since a bad
+/// entry is skipped and counted rather than refused.
+const SUPPORTED_INDEX_VERSION: u64 = 1;
 
 /// The response cap. A megabyte is roughly two thousand entries at the size
 /// the live index's own entries run, so this bounds a hostile or broken
@@ -201,11 +226,23 @@ pub enum IndexError {
     /// The bytes were not JSON at all. Carries the parser's complaint,
     /// never the offending bytes.
     Malformed(String),
-    /// The bytes were JSON, but the document was not a top-level array.
-    /// Distinguished from [`Self::Malformed`] because an index that parses
-    /// as, say, an object is a wrong document rather than a broken one, and
-    /// an empty listing would be the wrong answer to give for it.
-    NotAnArray,
+    /// The bytes were JSON, but the top-level document was not an object.
+    /// Distinguished from [`Self::Malformed`] because a document that
+    /// parses as, say, a bare array -- `shep` 0.1.0's own index shape --
+    /// is a wrong document rather than a broken one, and an empty listing
+    /// would be the wrong answer to give for it.
+    NotAnObject,
+    /// The document's `version` field was missing, or named a version this
+    /// build does not understand. Carries the value found, exactly as the
+    /// document had it, so the message can say what arrived and what this
+    /// build wanted instead; `None` when the key was absent entirely.
+    UnsupportedVersion {
+        /// The `version` value the document carried, if any.
+        found: Option<Value>,
+    },
+    /// The document named a `version` this build understands, but its
+    /// `dogs` field was missing or was not itself an array.
+    MissingDogsArray,
 }
 
 impl fmt::Display for IndexError {
@@ -218,7 +255,22 @@ impl fmt::Display for IndexError {
             ),
             Self::Fetch(source) => write!(f, "{source}"),
             Self::Malformed(reason) => write!(f, "the dog index was not valid json: {reason}"),
-            Self::NotAnArray => write!(f, "the dog index was not a json array"),
+            Self::NotAnObject => write!(
+                f,
+                "the dog index was not a json object -- a bare array is the shape shep 0.1.0 \
+                 read, and is no longer accepted"
+            ),
+            Self::UnsupportedVersion { found } => {
+                let found = found
+                    .as_ref()
+                    .map_or_else(|| "unspecified".to_string(), Value::to_string);
+                write!(
+                    f,
+                    "the dog index is version {found}, which this shep does not understand \
+                     (this build reads version {SUPPORTED_INDEX_VERSION}); upgrade shep to read it"
+                )
+            }
+            Self::MissingDogsArray => write!(f, "the dog index has no \"dogs\" array"),
         }
     }
 }
@@ -227,7 +279,11 @@ impl core::error::Error for IndexError {
     fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
         match self {
             Self::Fetch(source) => Some(source),
-            Self::InsecureUrl(_) | Self::Malformed(_) | Self::NotAnArray => None,
+            Self::InsecureUrl(_)
+            | Self::Malformed(_)
+            | Self::NotAnObject
+            | Self::UnsupportedVersion { .. }
+            | Self::MissingDogsArray => None,
         }
     }
 }
@@ -263,8 +319,9 @@ pub fn index_url() -> String {
 ///   was redirected, answered non-2xx, exceeded [`SIZE_LIMIT`], or ran past
 ///   [`TIMEOUT`]. See [`crate::fetch`]'s own module doc for the full
 ///   refusal order.
-/// - [`IndexError::Malformed`], [`IndexError::NotAnArray`] — as
-///   [`parse_index`].
+/// - [`IndexError::Malformed`], [`IndexError::NotAnObject`],
+///   [`IndexError::UnsupportedVersion`], [`IndexError::MissingDogsArray`] —
+///   as [`parse_index`].
 pub async fn fetch_index(url: &str) -> Result<Index, IndexError> {
     let target = fetch::parse_url(url)?;
     require_secure_url(url, &target)?;
@@ -308,21 +365,35 @@ fn require_secure_url(url: &str, target: &fetch::Target) -> Result<(), IndexErro
 ///
 /// # Errors
 /// - [`IndexError::Malformed`] — `bytes` are not JSON, or not UTF-8.
-/// - [`IndexError::NotAnArray`] — `bytes` are JSON, but not an array.
+/// - [`IndexError::NotAnObject`] — `bytes` are JSON, but the top level is
+///   not an object (a bare array, `shep` 0.1.0's own shape, included).
+/// - [`IndexError::UnsupportedVersion`] — `version` is missing, or is not
+///   [`SUPPORTED_INDEX_VERSION`].
+/// - [`IndexError::MissingDogsArray`] — `version` is understood, but
+///   `dogs` is missing or is not an array.
 ///
 /// Nothing an individual entry can do produces an error. A bad entry is
 /// counted in [`Index::skipped`] and dropped.
 pub fn parse_index(bytes: &[u8]) -> Result<Index, IndexError> {
     let document: Value =
         serde_json::from_slice(bytes).map_err(|err| IndexError::Malformed(err.to_string()))?;
-    let Value::Array(entries) = document else {
-        return Err(IndexError::NotAnArray);
+    let Value::Object(document) = document else {
+        return Err(IndexError::NotAnObject);
+    };
+    let version = document.get("version").and_then(Value::as_u64);
+    if version != Some(SUPPORTED_INDEX_VERSION) {
+        return Err(IndexError::UnsupportedVersion {
+            found: document.get("version").cloned(),
+        });
+    }
+    let Some(entries) = document.get("dogs").and_then(Value::as_array) else {
+        return Err(IndexError::MissingDogsArray);
     };
 
     let mut dogs = Vec::with_capacity(entries.len());
     let mut skipped = 0;
     let mut sanitised = 0;
-    for entry in &entries {
+    for entry in entries {
         // Per entry, not per field: an entry with three hostile strings is
         // one row to go and look at, not three.
         let mut entry_sanitised = false;
@@ -473,10 +544,25 @@ mod tests {
     /// would have to escape it — serde_json refuses an unescaped control
     /// character inside a string, so a hand-formatted fixture would fail to
     /// parse for the wrong reason.
+    /// Wraps `entries` in the real document shape: `{"$schema": ...,
+    /// "version": 1, "dogs": [...]}`. Every fixture below a real index
+    /// document builds through this, never a bare
+    /// `serde_json::Value::Array` -- that shape is what
+    /// [`the_old_bare_array_format_is_refused`] proves `parse_index`
+    /// refuses now.
+    fn wrap_index(entries: Vec<Value>) -> String {
+        serde_json::json!({
+            "$schema": "https://shep.turtlesocks.dev/dogs.schema.json",
+            "version": SUPPORTED_INDEX_VERSION,
+            "dogs": entries,
+        })
+        .to_string()
+    }
+
     fn one_entry_with(field: &str, value: &str) -> String {
         let mut entry = valid_entry();
         entry[field] = serde_json::Value::String(value.to_string());
-        serde_json::Value::Array(vec![entry]).to_string()
+        wrap_index(vec![entry])
     }
 
     fn one_entry_with_description(description: &str) -> String {
@@ -516,7 +602,10 @@ mod tests {
     /// Three entries, the middle one missing `adopt_as` — the field whose
     /// absence is silent everywhere else, since a dog adopted under the
     /// wrong name loses its whole config section without saying so.
-    const THREE_ENTRIES_MIDDLE_BROKEN: &[u8] = br#"[
+    const THREE_ENTRIES_MIDDLE_BROKEN: &[u8] = br#"{
+      "$schema": "https://shep.turtlesocks.dev/dogs.schema.json",
+      "version": 1,
+      "dogs": [
       {
         "name": "Spot",
         "package": "shep-log-rotate",
@@ -546,7 +635,7 @@ mod tests {
         "category": "health",
         "source": { "kind": "go-install", "module": "github.com/example/shep-watchdog" }
       }
-    ]"#;
+    ]}"#;
 
     #[test]
     fn a_sanitised_entry_still_lists_and_is_counted() {
@@ -583,14 +672,77 @@ mod tests {
         assert_eq!(index.skipped, 1);
     }
 
+    /// fails if `shep` 0.1.0's own index shape -- a bare top-level array,
+    /// no wrapper at all -- is still silently accepted. This is the
+    /// breaking change the wrapper introduces, proven directly rather than
+    /// assumed: a published index in the new shape must not also be
+    /// readable as the old one, or a version-skew bug here would go
+    /// unnoticed until an actual 0.1.0 install hit it.
     #[test]
-    fn a_document_that_is_not_an_array_is_an_error_not_an_empty_list() {
-        assert!(parse_index(b"{}").is_err());
+    fn the_old_bare_array_format_is_refused() {
+        let bare = serde_json::Value::Array(vec![valid_entry()]).to_string();
+        assert!(
+            matches!(parse_index(bare.as_bytes()), Err(IndexError::NotAnObject)),
+            "a bare array must be refused now, not silently accepted"
+        );
+    }
+
+    /// fails if a well-formed object with no `version` field at all reads
+    /// as malformed rather than as an unsupported (in this case: entirely
+    /// unspecified) version -- the two are different refusals with
+    /// different operator actions, and conflating them would send someone
+    /// hunting for a JSON syntax error that is not there.
+    #[test]
+    fn an_object_with_no_version_is_unsupported_not_malformed() {
+        let err = parse_index(b"{}").expect_err("no version field");
+        assert!(
+            matches!(err, IndexError::UnsupportedVersion { found: None }),
+            "{err:?}"
+        );
+        assert!(
+            err.to_string().contains("unspecified"),
+            "the message must say no version was given: {err}"
+        );
+    }
+
+    /// fails if a `version` this build does not recognise reaches the
+    /// operator as a parse error instead of a named refusal that says to
+    /// upgrade -- the entire reason the field exists rather than being
+    /// decoration. `99` is never going to be a real version this file
+    /// assigns.
+    ///
+    /// Mutation check: hardcoding `parse_index`'s version check to `true`
+    /// (accepting anything) reddens this -- `dogs: []` would otherwise
+    /// parse to an empty, successful index instead of refusing.
+    #[test]
+    fn a_version_this_build_does_not_understand_is_refused_with_an_upgrade_message() {
+        let document = serde_json::json!({ "version": 99, "dogs": [] }).to_string();
+        let err = parse_index(document.as_bytes()).expect_err("unsupported version");
+        let IndexError::UnsupportedVersion { found } = &err else {
+            panic!("wrong variant: {err:?}");
+        };
+        assert_eq!(found.as_ref().and_then(serde_json::Value::as_u64), Some(99));
+        let message = err.to_string();
+        assert!(message.contains("99"), "{message}");
+        assert!(message.contains("upgrade"), "{message}");
+    }
+
+    /// fails if a document naming a supported version but no `dogs` field
+    /// at all is read as an empty index instead of refused -- an operator
+    /// whose self-hosted index dropped the field entirely by accident
+    /// needs to hear about it, not see a silently empty listing.
+    #[test]
+    fn a_supported_version_with_no_dogs_field_is_refused() {
+        let document = serde_json::json!({ "version": SUPPORTED_INDEX_VERSION }).to_string();
+        assert!(matches!(
+            parse_index(document.as_bytes()),
+            Err(IndexError::MissingDogsArray)
+        ));
     }
 
     #[test]
-    fn an_empty_array_is_a_valid_empty_index() {
-        let index = parse_index(b"[]").expect("parses");
+    fn an_empty_dogs_array_is_a_valid_empty_index() {
+        let index = parse_index(wrap_index(vec![]).as_bytes()).expect("parses");
         assert!(index.dogs.is_empty());
         assert_eq!(index.skipped, 0);
     }
@@ -611,7 +763,7 @@ mod tests {
         let mut entry = valid_entry();
         entry["name"] = serde_json::Value::String("Spot\u{1b}".to_string());
         entry["description"] = serde_json::Value::String("[2J and the screen is gone".to_string());
-        let document = serde_json::Value::Array(vec![entry]).to_string();
+        let document = wrap_index(vec![entry]);
 
         let index = parse_index(document.as_bytes()).expect("parses");
         assert_eq!(index.dogs.len(), 1);
@@ -656,7 +808,7 @@ mod tests {
         let mut entry = valid_entry();
         entry["description"] = serde_json::Value::String("hostile\u{1b}[2J".to_string());
         entry["category"] = serde_json::Value::String("logz".to_string());
-        let document = serde_json::Value::Array(vec![entry]).to_string();
+        let document = wrap_index(vec![entry]);
 
         let index = parse_index(document.as_bytes()).expect("parses");
         assert_eq!(index.skipped, 1);
@@ -674,7 +826,7 @@ mod tests {
         broken["name"] = serde_json::json!(42);
         let mut other = valid_entry();
         other["package"] = serde_json::Value::String("shep-watchdog".to_string());
-        let document = serde_json::Value::Array(vec![broken, other]).to_string();
+        let document = wrap_index(vec![broken, other]);
 
         let index = parse_index(document.as_bytes()).expect("parses");
         assert_eq!(index.dogs.len(), 1);
@@ -689,7 +841,7 @@ mod tests {
     fn a_cargo_source_parses_and_carries_no_fields_of_its_own() {
         let mut entry = valid_entry();
         entry["source"] = serde_json::json!({ "kind": "cargo" });
-        let document = serde_json::Value::Array(vec![entry]).to_string();
+        let document = wrap_index(vec![entry]);
 
         let index = parse_index(document.as_bytes()).expect("parses");
         assert_eq!(index.skipped, 0);
@@ -704,7 +856,7 @@ mod tests {
     fn a_non_https_cargo_git_source_url_is_skipped() {
         let mut entry = valid_entry();
         entry["source"] = serde_json::json!({ "kind": "cargo-git", "url": "http://example.com/x" });
-        let document = serde_json::Value::Array(vec![entry]).to_string();
+        let document = wrap_index(vec![entry]);
 
         let index = parse_index(document.as_bytes()).expect("parses");
         assert_eq!(index.dogs.len(), 0);
@@ -719,7 +871,7 @@ mod tests {
         let mut entry = valid_entry();
         entry["source"] =
             serde_json::json!({ "kind": "curl-bash", "url": "https://example.com/x" });
-        let document = serde_json::Value::Array(vec![entry]).to_string();
+        let document = wrap_index(vec![entry]);
 
         assert_eq!(parse_index(document.as_bytes()).expect("parses").skipped, 1);
     }
@@ -753,7 +905,7 @@ mod tests {
     fn a_cargo_source_keeps_the_version_it_names() {
         let mut entry = valid_entry();
         entry["source"] = serde_json::json!({ "kind": "cargo", "version": "0.1.0-alpha.1" });
-        let document = serde_json::Value::Array(vec![entry]).to_string();
+        let document = wrap_index(vec![entry]);
 
         let index = parse_index(document.as_bytes()).expect("parses");
         assert_eq!(
@@ -772,7 +924,7 @@ mod tests {
     fn a_cargo_source_with_an_empty_version_is_skipped() {
         let mut entry = valid_entry();
         entry["source"] = serde_json::json!({ "kind": "cargo", "version": "" });
-        let document = serde_json::Value::Array(vec![entry]).to_string();
+        let document = wrap_index(vec![entry]);
 
         let index = parse_index(document.as_bytes()).expect("parses");
         assert_eq!(index.dogs.len(), 0);
@@ -792,7 +944,7 @@ mod tests {
         for (kind, source) in SOURCE_KINDS {
             let mut entry = valid_entry();
             entry["source"] = serde_json::from_str(source).expect("fixture is JSON");
-            let document = serde_json::Value::Array(vec![entry]).to_string();
+            let document = wrap_index(vec![entry]);
 
             let index = parse_index(document.as_bytes()).expect("parses");
             assert_eq!(
@@ -874,6 +1026,54 @@ mod tests {
             site,
             CATEGORIES.to_vec(),
             "web/src/data/dogs.ts and dog_index.rs disagree about the categories"
+        );
+    }
+
+    /// fails if the checked-in editor schema (`web/public/dogs.schema.json`)
+    /// drifts from either list this file itself enforces -- the docs
+    /// trigger's own "$schema pointing at a 404 is worse than none" applies
+    /// just as much to "$schema pointing at a schema that lies". This is
+    /// the same drift-guard shape as the two tests above, aimed at the
+    /// schema instead of the docs site's `dogs.ts`, and reading real JSON
+    /// with `serde_json` rather than splitting text, since the schema (and
+    /// only the schema, of these three files) actually is JSON.
+    ///
+    /// Mutation check: deleting the `"cargo"` variant from the schema's
+    /// `source.oneOf` (its real, once-shipped bug -- caught by hand while
+    /// writing this test, not by the test itself, which is exactly the
+    /// gap this closes) reddens the source-kinds half of this assertion.
+    #[test]
+    fn the_schema_agrees_with_the_categories_and_source_kinds() {
+        const SCHEMA: &str = include_str!("../../../web/public/dogs.schema.json");
+        let schema: Value = serde_json::from_str(SCHEMA).expect("dogs.schema.json is valid json");
+        let entry_schema = &schema["properties"]["dogs"]["items"];
+
+        let schema_categories: Vec<&str> = entry_schema["properties"]["category"]["enum"]
+            .as_array()
+            .expect("category.enum is an array")
+            .iter()
+            .map(|v| v.as_str().expect("each category is a string"))
+            .collect();
+        assert_eq!(
+            schema_categories,
+            CATEGORIES.to_vec(),
+            "dogs.schema.json and dog_index.rs disagree about the categories"
+        );
+
+        let schema_kinds: Vec<&str> = entry_schema["properties"]["source"]["oneOf"]
+            .as_array()
+            .expect("source.oneOf is an array")
+            .iter()
+            .map(|variant| {
+                variant["properties"]["kind"]["const"]
+                    .as_str()
+                    .expect("each source variant names a const kind")
+            })
+            .collect();
+        let ours: Vec<&str> = SOURCE_KINDS.iter().map(|(kind, _)| *kind).collect();
+        assert_eq!(
+            schema_kinds, ours,
+            "dogs.schema.json and dog_index.rs disagree about the source kinds"
         );
     }
 

--- a/crates/shep-cli/src/dog_index.rs
+++ b/crates/shep-cli/src/dog_index.rs
@@ -355,6 +355,21 @@ fn require_secure_url(url: &str, target: &fetch::Target) -> Result<(), IndexErro
     }
 }
 
+/// Whether `version` spells [`SUPPORTED_INDEX_VERSION`], as either a JSON
+/// integer or a JSON float.
+///
+/// JSON itself draws no line between `1` and `1.0` -- both are the number
+/// one -- so `serde_json::Value::as_u64` alone is too narrow a check: it
+/// returns `None` for a number the parser represented as a float, which
+/// `1.0` (written with a decimal point, however the index was generated)
+/// always is. Refusing that spelling would tell an operator to "upgrade
+/// shep to read it" ([`IndexError::UnsupportedVersion`]'s own message)
+/// for an index this build already understands perfectly.
+fn version_is_supported(version: &Value) -> bool {
+    version.as_u64() == Some(SUPPORTED_INDEX_VERSION)
+        || version.as_f64() == Some(SUPPORTED_INDEX_VERSION as f64)
+}
+
 /// Parses `bytes` as a community dog index, validating and sanitising every
 /// entry.
 ///
@@ -380,8 +395,7 @@ pub fn parse_index(bytes: &[u8]) -> Result<Index, IndexError> {
     let Value::Object(document) = document else {
         return Err(IndexError::NotAnObject);
     };
-    let version = document.get("version").and_then(Value::as_u64);
-    if version != Some(SUPPORTED_INDEX_VERSION) {
+    if !document.get("version").is_some_and(version_is_supported) {
         return Err(IndexError::UnsupportedVersion {
             found: document.get("version").cloned(),
         });
@@ -725,6 +739,26 @@ mod tests {
         let message = err.to_string();
         assert!(message.contains("99"), "{message}");
         assert!(message.contains("upgrade"), "{message}");
+    }
+
+    /// fails if `"version": 1.0` (a decimal-point spelling of the same
+    /// number `SUPPORTED_INDEX_VERSION` names) is refused as unsupported.
+    /// JSON does not distinguish `1` from `1.0` -- both are the number
+    /// one -- so a hand-written or differently-serialised index spelling
+    /// it this way is not a version this build fails to understand; it is
+    /// the same version. Refusing it would send an operator to "upgrade
+    /// shep" (the exact message [`IndexError::UnsupportedVersion`]
+    /// carries) for a document this build already reads correctly.
+    ///
+    /// Mutation check: reverting `version_is_supported` to a bare
+    /// `Value::as_u64` comparison reddens this.
+    #[test]
+    fn a_version_spelled_with_a_decimal_point_is_still_supported() {
+        let as_decimal = SUPPORTED_INDEX_VERSION as f64;
+        let document = serde_json::json!({ "version": as_decimal, "dogs": [] }).to_string();
+        let index = parse_index(document.as_bytes())
+            .expect("a decimal-point spelling is the same number as SUPPORTED_INDEX_VERSION");
+        assert!(index.dogs.is_empty());
     }
 
     /// fails if a document naming a supported version but no `dogs` field

--- a/crates/shep-cli/src/dog_index.rs
+++ b/crates/shep-cli/src/dog_index.rs
@@ -529,9 +529,48 @@ fn is_https(url: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
+    use std::path::{Path, PathBuf};
+
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
     use super::*;
+
+    /// `web/`, three directories above this file, only when it actually
+    /// exists.
+    ///
+    /// It exists inside the shep workspace checkout and nowhere else:
+    /// `crates/shep-cli` has no package `include` rule (deliberately -- see
+    /// [`read_workspace_web_file`]), so once this crate is extracted on its
+    /// own -- crates.io, a vendored copy, `cargo package`'s own
+    /// verification -- `web/` is simply absent. The three drift guards
+    /// below need to tell those two situations apart before they can read
+    /// anything, which is a question only a runtime check can answer:
+    /// `include_str!` resolves at compile time regardless of which branch
+    /// a test reaches, so it could not tell them apart, and every one of
+    /// those downstream `cargo test` runs failed to compile before this
+    /// existed.
+    fn workspace_web_dir() -> Option<PathBuf> {
+        let dir = Path::new(concat!(env!("CARGO_MANIFEST_DIR"), "/../../web"));
+        dir.is_dir().then(|| dir.to_path_buf())
+    }
+
+    /// Reads `web/{relative}`, or `None` outside the workspace checkout
+    /// (see [`workspace_web_dir`]).
+    ///
+    /// `web/` present but `relative` missing is not that case -- it is real
+    /// drift inside the checkout the guard exists to catch -- and panics
+    /// exactly as loudly as the `include_str!` this replaces would have.
+    ///
+    /// # Panics
+    /// Inside the workspace, if `relative` cannot be read.
+    fn read_workspace_web_file(relative: &str) -> Option<String> {
+        let dir = workspace_web_dir()?;
+        Some(
+            std::fs::read_to_string(dir.join(relative)).unwrap_or_else(|err| {
+                panic!("web/{relative} exists in the workspace but could not be read: {err}")
+            }),
+        )
+    }
 
     /// The live index's own single entry, verbatim from
     /// `web/public/dogs.json` — a shape a real contributor's pull request
@@ -995,16 +1034,21 @@ mod tests {
     /// breaks. `cargo` was missing here for the whole of the index's first
     /// life, so every published dog would have been advertised with a git
     /// install; that gap is what this pins shut.
+    ///
+    /// Skips outside the workspace checkout -- see
+    /// [`read_workspace_web_file`].
     #[test]
     fn the_source_kinds_match_the_docs_site_list() {
-        const DOGS_TS: &str = include_str!("../../../web/src/data/dogs.ts");
+        let Some(dogs_ts) = read_workspace_web_file("src/data/dogs.ts") else {
+            return;
+        };
 
         // Past the `=` before splitting on quotes: the declaration reads
         // `const SOURCE_KINDS: readonly DogSource["kind"][] = [...]`, and
         // that `"kind"` in the type sits before the array. The category
         // test needs no such step because its declaration carries no
         // quotes ahead of its own `=`.
-        let after = DOGS_TS
+        let after = dogs_ts
             .split_once("const SOURCE_KINDS")
             .expect("web/src/data/dogs.ts declares SOURCE_KINDS")
             .1
@@ -1033,10 +1077,9 @@ mod tests {
     /// `shep dogs --available` that reads it -- counted only as an
     /// anonymous `1 entry skipped`.
     ///
-    /// `include_str!` rather than a runtime read, deliberately: a missing
-    /// file is then a compile error instead of a test that quietly passes
-    /// having checked nothing. It is inside `#[cfg(test)]`, so a packaged
-    /// crate without `web/` still builds.
+    /// Reads `web/src/data/dogs.ts` at runtime rather than with
+    /// `include_str!`, and skips outside the workspace checkout -- see
+    /// [`read_workspace_web_file`].
     ///
     /// Only the runtime array is read here. The `DogCategory` union above
     /// it in the same file cannot drift on its own -- the array is typed
@@ -1044,9 +1087,11 @@ mod tests {
     /// if they disagree.
     #[test]
     fn the_categories_match_the_docs_site_list() {
-        const DOGS_TS: &str = include_str!("../../../web/src/data/dogs.ts");
+        let Some(dogs_ts) = read_workspace_web_file("src/data/dogs.ts") else {
+            return;
+        };
 
-        let after = DOGS_TS
+        let after = dogs_ts
             .split_once("export const CATEGORIES")
             .expect("web/src/data/dogs.ts declares CATEGORIES")
             .1;
@@ -1076,10 +1121,15 @@ mod tests {
     /// `source.oneOf` (its real, once-shipped bug -- caught by hand while
     /// writing this test, not by the test itself, which is exactly the
     /// gap this closes) reddens the source-kinds half of this assertion.
+    ///
+    /// Skips outside the workspace checkout -- see
+    /// [`read_workspace_web_file`].
     #[test]
     fn the_schema_agrees_with_the_categories_and_source_kinds() {
-        const SCHEMA: &str = include_str!("../../../web/public/dogs.schema.json");
-        let schema: Value = serde_json::from_str(SCHEMA).expect("dogs.schema.json is valid json");
+        let Some(schema) = read_workspace_web_file("public/dogs.schema.json") else {
+            return;
+        };
+        let schema: Value = serde_json::from_str(&schema).expect("dogs.schema.json is valid json");
         let entry_schema = &schema["properties"]["dogs"]["items"];
 
         let schema_categories: Vec<&str> = entry_schema["properties"]["category"]["enum"]

--- a/crates/shep-cli/tests/cli_e2e.rs
+++ b/crates/shep-cli/tests/cli_e2e.rs
@@ -1215,35 +1215,45 @@ fn serve_dog_index(body: &str) -> String {
 /// add, and the whole reason `dog_index::sanitise` exists. Both are valid
 /// entries -- neither is dropped, so `skipped` stays zero and this fixture
 /// alone cannot exercise that count.
+///
+/// Wrapped in the `{"$schema": ..., "version": 1, "dogs": [...]}` object
+/// the real `dogs.json` carries -- a bare array here is exactly the shape
+/// `the_old_bare_array_format_is_refused` (`dog_index.rs`'s own unit
+/// tests) proves `parse_index` now refuses, and this fixture has to stay
+/// on the accepted side of that line to test anything else.
 fn two_entry_index_json() -> String {
-    serde_json::json!([
-        {
-            "name": "Spot",
-            "package": "shep-log-rotate",
-            "adopt_as": "log-rotate",
-            "description": "Rotates grown log files and asks the shepherd to reopen them.",
-            "repo": "https://github.com/TurtIeSocks/shep-log-rotate",
-            "license": "MIT OR Apache-2.0",
-            "category": "logs",
-            "source": {
-                "kind": "cargo-git",
-                "url": "https://github.com/TurtIeSocks/shep-log-rotate"
+    serde_json::json!({
+        "$schema": "https://shep.turtlesocks.dev/dogs.schema.json",
+        "version": 1,
+        "dogs": [
+            {
+                "name": "Spot",
+                "package": "shep-log-rotate",
+                "adopt_as": "log-rotate",
+                "description": "Rotates grown log files and asks the shepherd to reopen them.",
+                "repo": "https://github.com/TurtIeSocks/shep-log-rotate",
+                "license": "MIT OR Apache-2.0",
+                "category": "logs",
+                "source": {
+                    "kind": "cargo-git",
+                    "url": "https://github.com/TurtIeSocks/shep-log-rotate"
+                }
+            },
+            {
+                "name": "Rex",
+                "package": "shep-watchdog",
+                "adopt_as": "watchdog",
+                "description": "Barks when a sheep stops answering.\u{1b}[2J",
+                "repo": "https://github.com/example/shep-watchdog",
+                "license": "Apache-2.0",
+                "category": "health",
+                "source": {
+                    "kind": "go-install",
+                    "module": "github.com/example/shep-watchdog"
+                }
             }
-        },
-        {
-            "name": "Rex",
-            "package": "shep-watchdog",
-            "adopt_as": "watchdog",
-            "description": "Barks when a sheep stops answering.\u{1b}[2J",
-            "repo": "https://github.com/example/shep-watchdog",
-            "license": "Apache-2.0",
-            "category": "health",
-            "source": {
-                "kind": "go-install",
-                "module": "github.com/example/shep-watchdog"
-            }
-        }
-    ])
+        ]
+    })
     .to_string()
 }
 

--- a/docs/specs/deferred.md
+++ b/docs/specs/deferred.md
@@ -1165,3 +1165,46 @@ the restart, and the ordering across a flock. A design that cannot point at
 something `just` plus three lines of shell does not already do should stop
 there.
 
+
+### Rendering each dog's README as its own docs-site page — rejected
+
+Rin proposed this, 2026-08-26, then agreed to drop it once the reasoning
+below was laid out. Recorded so the argument does not have to be re-derived
+the next time it sounds like a nice idea.
+
+**The blocker was never XSS.** A hostile README running script on shep's own
+domain is a real risk, but it is a *solved* one: sanitise the rendered output,
+or render only a restricted Markdown subset, the same way `dog_index.rs`
+already sanitises every string that reaches a terminal out of `dogs.json`.
+That work is known and would not be the hard part.
+
+**The actual blocker is curation, and no sanitiser touches that.** An index
+entry is reviewed exactly once, in a pull request, by a human who read the
+bytes being merged. A README is reviewed never: it lives in the dog's own
+repository, and it can change the moment after that pull request lands, to
+anything its author wants, with nobody at shep looking again. Shipping this
+would turn one reviewed `dogs.json` entry into a standing licence for
+whoever controls that repository to publish arbitrary content on shep's own
+domain, under shep's own styling, forever and unreviewed.
+
+**A disclaimer does not fix it, because the failure mode is trust, not
+confusion.** Nobody who lands on `shep.turtlesocks.dev/dogs/whatever` reads
+it as a stranger's unmoderated page; they read it as shep's docs, reviewed
+the way shep's docs are reviewed. That trust is the entire reason the feature
+would be worth building, and it is exactly what turns a compromised or
+malicious README dangerous later: the page would be believed *because* it is
+on shep's site, not despite it. A footnote saying "we did not review this"
+does not change what a reader actually does once they are on the page.
+
+**The version that would be defensible, if this ever comes back:** fetch
+each README at build time rather than at request time, and pin what was
+fetched — a Flockfile-schema-style lockfile, not a live proxy — so any
+change upstream surfaces as a diff against this repo's own pull request
+history, reviewed exactly like a `dogs.json` entry already is, instead of
+taking effect on shep's site the moment somebody else's repository changes.
+And strip HTML outright rather than trying to sanitise it: a stripped-down
+renderer has no tag left to smuggle an attack through, where a sanitiser
+only ever has to lose once. Fetching at request time gives up the curation
+property completely no matter how good the sanitiser is, because the content
+a reviewer approved and the content actually being served are free to
+diverge starting with the very next upstream commit.

--- a/docs/specs/deferred.md
+++ b/docs/specs/deferred.md
@@ -1173,10 +1173,19 @@ below was laid out. Recorded so the argument does not have to be re-derived
 the next time it sounds like a nice idea.
 
 **The blocker was never XSS.** A hostile README running script on shep's own
-domain is a real risk, but it is a *solved* one: sanitise the rendered output,
-or render only a restricted Markdown subset, the same way `dog_index.rs`
-already sanitises every string that reaches a terminal out of `dogs.json`.
-That work is known and would not be the hard part.
+domain is a real risk, but it is a *solved* one in the general sense: render
+only a restricted Markdown subset, or run the HTML through an established
+sanitiser that strips `<script>`, `javascript:` hrefs, and `on*` attributes.
+
+That is not the same problem `dog_index.rs` already solves, and citing it as
+precedent here would be wrong. `terminal_safe::sanitise` strips control
+characters and invisible formatting characters for a *terminal* — it does
+nothing about a `<script>` tag, a `javascript:` href, or an `onerror`
+attribute, none of which are control characters. Terminal sanitisation and
+HTML sanitisation are different problems, and the first buys nothing for the
+second. The HTML work is still known and would not be the hard part — it is
+just work this repo has not written, not code already sitting in
+`dog_index.rs` waiting to be reused.
 
 **The actual blocker is curation, and no sanitiser touches that.** An index
 entry is reviewed exactly once, in a pull request, by a human who read the

--- a/web/public/dogs.json
+++ b/web/public/dogs.json
@@ -1,14 +1,18 @@
-[
-  {
-    "name": "Bella",
-    "package": "shep-log-rotate",
-    "adopt_as": "log-rotate",
-    "description": "Rotates grown log files and asks the shepherd to reopen them.",
-    "repo": "https://github.com/TurtIeSocks/shep-log-rotate",
-    "license": "MIT OR Apache-2.0",
-    "category": "logs",
-    "source": {
-      "kind": "cargo"
+{
+  "$schema": "https://shep.turtlesocks.dev/dogs.schema.json",
+  "version": 1,
+  "dogs": [
+    {
+      "name": "Bella",
+      "package": "shep-log-rotate",
+      "adopt_as": "log-rotate",
+      "description": "Rotates grown log files and asks the shepherd to reopen them.",
+      "repo": "https://github.com/TurtIeSocks/shep-log-rotate",
+      "license": "MIT OR Apache-2.0",
+      "category": "logs",
+      "source": {
+        "kind": "cargo"
+      }
     }
-  }
-]
+  ]
+}

--- a/web/public/dogs.schema.json
+++ b/web/public/dogs.schema.json
@@ -1,87 +1,114 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "shep community dog index",
-  "description": "Editor-time courtesy schema for web/public/dogs.json. web/src/data/dogs.ts's validate() is the actual gate this mirrors; if the two ever disagree, the validator wins. Point your editor at this file by path, since the data file is a top-level array and cannot carry its own \"$schema\" key.",
-  "type": "array",
-  "items": {
-    "type": "object",
-    "additionalProperties": false,
-    "required": [
-      "name",
-      "package",
-      "adopt_as",
-      "description",
-      "repo",
-      "license",
-      "category",
-      "source"
-    ],
-    "properties": {
-      "name": {
-        "type": "string",
-        "minLength": 1,
-        "description": "The dog's own name, unique (case-insensitively) across the index. Displayed as \"package (Name)\"."
-      },
-      "package": {
-        "type": "string",
-        "minLength": 1,
-        "description": "The crate or repository name; the real identity, also unique across the index."
-      },
-      "adopt_as": {
-        "type": "string",
-        "minLength": 1,
-        "description": "The name this dog expects to be adopted under: shep adopt <adopt_as> <path>."
-      },
-      "description": {
-        "type": "string",
-        "minLength": 1,
-        "description": "One line describing what the dog does."
-      },
-      "repo": {
-        "type": "string",
-        "format": "uri",
-        "pattern": "^https://",
-        "description": "HTTPS URL of the dog's repository, not just a domain or a profile page."
-      },
-      "license": {
-        "type": "string",
-        "minLength": 1,
-        "description": "SPDX license string."
-      },
-      "category": {
-        "type": "string",
-        "enum": ["logs", "metrics", "alerts", "health", "deploy", "other"]
-      },
-      "source": {
-        "oneOf": [
-          {
-            "type": "object",
-            "additionalProperties": false,
-            "required": ["kind", "url"],
-            "properties": {
-              "kind": { "const": "cargo-git" },
-              "url": { "type": "string", "minLength": 1 }
-            }
+  "description": "Editor-time courtesy schema for web/public/dogs.json. web/src/data/dogs.ts's validate() (wrapped by unwrap()) is the actual gate this mirrors; if the two ever disagree, the validator wins. \"version\" pins this document to the wrapper shape shep understands -- see dog_index.rs's own module doc for why a bare array is refused now.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["version", "dogs"],
+  "properties": {
+    "$schema": {
+      "type": "string"
+    },
+    "version": {
+      "const": 1,
+      "description": "The wrapper's own format version, not an entry's. Bump only alongside a shep release that understands the new shape."
+    },
+    "dogs": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "package",
+          "adopt_as",
+          "description",
+          "repo",
+          "license",
+          "category",
+          "source"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "description": "The dog's own name, unique (case-insensitively) across the index. Displayed as \"package (Name)\"."
           },
-          {
-            "type": "object",
-            "additionalProperties": false,
-            "required": ["kind", "module"],
-            "properties": {
-              "kind": { "const": "go-install" },
-              "module": { "type": "string", "minLength": 1 }
-            }
+          "package": {
+            "type": "string",
+            "minLength": 1,
+            "description": "The crate or repository name; the real identity, also unique across the index."
           },
-          {
-            "type": "object",
-            "additionalProperties": false,
-            "required": ["kind", "instructions"],
-            "properties": {
-              "kind": { "const": "manual" },
-              "instructions": { "type": "string", "minLength": 1 }
-            }
+          "adopt_as": {
+            "type": "string",
+            "minLength": 1,
+            "description": "The name this dog expects to be adopted under: shep adopt <path> --name <adopt_as>."
+          },
+          "description": {
+            "type": "string",
+            "minLength": 1,
+            "description": "One line describing what the dog does."
+          },
+          "repo": {
+            "type": "string",
+            "format": "uri",
+            "pattern": "^https://",
+            "description": "HTTPS URL of the dog's repository, not just a domain or a profile page."
+          },
+          "license": {
+            "type": "string",
+            "minLength": 1,
+            "description": "SPDX license string."
+          },
+          "category": {
+            "type": "string",
+            "enum": ["logs", "metrics", "alerts", "health", "deploy", "other"]
+          },
+          "source": {
+            "oneOf": [
+              {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["kind"],
+                "properties": {
+                  "kind": { "const": "cargo" },
+                  "version": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "The exact version to name, for a dog that needs one (a pre-release above all: cargo resolves * to the newest stable, and * never matches a pre-release). Omit for a normal release."
+                  }
+                }
+              },
+              {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["kind", "url"],
+                "properties": {
+                  "kind": { "const": "cargo-git" },
+                  "url": { "type": "string", "minLength": 1 }
+                }
+              },
+              {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["kind", "module"],
+                "properties": {
+                  "kind": { "const": "go-install" },
+                  "module": { "type": "string", "minLength": 1 }
+                }
+              },
+              {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["kind", "instructions"],
+                "properties": {
+                  "kind": { "const": "manual" },
+                  "instructions": { "type": "string", "minLength": 1 }
+                }
+              }
+            ]
           }
-        ]
+        }
       }
     }
   }

--- a/web/scripts/verify-dogs-index.ts
+++ b/web/scripts/verify-dogs-index.ts
@@ -14,7 +14,14 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
-import { validate, dogs, CATEGORIES, REQUIRED_FIELDS } from "../src/data/dogs.ts";
+import {
+  validate,
+  unwrapIndex,
+  dogs,
+  CATEGORIES,
+  REQUIRED_FIELDS,
+  SUPPORTED_INDEX_VERSION,
+} from "../src/data/dogs.ts";
 
 /** A valid entry, cloned and broken per case. */
 function good(): Record<string, unknown> {
@@ -101,8 +108,47 @@ test("no entry carries an em dash or an en dash", () => {
 
 test("the published schema and the validator agree", async () => {
   const schema = JSON.parse(await readFile(new URL("../public/dogs.schema.json", import.meta.url), "utf8"));
-  assert.deepEqual(schema.items.properties.category.enum, [...CATEGORIES]);
-  assert.deepEqual(schema.items.required.sort(), REQUIRED_FIELDS.toSorted());
+  const entrySchema = schema.properties.dogs.items;
+  assert.deepEqual(entrySchema.properties.category.enum, [...CATEGORIES]);
+  assert.deepEqual(entrySchema.required.sort(), REQUIRED_FIELDS.toSorted());
+});
+
+test("the schema and the wrapper version agree", async () => {
+  const schema = JSON.parse(await readFile(new URL("../public/dogs.schema.json", import.meta.url), "utf8"));
+  assert.equal(schema.properties.version.const, SUPPORTED_INDEX_VERSION);
+});
+
+// --- unwrapIndex: the object wrapper around the entries array -----------
+
+test("shep 0.1.0's own bare-array shape is refused, not silently read", () => {
+  assert.throws(() => unwrapIndex([good()]), (err: Error) => {
+    assert.match(err.message, /object/);
+    return true;
+  });
+});
+
+test("a version this build does not understand is refused", () => {
+  assert.throws(
+    () => unwrapIndex({ version: 99, dogs: [good()] }),
+    (err: Error) => {
+      assert.match(err.message, /99/);
+      assert.match(err.message, new RegExp(String(SUPPORTED_INDEX_VERSION)));
+      return true;
+    },
+  );
+});
+
+test("a missing version is refused the same as an unsupported one", () => {
+  assert.throws(() => unwrapIndex({ dogs: [good()] }), /version/);
+});
+
+test("a supported version with no dogs array is refused", () => {
+  assert.throws(() => unwrapIndex({ version: SUPPORTED_INDEX_VERSION }), /dogs/);
+});
+
+test("a wrapped, supported-version document unwraps to its dogs array", () => {
+  const entries = [good()];
+  assert.deepEqual(unwrapIndex({ version: SUPPORTED_INDEX_VERSION, dogs: entries }), entries);
 });
 
 // --- Extra refusal cases, beyond the brief's list. See task-1-report.md for

--- a/web/src/components/docs/CodeBlock.astro
+++ b/web/src/components/docs/CodeBlock.astro
@@ -15,28 +15,90 @@
  *
  * Pass `label` for a filename header bar (like a Flockfile panel) instead
  * of a bare terminal prompt.
+ *
+ * `iconCopy` swaps the default floating text button ("copy"/"copied",
+ * bottom-right of the code body) for an icon-only button inside the label
+ * header itself, right-aligned beside the label text. Opt-in, and needs
+ * `label` to have anywhere to sit — every page on the site keeps today's
+ * floating text button unless it asks for this. community-dogs.astro's
+ * merged install+adopt block is the first user: a header-pinned icon reads
+ * as "copy this whole block" more clearly than a button floating over the
+ * second of two stacked commands.
  */
 interface Props {
   /** Optional filename/header bar, e.g. "Flockfile.toml". Omit for a bare terminal block. */
   label?: string;
+  /** Icon-only copy button in the label header instead of a text button in the body. Needs `label`. */
+  iconCopy?: boolean;
 }
 
-const { label } = Astro.props;
+const { label, iconCopy = false } = Astro.props;
+const headerCopy = Boolean(label) && iconCopy;
 ---
 
 <div class="code-block">
-  {label && <div class="code-block-label">{label}</div>}
+  {
+    label && (
+      <div class="code-block-label">
+        <span>{label}</span>
+        {headerCopy && (
+          <button
+            type="button"
+            class="code-copy-icon press"
+            data-code-copy
+            style="--shadow-offset:2px; --press-offset:1px;"
+            aria-label="Copy command"
+          >
+            <svg
+              data-copy-icon
+              viewBox="0 0 24 24"
+              width="15"
+              height="15"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              aria-hidden="true"
+            >
+              <rect x="8" y="8" width="13" height="13" rx="2" />
+              <path d="M16 8V5a2 2 0 0 0-2-2H5a2 2 0 0 0-2 2v9a2 2 0 0 0 2 2h3" />
+            </svg>
+            <svg
+              data-copied-icon
+              viewBox="0 0 24 24"
+              width="15"
+              height="15"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              aria-hidden="true"
+              style="display:none"
+            >
+              <path d="M20 6 9 17l-5-5" />
+            </svg>
+          </button>
+        )}
+      </div>
+    )
+  }
   <div class="code-block-body">
     <pre class="code-block-pre"><slot /></pre>
-    <button
-      type="button"
-      class="code-copy press"
-      data-code-copy
-      style="--shadow-offset:2px; --press-offset:1px;"
-      aria-label="Copy code"
-    >
-      <span data-copy-label>copy</span>
-    </button>
+    {
+      !headerCopy && (
+        <button
+          type="button"
+          class="code-copy press"
+          data-code-copy
+          style="--shadow-offset:2px; --press-offset:1px;"
+          aria-label="Copy code"
+        >
+          <span data-copy-label>copy</span>
+        </button>
+      )
+    }
   </div>
 </div>
 
@@ -49,8 +111,12 @@ const { label } = Astro.props;
   }
 
   .code-block-label {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
     background: var(--paper-2);
-    padding: 10px 18px;
+    padding: 10px 14px 10px 18px;
     border-bottom: 2px solid var(--hair);
     font-family: "Space Mono", monospace;
     font-size: 12.5px;
@@ -89,6 +155,21 @@ const { label } = Astro.props;
     padding: 5px 10px;
     cursor: pointer;
   }
+
+  .code-copy-icon {
+    flex: none;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: var(--paper);
+    color: var(--ink);
+    border: 2px solid var(--line);
+    border-radius: 8px;
+    width: 26px;
+    height: 26px;
+    padding: 0;
+    cursor: pointer;
+  }
 </style>
 
 <script>
@@ -98,19 +179,28 @@ const { label } = Astro.props;
     .querySelectorAll<HTMLButtonElement>("[data-code-copy]")
     .forEach((button) => {
       const label = button.querySelector<HTMLSpanElement>("[data-copy-label]");
+      const copyIcon = button.querySelector<SVGElement>("[data-copy-icon]");
+      const copiedIcon = button.querySelector<SVGElement>("[data-copied-icon]");
       const pre = button
-        .closest(".code-block-body")
+        .closest(".code-block")
         ?.querySelector<HTMLPreElement>(".code-block-pre");
       let revertTimer: ReturnType<typeof setTimeout> | undefined;
+
+      const setCopied = (copied: boolean) => {
+        if (label) label.textContent = copied ? "copied" : "copy";
+        if (copyIcon) copyIcon.style.display = copied ? "none" : "";
+        if (copiedIcon) copiedIcon.style.display = copied ? "" : "none";
+        if (copyIcon || copiedIcon) {
+          button.setAttribute("aria-label", copied ? "Copied" : "Copy command");
+        }
+      };
 
       button.addEventListener("click", () => {
         const text = pre?.textContent ?? "";
         navigator.clipboard?.writeText(text);
-        if (label) label.textContent = "copied";
+        setCopied(true);
         clearTimeout(revertTimer);
-        revertTimer = setTimeout(() => {
-          if (label) label.textContent = "copy";
-        }, REVERT_DELAY_MS);
+        revertTimer = setTimeout(() => setCopied(false), REVERT_DELAY_MS);
       });
     });
 </script>

--- a/web/src/components/docs/CodeBlock.astro
+++ b/web/src/components/docs/CodeBlock.astro
@@ -195,9 +195,14 @@ const headerCopy = Boolean(label) && iconCopy;
         }
       };
 
-      button.addEventListener("click", () => {
+      button.addEventListener("click", async () => {
         const text = pre?.textContent ?? "";
-        navigator.clipboard?.writeText(text);
+        if (!navigator.clipboard) return;
+        try {
+          await navigator.clipboard.writeText(text);
+        } catch {
+          return;
+        }
         setCopied(true);
         clearTimeout(revertTimer);
         revertTimer = setTimeout(() => setCopied(false), REVERT_DELAY_MS);

--- a/web/src/data/dogs.ts
+++ b/web/src/data/dogs.ts
@@ -4,9 +4,20 @@
  * `web/public/dogs.json` is the single source. It lives in `public/`, not
  * here in `src/data/`, because it has a second consumer this module cannot
  * satisfy: the published site serves it verbatim at `/dogs.json`, a stable
- * URL a future `shep` command could read. Every other data file on this site
- * is a TypeScript module because only the site itself reads it; this one
- * has to be plain JSON so something outside the Astro build can too.
+ * URL `shep dogs --available` reads (`crates/shep-cli/src/dog_index.rs`).
+ * Every other data file on this site is a TypeScript module because only
+ * the site itself reads it; this one has to be plain JSON so something
+ * outside the Astro build can too.
+ *
+ * The file is an object, `{ "$schema": ..., "version": 1, "dogs": [...] }`,
+ * not a bare top-level array of entries -- `unwrapIndex()` below is what
+ * peels that open before `validate()` ever sees an entry, and it is a
+ * breaking change against `shep` 0.1.0, which read the old bare-array shape
+ * and nothing else. `$schema` gives a contributor's editor completion when
+ * they add a row; a bare array could never carry that, or `version` beside
+ * it. `version` is what lets a future, incompatible reshape of the wrapper
+ * announce itself instead of silently parsing wrong -- `dog_index.rs`'s own
+ * module doc has the fuller reasoning, shared by both readers of this file.
  *
  * This module is the gate: it validates that JSON at import time and throws
  * on the first bad entry, which fails `astro build` with the thrown message
@@ -16,6 +27,16 @@
  * type; `validate()` here is the one that actually decides.
  */
 import raw from "../../public/dogs.json" with { type: "json" };
+
+/**
+ * The only wrapper `version` this build's `unwrapIndex()` accepts. Kept in
+ * sync with `crates/shep-cli/src/dog_index.rs`'s own
+ * `SUPPORTED_INDEX_VERSION` by hand -- `the schema and the wrapper version
+ * agree` in `scripts/verify-dogs-index.ts` pins the two together the same
+ * way this file's own category and source-kind lists are pinned against
+ * that crate.
+ */
+export const SUPPORTED_INDEX_VERSION = 1;
 
 /** The six categories a dog can be filed under, in the order the page groups them. */
 export type DogCategory = "logs" | "metrics" | "alerts" | "health" | "deploy" | "other";
@@ -316,5 +337,34 @@ export function validate(raw: unknown): Dog[] {
   return result;
 }
 
+/**
+ * Peels the `{ "$schema": ..., "version": 1, "dogs": [...] }` wrapper open
+ * and hands `validate()` the bare array it has always taken. Kept separate
+ * from `validate()` itself so every existing entry-level test keeps calling
+ * `validate()` with a plain array, unaffected by the wrapper -- the entries
+ * inside `dogs` did not change, so the tests that check them should not
+ * have to.
+ *
+ * @throws {Error} if `raw` is not an object, names an unsupported
+ * `version`, or has no `dogs` array.
+ */
+export function unwrapIndex(raw: unknown): unknown[] {
+  if (!isRecord(raw)) {
+    throw new Error(
+      `dogs.json must be a top-level object with a "dogs" array, not ${Array.isArray(raw) ? "an array" : typeof raw}. ` +
+        `shep 0.1.0's own index was a bare array; that shape is no longer accepted.`,
+    );
+  }
+  if (raw.version !== SUPPORTED_INDEX_VERSION) {
+    throw new Error(
+      `dogs.json is version ${JSON.stringify(raw.version) ?? "unspecified"}, but this build only understands version ${SUPPORTED_INDEX_VERSION}.`,
+    );
+  }
+  if (!Array.isArray(raw.dogs)) {
+    throw new Error(`dogs.json's "dogs" field must be an array, not ${typeof raw.dogs}.`);
+  }
+  return raw.dogs;
+}
+
 /** The validated real index. Throws at import time if `dogs.json` is bad. */
-export const dogs: Dog[] = validate(raw);
+export const dogs: Dog[] = validate(unwrapIndex(raw));

--- a/web/src/pages/docs/community-dogs.astro
+++ b/web/src/pages/docs/community-dogs.astro
@@ -115,13 +115,19 @@ function adoptLine(dog: Dog): string {
                 </a>
               </p>
               {dog.source.kind === "manual" ? (
-                <p>
-                  <strong>Install:</strong> {dog.source.instructions}
-                </p>
+                <>
+                  <p>
+                    <strong>Install:</strong> {dog.source.instructions}
+                  </p>
+                  <CodeBlock label="adopt" iconCopy>
+                    {adoptLine(dog)}
+                  </CodeBlock>
+                </>
               ) : (
-                <CodeBlock label="install">{installLine(dog)}</CodeBlock>
+                <CodeBlock label="install & adopt" iconCopy>
+                  {`${installLine(dog)}\n${adoptLine(dog)}`}
+                </CodeBlock>
               )}
-              <CodeBlock label="adopt">{adoptLine(dog)}</CodeBlock>
             </article>
           ))}
         </section>


### PR DESCRIPTION
- `dogs.json` is now `{"$schema": ..., "version": 1, "dogs": [...]}` instead of a bare array. Breaking change against shep 0.1.0, done knowingly while shep is still hours old. Entries themselves are untouched
- `version` actually refuses now: a version this build doesn't recognize gets an upgrade message, not a parse error
- `dogs.schema.json` reshaped to match, and its `source.oneOf` was missing the `cargo` variant entirely, fixed along the way
- new drift-guard test compares the schema against the same category/source-kind lists `dog_index.rs` already enforces
- community-dogs card: install and adopt merge into one copyable block matching the real two-command sequence, copy button becomes a header icon (opt-in on `CodeBlock`, every other page keeps its plain text button)
- recorded a rejected idea (rendering a dog's README on the docs site) in `deferred.md` so the curation argument against it doesn't get relitigated

Three commits, one per item. Full gate green, `astro check` included (it caught a real prop-typing bug on the icon swap).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for version 1 dog indexes with schema validation.
  * Improved installation and adoption instructions with clearer, copyable commands.
  * Added icon-based copy controls for labeled code blocks.

* **Bug Fixes**
  * Added clearer validation for missing, unsupported, or malformed index data.
  * Prevented legacy unwrapped dog indexes from being accepted.
  * Improved copy-button behavior when clipboard access is unavailable or fails.

* **Documentation**
  * Clarified security considerations for rendering dog README content on the documentation site.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->