### PR TITLE
fix(test): the ping fixture froze the version

### DIFF
--- a/crates/shep-cli/tests/cli_e2e.rs
+++ b/crates/shep-cli/tests/cli_e2e.rs
@@ -1717,6 +1717,19 @@ fn json_format_matches_the_committed_fixtures() {
     );
     ping_envelope["data"]["home"] = serde_json::Value::Null;
     ping_envelope["data"]["socket"] = serde_json::Value::Null;
+    // `daemon_version` belongs with `pid`, `home` and `socket`: assert it is
+    // right, then null it. A fixture that freezes the version turns every
+    // release into a red test. release-plz bumps `[workspace.package]` and
+    // knows nothing about this file, so its release PR failed on exactly this
+    // (v0.1.1, 2026-08-26) and the alpha-to-0.1.0 bump did too. Comparing
+    // against the crate's own version still catches the drift worth catching,
+    // a ping that stops reporting a version or reports the wrong one.
+    assert_eq!(
+        ping_envelope["data"]["daemon_version"].as_str().unwrap(),
+        env!("CARGO_PKG_VERSION"),
+        "ping must report this build's own version"
+    );
+    ping_envelope["data"]["daemon_version"] = serde_json::Value::Null;
     assert_eq!(
         ping_envelope,
         load_fixture("ping"),

--- a/crates/shep-cli/tests/fixtures/ping.json
+++ b/crates/shep-cli/tests/fixtures/ping.json
@@ -3,7 +3,7 @@
   "command": "ping",
   "data": {
     "shepherd": "online",
-    "daemon_version": "0.1.0",
+    "daemon_version": null,
     "pid": null,
     "home": null,
     "socket": null


### PR DESCRIPTION
The ping fixture pinned `daemon_version` as a literal, so any version bump turned `json_format_matches_the_committed_fixtures` red. release-plz edits the manifest and knows nothing about the fixture, so its v0.1.1 release PR failed on ten jobs for a reason unrelated to the release.

- `daemon_version` now gets asserted against `env!("CARGO_PKG_VERSION")` and nulled, the same way `pid`, `home` and `socket` already are
- The fixture stores `null` beside the other three
- A ping that stops reporting a version, or reports the wrong one, still fails

Verified both ways: changing the expected value to `9.9.9` turns it red, and bumping the workspace version to `0.1.99` passes. The second is the exact case that broke the release PR.

The alpha to 0.1.0 bump this morning hit the same wall and I hand-edited the fixture instead of noticing it would happen every time.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated the JSON ping test to verify the reported daemon version matches the application build version.
  * Adjusted test expectations to support cases where the daemon version is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->