### PR TITLE
chore: release v0.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2058,7 +2058,7 @@ dependencies = [
 
 [[package]]
 name = "shep"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anstyle",
  "assert_cmd",
@@ -2095,11 +2095,11 @@ dependencies = [
 
 [[package]]
 name = "shep-cli"
-version = "0.1.0"
+version = "0.1.1"
 
 [[package]]
 name = "shep-client"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "futures-util",
  "nix 0.29.0",
@@ -2112,7 +2112,7 @@ dependencies = [
 
 [[package]]
 name = "shep-core"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "annotate-snippets",
  "anstyle",
@@ -2142,7 +2142,7 @@ dependencies = [
 
 [[package]]
 name = "shep-daemon"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "bytes",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 # 1.88 forced by serde-saphyr (let-chains, stabilized 1.88) — a current dep,
 # not a future one. Also the floor for ratatui/sysinfo/rmcp in later phases.
@@ -26,9 +26,9 @@ license = "MIT OR Apache-2.0"
 # the `[package]` table — so this literal is not sourced from
 # `workspace.package.version` above and a release bump has to touch both
 # places by hand. If that drifts, `cargo-release` is the mechanical fix.
-shep-core = { path = "crates/shep-core", version = "0.1.0" }
-shep-daemon = { path = "crates/shep-daemon", version = "0.1.0" }
-shep-client = { path = "crates/shep-client", version = "0.1.0" }
+shep-core = { path = "crates/shep-core", version = "0.1.1" }
+shep-daemon = { path = "crates/shep-daemon", version = "0.1.1" }
+shep-client = { path = "crates/shep-client", version = "0.1.1" }
 serde = { version = "1", default-features = false, features = ["derive"] }
 serde_json = { version = "1", default-features = false, features = ["std"] }
 toml = { version = "0.8", default-features = false, features = ["parse", "display"] }


### PR DESCRIPTION



## 🤖 New release

* `shep-core`: 0.1.0 -> 0.1.1 (✓ API compatible changes)
* `shep-daemon`: 0.1.0 -> 0.1.1
* `shep-client`: 0.1.0 -> 0.1.1
* `shep`: 0.1.0 -> 0.1.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>






</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the workspace to version 0.1.1.
  * Aligned component versions with the latest workspace release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->