### PR TITLE
fix(release): refuse to publish from a merge commit

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -161,6 +161,39 @@ jobs:
           git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
           git switch --force-create main "$TESTED_SHA"
           git branch --set-upstream-to=origin/main main
+      # release-plz 0.3.160, which is what the action below actually runs,
+      # does not necessarily release the commit it was handed. When the
+      # tested commit is a MERGE commit, `should_release` looks up the
+      # associated pull request, takes that PR's last commit `P`, checks
+      # `git branch --contains P`, and on a hit returns `YesWithCommit(P)`.
+      # `release` then runs a literal `git checkout P` against this working
+      # directory, and `cargo publish` packages from that same directory.
+      # So the tarball on crates.io would be built from `P`, not from the
+      # commit test.yml passed. Anything that landed on main after the
+      # release PR's last push is tested here and absent there.
+      #
+      # A squash or rebase merge does not hit this: the merged commit is
+      # new, the branch is deleted, `git branch --contains` finds nothing,
+      # and release-plz falls back to releasing what is checked out.
+      # release-plz fixed the squash case in its #1775 and #1801; the
+      # merge-commit case looks like the one those left behind.
+      #
+      # `release_always = false` does NOT protect against this. It only
+      # governs the branch where no associated PR is found at all, so
+      # requiring a release PR routes into the exposed path rather than
+      # around it.
+      #
+      # So refuse instead of publishing something nobody tested. One parent
+      # means squash or rebase and is safe; two or more means a merge commit.
+      - name: Refuse to publish from a merge commit
+        env:
+          TESTED_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          parents="$(git rev-list --parents -n 1 "$TESTED_SHA" | wc -w)"
+          if [ "$parents" -gt 2 ]; then
+            echo "::error::$TESTED_SHA is a merge commit, and release-plz 0.3.160 would publish the release PR's head commit instead of this one. Re-merge the release pull request with squash or rebase."
+            exit 1
+          fi
       - run: rustup toolchain install stable --profile minimal
       # Same pin as the job above, for the same reason.
       - uses: release-plz/action@2eb1d8bcb770b4c48ccfaad919734b38b51958c9 # v0.5.131


### PR DESCRIPTION
Squash or rebase this, not a merge commit, or the guard it adds will correctly refuse its own merge.

- `release` refuses when the tested commit is a merge commit, because release-plz would publish a different tree than the one CI ran

0.1.1 already published off #10, so this is not what ships it. That release is also the evidence for this PR. It went out from merge commit `da5e56a`, and all four tags landed on `5f3063d`, the pull request's head commit:

```
shep-client-v0.1.1  -> 5f3063d
shep-core-v0.1.1    -> 5f3063d
shep-daemon-v0.1.1  -> 5f3063d
shep-v0.1.1         -> 5f3063d
```

Nothing was harmed, because that branch already contained main's tip so the two trees were identical. The substitution is real though, and it is not only the tag. release-plz 0.3.160, which is the CLI the pinned action actually runs, does `git checkout P` against the working directory and then packages from it, so the crate uploaded to crates.io is built from the release PR's head rather than the merge commit that passed `test.yml`. Anything merged to main after the release PR's last push gets tested and then silently left out of the upload.

`release_always = false` does not help. It governs only the case where no associated PR is found, so requiring a release PR routes into the bug rather than around it.

Squash and rebase are unaffected: the merged commit is new, the branch is deleted, `git branch --contains` finds nothing, and release-plz releases what is checked out. release-plz fixed that case in #1775 and #1801, and this one looks like the leftover.

CodeRabbit raised it on #10 as tag integrity. The tags were the visible half.
