### PR TITLE
fix(cli): pad table cells by display columns, not character count

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2090,6 +2090,7 @@ dependencies = [
  "toml",
  "toml_edit",
  "tracing-subscriber",
+ "unicode-width",
  "webpki-roots 0.26.11",
 ]
 

--- a/crates/shep-cli/CHANGELOG.md
+++ b/crates/shep-cli/CHANGELOG.md
@@ -30,6 +30,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `shep bleats --no-follow` is no longer fixed at 50 lines. It shares the new
   `--lines` default of 15 and is controllable for the first time.
+- Table columns are padded by the columns a name draws in, not by its
+  character count. A CJK or emoji glyph counts as one character and draws as
+  two, so a name built from them hung over its own column and pushed every
+  column after it out of line. In `shep lookout` such a name could also lose
+  the `…` that says it was cut. The box-drawn table, the plain one and
+  `lookout` now measure the same way.
 
 ### Fixes
 

--- a/crates/shep-cli/Cargo.toml
+++ b/crates/shep-cli/Cargo.toml
@@ -64,6 +64,24 @@ sysinfo.workspace = true
 # than reached through `tokio_rustls::rustls`: rustls does not re-export
 # ring's hmac, and a crate that uses a dependency says so.
 ring = { version = "0.17", default-features = false }
+# How many terminal columns a `char` occupies, for `output::width` (which
+# every table cell is padded by) and `lookout`'s own `fit`. Both used to
+# count `char`s, so a CJK name or a log line built from double-width
+# characters overran its column and pushed every border after it -- see
+# `output/width.rs`'s own doc for the two different width questions this
+# crate asks. Adds ZERO crates to the tree: `ratatui-core` already pulls
+# this exact version in for its own grapheme measurement, and `shep-core`
+# reaches it through `serde-saphyr`'s `annotate-snippets` -- `Cargo.lock`
+# resolves one `unicode-width`, both before and after this change. Declared
+# here rather than left to feature unification with either of them, because
+# a crate that uses a dependency says so.
+#
+# `default-features = false` drops the `cjk` feature, which exists only to
+# provide `width_cjk` -- the East-Asian *Ambiguous* reading, where `▸` and
+# friends measure two columns instead of one. Plain `width` is the right
+# answer for a terminal nobody has told us is CJK-legacy, and it is the
+# reading `lookout::view::flock::mark`'s own doc already assumes.
+unicode-width = { version = "0.2", default-features = false }
 clap = { version = "4", default-features = false, features = ["std", "derive", "help", "usage", "error-context", "suggestions", "env", "wrap_help"] }
 # `default-features = false` is a no-op here — clap_complete's own default
 # feature set is empty — kept for consistency with the workspace rule.

--- a/crates/shep-cli/src/lookout/view/flock.rs
+++ b/crates/shep-cli/src/lookout/view/flock.rs
@@ -17,6 +17,7 @@ use ratatui::style::Style;
 use ratatui::text::{Line, Span};
 
 use super::super::app::{App, Row};
+use crate::output::width::char_columns;
 use crate::output::{exit_cell, human_bytes, human_duration};
 
 /// The narrowest terminal the TABLE will draw into.
@@ -248,40 +249,64 @@ pub fn name_width(width: u16, columns: &[Column]) -> u16 {
         .max(NAME_MIN)
 }
 
-/// `text` in exactly `width` characters: padded on the right, or truncated
-/// with a trailing `…`.
+/// `text` in exactly `width` display columns: padded on the right, or
+/// truncated with a trailing `…`.
 ///
-/// Counted in `char`s, never bytes — `{:<w$}` pads by character count, so a
-/// byte measurement over-pads every multi-byte name. `output::table` records
-/// having made the same choice for the same reason.
+/// Counted in terminal columns, never bytes and never `char`s. Bytes
+/// over-pad every multi-byte name. `char`s under-pad every double-width one:
+/// a CJK name or an emoji counts as one `char` and draws in two columns, so
+/// a row built by `char` count runs past its cell and shoves every column
+/// after it out of line — which for the last column means running off the
+/// end and losing the `…` that says the text was cut. That was this
+/// function's recorded limitation until [`crate::output::width::char_columns`]
+/// existed to fix it in one place; `output::table` pads by the same rule.
 ///
 /// A truncated name that looked whole would be a name an operator types into
 /// `shep stop`, so the ellipsis is not cosmetic.
 ///
-/// **Known limitation: `char`s, not display columns.** A double-width
-/// character (CJK, many emoji) counts as one `char` here but occupies two
-/// columns in the terminal, so a name or a log line built from them can run
-/// past `width` and lose its `…` truncation marker. Confirmed cosmetic, not
-/// a security issue: ratatui's own `Buffer::set_line` clips at the render
-/// area rather than bleeding into a neighbouring pane, and no ESC or CR byte
-/// ever reaches a buffer cell, so a hostile log line has no escape-injection
-/// path through this function. Fixing it means measuring display width
-/// (`unicode-width` or equivalent) instead of `char` count; not done here —
-/// see `docs/specs/deferred.md`'s "Known debt" section.
+/// **Escapes are not discounted here, deliberately** — this is the one place
+/// the two width questions in this crate part company.
+/// [`crate::output::width::visible_width`] skips an ANSI sequence because its
+/// callers write raw bytes to a terminal that will interpret one. Nothing on
+/// this path does: a `Span` hands ratatui text, ratatui draws it, and a log
+/// line carrying `\x1b[32m` puts a literal `32m` on screen occupying three
+/// columns. Measuring it as zero would under-count exactly the cell it was
+/// meant to protect.
+///
+/// The result is exactly `width` columns in **both** branches. A
+/// double-width character that will not fit the last column before the `…`
+/// is dropped and the gap is padded, so a cell never comes out short and the
+/// two-space separators between cells stay where the header put them.
 #[must_use]
 pub fn fit(text: &str, width: u16) -> String {
     let width = usize::from(width);
-    let count = text.chars().count();
-    if count <= width {
+    let columns: usize = text.chars().map(char_columns).sum();
+    if columns <= width {
         let mut out = String::from(text);
-        out.extend(core::iter::repeat_n(' ', width - count));
+        out.extend(core::iter::repeat_n(' ', width - columns));
         return out;
     }
     if width == 0 {
         return String::new();
     }
-    let mut out: String = text.chars().take(width - 1).collect();
+    // One column pays for the `…`; the rest is filled with as much of `text`
+    // as fits whole. A double-width character straddling the boundary is
+    // dropped rather than split — there is no half of it to draw — and the
+    // column it would have used is padded below so the cell still measures
+    // `width`.
+    let budget = width - 1;
+    let mut out = String::new();
+    let mut used = 0;
+    for c in text.chars() {
+        let c_width = char_columns(c);
+        if used + c_width > budget {
+            break;
+        }
+        out.push(c);
+        used += c_width;
+    }
     out.push('…');
+    out.extend(core::iter::repeat_n(' ', budget - used));
     out
 }
 
@@ -523,20 +548,96 @@ mod tests {
     /// `fit(..).chars().count() == width`, which is `width` in *both*
     /// branches under either measurement — so the byte-vs-char mutation
     /// could not redden it. The observable difference lives in the PAD
-    /// branch, where a three-character nine-byte name asks for nine columns
-    /// of padding budget it does not need and comes out short, and at the
-    /// exactly-fits boundary, where a byte count truncates a string that
-    /// already fits.
+    /// branch, where a nine-byte name asks for nine columns of padding
+    /// budget it does not need and comes out short, and at the exactly-fits
+    /// boundary, where a byte count truncates a string that already fits.
     #[test]
-    fn fit_counts_characters_not_bytes_when_it_pads_and_when_it_truncates() {
-        // Pad branch. `日本語` is 3 chars / 9 bytes: char-counted it gets 3
-        // trailing spaces, byte-counted it falls into the truncate branch.
-        assert_eq!(fit("日本語", 6), "日本語   ");
-        // Exactly fits. 7 chars / 11 bytes — a byte count cuts it to
+    fn fit_counts_columns_not_bytes_when_it_pads_and_when_it_truncates() {
+        // Pad branch. `日本語` is 9 bytes and 6 columns: measured properly
+        // it exactly fills a 6-wide cell, byte-counted it falls into the
+        // truncate branch.
+        assert_eq!(fit("日本語", 6), "日本語");
+        // Exactly fits. 7 columns / 11 bytes — a byte count cuts it to
         // `ünïcöd…`.
         assert_eq!(fit("ünïcödé", 7), "ünïcödé");
-        // Truncate branch, pinning which prefix survives.
-        assert_eq!(fit("日本語アプリ", 5), "日本語ア…");
+    }
+
+    /// fails if `fit` goes back to counting `char`s — the bug
+    /// `docs/specs/deferred.md` recorded and this change closes. A `char`
+    /// count gives `日本語` three and lets it into a 3-wide cell it draws
+    /// six columns in, and gives `日本語アプリ` a five-`char` prefix of
+    /// `日本語ア…` that draws nine.
+    ///
+    /// Every case asserts on CONTENT and on measured columns, for the same
+    /// reason the byte test above does: `chars().count()` alone is blind to
+    /// the mutation, and here so is `len()`.
+    #[test]
+    fn a_double_width_name_is_cut_to_the_columns_it_draws_in() {
+        // Truncate branch. Budget is 4 columns plus the `…`: two characters
+        // fit, the third would draw past the cell.
+        assert_eq!(fit("日本語アプリ", 5), "日本…");
+        assert_eq!(columns_of(&fit("日本語アプリ", 5)), 5);
+        // A `char` count would call this a pad — 3 chars into 3 columns —
+        // and emit `日本語`, six columns wide, with no `…` to say it was cut.
+        assert_eq!(fit("日本語", 3), "日…");
+        // The odd-width case the padding exists for: `日` fits the 2-column
+        // budget, `本` does not, and half a character is not drawable — so
+        // the leftover column is a space rather than a short cell.
+        assert_eq!(fit("日本語", 4), "日… ");
+        assert_eq!(columns_of(&fit("日本語", 4)), 4);
+        // Nothing but the marker fits, at either width.
+        assert_eq!(fit("日本語", 1), "…");
+        assert_eq!(fit("日本語", 2), "… ");
+    }
+
+    /// fails if a cell can come out narrower or wider than the width it was
+    /// asked for. Every caller concatenates cells with two-space separators
+    /// and no caller re-measures, so one short cell shifts every column
+    /// after it on that row alone — the drift is invisible in a single
+    /// cell's own test and obvious in a rendered table.
+    #[test]
+    fn every_cell_measures_exactly_the_width_it_was_given() {
+        let names = [
+            "web",
+            "payments-reconciliation-worker",
+            "日本語アプリ",
+            "café",
+            "cafe\u{301}",
+            "羊",
+            "",
+        ];
+        for name in names {
+            for width in 0..=12u16 {
+                let cell = fit(name, width);
+                assert_eq!(
+                    columns_of(&cell),
+                    usize::from(width),
+                    "fit({name:?}, {width}) == {cell:?}"
+                );
+            }
+        }
+    }
+
+    /// An ANSI escape is text here, not styling — see [`fit`]'s own doc. A
+    /// `Span` is not a terminal, so ratatui draws `\x1b[32m` as the literal
+    /// `32m` it is; measuring it as zero (which
+    /// `crate::output::width::visible_width` would, correctly, on its own
+    /// path) would let a hostile log line claim more columns than the cell
+    /// it was cut to fit.
+    #[test]
+    fn an_escape_sequence_is_measured_as_the_text_it_will_be_drawn_as() {
+        let styled = "\u{1b}[32mup";
+        // ESC is zero-width; `[32mup` is six columns.
+        assert_eq!(columns_of(styled), 6);
+        assert_eq!(columns_of(&fit(styled, 4)), 4);
+        assert!(fit(styled, 4).ends_with('…'));
+    }
+
+    /// The columns a rendered cell actually draws in, by the same rule
+    /// [`fit`] pads by. Not `chars().count()`: that is the measurement
+    /// under test.
+    fn columns_of(s: &str) -> usize {
+        s.chars().map(char_columns).sum()
     }
 
     /// fails if the selection marker stops being a plain character. Colour

--- a/crates/shep-cli/src/output/mod.rs
+++ b/crates/shep-cli/src/output/mod.rs
@@ -22,7 +22,11 @@
 pub(crate) mod paint;
 mod rows;
 mod table;
-mod width;
+// `pub(crate)` for `width::char_columns`, which `lookout::view::flock::fit`
+// pads by: one rule for how wide a `char` draws, shared by the two surfaces
+// that pad a cell, rather than a second copy that drifts on the first
+// double-width name. The same reasoning `paint` above is public for.
+pub(crate) mod width;
 
 use std::io;
 

--- a/crates/shep-cli/src/output/table.rs
+++ b/crates/shep-cli/src/output/table.rs
@@ -3,6 +3,7 @@
 //! payload type.
 
 use super::Render;
+use super::width::visible_width;
 
 /// Renders any payload as the padded table, returned rather than printed so
 /// a test can read it. [`emit`](super::emit) calls this for `Format::Table`.
@@ -46,10 +47,10 @@ pub fn render_table<T: Render>(data: &T) -> String {
         );
     }
 
-    let mut widths: Vec<usize> = headers.iter().map(|h| h.chars().count()).collect();
+    let mut widths: Vec<usize> = headers.iter().copied().map(visible_width).collect();
     for row in &rows {
         for (width, cell) in widths.iter_mut().zip(row) {
-            *width = (*width).max(cell.chars().count());
+            *width = (*width).max(visible_width(cell));
         }
     }
 
@@ -64,14 +65,20 @@ pub fn render_table<T: Render>(data: &T) -> String {
 /// Appends one row: every cell but the last padded to its column's width and
 /// followed by two spaces, the last cell unpadded so no line carries
 /// trailing whitespace.
+///
+/// Padded by hand rather than with `{cell:<width$}`, and the difference is
+/// the point: that format spec counts `char`s, so a CJK name gets half the
+/// spaces it needs and every column after it slides left. `boxed_row` below
+/// pads by [`visible_width`] for the same reason — this is the plain
+/// renderer catching up with the boxed one.
 fn write_row<'a>(out: &mut String, cells: impl Iterator<Item = &'a str>, widths: &[usize]) {
     let cells: Vec<&str> = cells.collect();
     let last = cells.len().saturating_sub(1);
     for (i, cell) in cells.into_iter().enumerate() {
-        if i == last {
-            out.push_str(cell);
-        } else {
-            out.push_str(&format!("{cell:<width$}", width = widths[i]));
+        out.push_str(cell);
+        if i != last {
+            let pad = widths[i].saturating_sub(visible_width(cell));
+            out.extend(core::iter::repeat_n(' ', pad));
             out.push_str("  ");
         }
     }
@@ -338,10 +345,10 @@ pub(crate) fn render_boxed_ex(
 fn column_widths(headers: &[&str], rows: &[Vec<String>], keep: &[usize]) -> Vec<usize> {
     keep.iter()
         .map(|&col| {
-            let mut w = crate::output::width::visible_width(headers[col]);
+            let mut w = visible_width(headers[col]);
             for row in rows {
                 if let Some(cell) = row.get(col) {
-                    w = w.max(crate::output::width::visible_width(cell));
+                    w = w.max(visible_width(cell));
                 }
             }
             w
@@ -356,7 +363,7 @@ fn column_widths(headers: &[&str], rows: &[Vec<String>], keep: &[usize]) -> Vec<
 fn boxed_row(cells: &[String], widths: &[usize]) -> String {
     let mut line = String::from("│");
     for (cell, w) in cells.iter().zip(widths) {
-        let pad = w.saturating_sub(crate::output::width::visible_width(cell));
+        let pad = w.saturating_sub(visible_width(cell));
         line.push(' ');
         line.push_str(cell);
         line.push_str(&" ".repeat(pad));
@@ -528,34 +535,60 @@ mod tests {
         assert_eq!(human_bytes(u64::MAX), "16.0E");
     }
 
-    /// "羊" is one character but three bytes in UTF-8. If column width were
-    /// computed with `str::len()` (bytes) instead of char count, a
-    /// six-character CJK name (18 bytes) would produce a far wider NAME
-    /// column than a six-character ASCII name (6 bytes) — even though
-    /// `{:<w$}` pads both to the same *character* width either way.
+    /// "羊" is one character, three bytes in UTF-8, and **two columns** on a
+    /// terminal. All three numbers differ, and only one of them is the width
+    /// of the column it needs.
+    ///
+    /// This test used to assert the middle one — that two names with equal
+    /// *character* counts render to equal-width rows — and that assertion was
+    /// the bug, pinned. A six-character CJK name draws twice as wide as a
+    /// six-character ASCII one, so a table that gives them the same column
+    /// hangs the CJK name over its own border and shoves every column after
+    /// it left. `docs/specs/deferred.md` recorded the same fault in
+    /// `lookout`'s `fit`; both are measured by
+    /// [`crate::output::width::char_columns`] now.
+    ///
+    /// So the property is stated in columns, and on the HEADER line as well
+    /// as the row. The two fixtures differ only in their name, so both lines
+    /// have to widen by exactly what that name draws wider — and only the
+    /// header line proves the *padding* moved, since the row's own NAME cell
+    /// is that name and would widen whatever the column did. Asserting on
+    /// one line alone would leave [`visible_width`] free to return a
+    /// constant.
+    ///
+    /// Not asserted: that a table's lines are all one width. `write_row`
+    /// leaves the last cell unpadded on purpose so no line carries trailing
+    /// whitespace, so they are not, and the boxed renderer's own
+    /// `every_line_of_a_boxed_table_has_the_same_visible_width` is where
+    /// that property belongs.
     #[test]
-    fn column_widths_count_characters_not_bytes() {
-        let ascii_name = "wwwwww".to_string(); // 6 chars, 6 bytes
-        let cjk_name = "羊".repeat(6); // 6 chars, 18 bytes
+    fn column_widths_count_display_columns_not_characters_or_bytes() {
+        let ascii_name = "wwwwww".to_string(); // 6 chars, 6 bytes, 6 columns
+        let cjk_name = "羊".repeat(6); // 6 chars, 18 bytes, 12 columns
         assert_eq!(ascii_name.chars().count(), cjk_name.chars().count());
 
-        let ascii_line = render_table(&FlockRows(vec![info_with_name(&ascii_name)]))
-            .lines()
-            .nth(1)
-            .unwrap()
-            .chars()
-            .count();
-        let cjk_line = render_table(&FlockRows(vec![info_with_name(&cjk_name)]))
-            .lines()
-            .nth(1)
-            .unwrap()
-            .chars()
-            .count();
+        let lines = |name: &str| -> (usize, usize) {
+            let table = render_table(&FlockRows(vec![info_with_name(name)]));
+            let mut lines = table.lines();
+            let header = visible_width(lines.next().expect("a header line"));
+            let row = visible_width(lines.next().expect("a row line"));
+            (header, row)
+        };
+        let (ascii_header, ascii_row) = lines(&ascii_name);
+        let (cjk_header, cjk_row) = lines(&cjk_name);
 
         assert_eq!(
-            ascii_line, cjk_line,
-            "two names with equal character counts must produce equal-width rendered rows, \
-             regardless of how many UTF-8 bytes either one takes"
+            cjk_header - ascii_header,
+            6,
+            "six `羊` draw six columns wider than six `w`, so the NAME column \
+             is padded six wider — a character count makes this 0 and a byte \
+             count makes it 12"
+        );
+        assert_eq!(
+            cjk_row - ascii_row,
+            6,
+            "and the row moves with its own header, or the two disagree about \
+             where the second column starts"
         );
     }
 
@@ -631,7 +664,7 @@ mod tests {
             let lines = table_lines(&out);
             let widths: Vec<usize> = lines
                 .iter()
-                .map(|l| crate::output::width::visible_width(l))
+                .map(|l| visible_width(l))
                 .collect();
             if let Some(&first) = widths.first() {
                 prop_assert!(

--- a/crates/shep-cli/src/output/width.rs
+++ b/crates/shep-cli/src/output/width.rs
@@ -1,5 +1,27 @@
 //! How wide a string looks, as opposed to how long it is.
 
+use unicode_width::UnicodeWidthChar;
+
+/// Columns one `char` occupies on a terminal.
+///
+/// The single rule both width questions in this crate are built on:
+/// [`visible_width`] below sums it over a string with ANSI escapes
+/// discounted, and `lookout::view::flock::fit` sums it over a string with
+/// nothing discounted. They differ in what they skip, never in what a
+/// character is worth, and this function is why.
+///
+/// A control character measures zero. `UnicodeWidthChar::width` returns
+/// `None` for exactly the `Cc` general category -- `U+0000..=U+001F` and
+/// `U+007F..=U+009F`, the same set `char::is_control` names -- and zero is
+/// the honest answer to "how wide is this": a newline starts a new line
+/// instead of advancing one, and a tab expands to a variable number nothing
+/// here can predict. Zero is not "safe to print"; [`sanitize_cell`] below is
+/// what makes it safe, and the two stay separate functions.
+#[must_use]
+pub(crate) fn char_columns(c: char) -> usize {
+    UnicodeWidthChar::width(c).unwrap_or(0)
+}
+
 /// Columns `s` occupies once ANSI escapes are discounted.
 ///
 /// A styled cell is `\x1b[32m(o.o)\x1b[0m`: 14 bytes, 5 columns. Padding it
@@ -8,18 +30,26 @@
 /// Three hand-drawn mockups during this feature's design made exactly this
 /// mistake.
 ///
-/// Counts characters rather than grapheme clusters or east-asian width.
-/// That is a deliberate floor, not an oversight: shep names are operator-
-/// chosen identifiers, the alternative is a `unicode-width` dependency for
-/// a case nobody has hit, and the property test in `table.rs` will catch it
-/// the moment someone does.
+/// Measures display columns, via [`char_columns`], not characters. `羊` is
+/// one `char` and two columns, so a six-character CJK name needs twice the
+/// budget of a six-character ASCII one; counting `char`s gave both six and
+/// pushed every border after the wide cell to the left. That floor was
+/// deliberate while `unicode-width` would have been a new crate for a case
+/// nobody had hit -- it is neither now, since `ratatui-core` already put it
+/// in this tree and `lookout` needs the same rule.
+///
+/// Grapheme clusters are still not what this counts, and that stays a
+/// deliberate floor: a combining mark measures zero and so rides along with
+/// its base character for free, which is the case that matters. What is not
+/// handled is a caller splitting a string *between* a base and its mark,
+/// and no caller here does -- both truncating callers stop on a whole
+/// `char` boundary and a zero-width mark never trips their budget check.
 ///
 /// Control characters (`char::is_control`, which includes `\n` and `\t`)
-/// measure as zero width. Neither occupies a column: a newline starts a new
-/// line instead of advancing one, and a tab expands to a variable number
-/// nothing here can predict. Zero is the honest answer to "how wide is
-/// this", not "safe to print" -- a control character can still split a
-/// table row in two or blow out a terminal's tab stops, which is why
+/// measure as zero width, which [`char_columns`] explains. Zero is the
+/// honest answer to "how wide is this", not "safe to print" -- a control
+/// character can still split a table row in two or blow out a terminal's
+/// tab stops, which is why
 /// [`sanitize_cell`] exists as this function's own sibling below:
 /// `table.rs`'s `render_boxed_ex` runs every cell through it before this
 /// function ever measures one, so by the time `visible_width` sees a cell,
@@ -51,8 +81,8 @@ pub(crate) fn visible_width(s: &str) -> usize {
                     }
                 }
             }
-        } else if !c.is_control() {
-            width += 1;
+        } else {
+            width += char_columns(c);
         }
     }
     width
@@ -156,10 +186,41 @@ mod tests {
 
     /// Non-ASCII names are real: a table that miscounts them misaligns for
     /// the people least able to work around it.
+    ///
+    /// The two halves are two different mistakes. `café` pins that this is
+    /// not a byte count -- 5 bytes, 4 columns. `日本` pins that it is not a
+    /// `char` count either: 2 `char`s, 6 bytes, and **4 columns**, which is
+    /// the reading a terminal actually draws. An earlier version of this
+    /// test asserted `2` here and was the thing keeping the bug pinned.
     #[test]
-    fn non_ascii_text_counts_characters() {
+    fn non_ascii_text_counts_display_columns() {
+        assert_eq!("café".len(), 5, "the raw string really is longer");
         assert_eq!(visible_width("café"), 4);
-        assert_eq!(visible_width("日本"), 2, "counted as chars, not bytes");
+        assert_eq!("日本".chars().count(), 2);
+        assert_eq!(visible_width("日本"), 4, "columns, not chars and not bytes");
+    }
+
+    /// fails if a combining mark is charged for a column of its own. `é`
+    /// spelled as `e` + `U+0301` is two `char`s and one column, and a table
+    /// that pads it by `char` count comes out one short. This is the case
+    /// [`visible_width`]'s doc gives for why grapheme clustering is not
+    /// needed on top of a per-`char` width rule.
+    #[test]
+    fn a_combining_mark_rides_along_with_its_base_character_for_free() {
+        let decomposed = "cafe\u{301}";
+        assert_eq!(decomposed.chars().count(), 5);
+        assert_eq!(visible_width(decomposed), 4);
+        assert_eq!(visible_width(decomposed), visible_width("café"));
+    }
+
+    /// fails if an escape's *parameter* bytes start being measured as the
+    /// wide characters they are not. Belt and braces on the CSI scan: the
+    /// per-`char` rule now returns something other than `1` for some
+    /// characters, so a scan that leaked `38;5;166m` would leak a width that
+    /// no longer even matches its character count.
+    #[test]
+    fn a_wide_character_beside_an_escape_is_measured_and_the_escape_is_not() {
+        assert_eq!(visible_width("\u{1b}[38;5;166m日本\u{1b}[0m"), 4);
     }
 
     /// A `\t` occupies no fixed number of columns -- expansion is a

--- a/docs/specs/deferred.md
+++ b/docs/specs/deferred.md
@@ -348,7 +348,7 @@ one. What would force it: an app class where the sheep is a supervisor that
 does not forward signals to its own workers, which is a real shape and simply
 has not come up here yet.
 
-### `lookout`'s flock table and bleats feed measure `char`s, not display columns
+### `lookout`'s flock table and bleats feed measure `char`s, not display columns -- FIXED, 2026-08-26
 
 [`crates/shep-cli/src/lookout/view/flock.rs`](../../crates/shep-cli/src/lookout/view/flock.rs)'s
 `fit` — the function every truncated line in `shep lookout` goes through —
@@ -371,6 +371,48 @@ width (`unicode-width` or equivalent) instead of `char` count — a new
 dependency this phase's review declined to add for a cosmetic gap. What would
 force it: an operator running `shep lookout` against sheep with CJK names or
 logs, where a missing `…` is confusing rather than theoretical.
+
+**Fixed 2026-08-26, and the dependency argument had expired.** `unicode-width`
+was already in this tree twice over — `ratatui-core` pulls it for its own
+grapheme measurement, and `shep-core` reaches it through `serde-saphyr`'s
+`annotate-snippets` — so naming it directly in `crates/shep-cli/Cargo.toml`
+added **zero crates**. `Cargo.lock` resolves one `unicode-width`, before and
+after.
+
+**Three call sites, not one.** Reading the code to fix `fit` turned up the
+same fault in the other two places shep pads a cell, neither of them recorded
+here:
+
+- `output/width.rs`'s `visible_width`, which every cell of the box-drawn
+  table (`shep style full`, the default) is padded by. Its own doc called the
+  `char` count "a deliberate floor" whose alternative was "a `unicode-width`
+  dependency for a case nobody has hit" — true when written, and the same
+  sentence that stops being true the moment `lookout` needs the crate anyway.
+- `output/table.rs`'s `render_table`, the `shep style plain` renderer, which
+  measured with `chars().count()` and padded with `{cell:<width$}` — a format
+  spec that pads by character count, so measuring alone would not have fixed
+  it.
+
+Fixing one and not the others would have left the same CJK name aligned under
+`full` and crooked under `plain`, which is worse than uniformly wrong. All
+three now share one rule, `output::width::char_columns`, and the two `str`-level
+questions stay separate on purpose: `visible_width` discounts ANSI escapes
+because its callers write raw bytes to a terminal that interprets them, and
+`fit` does not, because ratatui never interprets an escape inside a `Span` —
+a log line carrying `\x1b[32m` draws a literal `32m` and occupies three
+columns. Measuring that as zero would under-count the exact cell the fix was
+for.
+
+`fit` now returns exactly `width` columns in **both** branches. A double-width
+character that will not fit the last column before the `…` is dropped and the
+column padded, because there is no half of it to draw and a short cell shifts
+every column after it on that row alone.
+
+Mutation-checked: restoring the `char` count reddens 6 tests across all three
+surfaces. Grapheme clustering is still not done and is still a deliberate
+floor — a combining mark measures zero and rides along with its base
+character, which is the case that matters, and both truncating callers stop
+on a whole `char` boundary.
 
 ### A `.js` Flockfile has no evaluation timeout
 


### PR DESCRIPTION
Implements the deferred entry "`lookout`'s flock table and bleats feed measure `char`s, not display columns". Longer than my usual because the fix covers three call sites, not the one the entry names.

- `fit` measures terminal columns instead of `chars().count()`. A CJK or emoji glyph is one char and two columns, so a name overran its cell and could lose the `…` that says it was cut
- Same bug in `output::width::visible_width` (the `full` box table) and `output::table::render_table` (the `plain` one), neither recorded in deferred.md. Fixing only `lookout` leaves a name aligned under one style and crooked under the other, so all three share `output::width::char_columns` now
- `unicode-width` adds zero crates. `ratatui-core` and `serde-saphyr` already pull it and the lock diff is one line, so the entry's "declined to add a dependency" reasoning no longer holds
- `fit` returns exactly `width` columns in both branches, so a short cell never shifts the rest of the row
- `visible_width` still discounts ANSI escapes and `fit` deliberately does not: ratatui draws `\x1b[32m` inside a `Span` as a literal `32m`, three columns wide
- Two tests asserted the old behaviour rather than catching it, both rewritten. Mutation-checked: restoring the `char` count reddens 6 tests
- Not done, still a deliberate floor: grapheme clustering. A combining mark measures zero and rides along with its base character

Gate green: fmt, clippy `-D warnings`, `cargo test --workspace --all-features` (825 lib tests), `cargo doc` with `-D warnings`. No `web/` change triggered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected table alignment for CJK characters, emoji, combining marks, and other wide or zero-width characters.
  - Improved truncation to preserve exact terminal widths and retain ellipses.
  - Ensured ANSI escape sequences do not affect visible spacing or column calculations.
  - Applied consistent width handling across tables and `lookout` views.

- **Documentation**
  - Updated the deferred-work documentation and changelog to reflect the Unicode display-width fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->