### PR TITLE
chore: release v0.1.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2058,7 +2058,7 @@ dependencies = [
 
 [[package]]
 name = "shep"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anstyle",
  "assert_cmd",
@@ -2096,11 +2096,11 @@ dependencies = [
 
 [[package]]
 name = "shep-cli"
-version = "0.1.2"
+version = "0.1.3"
 
 [[package]]
 name = "shep-client"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "futures-util",
  "nix 0.29.0",
@@ -2113,7 +2113,7 @@ dependencies = [
 
 [[package]]
 name = "shep-core"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "annotate-snippets",
  "anstyle",
@@ -2143,7 +2143,7 @@ dependencies = [
 
 [[package]]
 name = "shep-daemon"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "bytes",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.2"
+version = "0.1.3"
 edition = "2024"
 # 1.88 forced by serde-saphyr (let-chains, stabilized 1.88) — a current dep,
 # not a future one. Also the floor for ratatui/sysinfo/rmcp in later phases.
@@ -26,9 +26,9 @@ license = "MIT OR Apache-2.0"
 # the `[package]` table — so this literal is not sourced from
 # `workspace.package.version` above and a release bump has to touch both
 # places by hand. If that drifts, `cargo-release` is the mechanical fix.
-shep-core = { path = "crates/shep-core", version = "0.1.2" }
-shep-daemon = { path = "crates/shep-daemon", version = "0.1.2" }
-shep-client = { path = "crates/shep-client", version = "0.1.2" }
+shep-core = { path = "crates/shep-core", version = "0.1.3" }
+shep-daemon = { path = "crates/shep-daemon", version = "0.1.3" }
+shep-client = { path = "crates/shep-client", version = "0.1.3" }
 serde = { version = "1", default-features = false, features = ["derive"] }
 serde_json = { version = "1", default-features = false, features = ["std"] }
 toml = { version = "0.8", default-features = false, features = ["parse", "display"] }


### PR DESCRIPTION



## 🤖 New release

* `shep-core`: 0.1.2 -> 0.1.3 (✓ API compatible changes)
* `shep-daemon`: 0.1.2 -> 0.1.3 (✓ API compatible changes)
* `shep-client`: 0.1.2 -> 0.1.3
* `shep`: 0.1.2 -> 0.1.3 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>






</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the package and workspace component versions to 0.1.3.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->