### PR TITLE
Stop shep start from ignoring a Flockfile edit, or half-registering a flock

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -158,7 +158,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: rustup toolchain install stable --profile minimal
-      - run: 'cargo test --workspace --locked --all-features -- --test-threads=1 ::slow:: two_concurrent_boots'
+      - run: 'cargo test --workspace --locked --all-features -- --test-threads=1 ::slow:: two_concurrent_boots signal_ignored_then_kill_tree_reaps'
   # `cargo llvm-cov` on its own runs `cargo test --tests`, and `--tests` does
   # not build a package's examples. `daemon_e2e`'s two reload tests exec
   # `examples/reuse_port_sheep`, the SO_REUSEPORT fixture the whole reload

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,21 +60,21 @@ jobs:
       - uses: actions/checkout@v4
       - run: rustup toolchain install ${{ matrix.toolchain }} --profile minimal
       # `--all-features` mirrors the task gate, as in `lint` above.
-      - run: 'cargo +${{ matrix.toolchain }} test --workspace --locked --all-features -- --skip ::slow:: --skip two_concurrent_boots'
+      - run: 'cargo +${{ matrix.toolchain }} test --workspace --locked --all-features -- --skip ::slow:: --skip two_concurrent_boots --skip signal_ignored_then_kill_tree_reaps'
   minimal-versions:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - run: rustup toolchain install nightly stable --profile minimal
       - run: cargo +nightly generate-lockfile -Z minimal-versions
-      - run: 'cargo +stable test --workspace -- --skip ::slow:: --skip two_concurrent_boots'
+      - run: 'cargo +stable test --workspace -- --skip ::slow:: --skip two_concurrent_boots --skip signal_ignored_then_kill_tree_reaps'
   musl:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - run: rustup toolchain install stable --profile minimal --target x86_64-unknown-linux-musl
       - run: sudo apt-get update && sudo apt-get install -y musl-tools
-      - run: 'cargo test --workspace --locked --target x86_64-unknown-linux-musl -- --skip ::slow:: --skip two_concurrent_boots'
+      - run: 'cargo test --workspace --locked --target x86_64-unknown-linux-musl -- --skip ::slow:: --skip two_concurrent_boots --skip signal_ignored_then_kill_tree_reaps'
   # CLAUDE.md's phase-gate cross-check
   # (`cargo check --workspace --all-targets --all-features --target
   # x86_64-pc-windows-gnu`) had no workflow behind it, so it only ran when a
@@ -114,8 +114,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: rustup toolchain install stable --profile minimal
-      - run: 'cargo test -p shep-daemon --locked --no-default-features -- --skip ::slow:: --skip two_concurrent_boots'
-      - run: 'cargo test --workspace --locked --all-features -- --skip ::slow:: --skip two_concurrent_boots'
+      - run: 'cargo test -p shep-daemon --locked --no-default-features -- --skip ::slow:: --skip two_concurrent_boots --skip signal_ignored_then_kill_tree_reaps'
+      - run: 'cargo test --workspace --locked --all-features -- --skip ::slow:: --skip two_concurrent_boots --skip signal_ignored_then_kill_tree_reaps'
   # Tests that need a quiet machine, run serially in a job of their own.
   #
   # Two groups belong here and neither is a flaky test in the usual sense:
@@ -126,8 +126,14 @@ jobs:
   # neighbour can stretch. `two_concurrent_boots_on_a_stale_socket_exactly_one_wins`
   # races two threads for the same $SHEP_HOME and asserts exactly one wins,
   # which depends on the loser looking after the winner has bound.
+  # `signal_ignored_then_kill_tree_reaps` is the same shape: it gives a shell
+  # 100ms to install `trap "" TERM` before signalling it, then asserts the
+  # process survived, so a runner that cannot schedule that shell inside the
+  # window reports a working trap as a broken one. The test's own comment
+  # names the race. Seen failing once on macos/1.88 while passing five of
+  # five locally at 0.41s each.
   #
-  # Every other job skips both groups so the matrix stays fast and honest.
+  # Every other job skips these groups so the matrix stays fast and honest.
   # This job runs them with `--test-threads=1` so the only load is their own.
   # They are NOT `#[ignore]`d: the tier's own doc says it exists so the full
   # suite covers the real backend, and this project has already found a Linux
@@ -176,7 +182,7 @@ jobs:
       - run: |
           source <(cargo llvm-cov show-env --sh)
           cargo llvm-cov clean --workspace
-          cargo test --workspace --locked -- --skip ::slow:: --skip two_concurrent_boots
+          cargo test --workspace --locked -- --skip ::slow:: --skip two_concurrent_boots --skip signal_ignored_then_kill_tree_reaps
           cargo llvm-cov report --lcov --output-path lcov.info
       - uses: actions/upload-artifact@v4
         with: { name: coverage, path: lcov.info }

--- a/crates/shep-cli/CHANGELOG.md
+++ b/crates/shep-cli/CHANGELOG.md
@@ -15,6 +15,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixes
 
+- Say so when a Flockfile app names a sheep the flock already has under a
+  different config, instead of ignoring the edit in silence. `shep start` on
+  a registered name adds instances rather than reconciling config, so
+  changing an app's `cwd` and re-running `shep start` left it running the old
+  one with nothing printed; the apps then crash-looped against a path that no
+  longer applied and only a `shep delete` plus a fresh start recovered them.
+  `start` now asks the daemon (`Request::ConfigDrift`) before resuming
+  anything and names the sheep and every field that differs, on stderr, so
+  `--format json` piping is unaffected. Reported, never applied: whether
+  `start` should reconcile by default or grow an `--update` flag is a
+  separate decision, and changing a running flock's `cwd` or argv underneath
+  an operator would be a worse surprise than the bug being fixed. Field names
+  only, never values, since `env` carries secrets.
+
 - Table columns are padded by the columns a name draws in, not by its
   character count. A CJK or emoji glyph counts as one character and draws as
   two, so a name built from them hung over its own column and pushed every

--- a/crates/shep-cli/src/commands/lifecycle.rs
+++ b/crates/shep-cli/src/commands/lifecycle.rs
@@ -626,6 +626,57 @@ async fn flock_now(client: &Client) -> Vec<shep_core::protocol::ProcessInfo> {
     }
 }
 
+/// Says so when a Flockfile app the flock already has is registered under a
+/// different config, naming the sheep and the fields that differ.
+///
+/// The defect this exists for: an operator edits `cwd` on two apps, re-runs
+/// `shep start`, and both keep running the old one. `Request::Start` on a
+/// name the flock already has adds instances rather than reconciling config,
+/// which is what `shep stock` depends on, so the edit is simply not applied.
+/// It was also not reported, which is the half being fixed: the edit
+/// vanished without a word and the apps crash-looped against a path that no
+/// longer applied.
+///
+/// Reports rather than applies. Whether `start` should reconcile by default,
+/// or grow an `--update` flag, is Rin's call and neither is taken here; a
+/// running flock changing its cwd or argv underneath an operator would be a
+/// worse surprise than the one being fixed.
+///
+/// Field NAMES only, never values: this reaches an operator's terminal and
+/// `env` carries secrets, so a differing `env` says `env` and stops (IR-41).
+/// [`AppConfig::drifted_fields`] is where that rule is enforced.
+///
+/// Silent on an unreachable daemon, an unexpected answer, or a daemon too
+/// old to know the request, the same call [`flock_now`] makes: failing a
+/// `start` over a warning it could not compute would trade a working command
+/// for a defensive one.
+///
+/// One request for the whole invocation, not one per app.
+async fn report_config_drift(
+    client: &Client,
+    streams: &mut Streams<'_>,
+    resumed: &[(AppConfig, shep_core::protocol::ProcessInfo)],
+) {
+    if resumed.is_empty() {
+        return;
+    }
+    let apps = resumed.iter().map(|(app, _)| app.clone()).collect();
+    let Ok(Response::Drifted(drifted)) = client.request(Request::ConfigDrift { apps }).await else {
+        return;
+    };
+    for drift in drifted {
+        let name = &drift.name;
+        let fields = drift.fields.join(", ");
+        let message = format!(
+            "{name} is registered with a different config ({fields}). `shep start` \
+             adds instances to a sheep the flock already has; it does not apply \
+             config edits, so the edit is not in effect. To apply it: `shep \
+             delete {name}`, then start again."
+        );
+        streams.aside("start", &message);
+    }
+}
+
 /// `shep.toml`'s `[interpreters]` entry for `script`'s own extension, if it
 /// has one and the map names it.
 ///
@@ -816,10 +867,24 @@ async fn start_one(
         Vec::new()
     };
 
-    let apps = match resolve_target(target, args.name.as_deref(), &stdin, args.flockfile) {
+    let mut apps = match resolve_target(target, args.name.as_deref(), &stdin, args.flockfile) {
         Ok(apps) => apps,
         Err(err) => return fail_target(streams, &err),
     };
+
+    if let Some(fold) = &args.fold {
+        for app in &mut apps {
+            app.fold = Some(fold.clone());
+        }
+    }
+    // After the per-app defaults above, so an explicit flag wins over both
+    // the script form's "where you are" default and a Flockfile's own value.
+    if let Some(cwd) = &args.cwd {
+        for app in &mut apps {
+            app.cwd = Some(cwd.clone());
+        }
+    }
+    apply_interpreters(&mut apps, interpreters, args.interpreter.as_deref());
     // The same rule the bare-name lookup above applies, now that the target
     // has become a set of named apps: a name the flock already has is that
     // sheep. Without this, `shep start ./thing` against a running `thing`
@@ -835,11 +900,15 @@ async fn start_one(
     let mut fresh = Vec::new();
     for app in apps {
         match flock.iter().find(|info| info.name == app.name) {
-            Some(existing) => resumed.push(existing.clone()),
+            Some(existing) => resumed.push((app, existing.clone())),
             None => fresh.push(app),
         }
     }
-    for existing in &resumed {
+    // Before the resumes below, not after: an operator who edited the file
+    // and gets a wall of restart output should read why none of it applied
+    // at the top of the run rather than under it.
+    report_config_drift(client, streams, &resumed).await;
+    for (_, existing) in &resumed {
         let code = resume(client, streams, existing, started).await;
         if code != ExitCode::Success {
             return code;
@@ -848,21 +917,7 @@ async fn start_one(
     if fresh.is_empty() {
         return ExitCode::Success;
     }
-    let mut apps = fresh;
-
-    if let Some(fold) = &args.fold {
-        for app in &mut apps {
-            app.fold = Some(fold.clone());
-        }
-    }
-    // After the per-app defaults above, so an explicit flag wins over both
-    // the script form's "where you are" default and a Flockfile's own value.
-    if let Some(cwd) = &args.cwd {
-        for app in &mut apps {
-            app.cwd = Some(cwd.clone());
-        }
-    }
-    apply_interpreters(&mut apps, interpreters, args.interpreter.as_deref());
+    let apps = fresh;
 
     let (procs, failure) = request_each(
         client,

--- a/crates/shep-cli/tests/cli_e2e.rs
+++ b/crates/shep-cli/tests/cli_e2e.rs
@@ -6244,3 +6244,64 @@ fn one_absent_script_refuses_the_whole_flockfile_and_registers_nothing() {
 
     graceful_kill(home);
 }
+
+/// A spawn that fails for a reason no preflight could see still names the
+/// sheep and the path it tried, and the `cwd` it tried it in.
+///
+/// The whole error an operator got was `error[spawn_failed]: the daemon
+/// reported SpawnFailed: process spawn failed: No such file or directory
+/// (os error 2)`. On an eleven-app Flockfile that named neither which app
+/// had failed nor which path had been tried.
+///
+/// A script that EXISTS and cannot be exec'd, deliberately: the batch check
+/// (`one_absent_script_refuses_the_whole_flockfile_and_registers_nothing`)
+/// tests existence only, so this reaches the real `spawn` and its real
+/// `EACCES` rather than being refused before it. That is also the honest
+/// residue of that check: something can always still fail at exec, and this
+/// is what an operator reads when it does.
+#[test]
+fn a_spawn_that_no_check_could_have_caught_still_names_the_sheep_and_the_path() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path();
+    let unrunnable = dir.path().join("unrunnable.sh");
+    std::fs::write(&unrunnable, "#!/bin/sh\nsleep 60\n").unwrap();
+    // Present, so the batch check passes it; no execute bit anywhere, which
+    // even a root-owned run cannot exec.
+    std::fs::set_permissions(&unrunnable, std::fs::Permissions::from_mode(0o644)).unwrap();
+    let flockfile = write_flockfile(
+        &dir,
+        &format!(
+            "[[app]]\nname = \"locked-out\"\nscript = \"{}\"\n",
+            unrunnable.display(),
+        ),
+    );
+    let mut guard = DaemonGuard::default();
+
+    let output = shep(home).arg("start").arg(&flockfile).output().unwrap();
+    guard.adopt_home(home);
+
+    assert_eq!(
+        output.status.code(),
+        Some(7),
+        "the spawn-failed exit code: {output:?}"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("locked-out"),
+        "the error must name the sheep: {stderr}"
+    );
+    assert!(
+        stderr.contains("unrunnable.sh"),
+        "the error must name the script it tried: {stderr}"
+    );
+    // Canonicalized: `start` fills an app's absent `cwd` from the
+    // Flockfile's own directory through `canonicalize`, and on macOS a
+    // tempdir's `/var/...` resolves to `/private/var/...`.
+    let flockfile_dir = std::fs::canonicalize(dir.path()).unwrap();
+    assert!(
+        stderr.contains(&format!("in {}", flockfile_dir.display())),
+        "the error must name the cwd it tried it in: {stderr}"
+    );
+
+    graceful_kill(home);
+}

--- a/crates/shep-cli/tests/cli_e2e.rs
+++ b/crates/shep-cli/tests/cli_e2e.rs
@@ -6156,6 +6156,11 @@ fn a_flockfile_edit_to_a_registered_sheep_is_reported_rather_than_swallowed() {
     // The edit, over the same path the daemon was told about.
     write_flockfile(&dir, &body(elsewhere.path(), "hunter2-after"));
     let again = shep(home).arg("start").arg(&flockfile).output().unwrap();
+    // Drift is a warning, not a failure. Without this the test reads only
+    // stderr, so a change that turned the report into a refusal would keep
+    // it green while breaking every operator script that runs `shep start`
+    // twice.
+    assert_success(&again);
 
     let stderr = String::from_utf8_lossy(&again.stderr);
     assert!(

--- a/crates/shep-cli/tests/cli_e2e.rs
+++ b/crates/shep-cli/tests/cli_e2e.rs
@@ -6173,3 +6173,74 @@ fn a_flockfile_edit_to_a_registered_sheep_is_reported_rather_than_swallowed() {
 
     graceful_kill(home);
 }
+
+/// One app whose script does not exist refuses the whole Flockfile, before
+/// anything is registered, and names every app that failed.
+///
+/// The defect: the third app of eleven pointed at an unbuilt binary. Apps
+/// one and two registered and started, app three failed to spawn, and apps
+/// four through eleven were never reached. The flock matched neither the
+/// file nor its previous state, and only `shep delete all` recovered it.
+///
+/// The empty listing at the end is the assertion that matters and the one
+/// the exit code alone cannot make: `start` reported a failure before this
+/// change too, with `good` left registered and running behind it.
+///
+/// What a broken implementation this catches: the check dropped (`good` is
+/// in the listing); the check run inside the registering loop rather than
+/// before it (`good` is registered before `unbuilt` is reached, same
+/// symptom); the error reporting only the count and not the path (the
+/// `never-built` assertion).
+#[test]
+fn one_absent_script_refuses_the_whole_flockfile_and_registers_nothing() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path();
+    let script = write_test_script(&dir);
+    // `good` FIRST, so a check that runs per app as it registers would have
+    // registered it by the time it reached `unbuilt`.
+    let flockfile = write_flockfile(
+        &dir,
+        &format!(
+            "[[app]]\nname = \"good\"\nscript = \"{}\"\n\n\
+             [[app]]\nname = \"unbuilt\"\nscript = \"{}/never-built\"\n",
+            script.display(),
+            dir.path().display(),
+        ),
+    );
+    let mut guard = DaemonGuard::default();
+
+    let output = shep(home).arg("start").arg(&flockfile).output().unwrap();
+    guard.adopt_home(home);
+
+    assert_eq!(
+        output.status.code(),
+        Some(7),
+        "the spawn-failed exit code: {output:?}"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("unbuilt"),
+        "the refusal must name the app: {stderr}"
+    );
+    assert!(
+        stderr.contains("never-built"),
+        "the refusal must name the path it looked at: {stderr}"
+    );
+
+    let flock = shep(home)
+        .arg("--format")
+        .arg("json")
+        .arg("flock")
+        .output()
+        .unwrap();
+    assert_success(&flock);
+    let envelope: serde_json::Value = serde_json::from_slice(&flock.stdout).unwrap();
+    assert_eq!(
+        envelope["data"].as_array().map(Vec::len),
+        Some(0),
+        "a Flockfile refused as a whole must leave NOTHING registered: {}",
+        envelope
+    );
+
+    graceful_kill(home);
+}

--- a/crates/shep-cli/tests/cli_e2e.rs
+++ b/crates/shep-cli/tests/cli_e2e.rs
@@ -6103,3 +6103,73 @@ fn an_unknown_verb_with_no_matching_dog_keeps_claps_own_suggestion() {
         "clap's own did-you-mean must still suggest the real verb: {stderr}"
     );
 }
+
+/// A Flockfile edit to a sheep the flock already has is reported, naming the
+/// sheep and every field that changed, and naming no VALUE.
+///
+/// The defect: changing `cwd` on two apps and re-running `shep start` left
+/// both running the old one, with no error and no warning. `Request::Start`
+/// on an existing name adds instances rather than reconciling config, which
+/// is deliberate and is what `shep stock` depends on, so the edit was simply
+/// not applied. The silence was the bug, and the apps then crash-looped
+/// against a path that no longer applied.
+///
+/// What a broken implementation this catches: the drift check dropped
+/// entirely (no `cwd` in stderr); the drift computed against an
+/// unnormalized config (every default the file did not spell out reported
+/// as changed, and the `env`/`cwd` assertions drown in noise); the report
+/// carrying values rather than names, which is what the `hunter2` assertion
+/// is for (IR-41). Asserting only that the config was NOT silently replaced
+/// would pass on the broken code, since not replacing it is exactly what
+/// the broken code did.
+///
+/// A one-app Flockfile where the real report had two: one sheep is enough to
+/// prove the message exists, and the daemon-side unit tier
+/// (`supervisor.rs::config_drift_names_an_edited_sheeps_fields_and_changes_nothing`)
+/// is where multiple fields and an unregistered app are pinned, at no
+/// process-spawning cost.
+#[test]
+fn a_flockfile_edit_to_a_registered_sheep_is_reported_rather_than_swallowed() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path();
+    let elsewhere = tempfile::tempdir().unwrap();
+    let script = write_test_script(&dir);
+    // `env` carries a value that must never be printed, and `cwd` a second
+    // changed field, so a report that stopped at the first difference fails
+    // here too.
+    let body = |cwd: &Path, token: &str| {
+        format!(
+            "[[app]]\nname = \"edited\"\nscript = \"{}\"\ncwd = \"{}\"\n\
+             env = {{ API_TOKEN = \"{token}\" }}\n",
+            script.display(),
+            cwd.display(),
+        )
+    };
+    let flockfile = write_flockfile(&dir, &body(home, "hunter2-before"));
+    let mut guard = DaemonGuard::default();
+
+    let boot = shep(home).arg("start").arg(&flockfile).output().unwrap();
+    guard.adopt_home(home);
+    assert_success(&boot);
+    poll_flock(home, |info| info["status"] == "online");
+
+    // The edit, over the same path the daemon was told about.
+    write_flockfile(&dir, &body(elsewhere.path(), "hunter2-after"));
+    let again = shep(home).arg("start").arg(&flockfile).output().unwrap();
+
+    let stderr = String::from_utf8_lossy(&again.stderr);
+    assert!(
+        stderr.contains("edited"),
+        "the report must name the sheep: {stderr}"
+    );
+    assert!(
+        stderr.contains("cwd") && stderr.contains("env"),
+        "the report must name every field that changed: {stderr}"
+    );
+    assert!(
+        !stderr.contains("hunter2"),
+        "a field's VALUE must never reach an operator's terminal (IR-41): {stderr}"
+    );
+
+    graceful_kill(home);
+}

--- a/crates/shep-cli/tests/cli_e2e.rs
+++ b/crates/shep-cli/tests/cli_e2e.rs
@@ -6356,6 +6356,22 @@ fn a_bare_command_off_the_path_takes_only_its_own_app_down() {
         Some(7),
         "the one app that cannot run still fails the command: {output:?}"
     );
+    // The useful sentence reaches the operator's own terminal, not only the
+    // shepherd's log. The batch check can never send it here -- a doubt must
+    // not fail a batch, and the `Start` reply is about the batch -- but once
+    // THIS app's spawn has failed the reply is about this app, and
+    // `SpawnFailed` already carries free-form text, so it needs no protocol
+    // change to say so.
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("is not on the shepherd's PATH"),
+        "the reply must explain WHY the program was not found, not only that \
+         it was not: {stderr}"
+    );
+    assert!(
+        stderr.contains("shep-no-such-interpreter-xyz") && stderr.contains("no-interpreter"),
+        "naming the program and the sheep: {stderr}"
+    );
 
     let data = poll_flock_data(home, FLOCK_DEADLINE, |data| {
         data.as_array().is_some_and(|rows| {

--- a/crates/shep-cli/tests/cli_e2e.rs
+++ b/crates/shep-cli/tests/cli_e2e.rs
@@ -6305,3 +6305,88 @@ fn a_spawn_that_no_check_could_have_caught_still_names_the_sheep_and_the_path() 
 
     graceful_kill(home);
 }
+
+/// A bare command that is not on the shepherd's PATH does NOT take the rest
+/// of the flock down with it. It is reported, its own app fails to spawn as
+/// it always did, and every other app in the Flockfile comes up.
+///
+/// The asymmetry against
+/// [`one_absent_script_refuses_the_whole_flockfile_and_registers_nothing`] is
+/// the whole point, and it is a line between two kinds of claim. A `script`
+/// with a `/` in it is a claim about the filesystem, which the daemon can
+/// settle and an operator can fix with a typo correction, so the batch is
+/// refused. A bare command is a claim about an ENVIRONMENT, and the one that
+/// decides is the daemon's, not the shell an operator tested in: a `shep
+/// startup` unit gets whatever `PATH` launchd or systemd hands it, and
+/// `assemble`'s fallback is `/usr/local/bin:/usr/bin:/bin`. Node from
+/// homebrew on Apple Silicon lives in `/opt/homebrew/bin` and nvm's under
+/// `$HOME`, so a real Flockfile's `script = "node"` resolves in a terminal
+/// and not under the unit. Refusing the batch there would keep twelve
+/// working apps down over one app's interpreter.
+///
+/// What a broken implementation this catches: the bare-command case
+/// promoted back to a batch refusal (`resolvable` is missing from the
+/// listing, which is the assertion that matters); the report dropped
+/// altogether, so an operator whose interpreter vanished gets no clue in the
+/// shepherd's log (the log assertion).
+#[test]
+fn a_bare_command_off_the_path_takes_only_its_own_app_down() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path();
+    let script = write_test_script(&dir);
+    // `resolvable` FIRST: it is the app that must survive, and a refusal of
+    // the whole batch would leave it unregistered rather than online.
+    let flockfile = write_flockfile(
+        &dir,
+        &format!(
+            "[[app]]\nname = \"resolvable\"\nscript = \"{}\"\n\n\
+             [[app]]\nname = \"no-interpreter\"\nscript = \"shep-no-such-interpreter-xyz\"\n",
+            script.display(),
+        ),
+    );
+    let mut guard = DaemonGuard::default();
+
+    let output = shep(home).arg("start").arg(&flockfile).output().unwrap();
+    guard.adopt_home(home);
+
+    // Exit 7 all the same: one app really did fail. What changed is what it
+    // took with it.
+    assert_eq!(
+        output.status.code(),
+        Some(7),
+        "the one app that cannot run still fails the command: {output:?}"
+    );
+
+    let data = poll_flock_data(home, FLOCK_DEADLINE, |data| {
+        data.as_array().is_some_and(|rows| {
+            rows.iter()
+                .any(|row| row["name"] == "resolvable" && row["status"] == "online")
+        })
+    });
+    // Found by hand rather than through `sheep_named`, which panics with its
+    // own message: the regression this case exists for makes the row ABSENT,
+    // and a red run has to say that rather than report a lookup failure deep
+    // in a helper.
+    let survivor = data
+        .as_array()
+        .and_then(|rows| rows.iter().find(|row| row["name"] == "resolvable"));
+    assert_eq!(
+        survivor.map(|row| &row["status"]).map(ToString::to_string),
+        Some("\"online\"".to_string()),
+        "an app whose own script resolves must come up regardless of a \
+         sibling's unresolvable interpreter, and must not be refused \
+         registration over it: {data}"
+    );
+
+    let log = std::fs::read_to_string(home.join("logs").join("shepd.err.log")).unwrap();
+    assert!(
+        log.contains("shep-no-such-interpreter-xyz") && log.contains("PATH"),
+        "the shepherd must still say which program it could not find: {log}"
+    );
+    assert!(
+        log.contains("no-interpreter"),
+        "and which sheep wanted it: {log}"
+    );
+
+    graceful_kill(home);
+}

--- a/crates/shep-core/CHANGELOG.md
+++ b/crates/shep-core/CHANGELOG.md
@@ -23,7 +23,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   fields, never their values, because `AppConfig::env` holds secrets and the
   answer is printed at an operator (IR-41). `drifted_fields` compares through
   serde rather than field by field, so a field added to `AppConfig` is
-  compared without a second edit. Additive: `PROTOCOL_VERSION` stays **1**, a
+  compared without a second edit, and sorts the result explicitly rather than
+  leaning on `serde_json::Map` being a `BTreeMap`, which holds only while the
+  additive `preserve_order` feature is off anywhere in the graph. Additive: `PROTOCOL_VERSION` stays **1**, a
   daemon that predates the request answers its existing "does not implement
   that request" error, and every previously pinned wire fixture is unchanged.
 

--- a/crates/shep-core/CHANGELOG.md
+++ b/crates/shep-core/CHANGELOG.md
@@ -10,6 +10,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Additions
+
+- Add `Request::ConfigDrift`, `Response::Drifted`, `SheepDrift`, and
+  `AppConfig::drifted_fields`. `ConfigDrift` asks which of a set of apps name
+  a sheep the flock already has under a DIFFERENT config, and changes
+  nothing. `Start` on an already-registered name adds instances rather than
+  reconciling config, which `shep stock` depends on, so an operator who
+  edited a Flockfile and re-ran `shep start` had the edit ignored with no
+  error and no warning; this is what a caller asks in order to say so.
+  `SheepDrift` carries the sheep's name and the names of the differing
+  fields, never their values, because `AppConfig::env` holds secrets and the
+  answer is printed at an operator (IR-41). `drifted_fields` compares through
+  serde rather than field by field, so a field added to `AppConfig` is
+  compared without a second edit. Additive: `PROTOCOL_VERSION` stays **1**, a
+  daemon that predates the request answers its existing "does not implement
+  that request" error, and every previously pinned wire fixture is unchanged.
+
 ## [0.1.1] - 2026-08-26
 
 ### Additions

--- a/crates/shep-core/src/config/app.rs
+++ b/crates/shep-core/src/config/app.rs
@@ -484,6 +484,58 @@ impl AppConfig {
             ..Self::default()
         }
     }
+
+    /// The names of the fields whose values differ between `self` and
+    /// `other`, in field-name order.
+    ///
+    /// Names only, never values. The one caller sends this list across the
+    /// wire to be printed at an operator, and [`AppConfig::env`] carries
+    /// secrets, so a differing `env` reports `"env"` and stops there (IR-41).
+    ///
+    /// Compare configs that have both been through
+    /// [`normalize`](crate::config::normalize). Two configs differing only
+    /// in what normalization would have filled in are not a difference an
+    /// operator can act on, and reporting them would make the caller noisy
+    /// about nothing.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use shep_core::config::AppConfig;
+    ///
+    /// let stored = AppConfig::minimal("web", "./srv");
+    /// let mut edited = stored.clone();
+    /// edited.cwd = Some("/srv".to_string());
+    ///
+    /// assert_eq!(stored.drifted_fields(&edited), vec!["cwd".to_string()]);
+    /// assert!(stored.drifted_fields(&stored).is_empty());
+    /// ```
+    #[must_use]
+    pub fn drifted_fields(&self, other: &Self) -> Vec<String> {
+        if self == other {
+            return Vec::new();
+        }
+        // Through serde rather than field by field, so a field added to this
+        // struct is compared without a second edit here. 44 hand-written
+        // comparisons is exactly the list that goes stale. `#[serde(default)]`
+        // with no `skip_serializing_if` means both sides serialize every
+        // field, so the two key sets are identical and iterating one is
+        // enough. `serde_json::Map` is a `BTreeMap`, which is where the
+        // field-name ordering comes from.
+        //
+        // An empty vector when either side fails to serialize as an object:
+        // there is no honest field list to report, and the caller must not
+        // fail over a warning it could not compute.
+        let (Ok(serde_json::Value::Object(mine)), Ok(serde_json::Value::Object(theirs))) =
+            (serde_json::to_value(self), serde_json::to_value(other))
+        else {
+            return Vec::new();
+        };
+        mine.iter()
+            .filter(|(key, value)| theirs.get(key.as_str()) != Some(value))
+            .map(|(key, _)| key.clone())
+            .collect()
+    }
 }
 
 #[cfg(test)]
@@ -608,6 +660,61 @@ target = "http://127.0.0.1:8080/healthz"
         assert_eq!(
             format!("{app:?}"),
             "AppConfig { name: \"web\", script: \"./srv\", env: <2 vars>, .. }"
+        );
+    }
+
+    #[test]
+    fn an_unedited_config_has_drifted_in_no_field() {
+        let app = AppConfig::minimal("web", "./srv");
+
+        assert!(app.drifted_fields(&app.clone()).is_empty());
+    }
+
+    #[test]
+    fn drift_names_every_edited_field_and_no_other() {
+        // The defect this exists for: an operator edits `cwd` in a Flockfile
+        // and re-runs `shep start`. Two fields, not one, so a comparator
+        // that stopped at the first difference fails here.
+        let stored = AppConfig::minimal("proto-api", "./proto-enum-api");
+        let mut edited = stored.clone();
+        edited.cwd = Some("/Users/rin/GitHub/pogo-proto-api".to_string());
+        edited.args = vec!["-config".to_string(), "config.toml".to_string()];
+
+        assert_eq!(
+            stored.drifted_fields(&edited),
+            vec!["args".to_string(), "cwd".to_string()]
+        );
+    }
+
+    #[test]
+    fn drift_reports_env_by_name_and_never_by_value() {
+        let stored = AppConfig::minimal("web", "./srv");
+        let mut edited = stored.clone();
+        edited
+            .env
+            .insert("DATABASE_URL".to_string(), "postgres://hunter2".to_string());
+
+        let fields = edited.drifted_fields(&stored);
+
+        assert_eq!(fields, vec!["env".to_string()]);
+        // The whole point of returning names: this list is printed at an
+        // operator, so nothing from a value may reach it (IR-41).
+        assert!(!fields.concat().contains("hunter2"));
+    }
+
+    #[test]
+    fn drift_is_symmetric() {
+        let stored = AppConfig::minimal("web", "./srv");
+        let mut edited = stored.clone();
+        edited.instances = 4;
+
+        assert_eq!(
+            stored.drifted_fields(&edited),
+            edited.drifted_fields(&stored)
+        );
+        assert_eq!(
+            stored.drifted_fields(&edited),
+            vec!["instances".to_string()]
         );
     }
 }

--- a/crates/shep-core/src/config/app.rs
+++ b/crates/shep-core/src/config/app.rs
@@ -493,7 +493,7 @@ impl AppConfig {
     /// secrets, so a differing `env` reports `"env"` and stops there (IR-41).
     ///
     /// Compare configs that have both been through
-    /// [`normalize`](crate::config::normalize). Two configs differing only
+    /// [`normalize`](fn@crate::config::normalize). Two configs differing only
     /// in what normalization would have filled in are not a difference an
     /// operator can act on, and reporting them would make the caller noisy
     /// about nothing.

--- a/crates/shep-core/src/config/app.rs
+++ b/crates/shep-core/src/config/app.rs
@@ -520,8 +520,15 @@ impl AppConfig {
         // comparisons is exactly the list that goes stale. `#[serde(default)]`
         // with no `skip_serializing_if` means both sides serialize every
         // field, so the two key sets are identical and iterating one is
-        // enough. `serde_json::Map` is a `BTreeMap`, which is where the
-        // field-name ordering comes from.
+        // enough.
+        //
+        // Sorted explicitly rather than relying on `serde_json::Map` being a
+        // `BTreeMap`: it is one only while `serde_json`'s `preserve_order`
+        // feature is off, and that feature is additive, so ANY crate in the
+        // graph turning it on would make this an `IndexMap` and silently
+        // switch the order to serialization order. Nothing enables it today.
+        // The sort costs a few field names and makes the doc above true by
+        // construction instead of by a dependency's default feature set.
         //
         // An empty vector when either side fails to serialize as an object:
         // there is no honest field list to report, and the caller must not
@@ -531,10 +538,13 @@ impl AppConfig {
         else {
             return Vec::new();
         };
-        mine.iter()
+        let mut fields: Vec<String> = mine
+            .iter()
             .filter(|(key, value)| theirs.get(key.as_str()) != Some(value))
             .map(|(key, _)| key.clone())
-            .collect()
+            .collect();
+        fields.sort_unstable();
+        fields
     }
 }
 

--- a/crates/shep-core/src/protocol/mod.rs
+++ b/crates/shep-core/src/protocol/mod.rs
@@ -17,7 +17,8 @@ pub use frame::ServerFrame;
 pub use request::{
     ActionOutcome, ActionReply, DogSectionToml, DogSource, Envelope, ExitInfo, Hello, HelloAck,
     HelloReply, Lamb, LineOutcome, LineReply, ProcessInfo, ProcessInfoBuilder, Reply, Request,
-    Response, RpcError, RpcErrorCode, SelectorSpec, SignalOutcome, SignalReply, Smit, SmitError,
+    Response, RpcError, RpcErrorCode, SelectorSpec, SheepDrift, SignalOutcome, SignalReply, Smit,
+    SmitError,
 };
 pub use wire::{MAX_FRAME_BYTES, WireError, codec, decode_frame, encode_frame};
 

--- a/crates/shep-core/src/protocol/request.rs
+++ b/crates/shep-core/src/protocol/request.rs
@@ -221,6 +221,27 @@ pub enum Request {
         /// untrusted); failures return [`RpcErrorCode::InvalidConfig`]
         apps: Vec<AppConfig>,
     },
+    /// Ask which of `apps` name a sheep the flock already has under a
+    /// different config
+    ///
+    /// Read-only: nothing is registered, started, or changed. [`Self::Start`]
+    /// on an already-registered name adds instances rather than reconciling
+    /// config, which is what `shep stock` relies on; this is how a caller
+    /// finds out that an edit it just read from a Flockfile is one `Start`
+    /// will not apply, instead of the edit vanishing without a word.
+    ///
+    /// Answers [`Response::Drifted`] with one [`SheepDrift`] per app that is
+    /// both registered and different. An app the flock does not have is
+    /// absent from the answer, not reported as unchanged: `Start` will
+    /// register it, so there is nothing to warn about.
+    ConfigDrift {
+        /// The configs to compare against, exactly as [`Self::Start`] would
+        /// carry them. The daemon MUST re-normalize (peer input is
+        /// untrusted, and an unnormalized config would report every default
+        /// it has not spelled out as a difference); failures return
+        /// [`RpcErrorCode::InvalidConfig`].
+        apps: Vec<AppConfig>,
+    },
     /// Stop matching sheep (stay registered)
     Stop {
         /// Which sheep
@@ -1020,6 +1041,46 @@ impl fmt::Debug for DogSectionToml {
     }
 }
 
+/// One registered sheep whose stored config differs from a caller's copy:
+/// the answer [`Request::ConfigDrift`] is asking for
+///
+/// Field NAMES only, never their values. This is built to be printed at an
+/// operator, and [`AppConfig::env`](crate::config::AppConfig::env) carries
+/// secrets, so a differing `env` reports `"env"` and nothing more (IR-41).
+/// `Debug` is derived for that reason: there is nothing here to redact.
+// wire format: changing field names is a breaking change
+//
+// `#[non_exhaustive]`: shep-core is a published library, an out-of-tree
+// consumer can match or construct this exhaustively today, and a third field
+// (which side is newer, say) would break them with no version bump to say
+// so (IR-20). [`SheepDrift::new`] is how the daemon builds one.
+#[non_exhaustive]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SheepDrift {
+    /// The sheep's name. Both configs share it by construction: it is what
+    /// matched them to each other.
+    pub name: String,
+    /// The [`AppConfig`](crate::config::AppConfig) fields that differ, in
+    /// field-name order. Never empty: a sheep with nothing to report is left
+    /// out of the answer entirely.
+    pub fields: Vec<String>,
+}
+
+impl SheepDrift {
+    /// Builds one sheep's report.
+    ///
+    /// No builder, unlike [`ProcessInfo`]: both fields are required and
+    /// neither can be defaulted, so there is no optional surface for one to
+    /// spare a caller.
+    #[must_use]
+    pub fn new(name: impl Into<String>, fields: Vec<String>) -> Self {
+        Self {
+            name: name.into(),
+            fields,
+        }
+    }
+}
+
 /// One RPC response (pairs with [`Request`] variants)
 ///
 /// Ten variants carry a bare `Vec<ProcessInfo>` (`Flock`, `Described`,
@@ -1055,6 +1116,11 @@ pub enum Response {
     Described(Vec<ProcessInfo>),
     /// Answer to `Start`
     Started(Vec<ProcessInfo>),
+    /// Answer to `ConfigDrift`: one entry per app that is registered under a
+    /// config different from the one asked about, and no entry for anything
+    /// else. An empty vector means every app asked about either matches or
+    /// is not registered at all.
+    Drifted(Vec<SheepDrift>),
     /// Answer to `Stop`
     Stopped(Vec<ProcessInfo>),
     /// Answer to `Restart`
@@ -1848,6 +1914,16 @@ mod tests {
                     smit: None,
                 },
             },
+            // An EMPTY `apps`, unlike `start`'s row above. The two carry the
+            // identical payload type, so a second `AppConfig` blob here would
+            // pin nothing `start`'s blob does not already pin, at fifty lines
+            // of snapshot. What is genuinely this row's own is the tag and
+            // the key the list travels under, and an empty list shows both.
+            Envelope {
+                id: 22,
+                deadline_ms: None,
+                body: Request::ConfigDrift { apps: Vec::new() },
+            },
         ];
         insta::assert_json_snapshot!("request_wire_v1", requests);
     }
@@ -2090,6 +2166,22 @@ mod tests {
                         .pid(Some(4242))
                         .smit(Some("\u{25b2} main@a1b2c3".to_string()))
                         .build(),
+                ])),
+            },
+            // Two entries in one reply, and each is the shape the other is
+            // not: a sheep drifting in one field and a sheep drifting in
+            // several. `env` is deliberately one of them, because reporting
+            // it as a bare NAME is the whole security property of this row
+            // (IR-41) and a fixture is where an out-of-tree reader learns
+            // that no value ever travels with it.
+            Reply {
+                id: 26,
+                result: Ok(Response::Drifted(vec![
+                    SheepDrift::new("web", vec!["cwd".to_string()]),
+                    SheepDrift::new(
+                        "api",
+                        vec!["args".to_string(), "env".to_string(), "script".to_string()],
+                    ),
                 ])),
             },
         ];

--- a/crates/shep-core/src/protocol/request.rs
+++ b/crates/shep-core/src/protocol/request.rs
@@ -1060,7 +1060,7 @@ pub struct SheepDrift {
     /// The sheep's name. Both configs share it by construction: it is what
     /// matched them to each other.
     pub name: String,
-    /// The [`AppConfig`](crate::config::AppConfig) fields that differ, in
+    /// The [`AppConfig`] fields that differ, in
     /// field-name order. Never empty: a sheep with nothing to report is left
     /// out of the answer entirely.
     pub fields: Vec<String>,

--- a/crates/shep-core/src/protocol/snapshots/shep_core__protocol__request__tests__reply_wire_v1.snap
+++ b/crates/shep-core/src/protocol/snapshots/shep_core__protocol__request__tests__reply_wire_v1.snap
@@ -440,5 +440,29 @@ expression: replies
         ]
       }
     }
+  },
+  {
+    "id": 26,
+    "result": {
+      "Ok": {
+        "kind": "drifted",
+        "data": [
+          {
+            "name": "web",
+            "fields": [
+              "cwd"
+            ]
+          },
+          {
+            "name": "api",
+            "fields": [
+              "args",
+              "env",
+              "script"
+            ]
+          }
+        ]
+      }
+    }
   }
 ]

--- a/crates/shep-core/src/protocol/snapshots/shep_core__protocol__request__tests__request_wire_v1.snap
+++ b/crates/shep-core/src/protocol/snapshots/shep_core__protocol__request__tests__request_wire_v1.snap
@@ -246,5 +246,13 @@ expression: requests
       "sheep": "web",
       "smit": null
     }
+  },
+  {
+    "id": 22,
+    "deadline_ms": null,
+    "body": {
+      "kind": "config_drift",
+      "apps": []
+    }
   }
 ]

--- a/crates/shep-daemon/CHANGELOG.md
+++ b/crates/shep-daemon/CHANGELOG.md
@@ -46,6 +46,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   before. Refusing there would keep a whole flock down at boot over one app's
   interpreter, which is worse than the partial registration being fixed.
 
+  A filesystem error that is not "no such file" never refuses a batch either.
+  `Path::exists` returns `false` on any `fs::metadata` error, so a permission
+  error on an intermediate directory, an unsettled mount and a race all read
+  identically to "absent"; the check now matches `ErrorKind::NotFound`
+  specifically, and everything else is a suspicion the spawn reports as it
+  always did.
+
+- Explain a bare program's spawn failure in the reply, not only in the log.
+  When a `script` or `interpreter` with no `/` in it fails to spawn, the
+  `SpawnFailed` message now carries "`node` is not on the shepherd's PATH
+  (...)" in place of the bare "tried `node`" clause, so an operator at a
+  terminal gets the diagnosis rather than only `No such file or directory`.
+  No protocol change: `SpawnFailed` already carries free-form text. A PATH of
+  more than four entries is summarised, because a daemon autostarted from a
+  shell inherits that shell's PATH, which measured two kilobytes and buried
+  the sentence that mattered.
+
 ### Additions
 
 - Add `SupervisorError::CannotStart`, a `Start` batch refused before anything
@@ -68,7 +85,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `TokioRunner` answers `Impossible` for a `/`-containing path that is not on
   the filesystem, `Doubtful` for a bare command missing from the `PATH` the
   child will actually be given, and `Unknown` for everything else, including
-  a relative path with no `cwd`. Existence only, never the executable bit.
+  a relative path with no `cwd` and any filesystem error other than
+  `NotFound`. Existence only, never the executable bit.
 
 - Answer `Request::ConfigDrift`: report which of a set of apps name a
   registered sheep whose stored config differs, and in which fields. Reads

--- a/crates/shep-daemon/CHANGELOG.md
+++ b/crates/shep-daemon/CHANGELOG.md
@@ -15,9 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Name the sheep and the path in a failed spawn's message. The whole error
   an operator got was `process spawn failed: No such file or directory (os
   error 2)`, which on an eleven-app Flockfile said neither which app had
-  failed nor which path had been tried. It now reads `<name>: process spawn
-  failed: <os error>; tried \`<script>\` in <cwd>`, with the `cwd` clause
-  present only when the app sets one. The path is the `script`/`interpreter`
+  failed nor which path had been tried. It now reads
+  ``<name>: process spawn failed: <os error>; tried `<script>` in <cwd>``,
+  with the `cwd` clause present only when the app sets one. The path is the `script`/`interpreter`
   and `cwd` as the Flockfile spells them rather than a resolution of the two,
   because that is where the edit has to be made. `shep stock`'s own partial-
   scale reply gains the path too and does not repeat the name, which it

--- a/crates/shep-daemon/CHANGELOG.md
+++ b/crates/shep-daemon/CHANGELOG.md
@@ -24,7 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   already opens with.
 
 - Check every app in a `Start` batch before registering any of it, and
-  register nothing if any of them fails. One app pointing at a script that
+  register nothing if any of them fails. One app pointing at a `script` that
   does not exist used to register and start the apps ahead of it, fail on
   that one, and never reach the apps behind it, leaving a flock that matched
   neither the Flockfile nor its previous state. The error now names every app
@@ -32,18 +32,43 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   failure alone. Passwd resolution for `user`/`group` is hoisted into the
   same pass for the same reason.
 
+  The refusal reaches only a `script` or `interpreter` containing a `/`. A
+  path is a claim about the filesystem, which the daemon can settle and an
+  operator can fix with a typo correction. A BARE command is a claim about an
+  environment, and the environment that decides is the daemon's rather than
+  the shell an operator tested in: a `shep startup` unit gives the shepherd
+  whatever `PATH` launchd or systemd hands it, and shep's own fallback is
+  `/usr/local/bin:/usr/bin:/bin`, so homebrew's `node` on Apple Silicon
+  (`/opt/homebrew/bin`) and nvm's (under `$HOME`) both resolve in a terminal
+  and neither resolves under the unit. A bare command that does not resolve
+  is reported in the shepherd's log, naming the sheep and the program, and
+  the batch goes ahead; that one app's spawn then fails exactly as it did
+  before. Refusing there would keep a whole flock down at boot over one app's
+  interpreter, which is worse than the partial registration being fixed.
+
 ### Additions
 
-- Add `ProcessRunner::preflight`, the reason a `SpawnSpec` cannot be spawned
-  when that is knowable without trying. Defaulted to `None` ("nothing
-  knowable in advance", never "this will work"), so an out-of-tree
-  implementor is unaffected and a runner that never touches the filesystem
-  gives the honest answer. `TokioRunner` reports a program that provably is
-  not there: an absolute path, a path relative to a `cwd`, or a bare command
-  against the PATH the child will actually be given. Deliberately narrow.
-  Existence only, never the executable bit; a relative path with no `cwd` and
-  a bare command with no PATH are both left to the spawn, because refusing a
-  Flockfile that would have run is worse than the bug it addresses.
+- Add `SupervisorError::CannotStart`, a `Start` batch refused before anything
+  was registered. Separate from `SpawnFailed` because nothing was spawned,
+  and an operator told "spawn failed" about a spawn that never happened is
+  being pointed at the wrong place; the two also differ in what they leave
+  behind, which is the part that matters operationally. It maps to the
+  existing `RpcErrorCode::SpawnFailed` all the same, so exit 7 and every
+  older client are unchanged: `RpcErrorCode` is versioned and a client
+  predating a new code could not decode the reply at all.
+
+- Add `ProcessRunner::preflight` and `Preflight`, what a runner can tell
+  about a `SpawnSpec` before anything is spawned. Three verdicts, because a
+  caller registering a batch has three different things to do with the
+  answer: `Unknown` ("nothing knowable in advance", never "this will work"),
+  `Impossible` (a certainty, and the only one a caller may refuse a whole
+  batch over), and `Doubtful` (report it and carry on). `preflight` is
+  defaulted to `Unknown`, so an out-of-tree implementor is unaffected and a
+  runner that never touches the filesystem gives the honest answer.
+  `TokioRunner` answers `Impossible` for a `/`-containing path that is not on
+  the filesystem, `Doubtful` for a bare command missing from the `PATH` the
+  child will actually be given, and `Unknown` for everything else, including
+  a relative path with no `cwd`. Existence only, never the executable bit.
 
 - Answer `Request::ConfigDrift`: report which of a set of apps name a
   registered sheep whose stored config differs, and in which fields. Reads

--- a/crates/shep-daemon/CHANGELOG.md
+++ b/crates/shep-daemon/CHANGELOG.md
@@ -10,7 +10,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixes
+
+- Check every app in a `Start` batch before registering any of it, and
+  register nothing if any of them fails. One app pointing at a script that
+  does not exist used to register and start the apps ahead of it, fail on
+  that one, and never reach the apps behind it, leaving a flock that matched
+  neither the Flockfile nor its previous state. The error now names every app
+  that failed and the path each was looked for at, rather than the first
+  failure alone. Passwd resolution for `user`/`group` is hoisted into the
+  same pass for the same reason.
+
 ### Additions
+
+- Add `ProcessRunner::preflight`, the reason a `SpawnSpec` cannot be spawned
+  when that is knowable without trying. Defaulted to `None` ("nothing
+  knowable in advance", never "this will work"), so an out-of-tree
+  implementor is unaffected and a runner that never touches the filesystem
+  gives the honest answer. `TokioRunner` reports a program that provably is
+  not there: an absolute path, a path relative to a `cwd`, or a bare command
+  against the PATH the child will actually be given. Deliberately narrow.
+  Existence only, never the executable bit; a relative path with no `cwd` and
+  a bare command with no PATH are both left to the spawn, because refusing a
+  Flockfile that would have run is worse than the bug it addresses.
 
 - Answer `Request::ConfigDrift`: report which of a set of apps name a
   registered sheep whose stored config differs, and in which fields. Reads

--- a/crates/shep-daemon/CHANGELOG.md
+++ b/crates/shep-daemon/CHANGELOG.md
@@ -12,6 +12,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixes
 
+- Name the sheep and the path in a failed spawn's message. The whole error
+  an operator got was `process spawn failed: No such file or directory (os
+  error 2)`, which on an eleven-app Flockfile said neither which app had
+  failed nor which path had been tried. It now reads `<name>: process spawn
+  failed: <os error>; tried \`<script>\` in <cwd>`, with the `cwd` clause
+  present only when the app sets one. The path is the `script`/`interpreter`
+  and `cwd` as the Flockfile spells them rather than a resolution of the two,
+  because that is where the edit has to be made. `shep stock`'s own partial-
+  scale reply gains the path too and does not repeat the name, which it
+  already opens with.
+
 - Check every app in a `Start` batch before registering any of it, and
   register nothing if any of them fails. One app pointing at a script that
   does not exist used to register and start the apps ahead of it, fail on

--- a/crates/shep-daemon/CHANGELOG.md
+++ b/crates/shep-daemon/CHANGELOG.md
@@ -67,6 +67,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the case the check exists for and the only one where an operator is holding
   a terminal.
 
+  The policy governs the SPAWN loop as well as the pre-registration check.
+  That loop returned on the first failure whatever the policy said, so a bad
+  entry that was not last still took every app after it down: `a-good` came
+  up, `b-bad` failed, and `c-good` was never registered at all. A muster roll
+  is written from a `BTreeMap` and restored in that order, so this was a
+  certainty whenever the broken name sorted first rather than a race. Under
+  `PerApp` a failed spawn now records that app, leaves it `Errored` and
+  visible, and moves to the next; the app's own remaining instances are
+  skipped, since they share a binary and would only add identical wrecks to
+  the listing. The error still names every app that failed, so the muster's
+  existing "failed to spawn one or more apps" log keeps its meaning.
+
 - Explain a bare program's spawn failure in the reply, not only in the log.
   When a `script` or `interpreter` with no `/` in it fails to spawn, the
   `SpawnFailed` message now carries "`node` is not on the shepherd's PATH

--- a/crates/shep-daemon/CHANGELOG.md
+++ b/crates/shep-daemon/CHANGELOG.md
@@ -67,6 +67,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the case the check exists for and the only one where an operator is holding
   a terminal.
 
+  The policy governs every point `do_start` can stop at, which took three
+  passes to get right: the pre-registration check, the spawn loop, and
+  `user`/`group` resolution. A `PerApp` batch now survives an app whose user
+  cannot be resolved, where one unresolvable name used to refuse an entire
+  muster restore.
+
+  Resolving credentials no longer builds a vector to zip against the apps.
+  That pairing was safe only while a failure returned early; once a failure
+  is SKIPPED, the two sequences drift, `zip` hands app 2 app 3's credentials,
+  and the last app is dropped without a word. That is a privilege
+  misassignment rather than a scheduling bug: the flock comes up looking
+  correct with processes under identities nobody chose. Each app now carries
+  its own credentials from the point of resolution, so there is no second
+  sequence to keep in step.
+
+  An app whose credentials fail is skipped rather than registered `Errored`,
+  unlike an app whose spawn fails. Nothing can be assembled without an
+  identity to assemble it for, and running it under the daemon's own identity
+  instead is the outcome being ruled out. Both are named in the error.
+
   The policy governs the SPAWN loop as well as the pre-registration check.
   That loop returned on the first failure whatever the policy said, so a bad
   entry that was not last still took every app after it down: `a-good` came

--- a/crates/shep-daemon/CHANGELOG.md
+++ b/crates/shep-daemon/CHANGELOG.md
@@ -10,6 +10,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Additions
+
+- Answer `Request::ConfigDrift`: report which of a set of apps name a
+  registered sheep whose stored config differs, and in which fields. Reads
+  the flock and changes nothing -- it registers, spawns and records nothing,
+  so it is answered during a shutdown rather than refused the way `Start` is.
+  The incoming configs are re-normalized first, on the same untrusted-peer
+  rule `Start` follows plus one of its own: an unnormalized config would
+  report every default it did not spell out as a difference from the
+  normalized copy the flock stores.
+
 ## [0.1.0] - 2026-08-26
 
 ### Additions

--- a/crates/shep-daemon/CHANGELOG.md
+++ b/crates/shep-daemon/CHANGELOG.md
@@ -53,6 +53,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   specifically, and everything else is a suspicion the spawn reports as it
   always did.
 
+- Keep the pre-registration refusal to the one caller it was written for.
+  `do_start` is shared, so the check reached two callers that must not have
+  it. A dog whose binary is missing was refused and left no trace, where it
+  belongs in the dogs table as `Errored`: `spawn_fresh` registers that row on
+  purpose, `shep dogs` renders it, and `dogs::spawn_dog_watch` subscribes to
+  it, so an operator who enabled a broken dog needs to see it rather than
+  find nothing. Worse, restoring a muster roll refused the WHOLE roll when
+  one saved app's binary had gone missing, so a machine came back from a
+  reboot with nothing running at all, unattended. Both now register each app
+  on its own merits, via a `BatchPolicy` the call site states explicitly.
+  All-or-nothing stays what `shep start` against a Flockfile does, which is
+  the case the check exists for and the only one where an operator is holding
+  a terminal.
+
 - Explain a bare program's spawn failure in the reply, not only in the log.
   When a `script` or `interpreter` with no `/` in it fails to spawn, the
   `SpawnFailed` message now carries "`node` is not on the shepherd's PATH

--- a/crates/shep-daemon/src/cron.rs
+++ b/crates/shep-daemon/src/cron.rs
@@ -231,10 +231,12 @@ pub fn spawn_cron_worker(
                         err @ (SupervisorError::ReopenFailed(_)
                         | SupervisorError::FlushFailed(_)
                         | SupervisorError::ReloadInFlight(_)
-                        | SupervisorError::InvalidScale(_)),
+                        | SupervisorError::InvalidScale(_)
+                        | SupervisorError::CannotStart(_)),
                     ) => {
-                        // A restart touches no log files, starts no reload
-                        // and scales nothing, so none of the four can arrive.
+                        // A restart touches no log files, starts no reload,
+                        // scales nothing and registers no batch, so none of
+                        // the five can arrive.
                         // Named rather than swept into a catch-all, so a
                         // variant this path CAN produce still fails to
                         // compile here.

--- a/crates/shep-daemon/src/fake.rs
+++ b/crates/shep-daemon/src/fake.rs
@@ -15,8 +15,8 @@ use tokio::time::{Duration, Instant, sleep_until};
 
 use crate::channel::{ChildMessage, ShepherdMessage};
 use crate::runner::{
-    ExitOutcome, LogCtl, LogLine, ProcIo, ProcessRunner, RunnerError, RunningProcess, SpawnSpec,
-    StdinWrite, StopSignal,
+    ExitOutcome, LogCtl, LogLine, Preflight, ProcIo, ProcessRunner, RunnerError, RunningProcess,
+    SpawnSpec, StdinWrite, StopSignal,
 };
 
 /// Capacity of every channel the fake wires up — generous enough that no
@@ -383,6 +383,15 @@ pub const FIRST_SCRIPTED_PID: u32 = 1000;
 /// Deterministic fake [`ProcessRunner`] driven by a pre-scripted [`ProcScript`] per spawn.
 pub struct ScriptedRunner {
     scripts: Mutex<VecDeque<ProcScript>>,
+    /// Sheep names whose [`ProcessRunner::preflight`] answers
+    /// [`Preflight::Impossible`], by name because that is what a caller has.
+    ///
+    /// Empty by default, which is this fake's whole point: it reads nothing
+    /// from a spec and so answers [`Preflight::Unknown`] for everything, the
+    /// same as the trait's own default. The supervisor's validating pass is
+    /// otherwise unreachable from a unit test, and a test written against
+    /// the default cannot fail no matter what that pass does.
+    refuse: Mutex<Vec<String>>,
     /// State + IO for every spawn, indexed by spawn order, behind ONE lock.
     /// Two separate `Mutex`es here (one for state, one for IO) would let
     /// concurrent spawns interleave their critical sections and desync a
@@ -404,7 +413,18 @@ impl ScriptedRunner {
         Self {
             scripts: Mutex::new(scripts.into_iter().collect()),
             spawned: Mutex::new(Vec::new()),
+            refuse: Mutex::new(Vec::new()),
         }
+    }
+
+    /// Makes `preflight` answer [`Preflight::Impossible`] for these sheep.
+    ///
+    /// For reaching the supervisor's pre-registration validating pass, which
+    /// no other fake behaviour can enter.
+    #[must_use]
+    pub fn refusing(self, names: &[&str]) -> Self {
+        *self.refuse.lock().unwrap() = names.iter().map(|n| (*n).to_string()).collect();
+        self
     }
 
     /// `kill_tree()` call count per proc, indexed by spawn order — the only
@@ -569,6 +589,15 @@ impl ScriptedRunner {
 
 impl ProcessRunner for ScriptedRunner {
     type Proc = FakeProc;
+
+    /// [`Preflight::Impossible`] for a name given to [`Self::refusing`],
+    /// [`Preflight::Unknown`] for everything else.
+    fn preflight(&self, spec: &SpawnSpec) -> Preflight {
+        if self.refuse.lock().unwrap().contains(&spec.name) {
+            return Preflight::Impossible(format!("no such file: {}", spec.program));
+        }
+        Preflight::Unknown
+    }
 
     /// Every field of `spec` besides `spec.channel` is still read by nothing
     /// here: the fake writes no files (`spec.out_file`/`err_file`) and runs

--- a/crates/shep-daemon/src/fake.rs
+++ b/crates/shep-daemon/src/fake.rs
@@ -383,6 +383,19 @@ pub const FIRST_SCRIPTED_PID: u32 = 1000;
 /// Deterministic fake [`ProcessRunner`] driven by a pre-scripted [`ProcScript`] per spawn.
 pub struct ScriptedRunner {
     scripts: Mutex<VecDeque<ProcScript>>,
+    /// Sheep names whose [`ProcessRunner::spawn`] fails, by name because
+    /// that is what a caller has.
+    ///
+    /// Sibling to [`Self::refuse`] and needed for the same class of reason:
+    /// scripts are consumed in spawn ORDER, so a test cannot make one
+    /// PARTICULAR app of several fail by arranging the script list. Reaching
+    /// `do_start`'s per-app failure handling needs a failure that lands on a
+    /// named app while its neighbours succeed.
+    ///
+    /// Checked before a script is popped, so a sheep named here consumes
+    /// nothing and the apps around it still get the scripts they were meant
+    /// to have.
+    fail_spawn: Mutex<Vec<String>>,
     /// Sheep names whose [`ProcessRunner::preflight`] answers
     /// [`Preflight::Impossible`], by name because that is what a caller has.
     ///
@@ -414,7 +427,19 @@ impl ScriptedRunner {
             scripts: Mutex::new(scripts.into_iter().collect()),
             spawned: Mutex::new(Vec::new()),
             refuse: Mutex::new(Vec::new()),
+            fail_spawn: Mutex::new(Vec::new()),
         }
+    }
+
+    /// Makes `spawn` fail for these sheep, without consuming a script.
+    ///
+    /// For reaching `do_start`'s per-app failure handling, which needs one
+    /// named app of several to fail while the others come up. Script order
+    /// alone cannot express that.
+    #[must_use]
+    pub fn failing_to_spawn(self, names: &[&str]) -> Self {
+        *self.fail_spawn.lock().unwrap() = names.iter().map(|n| (*n).to_string()).collect();
+        self
     }
 
     /// Makes `preflight` answer [`Preflight::Impossible`] for these sheep.
@@ -614,6 +639,13 @@ impl ProcessRunner for ScriptedRunner {
     /// — are proven against [`crate::tokio_runner::TokioRunner`] instead, in
     /// `tests/daemon_e2e.rs`.
     fn spawn(&self, spec: &SpawnSpec) -> Result<(Self::Proc, ProcIo), RunnerError> {
+        // Before the script is popped, so a sheep named to `failing_to_spawn`
+        // leaves the list alone for the apps around it.
+        if self.fail_spawn.lock().unwrap().contains(&spec.name) {
+            return Err(RunnerError::SpawnFailed(
+                "No such file or directory (os error 2)".to_string(),
+            ));
+        }
         let script = self
             .scripts
             .lock()

--- a/crates/shep-daemon/src/rpc.rs
+++ b/crates/shep-daemon/src/rpc.rs
@@ -271,6 +271,25 @@ async fn run(id: u64, conn: ConnId, request: Request, ctx: &RpcContext) -> Outco
                 }
             }
         },
+        // Re-normalized for the reason `Start` is, plus one of its own: an
+        // unnormalized config would report every default it did not spell
+        // out as a difference from the normalized copy the flock stores, so
+        // a Flockfile that changed nothing would be reported as drifting in
+        // a dozen fields.
+        //
+        // Nothing is recorded in the registry: this answers a question and
+        // registers nothing, so a `ConfigDrift` must not be able to change
+        // what the next `shep save` writes.
+        Request::ConfigDrift { apps } => match normalize_all(apps) {
+            Err(err) => reply(Err(RpcError {
+                code: RpcErrorCode::InvalidConfig,
+                message: err.to_string(),
+            })),
+            Ok(resolved) => match ctx.supervisor.config_drift(resolved).await {
+                Ok(drifted) => reply(Ok(Response::Drifted(drifted))),
+                Err(err) => reply(Err(rpc_error(&err))),
+            },
+        },
         Request::Stop { selector } => {
             selector_call(id, selector, |s| ctx.supervisor.stop(s), Response::Stopped).await
         }

--- a/crates/shep-daemon/src/rpc.rs
+++ b/crates/shep-daemon/src/rpc.rs
@@ -606,6 +606,20 @@ fn rpc_error(err: &SupervisorError) -> RpcError {
             code: RpcErrorCode::SpawnFailed,
             message: msg.clone(),
         },
+        // The same code as `SpawnFailed` above, on the rule this function
+        // already applies twice below: `RpcErrorCode` is versioned, a client
+        // predating a new code cannot decode the reply at all, and that costs
+        // the operator the message as well as the code. "Could not start it",
+        // and exit 7, is true of a batch refused before it was registered.
+        //
+        // The bare payload rather than `err.to_string()`, unlike the two
+        // `Internal` groups below: those share a code with something else and
+        // need `Display` to tell them apart, while this message already opens
+        // with "nothing was registered" and says everything the prefix would.
+        SupervisorError::CannotStart(msg) => RpcError {
+            code: RpcErrorCode::SpawnFailed,
+            message: msg.clone(),
+        },
         // `Internal` — an "unexpected daemon-side failure", which a log path
         // the daemon can no longer open, or can no longer empty, both are.
         // No code of its own: the wire enum is versioned, and a client that

--- a/crates/shep-daemon/src/runner.rs
+++ b/crates/shep-daemon/src/runner.rs
@@ -740,8 +740,7 @@ pub trait ProcessRunner: Send + Sync + 'static {
     /// - [`RunnerError::SpawnFailed`] — exec failure, permissions, missing binary.
     fn spawn(&self, spec: &SpawnSpec) -> Result<(Self::Proc, ProcIo), RunnerError>;
 
-    /// The reason `spec` cannot be spawned, if that is knowable without
-    /// trying
+    /// What is knowable about `spec` before anything is spawned
     ///
     /// Lets a caller refuse a whole batch before registering any of it. The
     /// defect this exists for: an eleven-app Flockfile whose third app
@@ -749,33 +748,77 @@ pub trait ProcessRunner: Send + Sync + 'static {
     /// failed on three, and never reached four through eleven, leaving a
     /// flock that matched neither the file nor its previous state.
     ///
-    /// `Option<String>` rather than `Result<(), RunnerError>`: nothing has
-    /// been attempted here, so there is no OS refusal to report, and
-    /// [`RunnerError::SpawnFailed`]'s own `Display` would say "process spawn
-    /// failed" about a process that was never spawned. The string is one
-    /// reason, no trailing punctuation, ready to be printed after a sheep's
-    /// name.
-    ///
-    /// `None` means "nothing knowable in advance", NOT "this will work".
-    /// A `Some` must therefore be a certainty rather than a suspicion:
-    /// refusing a Flockfile that would have run is far worse than the bug
-    /// this addresses, so anything an implementation cannot decide cheaply
-    /// and safely belongs in the `None` arm, where the spawn reports it as
-    /// it always did.
+    /// See [`Preflight`] for what separates a verdict a caller may refuse a
+    /// batch over from one it may only report. That split is the whole
+    /// design: a check that refuses too much is worse than the bug it
+    /// addresses, because it takes a flock down that would have come up.
     ///
     /// # Default implementation
     ///
-    /// `None`, always. A defaulted method rather than a required one for the
-    /// reason [`RunningProcess::signal_process`] gives: this is a `pub`
-    /// trait in a published library, and adding a required method to one is
-    /// a break for an out-of-tree implementor (IR-20). The default is also
-    /// the honest answer for a runner that never touches the filesystem,
-    /// which is what the crate's own fakes are.
+    /// [`Preflight::Unknown`], always. A defaulted method rather than a
+    /// required one for the reason [`RunningProcess::signal_process`] gives:
+    /// this is a `pub` trait in a published library, and adding a required
+    /// method to one is a break for an out-of-tree implementor (IR-20). The
+    /// default is also the honest answer for a runner that never touches the
+    /// filesystem, which is what the crate's own fakes are.
     #[must_use]
-    fn preflight(&self, spec: &SpawnSpec) -> Option<String> {
+    fn preflight(&self, spec: &SpawnSpec) -> Preflight {
         let _ = spec;
-        None
+        Preflight::Unknown
     }
+}
+
+/// What a [`ProcessRunner`] can tell about a [`SpawnSpec`] before anything is
+/// spawned
+///
+/// Three variants because a caller registering a BATCH has three different
+/// things to do with the answer, and collapsing any two of them costs a
+/// flock. The line that matters runs between [`Self::Impossible`] and
+/// [`Self::Doubtful`], and it is a line between two kinds of claim rather
+/// than between two confidence levels:
+///
+/// - a path with a `/` in it is a claim about the FILESYSTEM, which the
+///   daemon can check with certainty and an operator can fix with a typo
+///   correction.
+/// - a bare command is a claim about an ENVIRONMENT, and the environment
+///   that matters is the daemon's, not the shell the operator tested in. A
+///   `shep startup` unit gives the shepherd whatever `PATH` launchd or
+///   systemd hands it, so `node` from homebrew on Apple Silicon
+///   (`/opt/homebrew/bin`) and `node` from nvm (under `$HOME`) both resolve
+///   in a terminal and neither resolves under the unit.
+///
+/// Refusing a batch on the second kind would mean one app's interpreter
+/// keeping the other twelve down at boot, which is strictly worse than the
+/// partial registration the check exists to prevent.
+// `#[non_exhaustive]`: shep-daemon is a published library, an out-of-tree
+// consumer can match this exhaustively today, and a fourth verdict would
+// break them with no version bump to say so (IR-20).
+#[non_exhaustive]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Preflight {
+    /// Nothing is knowable in advance.
+    ///
+    /// NOT "this will work". Every form an implementation declines to decide
+    /// arrives here, alongside every form it decided is fine, and the two are
+    /// deliberately not distinguished: a caller may only ever act on the
+    /// other two variants.
+    Unknown,
+    /// The spawn cannot succeed, and that is a certainty rather than a
+    /// suspicion. Carries one reason, no trailing punctuation, ready to be
+    /// printed after a sheep's name.
+    ///
+    /// A caller registering a batch should refuse the WHOLE batch on this and
+    /// register none of it.
+    Impossible(String),
+    /// The spawn looks like it will fail, and a caller must not refuse a
+    /// batch over it. Carries a reason on the same terms as
+    /// [`Self::Impossible`].
+    ///
+    /// Report it and carry on: the spawn then fails for that one sheep
+    /// exactly as it would have anyway, and every other app in the batch
+    /// comes up. See this enum's own doc for why the two are not the same
+    /// question.
+    Doubtful(String),
 }
 
 /// Everything a spawn needs, pre-assembled by the assembler (a later task)

--- a/crates/shep-daemon/src/runner.rs
+++ b/crates/shep-daemon/src/runner.rs
@@ -739,6 +739,43 @@ pub trait ProcessRunner: Send + Sync + 'static {
     ///
     /// - [`RunnerError::SpawnFailed`] — exec failure, permissions, missing binary.
     fn spawn(&self, spec: &SpawnSpec) -> Result<(Self::Proc, ProcIo), RunnerError>;
+
+    /// The reason `spec` cannot be spawned, if that is knowable without
+    /// trying
+    ///
+    /// Lets a caller refuse a whole batch before registering any of it. The
+    /// defect this exists for: an eleven-app Flockfile whose third app
+    /// pointed at an unbuilt binary registered and started apps one and two,
+    /// failed on three, and never reached four through eleven, leaving a
+    /// flock that matched neither the file nor its previous state.
+    ///
+    /// `Option<String>` rather than `Result<(), RunnerError>`: nothing has
+    /// been attempted here, so there is no OS refusal to report, and
+    /// [`RunnerError::SpawnFailed`]'s own `Display` would say "process spawn
+    /// failed" about a process that was never spawned. The string is one
+    /// reason, no trailing punctuation, ready to be printed after a sheep's
+    /// name.
+    ///
+    /// `None` means "nothing knowable in advance", NOT "this will work".
+    /// A `Some` must therefore be a certainty rather than a suspicion:
+    /// refusing a Flockfile that would have run is far worse than the bug
+    /// this addresses, so anything an implementation cannot decide cheaply
+    /// and safely belongs in the `None` arm, where the spawn reports it as
+    /// it always did.
+    ///
+    /// # Default implementation
+    ///
+    /// `None`, always. A defaulted method rather than a required one for the
+    /// reason [`RunningProcess::signal_process`] gives: this is a `pub`
+    /// trait in a published library, and adding a required method to one is
+    /// a break for an out-of-tree implementor (IR-20). The default is also
+    /// the honest answer for a runner that never touches the filesystem,
+    /// which is what the crate's own fakes are.
+    #[must_use]
+    fn preflight(&self, spec: &SpawnSpec) -> Option<String> {
+        let _ = spec;
+        None
+    }
 }
 
 /// Everything a spawn needs, pre-assembled by the assembler (a later task)

--- a/crates/shep-daemon/src/snapshot.rs
+++ b/crates/shep-daemon/src/snapshot.rs
@@ -882,6 +882,86 @@ mod tests {
         handle.shutdown().await;
     }
 
+    /// fails if a bad entry that is not LAST takes every app after it down.
+    ///
+    /// The sibling case below has the broken app last in roll order, which is
+    /// exactly why it did not catch this: `do_start`'s spawn loop returned on
+    /// the first failure regardless of policy, so `BatchPolicy::PerApp`
+    /// bought nothing for anything sorted after the wreck. `a-good` came up,
+    /// `b-bad` failed, and `c-good` was never registered at all -- not
+    /// `Errored`, absent, with no log line.
+    ///
+    /// Not a race that might not bite. `FlockRegistry` is a `BTreeMap`, so
+    /// `roll` writes the saved apps alphabetically and `restorable` preserves
+    /// that order, which makes this a certainty whenever the broken name
+    /// sorts before a working one. The names here are `a-`/`b-`/`c-` so the
+    /// roll order below IS the production order.
+    ///
+    /// ONE `muster` call, deliberately. `shep muster`'s CLI path calls twice
+    /// -- an autostart boot restore, then an explicit `Request::Muster` --
+    /// and the second call re-registers what the first lost, which is what
+    /// hid this through three rounds of review. The single unattended
+    /// restore a real `shep startup` unit performs is the only path where it
+    /// matters and the only one with nobody watching, and it is the one this
+    /// exercises.
+    ///
+    /// `failing_to_spawn` is load-bearing: scripts are consumed in spawn
+    /// order, so no arrangement of the script list can make the MIDDLE app
+    /// fail while its neighbours come up.
+    #[tokio::test(start_paused = true)]
+    async fn a_bad_saved_app_does_not_take_the_apps_after_it_down() {
+        let dir = tempfile::tempdir().unwrap();
+        let paths = test_paths(&dir);
+        std::fs::create_dir_all(paths.snapshot.parent().unwrap()).unwrap();
+        let saved = |name: &str| SavedApp {
+            app: AppConfig::minimal(name, "./srv"),
+            instances_running: 1,
+        };
+        let roll = FlockSnapshot {
+            version: SNAPSHOT_VERSION,
+            saved_at_ms: 0,
+            apps: vec![saved("a-good"), saved("b-bad"), saved("c-good")],
+        };
+        write_atomic(&paths.snapshot, &roll).unwrap();
+
+        let (events, _rx) = tokio::sync::broadcast::channel(64);
+        let handle = spawn_supervisor(
+            // Two scripts for the two that must come up. `b-bad` consumes
+            // none, so a run that let it take one would starve `c-good` and
+            // fail here for a reason of its own.
+            ScriptedRunner::new(vec![ProcScript::never_exits(); 2]).failing_to_spawn(&["b-bad"]),
+            paths.clone(),
+            events,
+        );
+        let registry = FlockRegistry::new();
+
+        let restored = muster(&paths.snapshot, &registry, &handle).await.unwrap();
+        assert_eq!(
+            restored,
+            vec![
+                "a-good".to_string(),
+                "b-bad".to_string(),
+                "c-good".to_string()
+            ]
+        );
+
+        let mut listed = handle.list().await;
+        listed.sort_by(|a, b| a.name.cmp(&b.name));
+        let seen: Vec<(&str, ProcStatus)> =
+            listed.iter().map(|i| (i.name.as_str(), i.status)).collect();
+        assert_eq!(
+            seen,
+            vec![
+                ("a-good", ProcStatus::Online),
+                ("b-bad", ProcStatus::Errored),
+                ("c-good", ProcStatus::Online),
+            ],
+            "every app after the broken one must still get its turn, and the \
+             broken one must be visible rather than absent"
+        );
+        handle.shutdown().await;
+    }
+
     /// fails if ONE saved app that cannot start keeps the rest of the flock
     /// down at the next boot.
     ///

--- a/crates/shep-daemon/src/snapshot.rs
+++ b/crates/shep-daemon/src/snapshot.rs
@@ -457,7 +457,14 @@ pub(crate) async fn muster(
     // config it is actually running under, rather than having the roll's
     // copy written over it for the next save to persist.
     registry.record(&to_start);
-    if let Err(err) = supervisor.start(to_start).await {
+    // `start_restored`, not `start`: the difference is whether one saved app
+    // that cannot run keeps the rest of the flock down, and the comment below
+    // has always said it must not. `start` refuses a whole batch over an app
+    // whose script provably is not there, which is right for an operator
+    // typing `shep start` against a Flockfile and wrong here -- this runs at
+    // boot with nobody watching, and a binary missing after a rebuild would
+    // silently cost the machine its entire flock.
+    if let Err(err) = supervisor.start_restored(to_start).await {
         // One bad entry does not sink the muster — the same policy
         // `restorable` already applies at validation time. The sheep that
         // failed to spawn is already recorded `Errored` by the supervisor.
@@ -871,6 +878,76 @@ mod tests {
             seen,
             vec![("down", ProcStatus::Stopped), ("up", ProcStatus::Online)],
             "the sheep that was down is listed and stopped, not missing"
+        );
+        handle.shutdown().await;
+    }
+
+    /// fails if ONE saved app that cannot start keeps the rest of the flock
+    /// down at the next boot.
+    ///
+    /// The restore shares `do_start` with `Request::Start`, so the
+    /// pre-registration check written for an operator typing `shep start`
+    /// against a Flockfile reached this path too. Under it, a machine whose
+    /// saved `gone` had lost its binary to a rebuild came back with NOTHING
+    /// running -- not the twelve apps that were fine -- and did so at boot
+    /// with nobody watching. That is a strictly worse version of the
+    /// half-registered Flockfile the check exists to prevent, which is why
+    /// `muster` calls `start_restored` rather than `start`.
+    ///
+    /// The comment at that call site has always claimed "one bad entry does
+    /// not sink the muster". This is the case that makes the claim true
+    /// rather than aspirational.
+    ///
+    /// `refusing` is load-bearing and this case cannot fail without it:
+    /// `ScriptedRunner` reads nothing from a spec, so its `preflight`
+    /// answers `Unknown` for everything and the validating pass never
+    /// refuses anything at all.
+    ///
+    /// One script for two apps, so `gone` fails at its spawn as well. Both
+    /// halves matter: it must be REACHED (the regression refused it before
+    /// any spawn) and it must land as a visible `Errored` row rather than
+    /// vanishing.
+    #[tokio::test(start_paused = true)]
+    async fn one_unstartable_saved_app_does_not_keep_the_rest_of_the_flock_down() {
+        let dir = tempfile::tempdir().unwrap();
+        let paths = test_paths(&dir);
+        std::fs::create_dir_all(paths.snapshot.parent().unwrap()).unwrap();
+        let roll = FlockSnapshot {
+            version: SNAPSHOT_VERSION,
+            saved_at_ms: 0,
+            apps: vec![
+                SavedApp {
+                    app: AppConfig::minimal("good", "./srv"),
+                    instances_running: 1,
+                },
+                SavedApp {
+                    app: AppConfig::minimal("gone", "./deleted-by-a-rebuild"),
+                    instances_running: 1,
+                },
+            ],
+        };
+        write_atomic(&paths.snapshot, &roll).unwrap();
+
+        let (events, _rx) = tokio::sync::broadcast::channel(64);
+        let handle = spawn_supervisor(
+            ScriptedRunner::new(vec![ProcScript::never_exits()]).refusing(&["gone"]),
+            paths.clone(),
+            events,
+        );
+        let registry = FlockRegistry::new();
+
+        let restored = muster(&paths.snapshot, &registry, &handle).await.unwrap();
+        assert_eq!(restored, vec!["good".to_string(), "gone".to_string()]);
+
+        let mut listed = handle.list().await;
+        listed.sort_by(|a, b| a.name.cmp(&b.name));
+        let seen: Vec<(&str, ProcStatus)> =
+            listed.iter().map(|i| (i.name.as_str(), i.status)).collect();
+        assert_eq!(
+            seen,
+            vec![("gone", ProcStatus::Errored), ("good", ProcStatus::Online)],
+            "the app that could still run must come up, and the one that \
+             could not must be visible rather than absent"
         );
         handle.shutdown().await;
     }

--- a/crates/shep-daemon/src/supervisor.rs
+++ b/crates/shep-daemon/src/supervisor.rs
@@ -2213,7 +2213,12 @@ impl<R: ProcessRunner> Actor<R> {
             for instance in slots {
                 match self.spawn_fresh(&app, instance, credentials, dog.clone()) {
                     Ok(info) => results.push(info),
-                    Err(message) => return Err(SupervisorError::SpawnFailed(message)),
+                    // The sheep's name, which `spawn_fresh`'s message
+                    // deliberately leaves to its caller: one app of eleven
+                    // failing must say WHICH one.
+                    Err(message) => {
+                        return Err(SupervisorError::SpawnFailed(format!("{name}: {message}")));
+                    }
                 }
             }
         }
@@ -2475,7 +2480,22 @@ impl<R: ProcessRunner> Actor<R> {
                     },
                 );
                 self.emit(ProcessEventKind::Errored, info, true);
-                Err(error.to_string())
+                // Names the file exec was pointed at. `error` on its own was
+                // the whole message an operator got: "process spawn failed:
+                // No such file or directory (os error 2)", which told
+                // somebody starting an eleven-app Flockfile neither which
+                // app nor which path. The app's NAME is added by the caller
+                // rather than here, so `scale`'s own reply -- which already
+                // opens with the sheep's name -- does not say it twice.
+                //
+                // `spec.program` and `spec.cwd` verbatim, not a resolution of
+                // the two: they are what the Flockfile said, which is where
+                // the operator has to make the edit.
+                let attempted = match &spec.cwd {
+                    Some(cwd) => format!("`{}` in {}", spec.program, cwd.display()),
+                    None => format!("`{}`", spec.program),
+                };
+                Err(format!("{error}; tried {attempted}"))
             }
         }
     }
@@ -10720,6 +10740,45 @@ mod tests {
             Some(None),
             "the writer task outlived its sheep, parked on `recv()` and \
              holding the daemon's end of the shepherd channel"
+        );
+    }
+
+    /// Fails if a spawn failure goes back to naming neither the sheep nor
+    /// the path.
+    ///
+    /// The whole error an operator got was `error[spawn_failed]: the daemon
+    /// reported SpawnFailed: process spawn failed: No such file or directory
+    /// (os error 2)`. Starting an eleven-app Flockfile, that named neither
+    /// which app had failed nor which path had been tried.
+    ///
+    /// An exact string rather than two `contains`: the message is the whole
+    /// product here, and its shape is what a reader of a red run has to be
+    /// able to compare against.
+    ///
+    /// The `cwd` half is left to the end-to-end tier, which has a real one.
+    /// `AppConfig::minimal` sets none, and inventing one for this case would
+    /// pin a branch against a fixture rather than against a spawn.
+    #[tokio::test(start_paused = true)]
+    async fn a_failed_spawn_names_the_sheep_and_the_path_it_tried() {
+        let dir = tempfile::tempdir().unwrap();
+        // An EMPTY script pool, so `ScriptedRunner` refuses the first spawn
+        // it is asked for. What matters is that the refusal reaches the
+        // reply unchanged apart from the two things being added to it.
+        let (mut actor, _mailbox) = actor_with_one_online_sheep(&dir, Vec::new());
+
+        let (reply, answer) = oneshot::channel();
+        actor.handle_command(Command::Start {
+            apps: vec![normalize(AppConfig::minimal("api", "./api")).unwrap()],
+            reply,
+        });
+
+        let err = answer
+            .await
+            .expect("the actor answers every Start")
+            .expect_err("an empty script pool cannot spawn");
+        assert_eq!(
+            err.to_string(),
+            "spawn failed: api: process spawn failed: script exhausted; tried `./api`"
         );
     }
 

--- a/crates/shep-daemon/src/supervisor.rs
+++ b/crates/shep-daemon/src/supervisor.rs
@@ -2140,8 +2140,22 @@ impl<R: ProcessRunner> Actor<R> {
     }
 
     /// Expands each app through `instance_slots` + `assemble`, spawning one
-    /// instance per slot. Already-registered entries persist even when a
-    /// later spawn in the batch fails.
+    /// instance per slot, after checking every app in the batch.
+    ///
+    /// Nothing at all is registered if any app fails that check, and the
+    /// error names every one that did rather than the first. The defect
+    /// this exists for: the third app of an eleven-app Flockfile pointed at
+    /// an unbuilt binary, so apps one and two registered and started, app
+    /// three failed to spawn, and apps four through eleven were never
+    /// reached. The flock then matched neither the file nor its previous
+    /// state.
+    ///
+    /// A spawn that fails ANYWAY still leaves the batch part-registered, and
+    /// that is not a case this can close: exec is the only thing that knows
+    /// for certain, and the first instance is already running by the time
+    /// the second one is attempted. What it closes is the knowable half, and
+    /// [`ProcessRunner::preflight`] is deliberately narrow about what counts
+    /// as knowable.
     ///
     /// `dog` is written onto every entry this registers, and is `None` for
     /// every caller but [`Self::do_start_dog`] — see [`ProcessEntry::dog`]
@@ -2151,16 +2165,42 @@ impl<R: ProcessRunner> Actor<R> {
         apps: Vec<ResolvedApp>,
         dog: Option<DogSource>,
     ) -> Result<Vec<ProcessInfo>, SupervisorError> {
+        // Assembled at instance 0 and with no credentials: neither changes
+        // which file exec names, which is all `preflight` reads. The real
+        // per-instance spec is built again below.
+        let mut refusals = Vec::new();
+        // Resolved once per app in this Start batch, not once per instance:
+        // every instance of the same app shares one identity, and respawn()
+        // reuses this same value from ProcessEntry for every future restart
+        // instead of re-touching the passwd database (crate::privilege's
+        // module doc). Hoisted above the registering loop for this
+        // function's own reason: a passwd lookup that fails on the fourth
+        // app must not leave three registered either.
+        let mut credentials = Vec::with_capacity(apps.len());
+        for app in &apps {
+            let name = &app.config().name;
+            match privilege::resolve(app.config()) {
+                Ok(resolved) => credentials.push(resolved),
+                Err(err) => refusals.push(format!("{name}: {err}")),
+            }
+            if let Some(reason) = self.runner.preflight(&assemble(app, 0, &self.paths, None)) {
+                refusals.push(format!("{name}: {reason}"));
+            }
+        }
+        if !refusals.is_empty() {
+            return Err(SupervisorError::SpawnFailed(format!(
+                "nothing was registered; {} of {} apps cannot start: {}",
+                refusals.len(),
+                apps.len(),
+                refusals.join("; "),
+            )));
+        }
+
         let mut results = Vec::new();
-        for app in apps {
+        // Lengths agree exactly here: every app above pushed onto one of the
+        // two vectors, and a non-empty `refusals` has already returned.
+        for (app, credentials) in apps.into_iter().zip(credentials) {
             let name = app.config().name.clone();
-            // Resolved once per app in this Start batch, not once per
-            // instance: every instance of the same app shares one identity,
-            // and respawn() reuses this same value from ProcessEntry for
-            // every future restart instead of re-touching the passwd
-            // database (crate::privilege's module doc).
-            let credentials = privilege::resolve(app.config())
-                .map_err(|err| SupervisorError::SpawnFailed(err.to_string()))?;
             let mut existing: Vec<u32> = self
                 .sheep
                 .values()

--- a/crates/shep-daemon/src/supervisor.rs
+++ b/crates/shep-daemon/src/supervisor.rs
@@ -727,8 +727,11 @@ impl SupervisorHandle {
     ///
     /// # Errors
     ///
-    /// - [`SupervisorError::SpawnFailed`]: the first instance that failed to
-    ///   spawn (already-registered instances persist regardless).
+    /// - [`SupervisorError::SpawnFailed`]: at least one app could not be
+    ///   spawned, carrying one `"<name>: <reason>"` entry per such app joined
+    ///   by `"; "`. Every app in the batch was attempted regardless, each one
+    ///   that failed is registered `Errored` rather than left absent, and
+    ///   every app that could start is running.
     /// - [`SupervisorError::EngineStopped`]: the actor is gone.
     pub(crate) async fn start_restored(
         &self,
@@ -2342,9 +2345,10 @@ impl<R: ProcessRunner> Actor<R> {
         }
 
         let mut results = Vec::new();
+        let mut failures = Vec::new();
         // Lengths agree exactly here: every app above pushed onto one of the
         // two vectors, and a non-empty `refusals` has already returned.
-        for (app, credentials) in apps.into_iter().zip(credentials) {
+        'apps: for (app, credentials) in apps.into_iter().zip(credentials) {
             let name = app.config().name.clone();
             let mut existing: Vec<u32> = self
                 .sheep
@@ -2358,14 +2362,55 @@ impl<R: ProcessRunner> Actor<R> {
             for instance in slots {
                 match self.spawn_fresh(&app, instance, credentials, dog.clone()) {
                     Ok(info) => results.push(info),
-                    // The sheep's name, which `spawn_fresh`'s message
-                    // deliberately leaves to its caller: one app of eleven
-                    // failing must say WHICH one.
                     Err(message) => {
-                        return Err(SupervisorError::SpawnFailed(format!("{name}: {message}")));
+                        // The sheep's name, which `spawn_fresh`'s message
+                        // deliberately leaves to its caller: one app of
+                        // eleven failing must say WHICH one.
+                        let failure = format!("{name}: {message}");
+                        match policy {
+                            // The operator is holding a terminal and asked
+                            // for all-or-nothing. Stopping here is what
+                            // keeps the batch from getting any further than
+                            // it already has.
+                            BatchPolicy::AllOrNothing => {
+                                return Err(SupervisorError::SpawnFailed(failure));
+                            }
+                            // The half `BatchPolicy` gated the pass above
+                            // for and did not reach: a bad entry that is not
+                            // LAST used to take every app after it with it,
+                            // and a muster roll restores in alphabetical
+                            // order, so that is not a race but a certainty
+                            // whenever the broken name sorts first. Every
+                            // remaining app still gets its turn.
+                            //
+                            // `spawn_fresh` has already registered this one
+                            // `Errored` before returning, which is the row
+                            // the muster's own comment promises and the
+                            // event `dogs::spawn_dog_watch` subscribes to.
+                            BatchPolicy::PerApp => {
+                                failures.push(failure);
+                                // This app's remaining instances are skipped
+                                // rather than attempted. They share a binary
+                                // and a cwd with the one that just failed,
+                                // so they would fail identically and turn
+                                // one broken app into `instances` identical
+                                // wrecks in the listing. One row per broken
+                                // app, which is also what `AllOrNothing`
+                                // leaves behind.
+                                continue 'apps;
+                            }
+                        }
                     }
                 }
             }
+        }
+        // Every app was attempted, and at least one could not start. An
+        // `Err` rather than a partial `Ok`, so the caller's existing
+        // reporting still fires: `snapshot::muster` logs "failed to spawn one
+        // or more apps" off exactly this, and `do_start_dog` turns it into
+        // the dog's own refusal.
+        if !failures.is_empty() {
+            return Err(SupervisorError::SpawnFailed(failures.join("; ")));
         }
         Ok(results)
     }
@@ -9046,6 +9091,53 @@ mod tests {
         let errored = dog_row(&listed, 0);
         assert_eq!(errored.status, ProcStatus::Errored);
         assert_eq!(errored.dog, Some(DogSource::BuiltIn));
+    }
+
+    /// fails if `AllOrNothing` stops stopping at the first failed spawn.
+    ///
+    /// The mirror of `snapshot::tests::a_bad_saved_app_does_not_take_the_apps
+    /// _after_it_down`, and the reason the policy is a parameter rather than
+    /// a blanket change: teaching the spawn loop to carry on past a failure
+    /// is right for a muster restore and wrong for an operator's `shep
+    /// start`, who asked for all-or-nothing and is holding a terminal to read
+    /// the refusal. Without this case, "carry on" could quietly become the
+    /// behaviour for both.
+    ///
+    /// `failing_to_spawn` on the FIRST app, so what the assertion reads is
+    /// the second app's absence rather than its failure.
+    #[tokio::test(start_paused = true)]
+    async fn an_all_or_nothing_start_stops_at_the_first_failed_spawn() {
+        let dir = tempfile::tempdir().unwrap();
+        let (events, _rx) = broadcast::channel(64);
+        let handle = spawn_supervisor(
+            // A script for the second app, which must NOT get as far as
+            // using it: an exhausted pool would fail it for a reason of its
+            // own and make the assertion below say nothing.
+            ScriptedRunner::new(vec![ProcScript::never_exits()]).failing_to_spawn(&["first"]),
+            test_paths(&dir),
+            events,
+        );
+
+        let err = handle
+            .start(vec![
+                normalize(AppConfig::minimal("first", "./first")).unwrap(),
+                normalize(AppConfig::minimal("second", "./second")).unwrap(),
+            ])
+            .await
+            .expect_err("the first app cannot spawn");
+
+        assert!(matches!(err, SupervisorError::SpawnFailed(_)), "{err:?}");
+        let listed = handle.list().await;
+        assert_eq!(
+            listed
+                .iter()
+                .map(|i| (i.name.as_str(), i.status))
+                .collect::<Vec<_>>(),
+            vec![("first", ProcStatus::Errored)],
+            "an operator's `shep start` must not go on past a failure: the \
+             second app is never reached: {listed:?}"
+        );
+        handle.shutdown().await;
     }
 
     /// fails if a dog whose binary is missing is refused instead of being

--- a/crates/shep-daemon/src/supervisor.rs
+++ b/crates/shep-daemon/src/supervisor.rs
@@ -223,6 +223,14 @@ pub(crate) enum BatchPolicy {
     /// Note that neither is a batch in the sense the check was written for:
     /// a dog start is always one app, and a roll restore is a recovery
     /// rather than a request.
+    ///
+    /// What a failure leaves behind differs by cause, and the difference is
+    /// not cosmetic. A failed SPAWN leaves an `Errored` row, because
+    /// [`Actor::spawn_fresh`] registers the entry before it reports. An
+    /// unresolvable `user`/`group` leaves nothing, because there is no
+    /// identity to assemble a spawn for and running that app under the
+    /// daemon's own identity instead is the one outcome that must never
+    /// happen. Both are reported in the error either way.
     PerApp,
 }
 
@@ -728,10 +736,12 @@ impl SupervisorHandle {
     /// # Errors
     ///
     /// - [`SupervisorError::SpawnFailed`]: at least one app could not be
-    ///   spawned, carrying one `"<name>: <reason>"` entry per such app joined
-    ///   by `"; "`. Every app in the batch was attempted regardless, each one
-    ///   that failed is registered `Errored` rather than left absent, and
-    ///   every app that could start is running.
+    ///   started, carrying one `"<name>: <reason>"` entry per such app joined
+    ///   by `"; "`. Every app in the batch was attempted regardless, and
+    ///   every app that could start is running. An app whose SPAWN failed is
+    ///   registered `Errored` and visible; an app whose `user`/`group` could
+    ///   not be resolved leaves no row at all, since nothing can be
+    ///   assembled without an identity to assemble it for.
     /// - [`SupervisorError::EngineStopped`]: the actor is gone.
     pub(crate) async fn start_restored(
         &self,
@@ -2280,33 +2290,72 @@ impl<R: ProcessRunner> Actor<R> {
         dog: Option<DogSource>,
         policy: BatchPolicy,
     ) -> Result<Vec<ProcessInfo>, SupervisorError> {
-        // Assembled at instance 0 and with no credentials: neither changes
-        // which file exec names, which is all `preflight` reads. The real
-        // per-instance spec is built again below.
+        // Every app that survives this pass carries its OWN credentials, in
+        // one sequence rather than two.
+        //
+        // The shape this replaces was a `Vec<Option<Credentials>>` zipped
+        // against `apps`, and it was sound only while a credential failure
+        // returned early: the two vectors could differ in length, and a
+        // comment asserted they did not. The moment a failure is SKIPPED
+        // instead -- which is exactly what `PerApp` needs -- `credentials`
+        // grows shorter than `apps` while staying in order, and `zip` pairs
+        // app 2 with app 3's credentials and silently drops the last app.
+        // That is a privilege misassignment rather than a scheduling bug: a
+        // flock comes up looking correct with processes running under
+        // identities nobody chose, and nothing announces it. Pairing at the
+        // point of resolution removes the second sequence, so there is
+        // nothing left to keep in step and no invariant left to assert.
+        let mut ready: Vec<(ResolvedApp, Option<Credentials>)> = Vec::with_capacity(apps.len());
+        // `AllOrNothing` only, by construction: every push below is guarded
+        // on the policy, and a non-empty `refusals` returns before anything
+        // is registered.
         let mut refusals = Vec::new();
-        // Resolved once per app in this Start batch, not once per instance:
-        // every instance of the same app shares one identity, and respawn()
-        // reuses this same value from ProcessEntry for every future restart
-        // instead of re-touching the passwd database (crate::privilege's
-        // module doc). Hoisted above the registering loop for this
-        // function's own reason: a passwd lookup that fails on the fourth
-        // app must not leave three registered either.
-        let mut credentials = Vec::with_capacity(apps.len());
-        for app in &apps {
-            let name = &app.config().name;
-            match privilege::resolve(app.config()) {
-                Ok(resolved) => credentials.push(resolved),
+        // `PerApp` only, by the same construction. Joined into one error
+        // after every app has had its turn.
+        let mut failures = Vec::new();
+        let total = apps.len();
+        for app in apps {
+            let name = app.config().name.clone();
+            // Resolved once per app in this Start batch, not once per
+            // instance: every instance of the same app shares one identity,
+            // and respawn() reuses this same value from ProcessEntry for
+            // every future restart instead of re-touching the passwd
+            // database (crate::privilege's module doc). Ahead of the
+            // registering loop for this function's own reason too: a passwd
+            // lookup that fails on the fourth app must not leave three
+            // registered.
+            let credentials = match privilege::resolve(app.config()) {
+                Ok(resolved) => resolved,
                 Err(err) => {
                     // One refusal per app, not one per failed check. Both
                     // arms used to run, so an app failing credentials AND
                     // carrying an unresolvable path pushed twice and the
                     // summary below could say "4 of 2 apps cannot start".
                     // The reasons were each true; the count was not.
-                    refusals.push(format!("{name}: {err}"));
+                    //
+                    // Asks the policy, like every other stopping point in
+                    // this function. Under `PerApp` this app is skipped and
+                    // the rest of the batch goes on: an unresolvable `user`
+                    // on one saved app must not cost a muster restore the
+                    // whole flock.
+                    //
+                    // Skipped rather than registered `Errored`, unlike a
+                    // failed spawn. Nothing can be assembled without an
+                    // identity to assemble it for, and running it under the
+                    // daemon's own identity instead is the one outcome that
+                    // must never happen here. The failure is reported either
+                    // way; what differs is that this app leaves no row.
+                    match policy {
+                        BatchPolicy::AllOrNothing => refusals.push(format!("{name}: {err}")),
+                        BatchPolicy::PerApp => failures.push(format!("{name}: {err}")),
+                    }
                     continue;
                 }
-            }
-            match self.runner.preflight(&assemble(app, 0, &self.paths, None)) {
+            };
+            // Assembled at instance 0 and with no credentials: neither
+            // changes which file exec names, which is all `preflight` reads.
+            // The real per-instance spec is built again below.
+            match self.runner.preflight(&assemble(&app, 0, &self.paths, None)) {
                 Preflight::Unknown => {}
                 // Only ever a refusal under `AllOrNothing`. Under `PerApp`
                 // it is logged like a `Doubtful` and the app goes on to
@@ -2314,9 +2363,7 @@ impl<R: ProcessRunner> Actor<R> {
                 // and why each needs the row rather than the refusal.
                 Preflight::Impossible(reason) if policy == BatchPolicy::AllOrNothing => {
                     refusals.push(format!("{name}: {reason}"));
-                }
-                Preflight::Impossible(reason) => {
-                    tracing::warn!(sheep = %name, "{reason}");
+                    continue;
                 }
                 // Reported, never refused. A `Doubtful` is a claim about the
                 // daemon's environment rather than about a path, and the
@@ -2329,26 +2376,27 @@ impl<R: ProcessRunner> Actor<R> {
                 // The log rather than the reply: the reply is for the batch,
                 // and this is not a batch failure. At boot there is no
                 // operator holding a terminal to send it to either, and the
-                // shepherd's log is where they look.
-                Preflight::Doubtful(reason) => {
+                // shepherd's log is where they look. An `Impossible` under
+                // `PerApp` arrives here for the same reason.
+                Preflight::Impossible(reason) | Preflight::Doubtful(reason) => {
                     tracing::warn!(sheep = %name, "{reason}");
                 }
             }
+            ready.push((app, credentials));
         }
         if !refusals.is_empty() {
             return Err(SupervisorError::CannotStart(format!(
                 "nothing was registered; {} of {} apps cannot start: {}",
                 refusals.len(),
-                apps.len(),
+                total,
                 refusals.join("; "),
             )));
         }
 
         let mut results = Vec::new();
-        let mut failures = Vec::new();
-        // Lengths agree exactly here: every app above pushed onto one of the
-        // two vectors, and a non-empty `refusals` has already returned.
-        'apps: for (app, credentials) in apps.into_iter().zip(credentials) {
+        // Each pair came out of the pass above together and has travelled
+        // together since. No zip, no second sequence, no alignment to hold.
+        'apps: for (app, credentials) in ready {
             let name = app.config().name.clone();
             let mut existing: Vec<u32> = self
                 .sheep
@@ -9091,6 +9139,106 @@ mod tests {
         let errored = dog_row(&listed, 0);
         assert_eq!(errored.status, ProcStatus::Errored);
         assert_eq!(errored.dog, Some(DogSource::BuiltIn));
+    }
+
+    /// fails if an app's credentials can be paired with a DIFFERENT app.
+    ///
+    /// The hazard this exists for is not a scheduling bug, and it would not
+    /// announce itself. `do_start` used to resolve credentials into a
+    /// `Vec<Option<Credentials>>` and `zip` it against `apps`, sound only
+    /// while a credential failure returned early. Teaching that failure to
+    /// skip instead -- which is exactly what `PerApp` needs, so that one
+    /// unresolvable `user` cannot cost a muster restore its whole flock --
+    /// leaves `credentials` shorter than `apps` while still in order. `zip`
+    /// then pairs app 2 with app 3's credentials and drops the last app
+    /// silently, so the flock comes up looking correct with processes
+    /// running under identities nobody chose.
+    ///
+    /// The FIRST of three fails, because that is the ordering where the
+    /// drift starts at the very next app rather than somewhere behind it.
+    ///
+    /// Asserts the identity each app ACTUALLY got, not merely that it is
+    /// registered: `b-mine` and `c-plain` are both present under the broken
+    /// pairing too, holding each other's credentials. `b-mine` asks for this
+    /// process's own user, which resolves to a real uid without needing root
+    /// (`privilege::resolve` only refuses a CHANGE of identity), and
+    /// `c-plain` asks for none, so the two are distinguishable.
+    ///
+    /// What the broken pairing produces, for comparison: `a-bad` registered
+    /// and running as `b-mine`'s user despite having no resolvable user at
+    /// all, `b-mine` running as the daemon rather than as the user it asked
+    /// for, and `c-plain` absent.
+    ///
+    /// `#[cfg(unix)]`: `nix` is a unix-only dependency of this crate, and
+    /// `privilege::resolve` refuses any user request off-platform anyway.
+    #[cfg(unix)]
+    #[tokio::test(start_paused = true)]
+    async fn a_credential_failure_never_shifts_another_apps_identity() {
+        let dir = tempfile::tempdir().unwrap();
+        // Two scripts, for the two apps that must survive the first one's
+        // failure.
+        let (mut actor, _mailbox) =
+            actor_with_one_online_sheep(&dir, vec![ProcScript::never_exits(); 2]);
+
+        let own_uid = nix::unistd::geteuid();
+        let own_user = nix::unistd::User::from_uid(own_uid)
+            .expect("the passwd database is readable")
+            .expect("this process's own uid has a passwd entry")
+            .name;
+
+        let mut bad = AppConfig::minimal("a-bad", "./a");
+        bad.user = Some("definitely-not-a-real-shep-user".to_string());
+        let mut mine = AppConfig::minimal("b-mine", "./b");
+        mine.user = Some(own_user);
+        let plain = AppConfig::minimal("c-plain", "./c");
+
+        let (reply, answer) = oneshot::channel();
+        actor.handle_command(Command::Start {
+            apps: vec![
+                normalize(bad).unwrap(),
+                normalize(mine).unwrap(),
+                normalize(plain).unwrap(),
+            ],
+            policy: BatchPolicy::PerApp,
+            reply,
+        });
+
+        let err = answer
+            .await
+            .expect("the actor answers every Start")
+            .expect_err("one app has no resolvable user");
+        assert!(
+            err.to_string().contains("a-bad"),
+            "the failure must name the app whose user could not be resolved: {err}"
+        );
+
+        let identity = |name: &str| {
+            actor
+                .sheep
+                .values()
+                .find(|slot| slot.entry.spec.config().name == name)
+                .map(|slot| slot.entry.credentials)
+        };
+        assert_eq!(
+            identity("a-bad"),
+            None,
+            "an app with no resolvable user must not be registered at all, \
+             and must never inherit another app's identity"
+        );
+        assert_eq!(
+            identity("b-mine"),
+            Some(Some(Credentials {
+                uid: own_uid.as_raw(),
+                gid: None
+            })),
+            "the app that asked for a user must run as that user"
+        );
+        assert_eq!(
+            identity("c-plain"),
+            Some(None),
+            "the app that asked for no user must be registered, and must run \
+             as the daemon rather than as somebody else's uid"
+        );
     }
 
     /// fails if `AllOrNothing` stops stopping at the first failed spawn.

--- a/crates/shep-daemon/src/supervisor.rs
+++ b/crates/shep-daemon/src/supervisor.rs
@@ -48,7 +48,7 @@ use shep_core::config::{AppConfig, ResolvedApp, normalize};
 use shep_core::paths::ShepPaths;
 use shep_core::protocol::{
     ActionOutcome, ActionReply, BusEvent, DogSource, ExitInfo, LineOutcome, LineReply,
-    ProcessEventKind, ProcessInfo, SignalOutcome, SignalReply, Smit,
+    ProcessEventKind, ProcessInfo, SheepDrift, SignalOutcome, SignalReply, Smit,
 };
 use shep_core::selector::ProcessSelector;
 use shep_core::signals::OperatorSignal;
@@ -206,6 +206,21 @@ pub(crate) enum Command {
         apps: Vec<ResolvedApp>,
         /// Answers with every entry now registered, in the order given.
         reply: oneshot::Sender<Result<Vec<ProcessInfo>, SupervisorError>>,
+    },
+    /// Reports which of `apps` name a sheep registered under a different
+    /// config.
+    ///
+    /// Read-only, so it is answered during a shutdown like
+    /// [`Self::RegisterAtRest`] rather than refused like [`Self::Start`]:
+    /// nothing is registered, spawned or changed, so there is no child it
+    /// could leave outside the shutdown aggregation.
+    ConfigDrift {
+        /// Already-validated app specs to compare against the flock, exactly
+        /// as [`Self::Start`] would carry them.
+        apps: Vec<ResolvedApp>,
+        /// Answers with one entry per app that is both registered and
+        /// different, and no entry for anything else.
+        reply: oneshot::Sender<Result<Vec<SheepDrift>, SupervisorError>>,
     },
     /// Registers + spawns one dog, marked with where it came from.
     ///
@@ -653,6 +668,30 @@ impl SupervisorHandle {
         let (reply, rx) = oneshot::channel();
         self.tx
             .send(Msg::Command(Command::RegisterAtRest { apps, reply }))
+            .await
+            .map_err(|_| SupervisorError::EngineStopped)?;
+        rx.await.map_err(|_| SupervisorError::EngineStopped)?
+    }
+
+    /// Names the fields in which each app differs from the flock's own copy
+    /// of the sheep of the same name.
+    ///
+    /// Reads the flock and changes nothing. [`Self::start`] on a name the
+    /// flock already has adds instances rather than reconciling config,
+    /// which is what `shep stock` depends on; this is how a caller finds out
+    /// that an edit it just read from a Flockfile is one `start` will not
+    /// apply, rather than the edit vanishing without a word.
+    ///
+    /// # Errors
+    ///
+    /// - [`SupervisorError::EngineStopped`] - the actor is gone.
+    pub(crate) async fn config_drift(
+        &self,
+        apps: Vec<ResolvedApp>,
+    ) -> Result<Vec<SheepDrift>, SupervisorError> {
+        let (reply, rx) = oneshot::channel();
+        self.tx
+            .send(Msg::Command(Command::ConfigDrift { apps, reply }))
             .await
             .map_err(|_| SupervisorError::EngineStopped)?;
         rx.await.map_err(|_| SupervisorError::EngineStopped)?
@@ -1926,6 +1965,13 @@ impl<R: ProcessRunner> Actor<R> {
                 let _ = reply.send(Ok(registered));
                 false
             }
+            // Answered during a shutdown, unlike Start and for the mirror of
+            // CRITICAL-1's reason: it registers and spawns nothing, so there
+            // is no child it could leave outside the shutdown aggregation.
+            Command::ConfigDrift { apps, reply } => {
+                let _ = reply.send(Ok(self.config_drift(&apps)));
+                false
+            }
             // Rejected while `shutting_down` under CRITICAL-1's rule, the one
             // Start follows and for the same reason: a dog spawned after the
             // shutdown aggregation was computed is a child nothing will kill.
@@ -2202,6 +2248,35 @@ impl<R: ProcessRunner> Actor<R> {
             },
         );
         info
+    }
+
+    /// Names the fields in which each app differs from the registered sheep
+    /// of the same name, skipping every app that matches and every app the
+    /// flock does not have.
+    ///
+    /// `&self`: this reads the flock and changes nothing, which is the whole
+    /// point of it being a separate command rather than something `do_start`
+    /// reports on its way past. Applying an edit under a running sheep is
+    /// the outcome being ruled out, not the one being built.
+    ///
+    /// Several instances of one app share one config, so the first slot
+    /// found under a name answers for all of them. Instance count is not
+    /// what makes them differ; the stored config is.
+    fn config_drift(&self, apps: &[ResolvedApp]) -> Vec<SheepDrift> {
+        apps.iter()
+            .filter_map(|app| {
+                let incoming = app.config();
+                let stored = self
+                    .sheep
+                    .values()
+                    .find(|slot| slot.entry.spec.config().name == incoming.name)?
+                    .entry
+                    .spec
+                    .config();
+                let fields = stored.drifted_fields(incoming);
+                (!fields.is_empty()).then(|| SheepDrift::new(&incoming.name, fields))
+            })
+            .collect()
     }
 
     /// Registers + spawns one brand-new instance (a fresh id, `restarts: 0`).
@@ -10605,6 +10680,54 @@ mod tests {
             Some(None),
             "the writer task outlived its sheep, parked on `recv()` and \
              holding the daemon's end of the shepherd channel"
+        );
+    }
+
+    /// Fails if `config_drift` stops naming an edited field, starts naming a
+    /// field nobody edited, starts reporting an app the flock has never
+    /// heard of, or lets a VALUE out.
+    ///
+    /// The defect in miniature: an operator edits `cwd` in a Flockfile and
+    /// re-runs `shep start`, which adds instances rather than reconciling,
+    /// so the edit is not applied. It was also not reported, and that is
+    /// what this pins. The last assertion is the other half of the contract:
+    /// asking must not APPLY the edit either, or the report would be a
+    /// silent reconciliation with a message attached.
+    #[tokio::test(start_paused = true)]
+    async fn config_drift_names_an_edited_sheeps_fields_and_changes_nothing() {
+        let dir = tempfile::tempdir().unwrap();
+        let (actor, _mailbox) = actor_with_one_online_sheep(&dir, vec![ProcScript::never_exits()]);
+
+        // The fixture registered `AppConfig::minimal("web", "./srv")`. Two
+        // fields edited, not one, so a comparator that stopped at the first
+        // difference fails here; and `env` is one of them because reporting
+        // it by NAME alone is the security half of this (IR-41).
+        let mut edited = AppConfig::minimal("web", "./srv");
+        edited.cwd = Some("/srv/new".to_string());
+        edited
+            .env
+            .insert("DATABASE_URL".to_string(), "postgres://hunter2".to_string());
+        // A name the flock does not have. `start` will register it, so there
+        // is nothing to warn about and it must not appear in the answer.
+        let unknown = AppConfig::minimal("api", "./api");
+
+        let drift = actor.config_drift(&[normalize(edited).unwrap(), normalize(unknown).unwrap()]);
+
+        assert_eq!(
+            drift,
+            vec![SheepDrift::new(
+                "web",
+                vec!["cwd".to_string(), "env".to_string()]
+            )]
+        );
+        assert!(
+            !format!("{drift:?}").contains("hunter2"),
+            "a value must never travel with the field name that changed: {drift:?}"
+        );
+        assert_eq!(
+            actor.sheep[&0].entry.spec.config().cwd,
+            None,
+            "asking which fields differ must not apply them"
         );
     }
 

--- a/crates/shep-daemon/src/supervisor.rs
+++ b/crates/shep-daemon/src/supervisor.rs
@@ -180,6 +180,52 @@ impl ConnId {
 /// moment ago.
 type Smits = HashMap<String, (ConnId, String)>;
 
+/// Whether a [`Command::Start`] is all-or-nothing.
+///
+/// The pre-registration check in [`Actor::do_start`] exists for ONE caller's
+/// problem, and three others share that function. Making the policy a
+/// parameter is what stops the check reaching callers it was never meant for
+/// -- twice already it has, and both times the symptom was a flock that
+/// stayed down rather than a flock that came up half-registered.
+///
+/// `pub(crate)` like [`Command`] itself, and for the same reason: nothing
+/// outside this crate names it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum BatchPolicy {
+    /// Refuse the whole batch if any app in it provably cannot run, and
+    /// register none of it.
+    ///
+    /// What an operator typing `shep start` against a Flockfile asked for,
+    /// and the only caller this is right for. The defect it exists for: the
+    /// third app of eleven pointed at an unbuilt binary, so two registered
+    /// and started, one failed, and eight were never reached, leaving a
+    /// flock that matched neither the file nor its previous state. The
+    /// operator is holding a terminal, gets told, and can fix the file and
+    /// run it again.
+    AllOrNothing,
+    /// Register and spawn each app on its own merits, so one app that cannot
+    /// run costs only itself.
+    ///
+    /// What every other caller needs, and for two different reasons that
+    /// point the same way:
+    ///
+    /// - **Nobody is watching.** The muster roll restore runs at boot, and
+    ///   its own comment has always said "one bad entry does not sink the
+    ///   muster". A saved app whose binary is missing after a rebuild must
+    ///   not keep the other twelve down until somebody notices.
+    /// - **The failure IS the product.** A dog that cannot start belongs in
+    ///   the dogs table as `Errored`, which is what the operator who enabled
+    ///   it needs to see. [`Actor::spawn_fresh`] registers that row on
+    ///   purpose and says so, and `dogs::spawn_dog_watch` is a subscriber
+    ///   whose whole business is a dog reaching `Errored`. A refusal leaves
+    ///   no trace for either.
+    ///
+    /// Note that neither is a batch in the sense the check was written for:
+    /// a dog start is always one app, and a roll restore is a recovery
+    /// rather than a request.
+    PerApp,
+}
+
 /// Commands the supervisor actor accepts (wrapped in [`Msg::Command`]).
 ///
 /// `pub(crate)` like [`Msg`], and for the same reason: [`SupervisorHandle`] is
@@ -192,6 +238,8 @@ pub(crate) enum Command {
     Start {
         /// Already-validated app specs to expand into instances.
         apps: Vec<ResolvedApp>,
+        /// Whether one app that provably cannot run refuses the whole batch.
+        policy: BatchPolicy,
         /// Answers with every spawned instance, or the first spawn failure.
         reply: oneshot::Sender<Result<Vec<ProcessInfo>, SupervisorError>>,
     },
@@ -667,9 +715,40 @@ impl SupervisorHandle {
     ///   to spawn (already-registered instances persist regardless).
     /// - [`SupervisorError::EngineStopped`] — the actor is gone.
     pub async fn start(&self, apps: Vec<ResolvedApp>) -> Result<Vec<ProcessInfo>, SupervisorError> {
+        self.start_with(apps, BatchPolicy::AllOrNothing).await
+    }
+
+    /// [`Self::start`], but one app that cannot run costs only itself.
+    ///
+    /// For restoring a muster roll, which is the caller
+    /// [`BatchPolicy::PerApp`]'s doc opens with: it runs at boot with nobody
+    /// watching, and a saved app whose binary went missing must not keep the
+    /// rest of the flock down.
+    ///
+    /// # Errors
+    ///
+    /// - [`SupervisorError::SpawnFailed`]: the first instance that failed to
+    ///   spawn (already-registered instances persist regardless).
+    /// - [`SupervisorError::EngineStopped`]: the actor is gone.
+    pub(crate) async fn start_restored(
+        &self,
+        apps: Vec<ResolvedApp>,
+    ) -> Result<Vec<ProcessInfo>, SupervisorError> {
+        self.start_with(apps, BatchPolicy::PerApp).await
+    }
+
+    async fn start_with(
+        &self,
+        apps: Vec<ResolvedApp>,
+        policy: BatchPolicy,
+    ) -> Result<Vec<ProcessInfo>, SupervisorError> {
         let (reply, rx) = oneshot::channel();
         self.tx
-            .send(Msg::Command(Command::Start { apps, reply }))
+            .send(Msg::Command(Command::Start {
+                apps,
+                policy,
+                reply,
+            }))
             .await
             .map_err(|_| SupervisorError::EngineStopped)?;
         rx.await.map_err(|_| SupervisorError::EngineStopped)?
@@ -1969,11 +2048,15 @@ impl<R: ProcessRunner> Actor<R> {
             // begun — it would register + spawn a child the shutdown
             // aggregation (computed from `online` ids at the moment it ran)
             // can never know to kill, orphaning it after the actor exits.
-            Command::Start { apps, reply } => {
+            Command::Start {
+                apps,
+                policy,
+                reply,
+            } => {
                 let result = if self.shutting_down {
                     Err(SupervisorError::EngineStopped)
                 } else {
-                    self.do_start(apps, None)
+                    self.do_start(apps, None, policy)
                 };
                 let _ = reply.send(result);
                 false
@@ -2154,7 +2237,13 @@ impl<R: ProcessRunner> Actor<R> {
         {
             return Ok(to_info(&slot.entry, &self.smits));
         }
-        let started = self.do_start(vec![app], Some(source))?;
+        // `PerApp`, and this is the whole reason the policy is a parameter.
+        // A dog that cannot start must land in the dogs table as `Errored`,
+        // which `spawn_fresh`'s failure arm registers on purpose and
+        // `dogs::spawn_dog_watch` subscribes to. A refusal would leave the
+        // operator who enabled it no trace at all. There is no half-batch to
+        // prevent here either: a dog start is always exactly one app.
+        let started = self.do_start(vec![app], Some(source), BatchPolicy::PerApp)?;
         started
             .into_iter()
             .next()
@@ -2186,6 +2275,7 @@ impl<R: ProcessRunner> Actor<R> {
         &mut self,
         apps: Vec<ResolvedApp>,
         dog: Option<DogSource>,
+        policy: BatchPolicy,
     ) -> Result<Vec<ProcessInfo>, SupervisorError> {
         // Assembled at instance 0 and with no credentials: neither changes
         // which file exec names, which is all `preflight` reads. The real
@@ -2215,7 +2305,16 @@ impl<R: ProcessRunner> Actor<R> {
             }
             match self.runner.preflight(&assemble(app, 0, &self.paths, None)) {
                 Preflight::Unknown => {}
-                Preflight::Impossible(reason) => refusals.push(format!("{name}: {reason}")),
+                // Only ever a refusal under `AllOrNothing`. Under `PerApp`
+                // it is logged like a `Doubtful` and the app goes on to
+                // register: see `BatchPolicy::PerApp` for the two callers
+                // and why each needs the row rather than the refusal.
+                Preflight::Impossible(reason) if policy == BatchPolicy::AllOrNothing => {
+                    refusals.push(format!("{name}: {reason}"));
+                }
+                Preflight::Impossible(reason) => {
+                    tracing::warn!(sheep = %name, "{reason}");
+                }
                 // Reported, never refused. A `Doubtful` is a claim about the
                 // daemon's environment rather than about a path, and the
                 // daemon's environment under the unit `shep startup`
@@ -8949,6 +9048,59 @@ mod tests {
         assert_eq!(errored.dog, Some(DogSource::BuiltIn));
     }
 
+    /// fails if a dog whose binary is missing is refused instead of being
+    /// registered `Errored`.
+    ///
+    /// `do_start_dog` shares `do_start` with `Request::Start`, so the
+    /// pre-registration check written for a Flockfile batch reached dogs too
+    /// and turned a visible wreck into no trace at all. Three things depend
+    /// on the row: [`Actor::spawn_fresh`]'s failure arm registers it on
+    /// purpose and says so in its own doc, `shep dogs` renders it, and
+    /// `dogs::spawn_dog_watch` is a subscriber whose entire business is a
+    /// dog reaching `Errored`. An operator who enabled a dog wants to be
+    /// told it is broken, not to find nothing there.
+    ///
+    /// `refusing` is load-bearing and this case cannot fail without it.
+    /// `ScriptedRunner` reads nothing from a spec, so its `preflight`
+    /// answers `Unknown` like the trait default, the validating pass never
+    /// refuses anything, and the assertions below would hold whichever way
+    /// `do_start_dog` passed its policy.
+    ///
+    /// The error is asserted too, not only the row. `SpawnFailed` is a spawn
+    /// that was really attempted and really failed; `CannotStart` would mean
+    /// the batch was refused, which is the regression, and the two are
+    /// otherwise indistinguishable from the caller.
+    #[tokio::test(start_paused = true)]
+    async fn a_dog_that_cannot_spawn_is_registered_errored_rather_than_refused() {
+        let dir = tempfile::tempdir().unwrap();
+        let (events, _rx) = broadcast::channel(64);
+        // Empty scripts, so the spawn this now reaches fails on its own too:
+        // the point is that it is REACHED, and that the wreck is registered.
+        let runner = ScriptedRunner::new(Vec::new()).refusing(&["bark"]);
+        let handle = spawn_supervisor(runner, test_paths(&dir), events);
+
+        let err = handle
+            .start_dog(dog_app("bark"), DogSource::BuiltIn)
+            .await
+            .expect_err("nothing can spawn against an empty script pool");
+
+        assert!(
+            matches!(err, SupervisorError::SpawnFailed(_)),
+            "a dog must reach its spawn and fail there, not be refused \
+             before it registers: {err:?}"
+        );
+        let listed = handle.list().await;
+        assert_eq!(
+            listed
+                .iter()
+                .map(|i| (i.name.as_str(), i.status, i.dog.clone()))
+                .collect::<Vec<_>>(),
+            vec![("bark", ProcStatus::Errored, Some(DogSource::BuiltIn))],
+            "the dogs table must still show the dog, and show it broken"
+        );
+        handle.shutdown().await;
+    }
+
     /// fails if a reload's replacement is built without the marker.
     /// `shep reload bark` names the dog exactly, so it reaches it (a
     /// wildcard would not), and an unmarked replacement turns the dog into a
@@ -10890,6 +11042,7 @@ mod tests {
         let (reply, answer) = oneshot::channel();
         actor.handle_command(Command::Start {
             apps: vec![normalize(AppConfig::minimal("api", "./api")).unwrap()],
+            policy: BatchPolicy::AllOrNothing,
             reply,
         });
 
@@ -10992,6 +11145,7 @@ mod tests {
         let (reply, _answer) = oneshot::channel();
         actor.handle_command(Command::Start {
             apps: vec![normalize(app).unwrap()],
+            policy: BatchPolicy::AllOrNothing,
             reply,
         });
         assert!(

--- a/crates/shep-daemon/src/supervisor.rs
+++ b/crates/shep-daemon/src/supervisor.rs
@@ -2529,11 +2529,35 @@ impl<R: ProcessRunner> Actor<R> {
                 // `spec.program` and `spec.cwd` verbatim, not a resolution of
                 // the two: they are what the Flockfile said, which is where
                 // the operator has to make the edit.
-                let attempted = match &spec.cwd {
-                    Some(cwd) => format!("`{}` in {}", spec.program, cwd.display()),
-                    None => format!("`{}`", spec.program),
+                //
+                // A `Doubtful` verdict REPLACES that clause rather than
+                // joining it. This is the one channel the "not on the
+                // shepherd's PATH" sentence has to an operator holding a
+                // terminal: the batch check only ever logs it, because a
+                // doubt must not fail a batch and the `Start` reply is about
+                // the batch. Once THIS app's own spawn has failed, the reply
+                // is about this app, and the sentence belongs in it. It
+                // needs no protocol change: `SpawnFailed` already carries
+                // free-form text.
+                //
+                // Re-asking the runner rather than reading `error`'s kind:
+                // `RunnerError` carries the OS message already stringified,
+                // and widening it to carry an `ErrorKind` would be a public
+                // change to say something the runner can already answer. A
+                // second PATH walk, on a path that has already failed.
+                //
+                // Only `Doubtful`. An `Impossible` here means the file went
+                // away between the check and the spawn, and "tried `./srv`
+                // in /srv" names the literal the operator wrote plus the
+                // directory, which is what they need in order to edit it.
+                let attempted = match self.runner.preflight(&spec) {
+                    Preflight::Doubtful(reason) => reason,
+                    _ => match &spec.cwd {
+                        Some(cwd) => format!("tried `{}` in {}", spec.program, cwd.display()),
+                        None => format!("tried `{}`", spec.program),
+                    },
                 };
-                Err(format!("{error}; tried {attempted}"))
+                Err(format!("{error}; {attempted}"))
             }
         }
     }

--- a/crates/shep-daemon/src/supervisor.rs
+++ b/crates/shep-daemon/src/supervisor.rs
@@ -2203,7 +2203,15 @@ impl<R: ProcessRunner> Actor<R> {
             let name = &app.config().name;
             match privilege::resolve(app.config()) {
                 Ok(resolved) => credentials.push(resolved),
-                Err(err) => refusals.push(format!("{name}: {err}")),
+                Err(err) => {
+                    // One refusal per app, not one per failed check. Both
+                    // arms used to run, so an app failing credentials AND
+                    // carrying an unresolvable path pushed twice and the
+                    // summary below could say "4 of 2 apps cannot start".
+                    // The reasons were each true; the count was not.
+                    refusals.push(format!("{name}: {err}"));
+                    continue;
+                }
             }
             match self.runner.preflight(&assemble(app, 0, &self.paths, None)) {
                 Preflight::Unknown => {}
@@ -6978,6 +6986,49 @@ mod tests {
         assert!(
             handle.list().await.is_empty(),
             "a refusal before the registering pass must leave nothing registered"
+        );
+    }
+
+    /// fails if one app can contribute more than one refusal. Both checks in
+    /// the validating pass used to run unconditionally, so an app with an
+    /// unresolvable user AND an unresolvable path pushed twice, and a
+    /// two-app batch could tell an operator that "4 of 2 apps cannot start".
+    ///
+    /// Every reason in that message was true. Only the arithmetic was wrong,
+    /// which is why this asserts the COUNT rather than the reasons: the
+    /// reasons were never the broken part and a test pinning them would have
+    /// passed throughout.
+    #[tokio::test(start_paused = true)]
+    async fn a_refusal_is_counted_once_per_app_not_once_per_failed_check() {
+        let dir = tempfile::tempdir().unwrap();
+        let (events, _rx) = tokio::sync::broadcast::channel(64);
+        let handle = spawn_supervisor(
+            // `refusing` is what makes this test able to fail. Without it
+            // the fake answers `Preflight::Unknown` for everything, only the
+            // credentials check can refuse, and no app can push twice no
+            // matter what the counting code does.
+            ScriptedRunner::new(vec![ProcScript::never_exits()]).refusing(&["one", "two"]),
+            test_paths(&dir),
+            events,
+        );
+        // Two apps, each failing both checks it can fail: an unresolvable
+        // user, and a script preflight refuses.
+        let both_bad = |name: &str| {
+            let mut app = AppConfig::minimal(name, "./definitely-not-here");
+            app.cwd = Some(dir.path().display().to_string());
+            app.user = Some("definitely-not-a-real-shep-user".to_string());
+            normalize(app).unwrap()
+        };
+        let err = handle
+            .start(vec![both_bad("one"), both_bad("two")])
+            .await
+            .unwrap_err();
+        let SupervisorError::CannotStart(msg) = &err else {
+            panic!("expected CannotStart, got {err:?}");
+        };
+        assert!(
+            msg.contains("2 of 2 apps cannot start"),
+            "one refusal per app, never one per failed check: {msg}"
         );
     }
 

--- a/crates/shep-daemon/src/supervisor.rs
+++ b/crates/shep-daemon/src/supervisor.rs
@@ -65,7 +65,7 @@ use crate::probes::Prober;
 use crate::probes::os::OsProber;
 use crate::probes::ready::{Readiness, ReadinessSource, await_ready};
 use crate::runner::{
-    ExitOutcome, FlushError, LogCtl, ProcIo, ProcessRunner, ReopenError, RunnerError,
+    ExitOutcome, FlushError, LogCtl, Preflight, ProcIo, ProcessRunner, ReopenError, RunnerError,
     RunningProcess, SpawnSpec, StdinWrite, check_log_ancestry, open_log_path,
 };
 
@@ -513,8 +513,9 @@ pub(crate) enum Msg {
 
 /// Error type returned from supervisor commands.
 ///
-/// `#[non_exhaustive]`: seven variants today cover lookup, spawn, reload
-/// overlap, an invalid scale, and the two log-maintenance failure classes.
+/// `#[non_exhaustive]`: eight variants today cover lookup, spawn, a batch
+/// refused before it was registered, reload overlap, an invalid scale, and
+/// the two log-maintenance failure classes.
 /// The doc here used to forecast "a scale or pause verb" adding its own
 /// failure variant; the scale half of that has now landed as
 /// [`Self::InvalidScale`], and a pause verb, if one is ever built, is the
@@ -528,6 +529,26 @@ pub enum SupervisorError {
     NotFound,
     /// Spawn failed (carries the runner's message).
     SpawnFailed(String),
+    /// A `Start` batch was refused before anything was registered, because
+    /// at least one app in it provably could not run. Carries one
+    /// `"<name>: <reason>"` entry per such app, joined by `"; "`, behind a
+    /// count and the fact that nothing was registered.
+    ///
+    /// Separate from [`Self::SpawnFailed`] because NOTHING WAS SPAWNED, and
+    /// an operator reading "spawn failed" about a spawn that never happened
+    /// is being told something untrue about where to look. The two also
+    /// differ in what they leave behind, which is the part that matters
+    /// operationally: a `SpawnFailed` can leave earlier apps in the batch
+    /// registered and running, while this one guarantees an untouched flock.
+    ///
+    /// Maps to
+    /// [`RpcErrorCode::SpawnFailed`](shep_core::protocol::RpcErrorCode::SpawnFailed)
+    /// all the same, on the rule this file already applies to
+    /// [`Self::ReloadInFlight`]: `RpcErrorCode` is versioned, a client that
+    /// predates a new code cannot decode the reply at all, and that would
+    /// cost the operator the message as well as the code. "Could not start
+    /// it", and the exit code that goes with it, is true of both.
+    CannotStart(String),
     /// The selector reached an app that is already being reloaded; carries
     /// that app's name.
     ///
@@ -611,6 +632,7 @@ impl fmt::Display for SupervisorError {
         match self {
             Self::NotFound => f.write_str("selector matched no registered sheep"),
             Self::SpawnFailed(msg) => write!(f, "spawn failed: {msg}"),
+            Self::CannotStart(msg) => write!(f, "start refused: {msg}"),
             Self::ReloadInFlight(name) => write!(f, "{name} is already being reloaded"),
             Self::InvalidScale(msg) => write!(f, "cannot scale: {msg}"),
             Self::ReopenFailed(msg) => write!(f, "log reopen failed: {msg}"),
@@ -2183,12 +2205,28 @@ impl<R: ProcessRunner> Actor<R> {
                 Ok(resolved) => credentials.push(resolved),
                 Err(err) => refusals.push(format!("{name}: {err}")),
             }
-            if let Some(reason) = self.runner.preflight(&assemble(app, 0, &self.paths, None)) {
-                refusals.push(format!("{name}: {reason}"));
+            match self.runner.preflight(&assemble(app, 0, &self.paths, None)) {
+                Preflight::Unknown => {}
+                Preflight::Impossible(reason) => refusals.push(format!("{name}: {reason}")),
+                // Reported, never refused. A `Doubtful` is a claim about the
+                // daemon's environment rather than about a path, and the
+                // daemon's environment under the unit `shep startup`
+                // installs is not the shell an operator tested in: refusing
+                // here would keep a whole flock down at boot because one
+                // app's `node` is in `/opt/homebrew/bin`. That app's spawn
+                // fails on its own in a moment, naming the same program.
+                //
+                // The log rather than the reply: the reply is for the batch,
+                // and this is not a batch failure. At boot there is no
+                // operator holding a terminal to send it to either, and the
+                // shepherd's log is where they look.
+                Preflight::Doubtful(reason) => {
+                    tracing::warn!(sheep = %name, "{reason}");
+                }
             }
         }
         if !refusals.is_empty() {
-            return Err(SupervisorError::SpawnFailed(format!(
+            return Err(SupervisorError::CannotStart(format!(
                 "nothing was registered; {} of {} apps cannot start: {}",
                 refusals.len(),
                 apps.len(),
@@ -6908,7 +6946,15 @@ mod tests {
             .start(vec![normalize(app).unwrap()])
             .await
             .unwrap_err();
-        assert!(matches!(err, SupervisorError::SpawnFailed(_)));
+        // `CannotStart`, not `SpawnFailed`: passwd resolution happens in the
+        // pass that runs BEFORE anything is registered, so nothing was
+        // spawned and nothing was left behind. Saying "spawn failed" here
+        // would point an operator at a spawn that never happened.
+        assert!(matches!(err, SupervisorError::CannotStart(_)), "{err:?}");
+        assert!(
+            handle.list().await.is_empty(),
+            "a refusal before the registering pass must leave nothing registered"
+        );
     }
 
     #[tokio::test(start_paused = true)]

--- a/crates/shep-daemon/src/supervisor.rs
+++ b/crates/shep-daemon/src/supervisor.rs
@@ -719,6 +719,13 @@ impl SupervisorHandle {
     ///
     /// # Errors
     ///
+    /// - [`SupervisorError::CannotStart`] — at least one app provably could
+    ///   not run, so NOTHING was registered and the flock is exactly as it
+    ///   was. Carries one `"<name>: <reason>"` per refused app, never one
+    ///   per failed check. All or nothing, which is what an operator typing
+    ///   `shep start` against a Flockfile wants: a typo in the third app of
+    ///   eleven leaves nothing half-registered rather than a flock matching
+    ///   neither the file nor what was there before.
     /// - [`SupervisorError::SpawnFailed`] — the first instance that failed
     ///   to spawn (already-registered instances persist regardless).
     /// - [`SupervisorError::EngineStopped`] — the actor is gone.

--- a/crates/shep-daemon/src/tokio_runner.rs
+++ b/crates/shep-daemon/src/tokio_runner.rs
@@ -229,8 +229,65 @@ fn to_nix_operator_signal(sig: OperatorSignal) -> Signal {
     }
 }
 
+/// Why exec will not find `spec.program`, when that is a question with one
+/// answer.
+///
+/// A `Some` is a certainty, never a suspicion. Every form this cannot decide
+/// cheaply and safely returns `None` and is left to fail at the spawn as it
+/// always did, because refusing a Flockfile that would have run is far worse
+/// than the partial-registration bug the caller is fixing
+/// ([`ProcessRunner::preflight`]). Two such forms:
+///
+/// - a relative path with no `cwd`. The child would resolve it against the
+///   DAEMON's working directory, whatever the shepherd happened to be
+///   autostarted from, and a refusal is not worth betting on that.
+/// - a bare command with no usable `PATH` in `spec.env`. `assemble`'s
+///   `base_env` always seeds one, so only a spec built some other way gets
+///   here.
+///
+/// The bare-command arm searches `spec.env`'s own `PATH`, not the daemon's
+/// ambient one: that map IS the child's whole environment (`spawn` calls
+/// `env_clear` then `envs`), so it is the exact list exec is about to walk.
+/// `node` and `npx` in a real Flockfile take this arm.
+///
+/// Existence only, never the executable bit: a file that is there and cannot
+/// be exec'd is the spawn's business, and mode bits under a `user`/`group`
+/// drop are not a thing to be confident about from here.
+fn program_not_found(spec: &SpawnSpec) -> Option<String> {
+    if spec.program.is_empty() {
+        return None;
+    }
+    let program = Path::new(&spec.program);
+    if spec.program.contains('/') {
+        let full = if program.is_absolute() {
+            program.to_path_buf()
+        } else {
+            spec.cwd.as_ref()?.join(program)
+        };
+        return (!full.exists()).then(|| format!("no such file: {}", full.display()));
+    }
+    let path = spec.env.get("PATH").filter(|value| !value.is_empty())?;
+    let found = path
+        .split(':')
+        .filter(|dir| !dir.is_empty())
+        .any(|dir| Path::new(dir).join(program).exists());
+    (!found).then(|| format!("`{}` is not on the shepherd's PATH ({path})", spec.program))
+}
+
 impl ProcessRunner for TokioRunner {
     type Proc = TokioProc;
+
+    /// Reports a `program` that provably is not there, and nothing else.
+    ///
+    /// `program` is what `assemble` resolved the app's `script` and
+    /// `interpreter` down to, so this checks the one file exec will name and
+    /// never a script that an interpreter takes as its first ARGUMENT: an
+    /// app running `npx next start` is checked at `npx`, and `next` is
+    /// npx's business. Deliberately under-tightened, per
+    /// [`program_not_found`].
+    fn preflight(&self, spec: &SpawnSpec) -> Option<String> {
+        program_not_found(spec)
+    }
 
     fn spawn(&self, spec: &SpawnSpec) -> Result<(Self::Proc, ProcIo), RunnerError> {
         let mut command = Command::new(&spec.program);
@@ -1008,6 +1065,7 @@ fn spawn_channel_pumps(
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeMap;
     use std::fs;
     use std::time::Duration;
 
@@ -1717,6 +1775,98 @@ mod tests {
                 .expect("its sender must outlive the write")
                 .is_ok()
         );
+    }
+
+    /// A [`SpawnSpec`] carrying only what [`program_not_found`] reads. Every
+    /// other field is left at whatever is cheapest: nothing below spawns
+    /// anything, so nothing below can be affected by them.
+    fn preflight_spec(program: &str, cwd: Option<PathBuf>, path: Option<&str>) -> SpawnSpec {
+        let mut env = BTreeMap::new();
+        if let Some(path) = path {
+            env.insert("PATH".to_string(), path.to_string());
+        }
+        SpawnSpec {
+            name: "web".to_string(),
+            program: program.to_string(),
+            args: Vec::new(),
+            cwd,
+            env,
+            out_file: PathBuf::from("/dev/null"),
+            err_file: PathBuf::from("/dev/null"),
+            channel: false,
+            stdin: false,
+            credentials: None,
+        }
+    }
+
+    /// fails if a form the preflight must not decide starts being refused.
+    ///
+    /// This is the direction that costs a working Flockfile, so it is the
+    /// list worth pinning as a sweep rather than one representative case.
+    /// Every entry here is a real shape from the testbed Flockfile that
+    /// produced the defect: absolute (`heatrotom`), relative to a `cwd`
+    /// (`obscura`), a bare command on PATH (`node`, `npx`).
+    #[test]
+    fn a_program_that_is_really_there_is_never_refused() {
+        let dir = tempfile::tempdir().unwrap();
+        let bin = dir.path().join("srv");
+        fs::write(&bin, "#!/bin/sh\n").unwrap();
+        let path_dir = dir.path().to_string_lossy().into_owned();
+
+        for spec in [
+            preflight_spec(&bin.to_string_lossy(), None, None),
+            preflight_spec("./srv", Some(dir.path().to_path_buf()), None),
+            preflight_spec("srv", None, Some(&path_dir)),
+            // The second PATH entry rather than the first, so a search that
+            // only ever looks at one directory fails here.
+            preflight_spec("srv", None, Some(&format!("/nonexistent:{path_dir}"))),
+            // Not decidable, and so not decided: a relative path with no
+            // `cwd` would be resolved against whatever directory the
+            // shepherd was autostarted from.
+            preflight_spec("./srv", None, None),
+            // Likewise a bare name with no PATH to search.
+            preflight_spec("srv", None, None),
+            preflight_spec("srv", None, Some("")),
+            preflight_spec("", None, None),
+        ] {
+            assert_eq!(
+                program_not_found(&spec),
+                None,
+                "refused a spec it cannot be certain about: {spec:?}"
+            );
+        }
+    }
+
+    /// fails if the check stops catching the defect: the third app of an
+    /// eleven-app Flockfile pointing at an unbuilt binary, which registered
+    /// two apps, failed, and never reached the other eight.
+    ///
+    /// The reason string is asserted to carry the resolved PATH, not the
+    /// `./proto-enum-api` the operator wrote, because "no such file:
+    /// ./proto-enum-api" is exactly the message that left them guessing
+    /// which directory it was looked for in.
+    #[test]
+    fn a_program_that_is_provably_absent_is_named_with_the_path_that_was_tried() {
+        let dir = tempfile::tempdir().unwrap();
+
+        let relative = program_not_found(&preflight_spec(
+            "./proto-enum-api",
+            Some(dir.path().to_path_buf()),
+            None,
+        ))
+        .expect("a relative script under a real cwd is decidable");
+        assert_eq!(
+            relative,
+            format!("no such file: {}/./proto-enum-api", dir.path().display())
+        );
+
+        let absolute = program_not_found(&preflight_spec("/nonexistent/srv", None, None))
+            .expect("an absolute script is decidable");
+        assert_eq!(absolute, "no such file: /nonexistent/srv");
+
+        let bare = program_not_found(&preflight_spec("node", None, Some("/nonexistent")))
+            .expect("a bare command against a real PATH is decidable");
+        assert_eq!(bare, "`node` is not on the shepherd's PATH (/nonexistent)");
     }
 
     // Everything else in this module needs a real OS child and lives in

--- a/crates/shep-daemon/src/tokio_runner.rs
+++ b/crates/shep-daemon/src/tokio_runner.rs
@@ -283,8 +283,11 @@ impl ProcessRunner for TokioRunner {
     /// `interpreter` down to, so this checks the one file exec will name and
     /// never a script that an interpreter takes as its first ARGUMENT: an
     /// app running `npx next start` is checked at `npx`, and `next` is
-    /// npx's business. Deliberately under-tightened, per
-    /// [`program_not_found`].
+    /// npx's business.
+    ///
+    /// Deliberately under-tightened: see this module's `program_not_found`
+    /// for every form it declines to decide and why each one is left to the
+    /// spawn.
     fn preflight(&self, spec: &SpawnSpec) -> Option<String> {
         program_not_found(spec)
     }

--- a/crates/shep-daemon/src/tokio_runner.rs
+++ b/crates/shep-daemon/src/tokio_runner.rs
@@ -45,8 +45,9 @@ use tokio::sync::mpsc;
 use crate::boot::DIR_MODE;
 use crate::channel::{CHANNEL_VERSION, ChildMessage, ShepherdMessage};
 use crate::runner::{
-    ExitOutcome, FlushError, LogCtl, LogLine, ProcIo, ProcessRunner, ReopenError, RunnerError,
-    RunningProcess, SpawnSpec, StdinWrite, StopSignal, check_log_ancestry, open_log_path,
+    ExitOutcome, FlushError, LogCtl, LogLine, Preflight, ProcIo, ProcessRunner, ReopenError,
+    RunnerError, RunningProcess, SpawnSpec, StdinWrite, StopSignal, check_log_ancestry,
+    open_log_path,
 };
 
 /// Capacity of every channel a spawn wires up — generous enough that a
@@ -229,49 +230,76 @@ fn to_nix_operator_signal(sig: OperatorSignal) -> Signal {
     }
 }
 
-/// Why exec will not find `spec.program`, when that is a question with one
-/// answer.
+/// What exec will make of `spec.program`, before anything is spawned.
 ///
-/// A `Some` is a certainty, never a suspicion. Every form this cannot decide
-/// cheaply and safely returns `None` and is left to fail at the spawn as it
-/// always did, because refusing a Flockfile that would have run is far worse
-/// than the partial-registration bug the caller is fixing
-/// ([`ProcessRunner::preflight`]). Two such forms:
+/// Two arms, and which one a program takes is decided by a single `/`:
 ///
+/// - **With a `/`** the program is a path, and a path is a claim about the
+///   filesystem this can settle. Absolute, or relative to `spec.cwd`, and
+///   either way the file is either there or it is not.
+///   [`Preflight::Impossible`], which its caller refuses a whole batch over.
+/// - **Without one** it is a bare command exec resolves through `PATH`, and
+///   that is a claim about an environment rather than about a path. At most
+///   [`Preflight::Doubtful`], never `Impossible`. See [`Preflight`] for the
+///   argument; the short version is that a `shep startup` unit's `PATH` is
+///   not the operator's shell's, so refusing a batch here would keep a whole
+///   flock down over one app's interpreter.
+///
+/// The PATH searched is `spec.env`'s own, not the daemon's ambient one: that
+/// map IS the child's whole environment (`spawn` calls `env_clear` then
+/// `envs`), so it is the exact list exec is about to walk, and naming it in
+/// the message is what tells an operator which `PATH` was actually looked in.
+///
+/// [`Preflight::Unknown`] for everything else, which is anything that would
+/// have to be guessed at:
+///
+/// - a program that resolves, whether by path or on `PATH`. Reported as
+///   "nothing knowable", not as "this will work": the executable bit, the
+///   shebang and the `user`/`group` drop are all still ahead of it.
 /// - a relative path with no `cwd`. The child would resolve it against the
 ///   DAEMON's working directory, whatever the shepherd happened to be
-///   autostarted from, and a refusal is not worth betting on that.
+///   autostarted from.
 /// - a bare command with no usable `PATH` in `spec.env`. `assemble`'s
 ///   `base_env` always seeds one, so only a spec built some other way gets
 ///   here.
-///
-/// The bare-command arm searches `spec.env`'s own `PATH`, not the daemon's
-/// ambient one: that map IS the child's whole environment (`spawn` calls
-/// `env_clear` then `envs`), so it is the exact list exec is about to walk.
-/// `node` and `npx` in a real Flockfile take this arm.
+/// - an empty program, which `normalize` refuses upstream.
 ///
 /// Existence only, never the executable bit: a file that is there and cannot
 /// be exec'd is the spawn's business, and mode bits under a `user`/`group`
 /// drop are not a thing to be confident about from here.
-fn program_not_found(spec: &SpawnSpec) -> Option<String> {
+fn what_exec_will_find(spec: &SpawnSpec) -> Preflight {
     if spec.program.is_empty() {
-        return None;
+        return Preflight::Unknown;
     }
     let program = Path::new(&spec.program);
     if spec.program.contains('/') {
         let full = if program.is_absolute() {
             program.to_path_buf()
         } else {
-            spec.cwd.as_ref()?.join(program)
+            match &spec.cwd {
+                Some(cwd) => cwd.join(program),
+                None => return Preflight::Unknown,
+            }
         };
-        return (!full.exists()).then(|| format!("no such file: {}", full.display()));
+        if full.exists() {
+            return Preflight::Unknown;
+        }
+        return Preflight::Impossible(format!("no such file: {}", full.display()));
     }
-    let path = spec.env.get("PATH").filter(|value| !value.is_empty())?;
+    let Some(path) = spec.env.get("PATH").filter(|value| !value.is_empty()) else {
+        return Preflight::Unknown;
+    };
     let found = path
         .split(':')
         .filter(|dir| !dir.is_empty())
         .any(|dir| Path::new(dir).join(program).exists());
-    (!found).then(|| format!("`{}` is not on the shepherd's PATH ({path})", spec.program))
+    if found {
+        return Preflight::Unknown;
+    }
+    Preflight::Doubtful(format!(
+        "`{}` is not on the shepherd's PATH ({path})",
+        spec.program
+    ))
 }
 
 impl ProcessRunner for TokioRunner {
@@ -285,11 +313,11 @@ impl ProcessRunner for TokioRunner {
     /// app running `npx next start` is checked at `npx`, and `next` is
     /// npx's business.
     ///
-    /// Deliberately under-tightened: see this module's `program_not_found`
-    /// for every form it declines to decide and why each one is left to the
-    /// spawn.
-    fn preflight(&self, spec: &SpawnSpec) -> Option<String> {
-        program_not_found(spec)
+    /// Deliberately under-tightened: see this module's `what_exec_will_find`
+    /// for every form it declines to decide, and for why a bare command is
+    /// only ever doubted while a path can be refused.
+    fn preflight(&self, spec: &SpawnSpec) -> Preflight {
+        what_exec_will_find(spec)
     }
 
     fn spawn(&self, spec: &SpawnSpec) -> Result<(Self::Proc, ProcIo), RunnerError> {
@@ -1810,7 +1838,7 @@ mod tests {
     /// produced the defect: absolute (`heatrotom`), relative to a `cwd`
     /// (`obscura`), a bare command on PATH (`node`, `npx`).
     #[test]
-    fn a_program_that_is_really_there_is_never_refused() {
+    fn a_program_that_is_really_there_is_nothing_to_report() {
         let dir = tempfile::tempdir().unwrap();
         let bin = dir.path().join("srv");
         fs::write(&bin, "#!/bin/sh\n").unwrap();
@@ -1833,9 +1861,9 @@ mod tests {
             preflight_spec("", None, None),
         ] {
             assert_eq!(
-                program_not_found(&spec),
-                None,
-                "refused a spec it cannot be certain about: {spec:?}"
+                what_exec_will_find(&spec),
+                Preflight::Unknown,
+                "reported something about a spec it cannot be certain about: {spec:?}"
             );
         }
     }
@@ -1844,32 +1872,61 @@ mod tests {
     /// eleven-app Flockfile pointing at an unbuilt binary, which registered
     /// two apps, failed, and never reached the other eight.
     ///
-    /// The reason string is asserted to carry the resolved PATH, not the
+    /// `Impossible`, which its caller refuses the whole batch over, and only
+    /// ever for a program with a `/` in it. A path is a claim about the
+    /// filesystem, and this is what makes it a claim the daemon can settle.
+    ///
+    /// The reason string is asserted to carry the RESOLVED path, not the
     /// `./proto-enum-api` the operator wrote, because "no such file:
     /// ./proto-enum-api" is exactly the message that left them guessing
     /// which directory it was looked for in.
     #[test]
-    fn a_program_that_is_provably_absent_is_named_with_the_path_that_was_tried() {
+    fn an_absent_path_is_impossible_and_names_the_path_that_was_tried() {
         let dir = tempfile::tempdir().unwrap();
 
-        let relative = program_not_found(&preflight_spec(
-            "./proto-enum-api",
-            Some(dir.path().to_path_buf()),
-            None,
-        ))
-        .expect("a relative script under a real cwd is decidable");
         assert_eq!(
-            relative,
-            format!("no such file: {}/./proto-enum-api", dir.path().display())
+            what_exec_will_find(&preflight_spec(
+                "./proto-enum-api",
+                Some(dir.path().to_path_buf()),
+                None,
+            )),
+            Preflight::Impossible(format!(
+                "no such file: {}/./proto-enum-api",
+                dir.path().display()
+            )),
         );
+        assert_eq!(
+            what_exec_will_find(&preflight_spec("/nonexistent/srv", None, None)),
+            Preflight::Impossible("no such file: /nonexistent/srv".to_string()),
+        );
+    }
 
-        let absolute = program_not_found(&preflight_spec("/nonexistent/srv", None, None))
-            .expect("an absolute script is decidable");
-        assert_eq!(absolute, "no such file: /nonexistent/srv");
+    /// fails if a bare command off the PATH ever becomes `Impossible`, which
+    /// is the assertion this case exists for.
+    ///
+    /// `Doubtful` is reported and carried on with, never refused. The
+    /// daemon's own PATH under the unit `shep startup` installs is not the
+    /// shell an operator tested in: homebrew's `node` on Apple Silicon is in
+    /// `/opt/homebrew/bin` and nvm's is under `$HOME`, so a `shep startup`
+    /// flock whose one Node app cannot resolve `node` must still bring up
+    /// every other app. Refusing here would keep the whole flock down.
+    ///
+    /// The PATH that was searched is in the message on purpose. "`node` is
+    /// not on the shepherd's PATH" without saying WHICH path sends an
+    /// operator to check the one in their terminal, which is the one that
+    /// works.
+    #[test]
+    fn a_bare_command_off_the_path_is_only_ever_doubtful() {
+        let found = what_exec_will_find(&preflight_spec("node", None, Some("/nonexistent")));
 
-        let bare = program_not_found(&preflight_spec("node", None, Some("/nonexistent")))
-            .expect("a bare command against a real PATH is decidable");
-        assert_eq!(bare, "`node` is not on the shepherd's PATH (/nonexistent)");
+        assert_eq!(
+            found,
+            Preflight::Doubtful("`node` is not on the shepherd's PATH (/nonexistent)".to_string()),
+        );
+        assert!(
+            !matches!(found, Preflight::Impossible(_)),
+            "a claim about an environment must never refuse a batch"
+        );
     }
 
     // Everything else in this module needs a real OS child and lives in

--- a/crates/shep-daemon/src/tokio_runner.rs
+++ b/crates/shep-daemon/src/tokio_runner.rs
@@ -25,6 +25,7 @@
 //! side of the channel sees a clean EOF once the child closes or exits
 //! rather than being kept artificially open by our own leftover reference.
 
+use std::fs;
 use std::io;
 use std::os::fd::OwnedFd;
 use std::os::unix::process::ExitStatusExt as _;
@@ -266,7 +267,10 @@ fn to_nix_operator_signal(sig: OperatorSignal) -> Signal {
 ///
 /// Existence only, never the executable bit: a file that is there and cannot
 /// be exec'd is the spawn's business, and mode bits under a `user`/`group`
-/// drop are not a thing to be confident about from here.
+/// drop are not a thing to be confident about from here. And existence is
+/// read through [`definitely_absent`] rather than [`Path::exists`], which
+/// collapses a permission error into "absent" -- see that function for why
+/// the distinction decides whether a flock comes up.
 fn what_exec_will_find(spec: &SpawnSpec) -> Preflight {
     if spec.program.is_empty() {
         return Preflight::Unknown;
@@ -281,7 +285,7 @@ fn what_exec_will_find(spec: &SpawnSpec) -> Preflight {
                 None => return Preflight::Unknown,
             }
         };
-        if full.exists() {
+        if !definitely_absent(&full) {
             return Preflight::Unknown;
         }
         return Preflight::Impossible(format!("no such file: {}", full.display()));
@@ -289,17 +293,84 @@ fn what_exec_will_find(spec: &SpawnSpec) -> Preflight {
     let Some(path) = spec.env.get("PATH").filter(|value| !value.is_empty()) else {
         return Preflight::Unknown;
     };
-    let found = path
-        .split(':')
-        .filter(|dir| !dir.is_empty())
-        .any(|dir| Path::new(dir).join(program).exists());
-    if found {
-        return Preflight::Unknown;
+    // Absent from the PATH only if EVERY entry says so, and only if every
+    // entry that did not was a plain `NotFound`. One unreadable directory
+    // means exec may still find the program there, and claiming otherwise
+    // would put a sentence in the shepherd's log that is simply untrue.
+    // Cheaper to be wrong here than in the arm above -- this one can only
+    // reach a log line, never a refusal -- but a misleading message is the
+    // same class of fault either way.
+    for dir in path.split(':').filter(|dir| !dir.is_empty()) {
+        match fs::metadata(Path::new(dir).join(program)) {
+            Ok(_) => return Preflight::Unknown,
+            Err(err) if err.kind() == io::ErrorKind::NotFound => {}
+            Err(_) => return Preflight::Unknown,
+        }
     }
     Preflight::Doubtful(format!(
-        "`{}` is not on the shepherd's PATH ({path})",
-        spec.program
+        "`{}` is not on the shepherd's PATH ({})",
+        spec.program,
+        summarise_path(path)
     ))
+}
+
+/// How many `PATH` entries a preflight message names before summarising the
+/// rest.
+///
+/// Four, because the `PATH` that matters here is a startup unit's and
+/// [`base_env`](crate::assemble)'s fallback for a unit that has none is three
+/// entries (`/usr/local/bin:/usr/bin:/bin`). The case an operator actually
+/// hits therefore prints in full, with one to spare.
+///
+/// The case being cut off is an interactive shell's `PATH`, measured at
+/// thirty-one entries and just over two kilobytes on this machine, which is
+/// unreadable in a terminal error. It is also the case where printing it in
+/// full teaches nothing: a daemon autostarted from a shell inherited that
+/// operator's own `PATH`, so it is the one they would go and check anyway.
+const PATH_ENTRIES_IN_MESSAGE: usize = 4;
+
+/// `path` as a message should print it: in full when short, and otherwise its
+/// first [`PATH_ENTRIES_IN_MESSAGE`] entries with a count of the rest.
+///
+/// The shape of the `PATH` is what the reader needs, not every byte of it.
+/// Seeing `/usr/local/bin:/usr/bin:/bin` is what tells an operator the
+/// shepherd is running under a unit rather than under their shell, which is
+/// the whole diagnosis.
+fn summarise_path(path: &str) -> String {
+    let entries: Vec<&str> = path.split(':').filter(|dir| !dir.is_empty()).collect();
+    if entries.len() <= PATH_ENTRIES_IN_MESSAGE {
+        return path.to_string();
+    }
+    format!(
+        "{} and {} more entries",
+        entries[..PATH_ENTRIES_IN_MESSAGE].join(":"),
+        entries.len() - PATH_ENTRIES_IN_MESSAGE,
+    )
+}
+
+/// Whether the filesystem says, without qualification, that `path` is not
+/// there.
+///
+/// [`Path::exists`] is the obvious call here and is the wrong one. It is
+/// documented to return `false` on ANY [`fs::metadata`] error, so a
+/// permission error on an intermediate directory, an unsettled mount and a
+/// race all read identically to "absent". Every one of those would have made
+/// [`what_exec_will_find`] answer [`Preflight::Impossible`] and refuse a
+/// whole batch on a filesystem that was merely unavailable for a moment,
+/// which is the failure mode that verdict exists to avoid.
+///
+/// So: `NotFound` and nothing else. `PermissionDenied` included, anything
+/// that is not a flat "no such file" is a suspicion rather than a certainty
+/// and belongs in [`Preflight::Unknown`], where the spawn reports it as it
+/// always did and no other app in the batch pays for it.
+///
+/// Follows symlinks, as `exists` did and as exec does: a symlink whose
+/// target is gone answers `NotFound` here, which is a real certainty and the
+/// right one. A directory and a file with no execute bit both answer `Ok`
+/// and so are not absent, which is also right -- neither can be exec'd, but
+/// that is the spawn's business and not a claim this can settle.
+fn definitely_absent(path: &Path) -> bool {
+    matches!(fs::metadata(path), Err(err) if err.kind() == io::ErrorKind::NotFound)
 }
 
 impl ProcessRunner for TokioRunner {
@@ -1098,6 +1169,7 @@ fn spawn_channel_pumps(
 mod tests {
     use std::collections::BTreeMap;
     use std::fs;
+    use std::os::unix::fs::PermissionsExt as _;
     use std::time::Duration;
 
     use tokio::io::DuplexStream;
@@ -1808,7 +1880,7 @@ mod tests {
         );
     }
 
-    /// A [`SpawnSpec`] carrying only what [`program_not_found`] reads. Every
+    /// A [`SpawnSpec`] carrying only what [`what_exec_will_find`] reads. Every
     /// other field is left at whatever is cheapest: nothing below spawns
     /// anything, so nothing below can be affected by them.
     fn preflight_spec(program: &str, cwd: Option<PathBuf>, path: Option<&str>) -> SpawnSpec {
@@ -1901,6 +1973,89 @@ mod tests {
         );
     }
 
+    /// fails if a filesystem error that is not "no such file" is ever read as
+    /// absence.
+    ///
+    /// [`Path::exists`] returns `false` on ANY [`fs::metadata`] error, so an
+    /// unreadable intermediate directory, an unsettled mount and a race all
+    /// look exactly like a missing file. Under the previous `exists` call
+    /// each of them answered [`Preflight::Impossible`] and refused a whole
+    /// batch over a filesystem that was merely unavailable for a moment.
+    ///
+    /// Two provocations, because one of them cannot be trusted to bite
+    /// everywhere:
+    ///
+    /// - **`ENOTDIR`**, a regular file used as an intermediate path
+    ///   component. Uid-independent, so it runs on every machine and in
+    ///   every container, and this is the case that keeps the test honest
+    ///   when the second one is skipped.
+    /// - **`EACCES`**, a `chmod 000` directory. The scenario an operator
+    ///   actually hits, and the one worth naming, but root bypasses
+    ///   directory search permission, so under a root CI container the
+    ///   `chmod` does not bite and the lookup would answer a true
+    ///   `NotFound`. Skipped there rather than asserted vacuously.
+    ///
+    /// The mode is restored BEFORE the assertion rather than after: a failed
+    /// assertion panics, and a `TempDir` whose `Drop` cannot descend into a
+    /// `chmod 000` directory turns one red test into a leaked directory and
+    /// a second, unrelated error.
+    #[test]
+    fn a_filesystem_error_that_is_not_absence_is_never_impossible() {
+        let dir = tempfile::tempdir().unwrap();
+
+        // ENOTDIR: `wall` is a file, so nothing can be under it.
+        let wall = dir.path().join("wall");
+        fs::write(&wall, "not a directory\n").unwrap();
+        let through_a_file = wall.join("srv");
+        let kind = fs::metadata(&through_a_file).unwrap_err().kind();
+        assert_ne!(
+            kind,
+            io::ErrorKind::NotFound,
+            "the provocation must be an error OTHER than not-found, or this \
+             case proves nothing: {kind:?}"
+        );
+        assert_eq!(
+            what_exec_will_find(&preflight_spec(
+                &through_a_file.to_string_lossy(),
+                None,
+                None
+            )),
+            Preflight::Unknown,
+            "a path shep could not read is a suspicion, not a certainty, and \
+             must never refuse a batch"
+        );
+
+        // EACCES: an unreadable directory between the cwd and the program.
+        if nix::unistd::Uid::effective().is_root() {
+            return;
+        }
+        let locked = dir.path().join("locked");
+        fs::create_dir(&locked).unwrap();
+        fs::set_permissions(&locked, fs::Permissions::from_mode(0o000)).unwrap();
+        let behind_the_wall = locked.join("srv");
+        let observed = fs::metadata(&behind_the_wall)
+            .map(|_| ())
+            .map_err(|e| e.kind());
+        let verdict = what_exec_will_find(&preflight_spec(
+            &behind_the_wall.to_string_lossy(),
+            None,
+            None,
+        ));
+        fs::set_permissions(&locked, fs::Permissions::from_mode(0o755)).unwrap();
+
+        assert_eq!(
+            observed,
+            Err(io::ErrorKind::PermissionDenied),
+            "the chmod must actually bite, or the assertion below is vacuous"
+        );
+        assert_eq!(
+            verdict,
+            Preflight::Unknown,
+            "a permission error on the way to the program must not take the \
+             rest of the flock down with it"
+        );
+    }
+
     /// fails if a bare command off the PATH ever becomes `Impossible`, which
     /// is the assertion this case exists for.
     ///
@@ -1927,6 +2082,33 @@ mod tests {
             !matches!(found, Preflight::Impossible(_)),
             "a claim about an environment must never refuse a batch"
         );
+    }
+
+    /// fails if a long PATH is printed in full, or a short one is not.
+    ///
+    /// This message reaches a terminal now, not only the shepherd's log:
+    /// `spawn_fresh` puts a `Doubtful` reason into the reply once that app's
+    /// own spawn has failed. An interactive shell's PATH measured just over
+    /// two kilobytes across thirty-one entries on this machine, and dumping
+    /// that into `error[spawn_failed]:` buries the sentence that matters.
+    ///
+    /// The short case is the one that must survive intact: a `shep startup`
+    /// unit with no PATH of its own gets `assemble`'s three-entry fallback,
+    /// and seeing those three IS the diagnosis.
+    #[test]
+    fn a_long_path_is_summarised_and_a_startup_units_own_path_is_not() {
+        let fallback = "/usr/local/bin:/usr/bin:/bin";
+        assert_eq!(
+            summarise_path(fallback),
+            fallback,
+            "the PATH a unit actually gets must print in full"
+        );
+
+        let long = "/a:/b:/c:/d:/e:/f";
+        assert_eq!(summarise_path(long), "/a:/b:/c:/d and 2 more entries");
+
+        // Exactly at the cap, which is where an off-by-one would show.
+        assert_eq!(summarise_path("/a:/b:/c:/d"), "/a:/b:/c:/d");
     }
 
     // Everything else in this module needs a real OS child and lives in

--- a/crates/shep-daemon/src/watch/mod.rs
+++ b/crates/shep-daemon/src/watch/mod.rs
@@ -467,10 +467,12 @@ async fn run_group(
                 err @ (SupervisorError::ReopenFailed(_)
                 | SupervisorError::FlushFailed(_)
                 | SupervisorError::ReloadInFlight(_)
-                | SupervisorError::InvalidScale(_)),
+                | SupervisorError::InvalidScale(_)
+                | SupervisorError::CannotStart(_)),
             ) => {
-                // A restart touches no log files, starts no reload and scales
-                // nothing, so none of the four can arrive. Named rather than
+                // A restart touches no log files, starts no reload, scales
+                // nothing and registers no batch, so none of the five can
+                // arrive. Named rather than
                 // swept into a catch-all, so a variant this path CAN produce
                 // still fails to compile here.
                 tracing::warn!(name, %err, "watch-triggered restart reported an unrelated failure");


### PR DESCRIPTION
Three fixes to `shep start`, all found by running a real 13-app Flockfile rather than by reading code.

- editing a Flockfile and re-running `shep start` silently kept the old config. It now names the sheep and the fields that differ
- one bad script path aborted the whole start after registering some of the apps. Nothing registers now unless every app can start
- the spawn error named neither the app nor the path it tried

`Start` on an existing name still adds instances rather than reconciling, because `shep stock` depends on that. The bug was the silence, not the behaviour.

The batch only refuses over a path shep can actually check. A `/`-containing path that is missing is a typo and refuses everything. A bare command missing from the daemon's PATH is reported and lets the rest through, because `shep startup`'s unit gets a minimal PATH and node from homebrew or nvm is not on it. A whole flock staying down because one app cannot find its interpreter is worse than the bug being fixed.

Only `NotFound` counts as absent. A permission error or an unsettled mount reads as unknown and never refuses a batch.

`shep start` still exits 0 when it reports drift, and the warning goes to stderr. Deliberate, and a one-line change if you want the other behaviour.

Known gap: an app whose PATH warning never becomes a spawn failure, because an earlier app in the batch failed first, has that warning in the shepherd's log alone. Closing it needs a warning channel on the `Start` reply, which is a protocol change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `shep start` detects configuration drift for registered apps and reports affected apps and changed field names without revealing secret values.
  * Added clearer process-launch diagnostics, including the app, command, and working directory.
  * Startup validation now identifies definite executable and command failures before launching apps.

* **Bug Fixes**
  * Invalid executable paths and credential failures now prevent partial batch registration.
  * Missing bare commands fail only the affected app when others can start successfully.
  * Invalid Flockfiles are rejected before apps are registered.
  * Restored apps can fail individually without blocking subsequent apps.
  * Drift checks do not apply changes or alter JSON output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->