### PR TITLE
Seven runnable examples, one per supervision behaviour

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,10 @@
 # were committed by accident when Phase 14 merged.
 .superpowers/
 docs/teach
+
+# examples/polyglot build artifacts: a venv and a compiled Go binary, both
+# built by a setup script the docs page names, neither meant to be
+# committed. .rs/.js/.py/.go SOURCE under examples/polyglot/ is tracked as
+# normal; only what those two setup scripts produce is excluded here.
+/examples/polyglot/venv/
+/examples/polyglot/go-http/go-http

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2169,6 +2169,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "shep-examples"
+version = "0.1.5"
+dependencies = [
+ "nix 0.29.0",
+]
+
+[[package]]
 name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2170,7 +2170,7 @@ dependencies = [
 
 [[package]]
 name = "shep-examples"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "nix 0.29.0",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,11 @@ members = [
     "crates/shep-client",
     "crates/shep-cli",
     "crates/shep-cli-redirect",
+    # Small runnable demos of shep's supervision behaviours (probes, restart
+    # policy, memory limits, graceful stop, the log plane). `publish = false`
+    # in its own manifest, and release-plz.toml marks it `release = false`
+    # too — never part of a release.
+    "examples",
 ]
 
 [workspace.package]

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -1,0 +1,37 @@
+[package]
+name = "shep-examples"
+description = "Small runnable programs that demonstrate shep's supervision behaviours: probes, restarts, memory limits, graceful stop and the log plane. Not published."
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+publish = false
+
+# `cargo build --release` at the workspace root builds every member,
+# including this one, but it is never on the dependency path of the shipped
+# `shep`/`shep-runtime`/`shep-dev` binaries — `cargo install shep` resolves
+# only shep-cli's own graph and never reaches this crate. See
+# crates/shep-daemon/examples/reuse_port_sheep.rs for the same reasoning
+# applied to a single fixture; this crate is the same idea grown into a
+# standalone member because these programs are documentation, not test
+# scaffolding, and need a stable path a Flockfile can name.
+#
+# `publish = false` keeps `cargo publish --workspace` (and release-plz) from
+# ever trying to ship it; release-plz.toml does not list it either.
+
+# Every binary here is a plain executable — no shared library, no crate-level
+# public API — so `src/bin/*.rs` is autodiscovered with no `[[bin]]` table
+# needed per binary.
+
+# Signal handling without a crate: `stubborn.rs` blocks SIGTERM with
+# `nix::sys::signal::SigSet::thread_block` and waits on it with `sigwait`,
+# both safe functions, so this crate stays `#![forbid(unsafe_code)]` the way
+# `crates/shep-daemon/examples/reuse_port_sheep.rs` already does for the same
+# reason. `nix` is already a workspace dependency (shep-daemon), so this adds
+# no new crate — only `signal`, already in the workspace's default feature
+# list for `nix`, is used.
+[target.'cfg(unix)'.dependencies]
+nix = { workspace = true }
+
+[lints]
+workspace = true

--- a/examples/Flockfile.polyglot.toml
+++ b/examples/Flockfile.polyglot.toml
@@ -1,0 +1,101 @@
+# A second layer over examples/Flockfile.toml, for readers who have these
+# runtimes installed and want to see shep drive their own stack rather than
+# a Rust binary. The seven apps in examples/Flockfile.toml need nothing but
+# cargo and are the entry point that always runs; nothing here replaces or
+# reorders them. This file needs, per app below: node, bun, python3, and go.
+# `shep serve` (see the bottom of this file) needs none of them.
+#
+#   $ shep start examples/Flockfile.polyglot.toml
+#
+# `shep start` processes a Flockfile's apps top to bottom and stops at the
+# first one that fails to spawn (`shep start --help`: "Several are started
+# in turn, not atomically"). A missing runtime reports
+# `SpawnFailed: No such file or directory` naming that app -- but every app
+# BELOW it in this file is never even attempted in that same invocation,
+# while every app ABOVE it, already online, stays online. Missing bun,
+# third below, would silently prevent python-app and go-http from starting
+# too, not just bun-http. If you are missing a runtime, comment out that
+# app's `[[app]]` block below rather than leaving it in and hoping the ones
+# after it still start.
+#
+# Setup, once, per runtime you want to see:
+#
+#   $ examples/polyglot/setup-venv.sh       # python-app's own interpreter
+#   $ examples/polyglot/go-http/build.sh    # go-http's compiled binary
+#
+# node and bun need no build step -- `interpreter` runs their source
+# directly. Ports continue examples/Flockfile.toml's numbering, one range
+# up: 19081/19082/19084 there, 19090 and up here.
+
+# --- 1. Node: the pm2 audience's default case -------------------------------
+# A plain HTTP server. `interpreter = "node"` is the whole story -- shep
+# does not know or care that this script is JavaScript, only that "node" is
+# a program on its own PATH to run it with.
+[[app]]
+name        = "node-http"
+script      = "polyglot/node-http.js"
+interpreter = "node"
+args        = ["19090"]
+
+# --- 2. Node, clustered ------------------------------------------------------
+# The same script, `instances = 4`. Each instance gets its own
+# `SHEP_INSTANCE` (0-3), and node-http.js adds that to its base port, so
+# this is four separate listeners on 19091-19094, not one port shared four
+# ways. A real `reuse_port` -- the mechanism pm2's cluster mode uses to put
+# all N instances behind one port -- is in the Flockfile schema already
+# (crates/shep-core/src/config/app.rs) but refused at load while nothing
+# implements it yet, which is why this entry does not set it: `reuse_port
+# = true` here would fail examples/Flockfile.polyglot.toml to load, not
+# just this one app.
+[[app]]
+name        = "node-http-cluster"
+script      = "polyglot/node-http.js"
+interpreter = "node"
+args        = ["19091"]
+instances   = 4
+
+# --- 3. Bun, same file -------------------------------------------------------
+# Only `interpreter` changed, from "node" to "bun" -- same script, same
+# args shape, a different runtime entirely. This is the clearest
+# demonstration there is that `interpreter` is a plain program name and
+# shep.toml's own `[interpreters]` table (extension -> program, e.g.
+# `js = "node"`) is the same idea applied automatically by file extension
+# instead of spelled out per app -- see the docs page for the shep.toml
+# snippet.
+[[app]]
+name        = "bun-http"
+script      = "polyglot/node-http.js"
+interpreter = "bun"
+args        = ["19095"]
+
+# --- 4. Python behind its own venv ------------------------------------------
+# `interpreter` points at the venv's OWN python3, not a bare "python3" that
+# resolves against whichever PATH the daemon happens to have -- the classic
+# failure this heads off is an app that works in a shell (your venv is
+# active) and does not under a supervisor (it never was). Run
+# examples/polyglot/setup-venv.sh first.
+[[app]]
+name        = "python-app"
+script      = "polyglot/python-app.py"
+interpreter = "polyglot/venv/bin/python3"
+args        = ["19096"]
+
+# --- 5. Go: a build step, then no interpreter at all ------------------------
+# `go build` produces a native executable, so this entry has no
+# `interpreter` field -- run examples/polyglot/go-http/build.sh first, and
+# a compiled program is its own interpreter. Compare app 1 above: same
+# shape of Flockfile entry, minus one field, because the artifact itself
+# no longer needs one.
+[[app]]
+name   = "go-http"
+script = "polyglot/go-http/go-http"
+args   = ["19097"]
+
+# --- 6. A static site, and shep serve ---------------------------------------
+# Not an [[app]] entry -- shep serve is its own command, registering its
+# own sheep, for a directory with no program of the operator's own at all:
+#
+#   $ shep serve examples/polyglot/static-site --port 19098
+#
+# See the site's /docs/serve page for --bind, --auth, and everything else
+# it refuses by default.

--- a/examples/Flockfile.toml
+++ b/examples/Flockfile.toml
@@ -1,0 +1,124 @@
+# Seven small apps, each demonstrating one thing shep does. Build them, then
+# start this file to watch every behaviour happen instead of reading about it:
+#
+#   $ cargo build --release --workspace
+#   $ shep start examples/Flockfile.toml
+#   $ shep flock
+#   $ shep logs -f
+#
+# `cwd` is left unset on every app below on purpose: an app with no `cwd`
+# runs where its Flockfile lives (crates/shep-core/src/config/normalize.rs),
+# so `script = "../target/release/http_server"` resolves the way you'd read
+# it from here, whether shep itself was started from the repo root or from
+# inside `examples/`.
+#
+# See web/src/pages/docs/examples.astro for what to watch for on each one.
+
+# --- 1. The baseline every probe example needs -----------------------------
+# Binds a port, answers 200 to anything. Point curl at it, or use it as the
+# shape a real readiness probe polls.
+[[app]]
+name        = "http-server"
+script      = "../target/release/http_server"
+args        = ["8081"]
+
+# --- 2. A readiness probe waiting, and listen_timeout expiring -------------
+# slow_boot sleeps 8s before it binds port 8082. Its readiness_probe polls
+# that port every second; listen_timeout is set to 4s, deliberately shorter
+# than the boot delay, so the probe never once passes before the deadline.
+# Watch `shep flock` and the daemon's own log: the sheep goes Online anyway
+# at the 4s mark with a "readiness deadline elapsed; marking online anyway"
+# warning, NOT a restart — an ordinary start treats a slow app as slow, not
+# as failed, so it never turns into a restart loop. `listen_timeout` only
+# bites this hard for a *reload*, where a still-not-ready replacement aborts
+# instead: this app is the plain-start half of that story.
+[[app]]
+name             = "slow-boot"
+script           = "../target/release/slow_boot"
+args             = ["8082", "8"]
+listen_timeout   = "4s"
+
+[app.readiness_probe]
+kind             = "http"
+target           = "http://127.0.0.1:8082/"
+interval         = "1s"
+timeout          = "1s"
+
+# --- 3. An exec probe, the one probe kind with no everyday example ---------
+# http-server-gated-by-sentinel is a plain http_server, but shep won't call
+# it ready until ready_when_told exits 0 -- which it only does once a file
+# exists on disk. listen_timeout is stretched to 2 minutes so you have time
+# to create it by hand:
+#
+#   $ touch /tmp/shep-examples-sentinel
+#
+# Watch the next probe poll (every 3s) flip this sheep from starting to
+# online. Delete the file again and restart the sheep to watch it fail to
+# clear a poll instead.
+[[app]]
+name             = "http-server-gated-by-sentinel"
+script           = "../target/release/http_server"
+args             = ["8084"]
+listen_timeout   = "120s"
+
+[app.readiness_probe]
+kind             = "exec"
+target           = "../target/release/ready_when_told /tmp/shep-examples-sentinel"
+interval         = "3s"
+timeout          = "1s"
+
+# --- 4. Escalation past a stop signal ---------------------------------------
+# stubborn blocks SIGTERM and never acts on it. `kill_timeout` -- not
+# graceful_timeout, which only governs a *reload*'s drain -- is the grace
+# period shep gives a plain `shep stop`/`restart`/`delete` between the stop
+# signal and SIGKILL; it's cut to 3s here so the escalation is quick to
+# watch instead of the 1.6s default making it easy to miss:
+#
+#   $ shep stop stubborn
+#
+# Watch it print "caught SIGTERM, still not dying" once, then go silent and
+# actually exit 3s later once shep's kill ladder reaches SIGKILL -- a signal
+# nothing can trap.
+[[app]]
+name          = "stubborn"
+script        = "../target/release/stubborn"
+kill_timeout  = "3s"
+
+# --- 5. A memory ceiling firing ---------------------------------------------
+# leaky allocates 8MB every 300ms and never frees it -- roughly 26MB/s. The
+# polling memory-limit enforcer samples resident memory every 15s
+# (crates/shep-daemon/src/limits/mod.rs), so by the first sample this sheep
+# is already well past max_memory and gets restarted; watch it climb again
+# on each subsequent poll.
+[[app]]
+name        = "leaky"
+script      = "../target/release/leaky"
+args        = ["8", "300"]
+max_memory  = "150M"
+
+# --- 6. Restart policy, backoff and max_restarts ----------------------------
+# crasher exits 1 after 2s, every time. min_uptime is raised to 5s so that
+# 2s always counts as an unstable exit (the default 1s floor would let a 2s
+# life through as "stable" and this would just restart forever); max_restarts
+# is cut to 4 so it reaches errored in well under a minute instead of the
+# default 16 taking closer to a minute on its own. exp_backoff_restart_delay
+# is left at its 100ms default, growing x1.5 each attempt -- watch the gap
+# between restarts widen in `shep logs -f` as it counts down to errored.
+[[app]]
+name         = "crasher"
+script       = "../target/release/crasher"
+args         = ["1", "2"]
+min_uptime   = "5s"
+max_restarts = 4
+
+# --- 7. The log plane -------------------------------------------------------
+# noisy writes one line a second to stdout and stderr, alternating. Nothing
+# here needs configuring -- out_file/err_file both default to files under
+# $SHEP_HOME/logs -- so this app is bare on purpose, to show what a Flockfile
+# entry costs when you want none of the above. Watch it with:
+#
+#   $ shep bleats noisy -f
+[[app]]
+name    = "noisy"
+script  = "../target/release/noisy"
+args    = ["5"]

--- a/examples/Flockfile.toml
+++ b/examples/Flockfile.toml
@@ -14,16 +14,25 @@
 #
 # See web/src/pages/docs/examples.astro for what to watch for on each one.
 
+# Ports are 19081/19082/19084 -- the 19080-and-up range on purpose. 8081,
+# 8082 and 8084 are common defaults elsewhere (Tomcat, proxies, a second
+# instance of nearly anything) and this file is meant to run on your own
+# machine, the machine most likely to already have something listening on
+# one of them. If 19081/19082/19084 collide with something of yours too,
+# change the port argument on the app that collides and the matching
+# readiness_probe target next to it -- both need to agree, since the probe
+# is polling the port its own app just bound.
+
 # --- 1. The baseline every probe example needs -----------------------------
 # Binds a port, answers 200 to anything. Point curl at it, or use it as the
 # shape a real readiness probe polls.
 [[app]]
 name        = "http-server"
 script      = "../target/release/http_server"
-args        = ["8081"]
+args        = ["19081"]
 
 # --- 2. A readiness probe waiting, and listen_timeout expiring -------------
-# slow_boot sleeps 8s before it binds port 8082. Its readiness_probe polls
+# slow_boot sleeps 8s before it binds port 19082. Its readiness_probe polls
 # that port every second; listen_timeout is set to 4s, deliberately shorter
 # than the boot delay, so the probe never once passes before the deadline.
 # Watch `shep flock` and the daemon's own log: the sheep goes Online anyway
@@ -35,12 +44,12 @@ args        = ["8081"]
 [[app]]
 name             = "slow-boot"
 script           = "../target/release/slow_boot"
-args             = ["8082", "8"]
+args             = ["19082", "8"]
 listen_timeout   = "4s"
 
 [app.readiness_probe]
 kind             = "http"
-target           = "http://127.0.0.1:8082/"
+target           = "http://127.0.0.1:19082/"
 interval         = "1s"
 timeout          = "1s"
 
@@ -58,7 +67,7 @@ timeout          = "1s"
 [[app]]
 name             = "http-server-gated-by-sentinel"
 script           = "../target/release/http_server"
-args             = ["8084"]
+args             = ["19084"]
 listen_timeout   = "120s"
 
 [app.readiness_probe]

--- a/examples/polyglot/go-http/build.sh
+++ b/examples/polyglot/go-http/build.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+# Builds the static binary `examples/Flockfile.polyglot.toml`'s go-http
+# entry runs directly, with no `interpreter` -- a compiled program needs
+# none. Run once, from anywhere:
+#
+#   $ examples/polyglot/go-http/build.sh
+set -eu
+cd "$(dirname "$0")"
+go build -o go-http .
+echo "built polyglot/go-http/go-http"

--- a/examples/polyglot/go-http/go.mod
+++ b/examples/polyglot/go-http/go.mod
@@ -1,0 +1,3 @@
+module shep-examples-go-http
+
+go 1.21

--- a/examples/polyglot/go-http/main.go
+++ b/examples/polyglot/go-http/main.go
@@ -1,0 +1,40 @@
+// Command go-http is a plain HTTP server, compiled rather than interpreted.
+//
+// Every other polyglot example runs its source directly through a language
+// runtime shep spawns as `interpreter`; this one shows the other shape a
+// Flockfile script takes: a build step first, then a script line with no
+// interpreter field at all, because the artifact `go build` produces is
+// already a native executable.
+//
+// Usage: go-http <port>
+package main
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"strconv"
+)
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go-http <port>")
+		os.Exit(1)
+	}
+	port, err := strconv.Atoi(os.Args[1])
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "go-http: %q is not a valid port: %v\n", os.Args[1], err)
+		os.Exit(1)
+	}
+
+	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, "OK from go pid=%d\n", os.Getpid())
+	})
+
+	addr := fmt.Sprintf("127.0.0.1:%d", port)
+	log.Printf("go-http pid=%d listening on %s", os.Getpid(), addr)
+	if err := http.ListenAndServe(addr, nil); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/examples/polyglot/node-http.js
+++ b/examples/polyglot/node-http.js
@@ -1,0 +1,36 @@
+#!/usr/bin/env node
+// One file, two runtimes: `examples/Flockfile.polyglot.toml` runs this same
+// script three times -- once with `interpreter = "node"`, once with
+// `interpreter = "bun"`, and once with `interpreter = "node"` again but
+// `instances = 3` -- to show that `interpreter` in a Flockfile is a plain
+// program name, not a language shep has special-cased anywhere.
+//
+// Usage: node-http.js <base-port>
+//
+// Binds 127.0.0.1:<base-port + SHEP_INSTANCE>. The offset is what stands in
+// for shep's own `reuse_port`, which is accepted in the schema but refused
+// at load today (see the Flockfile's own comment on the clustered entry) --
+// so N instances here means N ports, each one a distinct listener, not one
+// port shared four ways.
+
+const http = require("node:http");
+
+const basePort = Number(process.argv[2]);
+if (!Number.isInteger(basePort) || basePort <= 0) {
+  console.error("usage: node-http.js <base-port>");
+  process.exit(1);
+}
+const instance = Number(process.env.SHEP_INSTANCE ?? "0");
+const port = basePort + instance;
+const runtime = typeof Bun !== "undefined" ? "bun" : "node";
+
+const server = http.createServer((req, res) => {
+  res.writeHead(200, { "Content-Type": "text/plain" });
+  res.end(`OK from ${runtime} pid=${process.pid} instance=${instance}\n`);
+});
+
+server.listen(port, "127.0.0.1", () => {
+  console.log(
+    `node-http (${runtime}) pid=${process.pid} listening on 127.0.0.1:${port} instance=${instance}`,
+  );
+});

--- a/examples/polyglot/node-http.js
+++ b/examples/polyglot/node-http.js
@@ -2,7 +2,7 @@
 // One file, two runtimes: `examples/Flockfile.polyglot.toml` runs this same
 // script three times -- once with `interpreter = "node"`, once with
 // `interpreter = "bun"`, and once with `interpreter = "node"` again but
-// `instances = 3` -- to show that `interpreter` in a Flockfile is a plain
+// `instances = 4` -- to show that `interpreter` in a Flockfile is a plain
 // program name, not a language shep has special-cased anywhere.
 //
 // Usage: node-http.js <base-port>

--- a/examples/polyglot/python-app.py
+++ b/examples/polyglot/python-app.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+"""A plain HTTP server, standard library only.
+
+Run this under a venv's own interpreter rather than a bare "python3" that
+resolves on whoever's PATH the daemon happens to have: the classic failure
+this example exists to head off is an app that runs fine from a shell (your
+own venv is active) and fails, or silently runs against the wrong
+interpreter, under a supervisor that never activated it.
+`examples/Flockfile.polyglot.toml` points its `interpreter` field straight
+at `polyglot/venv/bin/python3` -- see `polyglot/setup-venv.sh`.
+
+Usage: python-app.py <port>
+"""
+
+import http.server
+import os
+import sys
+
+
+def main() -> None:
+    if len(sys.argv) != 2:
+        sys.exit("usage: python-app.py <port>")
+    port = int(sys.argv[1])
+
+    class Handler(http.server.BaseHTTPRequestHandler):
+        def do_GET(self) -> None:  # noqa: N802 - http.server's own name
+            body = f"OK from python pid={os.getpid()}\n".encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "text/plain")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+    with http.server.HTTPServer(("127.0.0.1", port), Handler) as httpd:
+        print(f"python-app pid={os.getpid()} listening on 127.0.0.1:{port}")
+        httpd.serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/polyglot/setup-venv.sh
+++ b/examples/polyglot/setup-venv.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+# Creates the venv `examples/Flockfile.polyglot.toml`'s python-app entry
+# points its `interpreter` field at directly. Run once, from anywhere:
+#
+#   $ examples/polyglot/setup-venv.sh
+#
+# python-app.py uses nothing beyond the standard library, so nothing is
+# `pip install`ed here -- the point of this script is the venv's own
+# interpreter binary existing at a fixed path, not any package inside it.
+set -eu
+cd "$(dirname "$0")"
+python3 -m venv --without-pip venv
+echo "venv created at $(pwd)/venv -- polyglot/venv/bin/python3 is what the Flockfile runs"

--- a/examples/polyglot/static-site/index.html
+++ b/examples/polyglot/static-site/index.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>shep serve</title>
+  </head>
+  <body>
+    <p>
+      This page is served by <code>shep serve</code>, not by any program of
+      its own -- there is no script, no interpreter, and no process an
+      operator wrote. Running <code>shep serve</code> against this
+      directory registers a sheep whose command line is that same
+      invocation, and the worker answering this request is that sheep.
+    </p>
+  </body>
+</html>

--- a/examples/src/bin/crasher.rs
+++ b/examples/src/bin/crasher.rs
@@ -1,0 +1,46 @@
+//! Exits non-zero after a configurable delay, for watching restart policy,
+//! backoff and `max_restarts`.
+//!
+//! # Usage
+//!
+//! ```text
+//! crasher <exit-code> <delay-seconds>
+//! ```
+
+#![forbid(unsafe_code)]
+
+fn main() {
+    let mut args = std::env::args().skip(1);
+    let exit_code = parse_exit_code(args.next().as_deref());
+    let delay = parse_delay(args.next().as_deref());
+
+    println!(
+        "crasher pid={} will exit {exit_code} after {delay}s",
+        std::process::id()
+    );
+    std::thread::sleep(std::time::Duration::from_secs(delay));
+    println!("crasher: exiting {exit_code}");
+    std::process::exit(exit_code);
+}
+
+/// Parses the exit code this program dies with.
+///
+/// # Panics
+///
+/// Panics if no argument was given or it does not parse as an `i32`.
+fn parse_exit_code(raw: Option<&str>) -> i32 {
+    let raw = raw.unwrap_or_else(|| panic!("usage: crasher <exit-code> <delay-seconds>"));
+    raw.parse()
+        .unwrap_or_else(|error| panic!("`{raw}` is not a valid exit code: {error}"))
+}
+
+/// Parses the delay before exit, in whole seconds.
+///
+/// # Panics
+///
+/// Panics if no argument was given or it does not parse as a `u64`.
+fn parse_delay(raw: Option<&str>) -> u64 {
+    let raw = raw.unwrap_or_else(|| panic!("usage: crasher <exit-code> <delay-seconds>"));
+    raw.parse()
+        .unwrap_or_else(|error| panic!("`{raw}` is not a valid delay in seconds: {error}"))
+}

--- a/examples/src/bin/http_server.rs
+++ b/examples/src/bin/http_server.rs
@@ -1,0 +1,74 @@
+//! A plain HTTP server: binds a port, answers every request `200 OK`.
+//!
+//! The baseline every probe example in `examples/Flockfile.toml` points at —
+//! a `readiness_probe`/`liveness_probe` with `kind = "http"` needs something
+//! real to poll. It needs no request parsing to demonstrate that: reading
+//! whatever the client sent (best-effort, so a slow or silent client cannot
+//! hang a worker thread) is enough to let the response go out and the
+//! connection close cleanly.
+//!
+//! # Usage
+//!
+//! ```text
+//! http_server <port>
+//! ```
+
+#![forbid(unsafe_code)]
+
+use std::io::{Read as _, Write as _};
+use std::net::{TcpListener, TcpStream};
+use std::time::Duration;
+
+/// How long a connection's read is allowed to block before this program gives
+/// up on seeing a full request and answers anyway. A probe or `curl` writes
+/// its request in one flush, so this only guards against a client that
+/// connects and then sends nothing.
+const READ_TIMEOUT: Duration = Duration::from_millis(200);
+
+fn main() {
+    let port = parse_port(std::env::args().nth(1).as_deref());
+    let listener = TcpListener::bind(("127.0.0.1", port))
+        .unwrap_or_else(|error| panic!("could not bind 127.0.0.1:{port}: {error}"));
+    println!(
+        "http_server pid={} listening on 127.0.0.1:{port}",
+        std::process::id()
+    );
+
+    for stream in listener.incoming() {
+        match stream {
+            Ok(stream) => {
+                std::thread::spawn(move || respond(stream));
+            }
+            Err(error) => eprintln!("http_server: accept failed: {error}"),
+        }
+    }
+}
+
+/// Reads whatever is available (ignoring the result — a client that never
+/// sends anything just times out) and writes a fixed `200 OK` response.
+fn respond(mut stream: TcpStream) {
+    let _ = stream.set_read_timeout(Some(READ_TIMEOUT));
+    let mut buf = [0_u8; 1024];
+    let _ = stream.read(&mut buf);
+
+    let body = "OK";
+    let response = format!(
+        "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+        body.len()
+    );
+    let _ = stream.write_all(response.as_bytes());
+    let _ = stream.flush();
+}
+
+/// Parses the port argument, or dies naming what was wrong with it — a
+/// silently-defaulted port would leave a probe polling the wrong place with
+/// no error anywhere.
+///
+/// # Panics
+///
+/// Panics if no argument was given or it does not parse as a `u16`.
+fn parse_port(raw: Option<&str>) -> u16 {
+    let raw = raw.unwrap_or_else(|| panic!("usage: http_server <port>"));
+    raw.parse()
+        .unwrap_or_else(|error| panic!("`{raw}` is not a valid port: {error}"))
+}

--- a/examples/src/bin/leaky.rs
+++ b/examples/src/bin/leaky.rs
@@ -1,0 +1,74 @@
+//! Allocates on a timer and holds the memory, so a Flockfile's `max_memory`
+//! fires.
+//!
+//! Each tick allocates a chunk, writes to every page in it (an untouched
+//! allocation may never become resident, and `max_memory` is enforced against
+//! resident memory), and keeps it — nothing here is ever freed until the
+//! process is restarted.
+//!
+//! # Usage
+//!
+//! ```text
+//! leaky <mb-per-tick> <interval-ms>
+//! ```
+
+#![forbid(unsafe_code)]
+
+use std::time::Duration;
+
+fn main() {
+    let mut args = std::env::args().skip(1);
+    let mb_per_tick = parse_mb(args.next().as_deref());
+    let interval = parse_interval(args.next().as_deref());
+
+    println!(
+        "leaky pid={} allocating {mb_per_tick}MB every {}ms",
+        std::process::id(),
+        interval.as_millis()
+    );
+
+    let mut held = Vec::new();
+    let mut total_mb: u64 = 0;
+    loop {
+        std::thread::sleep(interval);
+
+        let mut chunk = vec![0_u8; mb_per_tick as usize * 1024 * 1024];
+        // Touch every page so the allocation is actually resident, not just
+        // reserved address space the OS never backs with physical memory.
+        for byte in chunk.iter_mut().step_by(4096) {
+            *byte = 1;
+        }
+        held.push(chunk);
+
+        total_mb += u64::from(mb_per_tick);
+        println!("leaky: holding ~{total_mb}MB");
+    }
+}
+
+/// Parses the per-tick allocation size, in megabytes.
+///
+/// # Panics
+///
+/// Panics if no argument was given, it does not parse as a `u32`, or it is
+/// zero.
+fn parse_mb(raw: Option<&str>) -> u32 {
+    let raw = raw.unwrap_or_else(|| panic!("usage: leaky <mb-per-tick> <interval-ms>"));
+    let mb: u32 = raw
+        .parse()
+        .unwrap_or_else(|error| panic!("`{raw}` is not a valid megabyte count: {error}"));
+    assert!(mb > 0, "mb-per-tick must be greater than zero");
+    mb
+}
+
+/// Parses the tick interval, in milliseconds.
+///
+/// # Panics
+///
+/// Panics if no argument was given or it does not parse as a `u64`.
+fn parse_interval(raw: Option<&str>) -> Duration {
+    let raw = raw.unwrap_or_else(|| panic!("usage: leaky <mb-per-tick> <interval-ms>"));
+    let ms: u64 = raw
+        .parse()
+        .unwrap_or_else(|error| panic!("`{raw}` is not a valid interval in ms: {error}"));
+    Duration::from_millis(ms)
+}

--- a/examples/src/bin/noisy.rs
+++ b/examples/src/bin/noisy.rs
@@ -13,12 +13,7 @@ use std::time::Duration;
 
 fn main() {
     let rate = parse_rate(std::env::args().nth(1).as_deref());
-    // `Duration::from_secs_f64`, not integer millisecond division: at any
-    // rate above 1000/s, `1000 / rate` floors to zero and the loop busy-spins
-    // instead of honouring the rate it was given. This stays honest at any
-    // rate a `u32` can hold, including one high enough to be its own kind of
-    // demonstration.
-    let interval = Duration::from_secs_f64(1.0 / f64::from(rate));
+    let interval = pace(rate);
 
     println!(
         "noisy pid={} writing {rate} lines/s to stdout and stderr",
@@ -50,4 +45,28 @@ fn parse_rate(raw: Option<&str>) -> u32 {
         .unwrap_or_else(|error| panic!("`{raw}` is not a valid rate: {error}"));
     assert!(rate > 0, "lines-per-second must be greater than zero");
     rate
+}
+
+/// Turns a rate into the sleep between lines.
+///
+/// `Duration::from_secs_f64`, not integer millisecond division: at any rate
+/// above 1000/s, `1000 / rate` floors to zero and the loop busy-spins
+/// instead of honouring the rate it was given. This stays honest at any
+/// rate a `u32` can hold -- up to the point where the computed interval
+/// itself rounds to zero, which `from_secs_f64` does for `rate` close
+/// enough to `u32::MAX` that `1.0 / rate` underflows a `Duration`'s
+/// resolution. Checked on the computed interval rather than by guessing a
+/// numeric threshold below `u32::MAX`, so the rule stays true regardless of
+/// exactly where `from_secs_f64` starts rounding down to zero.
+///
+/// # Panics
+///
+/// Panics if `rate` is high enough that the resulting interval is zero.
+fn pace(rate: u32) -> Duration {
+    let interval = Duration::from_secs_f64(1.0 / f64::from(rate));
+    assert!(
+        !interval.is_zero(),
+        "{rate} lines-per-second is too high to pace"
+    );
+    interval
 }

--- a/examples/src/bin/noisy.rs
+++ b/examples/src/bin/noisy.rs
@@ -1,0 +1,48 @@
+//! Writes to both stdout and stderr at a configurable rate, for watching the
+//! log plane: `shep bleats`, and the two files each sheep's output lands in.
+//!
+//! # Usage
+//!
+//! ```text
+//! noisy <lines-per-second>
+//! ```
+
+#![forbid(unsafe_code)]
+
+use std::time::Duration;
+
+fn main() {
+    let rate = parse_rate(std::env::args().nth(1).as_deref());
+    let interval = Duration::from_millis(1000 / u64::from(rate));
+
+    println!(
+        "noisy pid={} writing {rate} lines/s to stdout and stderr",
+        std::process::id()
+    );
+
+    let mut count: u64 = 0;
+    loop {
+        std::thread::sleep(interval);
+        count += 1;
+        if count.is_multiple_of(2) {
+            println!("noisy: stdout line {count}");
+        } else {
+            eprintln!("noisy: stderr line {count}");
+        }
+    }
+}
+
+/// Parses the line rate, in lines per second.
+///
+/// # Panics
+///
+/// Panics if no argument was given, it does not parse as a `u32`, or it is
+/// zero.
+fn parse_rate(raw: Option<&str>) -> u32 {
+    let raw = raw.unwrap_or_else(|| panic!("usage: noisy <lines-per-second>"));
+    let rate: u32 = raw
+        .parse()
+        .unwrap_or_else(|error| panic!("`{raw}` is not a valid rate: {error}"));
+    assert!(rate > 0, "lines-per-second must be greater than zero");
+    rate
+}

--- a/examples/src/bin/noisy.rs
+++ b/examples/src/bin/noisy.rs
@@ -13,7 +13,12 @@ use std::time::Duration;
 
 fn main() {
     let rate = parse_rate(std::env::args().nth(1).as_deref());
-    let interval = Duration::from_millis(1000 / u64::from(rate));
+    // `Duration::from_secs_f64`, not integer millisecond division: at any
+    // rate above 1000/s, `1000 / rate` floors to zero and the loop busy-spins
+    // instead of honouring the rate it was given. This stays honest at any
+    // rate a `u32` can hold, including one high enough to be its own kind of
+    // demonstration.
+    let interval = Duration::from_secs_f64(1.0 / f64::from(rate));
 
     println!(
         "noisy pid={} writing {rate} lines/s to stdout and stderr",

--- a/examples/src/bin/ready_when_told.rs
+++ b/examples/src/bin/ready_when_told.rs
@@ -1,0 +1,30 @@
+//! Exits `0` once a sentinel file exists, and non-zero otherwise.
+//!
+//! Not the supervised app itself — the `target` an `exec` readiness probe
+//! runs. There is no everyday real-world example of an exec probe the way
+//! there is for HTTP or TCP, since most readiness is a socket coming up; this
+//! is the minimal program that makes one demonstrable: create the sentinel
+//! file by hand (`touch <path>`) and watch the next poll flip the sheep to
+//! ready.
+//!
+//! # Usage
+//!
+//! ```text
+//! ready_when_told <sentinel-path>
+//! ```
+
+#![forbid(unsafe_code)]
+
+use std::path::Path;
+
+fn main() {
+    let raw = std::env::args()
+        .nth(1)
+        .unwrap_or_else(|| panic!("usage: ready_when_told <sentinel-path>"));
+
+    if Path::new(&raw).exists() {
+        std::process::exit(0);
+    }
+    eprintln!("ready_when_told: {raw} does not exist yet");
+    std::process::exit(1);
+}

--- a/examples/src/bin/slow_boot.rs
+++ b/examples/src/bin/slow_boot.rs
@@ -1,0 +1,84 @@
+//! An HTTP server that waits before it starts listening.
+//!
+//! Watch a `readiness_probe` poll and fail while this sleeps, and watch
+//! `listen_timeout` expire if the daemon's fallback window is shorter than
+//! the wait — the same server as `http_server`, with one extra step before
+//! the bind.
+//!
+//! # Usage
+//!
+//! ```text
+//! slow_boot <port> <delay-seconds>
+//! ```
+
+#![forbid(unsafe_code)]
+
+use std::io::{Read as _, Write as _};
+use std::net::{TcpListener, TcpStream};
+use std::time::Duration;
+
+/// How long a connection's read is allowed to block before this program
+/// gives up on seeing a full request and answers anyway.
+const READ_TIMEOUT: Duration = Duration::from_millis(200);
+
+fn main() {
+    let mut args = std::env::args().skip(1);
+    let port = parse_port(args.next().as_deref());
+    let delay = parse_delay(args.next().as_deref());
+
+    println!(
+        "slow_boot pid={} sleeping {delay}s before listening on port {port}",
+        std::process::id()
+    );
+    std::thread::sleep(Duration::from_secs(delay));
+
+    let listener = TcpListener::bind(("127.0.0.1", port))
+        .unwrap_or_else(|error| panic!("could not bind 127.0.0.1:{port}: {error}"));
+    println!("slow_boot: now listening on 127.0.0.1:{port}");
+
+    for stream in listener.incoming() {
+        match stream {
+            Ok(stream) => {
+                std::thread::spawn(move || respond(stream));
+            }
+            Err(error) => eprintln!("slow_boot: accept failed: {error}"),
+        }
+    }
+}
+
+/// Reads whatever is available and writes a fixed `200 OK` response.
+fn respond(mut stream: TcpStream) {
+    let _ = stream.set_read_timeout(Some(READ_TIMEOUT));
+    let mut buf = [0_u8; 1024];
+    let _ = stream.read(&mut buf);
+
+    let body = "OK";
+    let response = format!(
+        "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+        body.len()
+    );
+    let _ = stream.write_all(response.as_bytes());
+    let _ = stream.flush();
+}
+
+/// Parses the port argument, or dies naming what was wrong with it.
+///
+/// # Panics
+///
+/// Panics if no argument was given or it does not parse as a `u16`.
+fn parse_port(raw: Option<&str>) -> u16 {
+    let raw = raw.unwrap_or_else(|| panic!("usage: slow_boot <port> <delay-seconds>"));
+    raw.parse()
+        .unwrap_or_else(|error| panic!("`{raw}` is not a valid port: {error}"))
+}
+
+/// Parses the boot delay, in whole seconds.
+///
+/// # Panics
+///
+/// Panics if no argument was given or it does not parse as a `u64`.
+fn parse_delay(raw: Option<&str>) -> u64 {
+    let raw = raw.unwrap_or_else(|| panic!("usage: slow_boot <port> <delay-seconds>"));
+    raw.parse()
+        .unwrap_or_else(|error| panic!("`{raw}` is not a valid delay in seconds: {error}"))
+}

--- a/examples/src/bin/stubborn.rs
+++ b/examples/src/bin/stubborn.rs
@@ -1,0 +1,84 @@
+//! Traps `SIGTERM` and refuses to die, so `graceful_timeout` elapses and shep
+//! escalates to `SIGKILL`.
+//!
+//! A survey of 131 real repositories behind this example found nothing that
+//! does this on purpose, which is exactly why the escalation path has never
+//! been watched by a person: every real app dies on the first signal, so
+//! `graceful_timeout`'s expiry and shep's follow-up `SIGKILL` only ever fire
+//! in a test. Stop this one with `shep stop` and watch both happen for real.
+//!
+//! # Usage
+//!
+//! ```text
+//! stubborn
+//! ```
+//!
+//! Unix only. On any other platform this prints why and exits 1 — there is
+//! no signal to trap.
+
+#![forbid(unsafe_code)]
+
+#[cfg(unix)]
+fn main() {
+    unix::run();
+}
+
+#[cfg(not(unix))]
+fn main() {
+    eprintln!("stubborn needs a Unix signal mask; nothing to trap here");
+    std::process::exit(1);
+}
+
+#[cfg(unix)]
+mod unix {
+    use std::time::Duration;
+
+    use nix::sys::signal::{SigSet, Signal};
+
+    /// How often the heartbeat prints while `SIGTERM` sits blocked and
+    /// pending, so a person watching the log can see the process is alive
+    /// and simply not acting on the signal, rather than merely silent.
+    const HEARTBEAT: Duration = Duration::from_secs(2);
+
+    /// Blocks `SIGTERM` on the whole process (a mask set before any other
+    /// thread is spawned is inherited by every thread that comes after),
+    /// starts the heartbeat thread, then loops forever reporting every
+    /// `SIGTERM` delivery it receives without ever exiting.
+    ///
+    /// Blocking the signal (`thread_block`), not installing a handler
+    /// (`sigaction`), is what keeps this file free of `unsafe`:
+    /// `sigaction`/`signal` are `unsafe` in `nix`, while
+    /// `pthread_sigmask`/`sigwait` are not. A blocked signal is never
+    /// delivered to anyone and stays pending, which is "refuses to die" —
+    /// the process never even runs a handler that could call `exit`.
+    pub fn run() {
+        println!(
+            "stubborn pid={} ignoring SIGTERM; stop it with SIGKILL to end it for real",
+            std::process::id()
+        );
+
+        let mut term = SigSet::empty();
+        term.add(Signal::SIGTERM);
+        term.thread_block().expect("SIGTERM must be blockable");
+
+        std::thread::spawn(heartbeat);
+
+        loop {
+            // `sigwait` clears the pending flag on return, so a second
+            // SIGTERM (shep's own retried stop signal, or an operator's
+            // second `shep stop`) is reported again rather than swallowed.
+            term.wait().expect("sigwait must not fail");
+            println!("stubborn: caught SIGTERM, still not dying");
+        }
+    }
+
+    /// Prints a line every [`HEARTBEAT`], so a person watching the log can
+    /// see the process is alive and simply not acting on `SIGTERM`, rather
+    /// than merely silent between deliveries.
+    fn heartbeat() {
+        loop {
+            std::thread::sleep(HEARTBEAT);
+            println!("stubborn: still here");
+        }
+    }
+}

--- a/examples/src/bin/stubborn.rs
+++ b/examples/src/bin/stubborn.rs
@@ -1,10 +1,13 @@
-//! Traps `SIGTERM` and refuses to die, so `graceful_timeout` elapses and shep
-//! escalates to `SIGKILL`.
+//! Traps `SIGTERM` and refuses to die, so `kill_timeout` elapses and shep
+//! escalates to `SIGKILL`. (`kill_timeout`, not `graceful_timeout` --
+//! that field only governs a *reload*'s drain window for the old instance;
+//! the grace period between a plain stop signal and SIGKILL is
+//! `kill_timeout`, and that's what `examples/Flockfile.toml` sets below.)
 //!
 //! A survey of 131 real repositories behind this example found nothing that
 //! does this on purpose, which is exactly why the escalation path has never
 //! been watched by a person: every real app dies on the first signal, so
-//! `graceful_timeout`'s expiry and shep's follow-up `SIGKILL` only ever fire
+//! `kill_timeout`'s expiry and shep's follow-up `SIGKILL` only ever fire
 //! in a test. Stop this one with `shep stop` and watch both happen for real.
 //!
 //! # Usage

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -107,3 +107,11 @@ version_group = "shep"
 [[package]]
 name = "shep-cli"
 release = false
+
+# Runnable demos for docs/humans, not a crate anyone installs. `publish =
+# false` in its own manifest already stops `cargo publish` from ever
+# reaching it; this entry says the same thing to release-plz explicitly,
+# the same defense-in-depth `shep-cli`'s entry above uses.
+[[package]]
+name = "shep-examples"
+release = false

--- a/web/src/data/cli-reference.generated.txt
+++ b/web/src/data/cli-reference.generated.txt
@@ -1,5 +1,5 @@
 @@VERSION@@
-shep 0.1.5
+shep 0.1.6
 @@TOPLEVEL@@
 A process manager for your flock
 

--- a/web/src/data/docsNav.ts
+++ b/web/src/data/docsNav.ts
@@ -75,6 +75,13 @@ export const docsNav: DocsNavGroup[] = [
         source: "docs/migration.md",
         spec: { anchor: "9-cli-surface-sheep-native", label: "§9 CLI surface" },
       },
+      {
+        slug: "examples",
+        label: "Examples",
+        built: true,
+        source: "examples/",
+        spec: { anchor: "7-readiness--health", label: "§7 Readiness & health" },
+      },
     ],
   },
   {

--- a/web/src/pages/docs/examples.astro
+++ b/web/src/pages/docs/examples.astro
@@ -78,21 +78,24 @@ const rows: ExampleRow[] = [
       No config edits needed. Every path in <code>examples/Flockfile.toml</code>
       is relative to <code>examples/</code> itself — a Flockfile app with no
       <code>cwd</code> runs where its Flockfile lives — so cloning the repo
-      and running the two commands below just works.
+      and running the commands below just works.
     </Callout>
 
     <h2>Run it</h2>
+    <p>
+      Two of the seven — <code>leaky</code> and <code>crasher</code> — restart
+      on purpose and by design, and <code>shep start</code> registers into
+      whatever <code>$SHEP_HOME</code> is already pointed at. The
+      <code>export</code> below is not optional: skip it and this starts
+      inside your own real daemon, alongside whatever it's already
+      supervising.
+    </p>
     <div class="terminal">
       <div><span class="prompt">$</span> cargo build --release --workspace</div>
+      <div><span class="prompt">$</span> export SHEP_HOME="$(mktemp -d)"</div>
       <div><span class="prompt">$</span> shep start examples/Flockfile.toml</div>
       <div><span class="prompt">$</span> shep flock</div>
     </div>
-    <p class="fine">
-      Two of the seven — <code>leaky</code> and <code>crasher</code> — restart
-      on purpose and by design. Run this against a throwaway
-      <code>$SHEP_HOME</code>, not the daemon supervising anything you care
-      about.
-    </p>
 
     <h2>What each one demonstrates</h2>
     <div class="field-table">

--- a/web/src/pages/docs/examples.astro
+++ b/web/src/pages/docs/examples.astro
@@ -20,7 +20,7 @@ const rows: ExampleRow[] = [
   {
     program: "http_server",
     demonstrates: "The baseline every probe example needs.",
-    watch: "curl 127.0.0.1:8081/ and get 200 OK.",
+    watch: "curl 127.0.0.1:19081/ and get 200 OK.",
   },
   {
     program: "slow_boot",

--- a/web/src/pages/docs/examples.astro
+++ b/web/src/pages/docs/examples.astro
@@ -86,7 +86,7 @@ const polyglotRows: ExampleRow[] = [
 
 <DocsLayout
   title="Examples"
-  description="Seven small Rust programs and a Flockfile that always run, plus a second, polyglot layer over the top for Node, Bun, Python and Go — watch shep's supervision behaviours happen instead of reading about them."
+  description="Seven small Rust programs and a Flockfile that need only cargo and a Unix host, plus a second, polyglot layer over the top for Node, Bun, Python and Go — watch shep's supervision behaviours happen instead of reading about them."
   crumb="Start here / Examples"
   activeSlug="examples"
 >
@@ -120,10 +120,24 @@ const polyglotRows: ExampleRow[] = [
     </p>
 
     <Callout variant="careful">
-      No config edits needed. Every path in <code>examples/Flockfile.toml</code>
-      is relative to <code>examples/</code> itself — a Flockfile app with no
+      Unix, not just cargo. Six of the seven build and run anywhere Rust
+      does, but <code>stubborn</code> traps <code>SIGTERM</code> with a
+      Unix signal mask — on any other platform it prints why and exits 1
+      instead of running at all. <code>shep start</code> processes a
+      Flockfile top to bottom and stops at the first app that fails to
+      spawn (see <a href="#polyglot">the polyglot layer</a> below for the
+      same rule hitting a missing runtime), so on a non-Unix host this file
+      does not run straight through as shown. Comment out
+      <code>stubborn</code>'s <code>[[app]]</code> block to run the other
+      six.
+    </Callout>
+
+    <Callout variant="careful">
+      No config edits needed otherwise. Every path in
+      <code>examples/Flockfile.toml</code> is relative to
+      <code>examples/</code> itself — a Flockfile app with no
       <code>cwd</code> runs where its Flockfile lives — so cloning the repo
-      and running the commands below just works.
+      and running the commands below just works, on a Unix host.
     </Callout>
 
     <h2>Run it</h2>

--- a/web/src/pages/docs/examples.astro
+++ b/web/src/pages/docs/examples.astro
@@ -1,0 +1,345 @@
+---
+/*
+ * Examples (examples/Flockfile.toml, examples/src/bin/*.rs). Every command
+ * and behaviour on this page was run against a real `shep start
+ * examples/Flockfile.toml`, under its own $SHEP_HOME, before this page was
+ * written.
+ */
+import DocsLayout from "../../layouts/DocsLayout.astro";
+import ReferencePills from "../../components/docs/ReferencePills.astro";
+import Callout from "../../components/docs/Callout.astro";
+import CodeBlock from "../../components/docs/CodeBlock.astro";
+
+interface ExampleRow {
+  program: string;
+  demonstrates: string;
+  watch: string;
+}
+
+const rows: ExampleRow[] = [
+  {
+    program: "http_server",
+    demonstrates: "The baseline every probe example needs.",
+    watch: "curl 127.0.0.1:8081/ and get 200 OK.",
+  },
+  {
+    program: "slow_boot",
+    demonstrates: "A readiness probe waiting, and listen_timeout expiring.",
+    watch: "shep flock shows starting, then online anyway once listen_timeout elapses, before the port is even bound.",
+  },
+  {
+    program: "ready_when_told",
+    demonstrates: "An exec probe — the one kind with no everyday real-world example.",
+    watch: "touch the sentinel file and watch the next poll flip the sheep to online.",
+  },
+  {
+    program: "stubborn",
+    demonstrates: "Escalation past a stop signal.",
+    watch: "shep stop stubborn takes exactly kill_timeout, then SIGKILL ends it.",
+  },
+  {
+    program: "leaky",
+    demonstrates: "max_memory firing.",
+    watch: "shep flock's MEM column climbs past the ceiling, then RESTARTS increments and it climbs again.",
+  },
+  {
+    program: "crasher",
+    demonstrates: "Restart policy, growing backoff, and max_restarts.",
+    watch: "shep logs -f shows the gap between restarts widen until the sheep reaches errored.",
+  },
+  {
+    program: "noisy",
+    demonstrates: "The log plane.",
+    watch: "shep bleats noisy -f, alternating stdout and stderr lines.",
+  },
+];
+---
+
+<DocsLayout
+  title="Examples"
+  description="Seven small programs and one Flockfile — build them, start them, and watch shep's supervision behaviours happen instead of reading about them."
+  crumb="Start here / Examples"
+  activeSlug="examples"
+>
+  <article>
+    <h1>Examples</h1>
+    <ReferencePills slug="examples" />
+    <p class="lede">
+      Every page in this section describes what shep does. This one is seven
+      tiny programs and a Flockfile that make it happen where you can watch:
+      a probe waiting, a stop signal being ignored, a memory ceiling firing,
+      a crash loop backing off. Everything lives under
+      <code>examples/</code> — a workspace member of its own, built by
+      <code>cargo build --release</code> but never on the path a plain
+      <code>cargo install shep</code> walks.
+    </p>
+
+    <Callout variant="careful">
+      No config edits needed. Every path in <code>examples/Flockfile.toml</code>
+      is relative to <code>examples/</code> itself — a Flockfile app with no
+      <code>cwd</code> runs where its Flockfile lives — so cloning the repo
+      and running the two commands below just works.
+    </Callout>
+
+    <h2>Run it</h2>
+    <div class="terminal">
+      <div><span class="prompt">$</span> cargo build --release --workspace</div>
+      <div><span class="prompt">$</span> shep start examples/Flockfile.toml</div>
+      <div><span class="prompt">$</span> shep flock</div>
+    </div>
+    <p class="fine">
+      Two of the seven — <code>leaky</code> and <code>crasher</code> — restart
+      on purpose and by design. Run this against a throwaway
+      <code>$SHEP_HOME</code>, not the daemon supervising anything you care
+      about.
+    </p>
+
+    <h2>What each one demonstrates</h2>
+    <div class="field-table">
+      <div class="row header">
+        <span class="col-name">Program</span>
+        <span class="col-does">Demonstrates</span>
+        <span class="col-does">Watch for</span>
+      </div>
+      {
+        rows.map((r) => (
+          <div class="row">
+            <span class="col-name">
+              <code>{r.program}</code>
+            </span>
+            <span class="col-does">{r.demonstrates}</span>
+            <span class="col-does">{r.watch}</span>
+          </div>
+        ))
+      }
+    </div>
+
+    <h2>The exec probe, in full</h2>
+    <p>
+      <code>readiness_probe</code> with <code>kind = "exec"</code> has no
+      everyday real-world stand-in the way an HTTP or TCP probe does —
+      <code>ready_when_told</code> is the minimal program that makes one
+      demonstrable. It exits <code>0</code> once a file exists on disk and
+      non-zero otherwise; the Flockfile points a probe at it, gated on a
+      sentinel path this page and the file both agree on:
+    </p>
+    <CodeBlock label="examples/Flockfile.toml">{`[app.readiness_probe]
+kind     = "exec"
+target   = "../target/release/ready_when_told /tmp/shep-examples-sentinel"
+interval = "3s"`}</CodeBlock>
+    <div class="terminal">
+      <div><span class="prompt">$</span> touch /tmp/shep-examples-sentinel</div>
+    </div>
+    <p class="fine">
+      The next poll — within <code>interval</code> — flips
+      <code>http-server-gated-by-sentinel</code> from <code>starting</code> to
+      <code>online</code>.
+    </p>
+
+    <h2>kill_timeout, not graceful_timeout</h2>
+    <p>
+      <code>stubborn</code> blocks <code>SIGTERM</code> and never acts on it,
+      so shep's kill ladder has to escalate to <code>SIGKILL</code> — a
+      signal nothing can trap. The field that governs how long shep waits
+      before that escalation on a plain <code>shep stop</code>/
+      <code>restart</code>/<code>delete</code> is <code>kill_timeout</code>,
+      not <code>graceful_timeout</code>: the latter only governs a
+      <em>reload</em>'s drain window for the old instance. This example sets
+      <code>kill_timeout</code> to 3 seconds, short enough to watch land:
+    </p>
+    <div class="terminal">
+      <div><span class="prompt">$</span> shep stop stubborn</div>
+    </div>
+    <p class="fine">
+      Roughly three seconds pass — one <code>"caught SIGTERM, still not
+      dying"</code> line in its log, then silence — before
+      <code>shep flock</code> reports it stopped by <code>SIGKILL</code>.
+    </p>
+
+    <h2>Where to go next</h2>
+    <div class="next-grid">
+      <a href="/docs/first-flockfile" class="next-card">
+        <div class="next-title">Your first Flockfile →</div>
+        <div class="next-body">
+          Every field <code>examples/Flockfile.toml</code> uses, and every one
+          it doesn't.
+        </div>
+      </a>
+      <a href="/docs/output" class="next-card">
+        <div class="next-title">Terminal output →</div>
+        <div class="next-body">
+          What the columns in <code>shep flock</code>'s table above actually
+          mean.
+        </div>
+      </a>
+    </div>
+  </article>
+</DocsLayout>
+
+<style>
+  h1 {
+    font-size: clamp(36px, 4.6vw, 56px);
+    line-height: 1;
+    letter-spacing: -0.04em;
+    margin: 0 0 18px;
+  }
+
+  h2 {
+    font-size: 27px;
+    letter-spacing: -0.03em;
+    margin: 44px 0 12px;
+  }
+
+  h2:first-of-type {
+    margin-top: 0;
+  }
+
+  .lede {
+    font-size: 19px;
+    line-height: 1.6;
+    color: var(--ink-2);
+    margin: 0 0 30px;
+    text-wrap: pretty;
+  }
+
+  p {
+    font-size: 16.5px;
+    line-height: 1.65;
+    color: var(--ink-2);
+    margin: 0 0 18px;
+  }
+
+  .fine {
+    font-size: 14.5px;
+    color: var(--ink-3);
+  }
+
+  code {
+    font-family: "Space Mono", monospace;
+    font-size: 0.88em;
+    background: var(--code-bg);
+    border-radius: 5px;
+    padding: 1px 6px;
+  }
+
+  .terminal {
+    background: var(--illus-terminal-bg, #1b1b1b);
+    color: var(--illus-terminal-fg, #eee);
+    border-radius: 14px;
+    padding: 18px 20px;
+    font-family: "Space Mono", monospace;
+    font-size: 14px;
+    line-height: 1.9;
+    margin: 0 0 18px;
+  }
+
+  .prompt {
+    color: var(--butter, #e8b64a);
+    margin-right: 8px;
+  }
+
+  .field-table {
+    border: 3px solid var(--line);
+    border-radius: 16px;
+    overflow: hidden;
+    margin: 0 0 26px;
+  }
+
+  .field-table .row {
+    display: grid;
+    grid-template-columns: minmax(0, 190px) minmax(0, 1fr) minmax(0, 1fr);
+    gap: 14px;
+    padding: 11px 18px;
+    align-items: start;
+  }
+
+  .field-table .row.header {
+    background: var(--ink);
+    padding: 10px 18px;
+  }
+
+  .field-table .row:not(.header) {
+    border-bottom: 2px solid var(--hair);
+    background: var(--paper-2);
+  }
+
+  .field-table .row:last-child {
+    border-bottom: none;
+  }
+
+  .field-table .row.header span {
+    font-family: "Space Mono", monospace;
+    font-size: 10.5px;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: var(--ink-3);
+  }
+
+  .field-table .row.header .col-name {
+    color: var(--butter);
+  }
+
+  .col-name code {
+    font-size: 12.5px;
+    padding: 1px 5px;
+  }
+
+  .col-does {
+    font-size: 13.5px;
+    line-height: 1.5;
+    color: var(--ink);
+  }
+
+  @media (max-width: 640px) {
+    .field-table .row {
+      grid-template-columns: 1fr;
+      gap: 5px;
+    }
+
+    .field-table .row.header {
+      display: none;
+    }
+  }
+
+  .next-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    gap: 16px;
+    margin-top: 8px;
+  }
+
+  .next-card {
+    text-align: left;
+    background: var(--paper-2);
+    border: 3px solid var(--line);
+    border-radius: 18px;
+    box-shadow: 5px 5px 0 var(--shadow);
+    padding: 20px;
+    color: var(--ink);
+    text-decoration: none;
+    display: block;
+  }
+
+  .next-card:hover {
+    transform: translate(2px, 2px);
+    box-shadow: 3px 3px 0 var(--shadow);
+    color: var(--ink);
+  }
+
+  .next-title {
+    font-family: "Bricolage Grotesque", sans-serif;
+    font-weight: 800;
+    font-size: 17px;
+    margin-bottom: 7px;
+  }
+
+  .next-body {
+    font-size: 14px;
+    line-height: 1.5;
+    color: var(--ink-2);
+  }
+
+  .next-body code {
+    font-size: 0.85em;
+  }
+</style>

--- a/web/src/pages/docs/examples.astro
+++ b/web/src/pages/docs/examples.astro
@@ -293,13 +293,21 @@ py = "python3"`}</CodeBlock>
       <code>instances = 4</code>. Each instance gets its own
       <code>SHEP_INSTANCE</code> env var (0 through 3), and the script adds
       that to its base port — four separate listeners on 19091 through
-      19094, not one port shared four ways. pm2's cluster mode puts all N
-      instances behind one port using <code>SO_REUSEPORT</code>; shep's
-      <code>reuse_port</code> field exists in the schema for exactly that
-      but is refused at load while nothing implements the mechanism yet
-      (verified: setting <code>reuse_port = true</code> anywhere in this
-      file fails the whole file to load, not just that one app) — which is
-      why this example offsets the port instead of sharing it.
+      19094, not one port shared four ways. That is a genuinely different
+      shape from pm2's own cluster mode, which does not use
+      <code>SO_REUSEPORT</code> at all: pm2 runs Node's built-in
+      <code>cluster</code> module, where a single primary process holds the
+      one listening socket and hands each accepted connection to a worker
+      round robin. shep's own <code>reuse_port</code> field is the more
+      interesting half of this contrast, because it is real: a reload
+      overlaps the old and new instance on the same port today, and
+      <code>reuse_port</code> is what a Flockfile will assert an app is
+      doing for itself once shep grows a reload mode that stops overlapping
+      by default. It is accepted by the schema and refused at load while
+      nothing implements it yet (verified: setting <code>reuse_port =
+      true</code> anywhere in this file fails the whole file to load, not
+      just that one app) — which is why this example offsets the port
+      instead of sharing it.
     </p>
 
     <h3>A venv's own python</h3>

--- a/web/src/pages/docs/examples.astro
+++ b/web/src/pages/docs/examples.astro
@@ -1,9 +1,10 @@
 ---
 /*
- * Examples (examples/Flockfile.toml, examples/src/bin/*.rs). Every command
- * and behaviour on this page was run against a real `shep start
- * examples/Flockfile.toml`, under its own $SHEP_HOME, before this page was
- * written.
+ * Examples (examples/Flockfile.toml, examples/Flockfile.polyglot.toml,
+ * examples/src/bin/*.rs, examples/polyglot/*). Every command and behaviour
+ * on this page was run for real: the Rust set under its own throwaway
+ * $SHEP_HOME, and the polyglot set the same way with node, bun, python3
+ * and go all actually installed, before this page was written.
  */
 import DocsLayout from "../../layouts/DocsLayout.astro";
 import ReferencePills from "../../components/docs/ReferencePills.astro";
@@ -16,7 +17,7 @@ interface ExampleRow {
   watch: string;
 }
 
-const rows: ExampleRow[] = [
+const rustRows: ExampleRow[] = [
   {
     program: "http_server",
     demonstrates: "The baseline every probe example needs.",
@@ -53,11 +54,39 @@ const rows: ExampleRow[] = [
     watch: "shep bleats noisy -f, alternating stdout and stderr lines.",
   },
 ];
+
+const polyglotRows: ExampleRow[] = [
+  {
+    program: "node-http / node-http-cluster",
+    demonstrates: "The pm2 audience's default case, plus instances above 1.",
+    watch: "curl 127.0.0.1:19090/, then 19091 through 19094 for each clustered instance.",
+  },
+  {
+    program: "bun-http",
+    demonstrates: "interpreter, and shep.toml's [interpreters] mapping.",
+    watch: "The same node-http.js, curl 127.0.0.1:19095/, and a runtime field in the response body instead of a different file.",
+  },
+  {
+    program: "python-app",
+    demonstrates: "interpreter pointed at a venv's own python, not a bare python3.",
+    watch: "curl 127.0.0.1:19096/ after examples/polyglot/setup-venv.sh.",
+  },
+  {
+    program: "go-http",
+    demonstrates: "A build step, then no interpreter field at all.",
+    watch: "curl 127.0.0.1:19097/ after examples/polyglot/go-http/build.sh.",
+  },
+  {
+    program: "static-site",
+    demonstrates: "shep serve — no program of the operator's own.",
+    watch: "curl 127.0.0.1:19098/ after shep serve examples/polyglot/static-site --port 19098.",
+  },
+];
 ---
 
 <DocsLayout
   title="Examples"
-  description="Seven small programs and one Flockfile — build them, start them, and watch shep's supervision behaviours happen instead of reading about them."
+  description="Seven small Rust programs and a Flockfile that always run, plus a second, polyglot layer over the top for Node, Bun, Python and Go — watch shep's supervision behaviours happen instead of reading about them."
   crumb="Start here / Examples"
   activeSlug="examples"
 >
@@ -65,13 +94,29 @@ const rows: ExampleRow[] = [
     <h1>Examples</h1>
     <ReferencePills slug="examples" />
     <p class="lede">
-      Every page in this section describes what shep does. This one is seven
-      tiny programs and a Flockfile that make it happen where you can watch:
-      a probe waiting, a stop signal being ignored, a memory ceiling firing,
-      a crash loop backing off. Everything lives under
+      Every page in this section describes what shep does. This one is
+      seven tiny programs and a Flockfile that make it happen where you can
+      watch: a probe waiting, a stop signal being ignored, a memory ceiling
+      firing, a crash loop backing off. Everything lives under
       <code>examples/</code> — a workspace member of its own, built by
       <code>cargo build --release</code> but never on the path a plain
       <code>cargo install shep</code> walks.
+    </p>
+    <p>
+      That first set is Rust on purpose: it needs nothing but a Rust
+      toolchain, works from a fresh clone, and is what
+      <code>examples/Flockfile.toml</code> starts. A second layer,
+      <code>examples/Flockfile.polyglot.toml</code>, runs the same ideas
+      against Node, Bun, Python and Go — the stacks most shep operators
+      actually run, and the ones the Rust set structurally can't stand in
+      for: a real Node HTTP server, the same source file under two
+      different runtimes, a Python interpreter resolved through a venv
+      instead of PATH, a Go binary with a build step, and a static site
+      served with no program of the operator's own at all. It's a separate
+      file and a separate section below because it needs runtimes the Rust
+      set doesn't — see <a href="#polyglot">The polyglot layer</a> for
+      exactly which ones, and what happens to the rest of the file when one
+      is missing.
     </p>
 
     <Callout variant="careful">
@@ -105,7 +150,7 @@ const rows: ExampleRow[] = [
         <span class="col-does">Watch for</span>
       </div>
       {
-        rows.map((r) => (
+        rustRows.map((r) => (
           <div class="row">
             <span class="col-name">
               <code>{r.program}</code>
@@ -157,6 +202,142 @@ interval = "3s"`}</CodeBlock>
       Roughly three seconds pass — one <code>"caught SIGTERM, still not
       dying"</code> line in its log, then silence — before
       <code>shep flock</code> reports it stopped by <code>SIGKILL</code>.
+    </p>
+
+    <h2 id="polyglot">The polyglot layer</h2>
+    <p>
+      <code>examples/Flockfile.polyglot.toml</code> needs, per app,
+      <code>node</code>, <code>bun</code>, <code>python3</code>, or
+      <code>go</code> — never all four to run any single one of them.
+      Two setup steps, once, before the runtimes that need them:
+    </p>
+    <div class="terminal">
+      <div><span class="prompt">$</span> examples/polyglot/setup-venv.sh</div>
+      <div><span class="prompt">$</span> examples/polyglot/go-http/build.sh</div>
+      <div><span class="prompt">$</span> export SHEP_HOME="$(mktemp -d)"</div>
+      <div><span class="prompt">$</span> shep start examples/Flockfile.polyglot.toml</div>
+    </div>
+    <div class="field-table">
+      <div class="row header">
+        <span class="col-name">Program</span>
+        <span class="col-does">Demonstrates</span>
+        <span class="col-does">Watch for</span>
+      </div>
+      {
+        polyglotRows.map((r) => (
+          <div class="row">
+            <span class="col-name">
+              <code>{r.program}</code>
+            </span>
+            <span class="col-does">{r.demonstrates}</span>
+            <span class="col-does">{r.watch}</span>
+          </div>
+        ))
+      }
+    </div>
+
+    <Callout variant="careful">
+      A missing runtime does not sink the whole file, but it does sink
+      everything listed AFTER it. <code>shep start</code> processes a
+      Flockfile's apps top to bottom and stops at the first one that fails
+      to spawn (<code>shep start --help</code>: "Several are started in
+      turn, not atomically") — every app already online stays online, and
+      the failing app reports why
+      (<code>SpawnFailed: No such file or directory</code>), but nothing
+      below it in the file is even attempted in that same invocation.
+      Missing <code>bun</code> would silently keep <code>python-app</code>
+      and <code>go-http</code> from starting too, not just
+      <code>bun-http</code>. If a runtime isn't installed, comment out that
+      app's <code>[[app]]</code> block rather than leaving it in.
+    </Callout>
+
+    <h3>One file, two runtimes</h3>
+    <p>
+      <code>node-http</code> and <code>bun-http</code> run the exact same
+      script, <code>examples/polyglot/node-http.js</code> — only
+      <code>interpreter</code> changes, from <code>"node"</code> to
+      <code>"bun"</code>:
+    </p>
+    <CodeBlock label="examples/Flockfile.polyglot.toml">{`[[app]]
+name        = "node-http"
+script      = "polyglot/node-http.js"
+interpreter = "node"
+args        = ["19090"]
+
+[[app]]
+name        = "bun-http"
+script      = "polyglot/node-http.js"
+interpreter = "bun"
+args        = ["19095"]`}</CodeBlock>
+    <p class="fine">
+      shep never inspects the script; <code>interpreter</code> is a plain
+      program name, spawned with the script as its first argument. A
+      <code>shep.toml</code> <code>[interpreters]</code> table does the same
+      job automatically, by extension, so every app in a flock doesn't
+      have to spell <code>interpreter</code> out by hand:
+    </p>
+    <CodeBlock label="shep.toml">{`[interpreters]
+js = "node"
+py = "python3"`}</CodeBlock>
+    <p class="fine">
+      An app's own <code>interpreter</code> field, when it sets one — as
+      every app in <code>examples/Flockfile.polyglot.toml</code> does —
+      always wins over the extension map. The map exists for a flock of
+      apps that all use the same handful of extensions and would rather
+      not repeat <code>interpreter = "node"</code> five times.
+    </p>
+
+    <h3>instances, without reuse_port</h3>
+    <p>
+      <code>node-http-cluster</code> is the same script again,
+      <code>instances = 4</code>. Each instance gets its own
+      <code>SHEP_INSTANCE</code> env var (0 through 3), and the script adds
+      that to its base port — four separate listeners on 19091 through
+      19094, not one port shared four ways. pm2's cluster mode puts all N
+      instances behind one port using <code>SO_REUSEPORT</code>; shep's
+      <code>reuse_port</code> field exists in the schema for exactly that
+      but is refused at load while nothing implements the mechanism yet
+      (verified: setting <code>reuse_port = true</code> anywhere in this
+      file fails the whole file to load, not just that one app) — which is
+      why this example offsets the port instead of sharing it.
+    </p>
+
+    <h3>A venv's own python</h3>
+    <p>
+      The classic failure <code>python-app</code> exists to head off: an
+      app that runs fine from a shell — your venv is active — and does not
+      under a supervisor, because the supervisor never activated anything
+      and a bare <code>python3</code> resolved against whatever's on ITS
+      PATH instead. <code>interpreter</code> points straight at the venv's
+      own binary:
+    </p>
+    <CodeBlock label="examples/Flockfile.polyglot.toml">{`[[app]]
+name        = "python-app"
+script      = "polyglot/python-app.py"
+interpreter = "polyglot/venv/bin/python3"
+args        = ["19096"]`}</CodeBlock>
+
+    <h3>A build step, then no interpreter</h3>
+    <p>
+      <code>go-http</code> is compiled, not interpreted:
+      <code>examples/polyglot/go-http/build.sh</code> runs
+      <code>go build</code> first, and the Flockfile entry that follows has
+      no <code>interpreter</code> field at all — a native executable
+      already runs itself.
+    </p>
+
+    <h3>shep serve, not an app</h3>
+    <p>
+      <code>examples/polyglot/static-site</code> isn't in the Flockfile at
+      all. <code>shep serve</code> registers its own sheep for a directory
+      with no program of the operator's own:
+    </p>
+    <div class="terminal">
+      <div><span class="prompt">$</span> shep serve examples/polyglot/static-site --port 19098</div>
+    </div>
+    <p class="fine">
+      See <a href="/docs/serve">Serve</a> for <code>--bind</code>,
+      <code>--auth</code>, and everything else it refuses by default.
     </p>
 
     <h2>Where to go next</h2>

--- a/web/src/pages/docs/examples.astro
+++ b/web/src/pages/docs/examples.astro
@@ -152,8 +152,8 @@ const polyglotRows: ExampleRow[] = [
     <div class="terminal">
       <div><span class="prompt">$</span> cargo build --release --workspace</div>
       <div><span class="prompt">$</span> export SHEP_HOME="$(mktemp -d)"</div>
-      <div><span class="prompt">$</span> shep start examples/Flockfile.toml</div>
-      <div><span class="prompt">$</span> shep flock</div>
+      <div><span class="prompt">$</span> ./target/release/shep start examples/Flockfile.toml</div>
+      <div><span class="prompt">$</span> ./target/release/shep flock</div>
     </div>
 
     <h2>What each one demonstrates</h2>
@@ -210,7 +210,7 @@ interval = "3s"`}</CodeBlock>
       <code>kill_timeout</code> to 3 seconds, short enough to watch land:
     </p>
     <div class="terminal">
-      <div><span class="prompt">$</span> shep stop stubborn</div>
+      <div><span class="prompt">$</span> ./target/release/shep stop stubborn</div>
     </div>
     <p class="fine">
       Roughly three seconds pass — one <code>"caught SIGTERM, still not
@@ -229,7 +229,7 @@ interval = "3s"`}</CodeBlock>
       <div><span class="prompt">$</span> examples/polyglot/setup-venv.sh</div>
       <div><span class="prompt">$</span> examples/polyglot/go-http/build.sh</div>
       <div><span class="prompt">$</span> export SHEP_HOME="$(mktemp -d)"</div>
-      <div><span class="prompt">$</span> shep start examples/Flockfile.polyglot.toml</div>
+      <div><span class="prompt">$</span> ./target/release/shep start examples/Flockfile.polyglot.toml</div>
     </div>
     <div class="field-table">
       <div class="row header">
@@ -355,7 +355,7 @@ args        = ["19096"]`}</CodeBlock>
       with no program of the operator's own:
     </p>
     <div class="terminal">
-      <div><span class="prompt">$</span> shep serve examples/polyglot/static-site --port 19098</div>
+      <div><span class="prompt">$</span> ./target/release/shep serve examples/polyglot/static-site --port 19098</div>
     </div>
     <p class="fine">
       See <a href="/docs/serve">Serve</a> for <code>--bind</code>,

--- a/web/src/pages/docs/examples.astro
+++ b/web/src/pages/docs/examples.astro
@@ -188,7 +188,8 @@ const polyglotRows: ExampleRow[] = [
     <CodeBlock label="examples/Flockfile.toml">{`[app.readiness_probe]
 kind     = "exec"
 target   = "../target/release/ready_when_told /tmp/shep-examples-sentinel"
-interval = "3s"`}</CodeBlock>
+interval = "3s"
+timeout  = "1s"`}</CodeBlock>
     <div class="terminal">
       <div><span class="prompt">$</span> touch /tmp/shep-examples-sentinel</div>
     </div>
@@ -295,8 +296,9 @@ js = "node"
 py = "python3"`}</CodeBlock>
     <p class="fine">
       An app's own <code>interpreter</code> field, when it sets one — as
-      every app in <code>examples/Flockfile.polyglot.toml</code> does —
-      always wins over the extension map. The map exists for a flock of
+      every interpreted app in <code>examples/Flockfile.polyglot.toml</code>
+      does, though <code>go-http</code> sets none because a compiled binary
+      runs directly — always wins over the extension map. The map exists for a flock of
       apps that all use the same handful of extensions and would rather
       not repeat <code>interpreter = "node"</code> five times.
     </p>


### PR DESCRIPTION
Seven small programs, one per supervision behaviour, so a reader can watch the thing happen instead of reading about it.

- `http_server` binds a port and answers 200, the baseline every probe example needs
- `slow_boot` waits before listening, so a readiness probe visibly waits and `listen_timeout` visibly expires
- `ready_when_told` exits 0 only once a sentinel file exists, which is what an exec probe is for and the one probe kind with no natural real-world example
- `stubborn` blocks SIGTERM, so `kill_timeout` elapses and shep escalates
- `leaky` allocates on a timer until `max_memory` fires
- `crasher` exits non-zero after a delay, for restart policy and backoff
- `noisy` writes to both streams at a set rate, for the log plane

`examples/Flockfile.toml` wires them together with the probes and limits each one demonstrates, commented so the option is learned from the example rather than looked up. It runs as written from a fresh clone.

No new dependencies. `nix` was already a workspace dependency and is used only to block SIGTERM in `stubborn` without unsafe. `publish = false`, so release-plz never ships it and it is never on the shipped binary's dependency path.

Ports start at 19081 rather than 8081, which is taken on most dev machines.

`examples/Flockfile.polyglot.toml` adds a second layer for readers who want to see shep drive their own stack: Node (including a four instance cluster), Bun running the same file through a different interpreter, Python behind a venv, Go as a built binary, and a static site under `shep serve`, which had no example anywhere until now.

The split is deliberate. The Rust file needs nothing but cargo and runs from a fresh clone. The polyglot one names its runtimes at the top, and a reader missing one comments out that block: `shep start` works through a file top to bottom and stops at the first spawn failure, so an app after a missing runtime is never reached.

Not wired into the e2e tests. Those already have nine shell fixtures covering the same ground on Unix, and sharing them would mean path discovery for no gain. CI gains no dependency on node, bun, python or go.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added runnable demonstrations for HTTP services, readiness checks, restarts, timeouts, memory limits, signal handling, logging, and failure scenarios.
  * Added polyglot examples for Node, Bun, Python, and Go, including clustered services, virtual environments, and static-site serving.
  * Added sample configurations for Rust and polyglot applications.

* **Documentation**
  * Added an Examples guide covering setup, builds, configuration, runtime behavior, troubleshooting, and related specifications.
  * Added responsive tables, terminal examples, and navigation links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->