### PR TITLE
One listing order, one column layout, and folds that work on start

### DIFF
--- a/crates/shep-cli/CHANGELOG.md
+++ b/crates/shep-cli/CHANGELOG.md
@@ -13,6 +13,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Additions
+
+- `shep start` takes the selector grammar every other lifecycle verb takes:
+  `all`, `fold:<name>`, `/regex/`, globs, and a bare id. `shep stop
+  fold:backed` worked and `shep start fold:backed` refused with "backed is not
+  `-`, a recognised Flockfile, or an existing path", because `start` alone
+  took a different argument grammar. Folds were actionable everywhere except
+  the verb that creates things.
+
+- A bare token is also tried as a fold name, so `shep start backed` reaches
+  the fold `backed`. The full order, first tier that matches wins: a sheep by
+  id or name, then a fold, then a Flockfile, then a path on disk. Written down
+  in `shep start --help` and on the folds page, since a precedence rule is
+  only reasonable if the person it surprises can find out why.
+
+- `./backed` always means the file. A sheep name may never contain a path
+  separator, so a target carrying one skips the flock entirely. That is what
+  gives somebody whose fold shares a name with a file a way to say which they
+  meant.
+
 ### Fixes
 
 - Say so when a Flockfile app names a sheep the flock already has under a
@@ -28,6 +48,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   separate decision, and changing a running flock's `cwd` or argv underneath
   an operator would be a worse surprise than the bug being fixed. Field names
   only, never values, since `env` carries secrets.
+
+- A selector that matched nothing is reported as a selector. `shep start
+  fold:typo` said `fold:typo is not ... an existing path` and sent an operator
+  looking for a file they had never asked about; it now says no sheep is in a
+  fold called typo, and exits 3 like every other verb does.
 
 - Every lifecycle verb prints the whole flock afterwards, not only the rows it
   touched. `shep start koji` printed a one-row table containing koji; the

--- a/crates/shep-cli/CHANGELOG.md
+++ b/crates/shep-cli/CHANGELOG.md
@@ -15,6 +15,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Additions
 
+- The dogs table's columns line up with the sheep table's. Every column the
+  two share sits in the same order and each table's own columns come last, so
+  the dogs table gains `ID` and `EXIT` and moves `SOURCE` from second to last.
+  Both fields were already on the `ProcessInfo` it builds from, so this is no
+  wire change. `FOLD` and `SMIT` stay off it because they are impossible for a
+  dog rather than empty.
+
+- `SOURCE` carries the one trust distinction shep draws. `adopted` is a
+  third-party binary running at the shepherd's own trust level from an
+  operator-supplied path; `built-in` is shep running its own code. They no
+  longer look identical.
+
+- Colour reaches every table that has something to say with one, which is
+  seventeen of the twenty-two. The nine newly covered are the three per-sheep
+  reply tables (`trigger`, `signal`, `whisper`), `flush`'s two, `startup`'s,
+  `barks`, `kill` and `import`. Five stay plain on purpose, each with the
+  reason recorded on the impl.
+
+### Fixes
+
+- Cell colour is keyed on a column's NAME rather than its index. The old
+  `rows_for` painted `row[0]`, `row[4]`, `row[9]` and `row[10]`, which are
+  facts about one table's column order: reordering columns repointed every one
+  of them with nothing failing to compile and no test able to notice.
+
 - Colour reaches the seven `Render` impls that are not the flock table.
   `colour_cell` had only ever appeared inside `FlockRows`, so one of eight
   tables was coloured and the same dog read one way under `shep dogs` and

--- a/crates/shep-cli/CHANGELOG.md
+++ b/crates/shep-cli/CHANGELOG.md
@@ -29,6 +29,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   an operator would be a worse surprise than the bug being fixed. Field names
   only, never values, since `env` carries secrets.
 
+- `shep lookout`'s flock table draws by name, then by id, rather than by id.
+  It repolls every two seconds, so the tiebreak is what stops two instances of
+  one app swapping places under the cursor between refreshes.
+
+- `shep bleats` tails a flock's log files in name order, and `shep flock`
+  against a stopped shepherd lists the saved roll in name order. Both used
+  the order they happened to be handed.
+
 - Table columns are padded by the columns a name draws in, not by its
   character count. A CJK or emoji glyph counts as one character and draws as
   two, so a name built from them hung over its own column and pushed every

--- a/crates/shep-cli/CHANGELOG.md
+++ b/crates/shep-cli/CHANGELOG.md
@@ -28,10 +28,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   longer look identical.
 
 - Colour reaches every table that has something to say with one, which is
-  seventeen of the twenty-two. The nine newly covered are the three per-sheep
-  reply tables (`trigger`, `signal`, `whisper`), `flush`'s two, `startup`'s,
-  `barks`, `kill` and `import`. Five stay plain on purpose, each with the
-  reason recorded on the impl.
+  fifteen of the twenty-two in `output::rows`. The eight newly covered are the
+  three per-sheep reply tables (`trigger`, `signal`, `whisper`), `flush`'s
+  two, `startup`'s, `barks` and `kill`, plus `import`'s `REUSE_PORT`. Seven
+  stay plain on purpose, each with the reason recorded on its impl.
 
 ### Fixes
 

--- a/crates/shep-cli/CHANGELOG.md
+++ b/crates/shep-cli/CHANGELOG.md
@@ -29,6 +29,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   an operator would be a worse surprise than the bug being fixed. Field names
   only, never values, since `env` carries secrets.
 
+- Every lifecycle verb prints the whole flock afterwards, not only the rows it
+  touched. `shep start koji` printed a one-row table containing koji; the
+  question an operator has after a lifecycle command is what the flock looks
+  like now, which a one-row table cannot answer and which the exit code
+  already covered for the sheep they named. Applies to `start`, `stop`,
+  `restart`, `reload`, `delete` and `stock`. `describe` stays narrow, because
+  answering about one sheep is what it is for.
+
+- A lifecycle verb acting on a dog renders it through the dogs table rather
+  than the sheep table. `shep restart log-rotate` gave it an id, a face, and a
+  `FOLD` and `SMIT` a dog can never fill, while dropping the `SOURCE` column
+  that says whether it was adopted or is built in. Falls out of the change
+  above: the listing goes through the same renderer `shep flock` uses.
+
+- `--format json` is deliberately NOT widened by either of those. A script
+  running `shep stop web --format json` asked about `web`, so `data` still
+  holds `web`'s rows; widening it would break every consumer reading
+  `data[0]`. `shep flock --format json` is the way to ask for the flock.
+
 - `shep lookout`'s flock table draws by name, then by id, rather than by id.
   It repolls every two seconds, so the tiebreak is what stops two instances of
   one app swapping places under the cursor between refreshes.

--- a/crates/shep-cli/CHANGELOG.md
+++ b/crates/shep-cli/CHANGELOG.md
@@ -15,6 +15,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Additions
 
+- Colour reaches the seven `Render` impls that are not the flock table.
+  `colour_cell` had only ever appeared inside `FlockRows`, so one of eight
+  tables was coloured and the same dog read one way under `shep dogs` and
+  another under `shep flock`. The dogs table and the `enable`/`disable`/
+  `adopt`/`rehome` confirmations now take the flock table's own rules, and
+  `shep empty`'s table mutes its id and its placeholders. `describe`'s lamb
+  table stays plain: two identity columns with no state, no reading and no
+  placeholder, so there is nothing for a colour to carry.
+
 - `shep start` takes the selector grammar every other lifecycle verb takes:
   `all`, `fold:<name>`, `/regex/`, globs, and a bare id. `shep stop
   fold:backed` worked and `shep start fold:backed` refused with "backed is not

--- a/crates/shep-cli/CHANGELOG.md
+++ b/crates/shep-cli/CHANGELOG.md
@@ -33,13 +33,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   two, `startup`'s, `barks` and `kill`, plus `import`'s `REUSE_PORT`. Seven
   stay plain on purpose, each with the reason recorded on its impl.
 
-### Fixes
-
-- Cell colour is keyed on a column's NAME rather than its index. The old
-  `rows_for` painted `row[0]`, `row[4]`, `row[9]` and `row[10]`, which are
-  facts about one table's column order: reordering columns repointed every one
-  of them with nothing failing to compile and no test able to notice.
-
 - Colour reaches the seven `Render` impls that are not the flock table.
   `colour_cell` had only ever appeared inside `FlockRows`, so one of eight
   tables was coloured and the same dog read one way under `shep dogs` and
@@ -68,6 +61,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   meant.
 
 ### Fixes
+
+- Cell colour is keyed on a column's NAME rather than its index. The old
+  `rows_for` painted `row[0]`, `row[4]`, `row[9]` and `row[10]`, which are
+  facts about one table's column order: reordering columns repointed every one
+  of them with nothing failing to compile and no test able to notice.
 
 - Say so when a Flockfile app names a sheep the flock already has under a
   different config, instead of ignoring the edit in silence. `shep start` on

--- a/crates/shep-cli/src/cli.rs
+++ b/crates/shep-cli/src/cli.rs
@@ -566,11 +566,28 @@ pub enum Commands {
 /// Arguments to `shep start`.
 #[derive(Debug, clap::Args)]
 pub struct StartArgs {
-    /// Script paths, Flockfiles, names the flock already has, or `-` to read
-    /// Flockfile JSON from stdin
+    /// Selectors, script paths, Flockfiles, or `-` to read Flockfile JSON
+    /// from stdin
     ///
-    /// Omit them to start the Flockfile in the current directory, or, when
-    /// there is none, to bring a shepherd up with nothing running yet.
+    /// A target is resolved in four tiers and the first one that matches
+    /// wins: a sheep the flock already has, by id or by name; then a fold,
+    /// written either as `fold:<name>` or as the bare fold name; then a
+    /// Flockfile, by its extension; then a path on disk, started as a
+    /// script.
+    ///
+    /// So `shep start backed` starts the fold `backed` even when a file
+    /// called `backed` is sitting in the current directory. Write `./backed`
+    /// to mean the file: a sheep name may never contain a path separator, so
+    /// a target carrying one is always a path.
+    ///
+    /// The wildcard selectors work here too, and mean what they mean
+    /// everywhere else: `all`, `/regex/`, and glob patterns such as
+    /// `web-*`. They reach only sheep the flock already has, since there is
+    /// nothing to register. A sheep already running is reported and left
+    /// alone; `restart` is the verb that replaces one.
+    ///
+    /// Omit the targets to start the Flockfile in the current directory, or,
+    /// when there is none, to bring a shepherd up with nothing running yet.
     ///
     /// Several are started in turn, not atomically: if the second fails the
     /// first is already up, and the exit code is the first failure. `--name`

--- a/crates/shep-cli/src/commands/bleats.rs
+++ b/crates/shep-cli/src/commands/bleats.rs
@@ -294,9 +294,11 @@ pub(crate) fn read_tail(path: &Path, limit: usize) -> io::Result<(Vec<String>, b
 ///
 /// Within one sheep, `out_file` (unless `--err`) prints before `err_file`
 /// (unless `--out`) — this module's own doc states the ordering limitation
-/// that follows from it. Ids are sorted before anything is read: `cache` is
-/// a `HashMap`, whose iteration order is not the id order this command's
-/// `--format json` output is pinned against.
+/// that follows from it. The matched sheep are sorted before anything is
+/// read -- `cache` is a `HashMap` and its iteration order is arbitrary -- by
+/// name and then by id, the one order every operator-facing listing takes
+/// (`shep_core::protocol::sort_flock`). It was id order until that rule was
+/// made the only one.
 ///
 /// A `None` path means the shepherd predates the field (module doc,
 /// [`shep_core::protocol::ProcessInfo::out_file`]) — one `log_path_unknown`
@@ -1612,20 +1614,32 @@ mod tests {
         );
     }
 
-    /// Scripts the listing in DESCENDING id order, so the cache's `HashMap`
-    /// iteration order cannot be what makes ascending output pass.
+    /// fails if the sheep are tailed in the order the cache happens to hold
+    /// them, or in id order.
+    ///
+    /// The fixture is built so those two answers and the right one are all
+    /// different. `b` holds id 1 and `a` holds id 2, so id order is `b, a`
+    /// while name order is `a, b`; the listing is scripted `b, a` so the
+    /// cache's arbitrary `HashMap` order cannot be what makes the assertion
+    /// pass either.
+    ///
+    /// It read `a` 1, `b` 2 until this change, which made name order and id
+    /// order the same sequence -- so once `bleats` moved to name order the
+    /// test went on passing while no longer able to tell the two apart, and
+    /// its name still said `id`.
     #[tokio::test]
-    async fn files_are_printed_in_ascending_id_order() {
+    async fn files_are_printed_in_name_order() {
         let dir = tempfile::tempdir().unwrap();
         let sock = dir.path().join("s.sock");
         let a_path = write_log(dir.path(), "a-out.log", "line-from-a\n");
         let b_path = write_log(dir.path(), "b-out.log", "line-from-b\n");
 
         let (client, daemon) = fake_client_with_push(&sock).await;
-        let mut sheep_a = info(1, "a");
-        sheep_a.out_file = Some(a_path);
-        let mut sheep_b = info(2, "b");
+        // `b` takes the LOWER id, so id order and name order disagree.
+        let mut sheep_b = info(1, "b");
         sheep_b.out_file = Some(b_path);
+        let mut sheep_a = info(2, "a");
+        sheep_a.out_file = Some(a_path);
         daemon.reply_to_list(vec![sheep_b, sheep_a]);
 
         let mut out = Vec::new();
@@ -1646,15 +1660,11 @@ mod tests {
         }
         let rendered = String::from_utf8(out).unwrap();
 
-        let a_pos = rendered
-            .find("line-from-a")
-            .expect("id 1's line is present");
-        let b_pos = rendered
-            .find("line-from-b")
-            .expect("id 2's line is present");
+        let a_pos = rendered.find("line-from-a").expect("a's line is present");
+        let b_pos = rendered.find("line-from-b").expect("b's line is present");
         assert!(
             a_pos < b_pos,
-            "ascending id order means id 1 before id 2: {rendered}"
+            "name order puts `a` (id 2) before `b` (id 1): {rendered}"
         );
     }
 

--- a/crates/shep-cli/src/commands/bleats.rs
+++ b/crates/shep-cli/src/commands/bleats.rs
@@ -318,7 +318,11 @@ fn tail_log_files(
         .values()
         .filter(|info| selector.matches(&info.name, info.id, info.fold.as_deref()))
         .collect();
-    matched.sort_unstable_by_key(|info| info.id);
+    // Name then id, the one order every operator-facing shep listing takes
+    // (`shep_core::protocol::sort_flock`'s own doc). Not `sort_flock` itself:
+    // this is a `Vec<&ProcessInfo>` borrowed out of the cache, and copying the
+    // rows to reach the helper would buy nothing but a clone per sheep.
+    matched.sort_unstable_by(|a, b| (a.name.as_str(), a.id).cmp(&(b.name.as_str(), b.id)));
 
     let mut failure = false;
 

--- a/crates/shep-cli/src/commands/lifecycle.rs
+++ b/crates/shep-cli/src/commands/lifecycle.rs
@@ -17,10 +17,11 @@ use shep_client::{Client, START_DEADLINE};
 use shep_core::config::{AppConfig, FlockFormat, Flockfile, FlockfileError};
 use shep_core::protocol::{Request, Response, SelectorSpec};
 
+use crate::cli::Format;
 use crate::cli::{SelectorArgs, StartArgs, StockArgs};
 use crate::commands::selector::parse_selector;
 use crate::exit::ExitCode;
-use crate::output::{DeletedIds, FlockRows, Render, Streams, emit, write_outcome};
+use crate::output::{DeletedIds, FlockRows, Render, Streams, emit, emit_flock, write_outcome};
 
 /// What [`resolve_target`] can fail with. Module-scoped per IR-18, and named
 /// for the function rather than the verb on purpose: `start`'s own
@@ -369,8 +370,13 @@ pub fn resolve_target(
 }
 
 /// Sends `body` with `deadline` (`None` defers to the client's own default),
-/// renders whatever the daemon answers through [`emit`], and maps every way
-/// that can go wrong to its exit code.
+/// renders whatever the daemon answers through [`render_outcome`], and maps
+/// every way that can go wrong to its exit code.
+///
+/// `stock` is the only caller. It renders the flock afterwards for the same
+/// reason every other verb in this file does -- see [`render_outcome`] -- and
+/// its `extract` still names the narrow payload, because that is what
+/// `--format json` gets.
 ///
 /// `extract` pulls the verb's own payload out of `Response`; `Response` is
 /// `#[non_exhaustive]` (Global Constraints), so an answer `extract` does not
@@ -390,13 +396,7 @@ where
 {
     match client.request_with_deadline(body, deadline).await {
         Ok(response) => match extract(response) {
-            Some(payload) => write_outcome(emit(
-                &mut *streams.out,
-                streams.fmt,
-                command,
-                payload,
-                streams.style,
-            )),
+            Some(payload) => render_outcome(client, streams, command, payload).await,
             None => {
                 let message = "the daemon answered with a response this client does not understand";
                 streams.fail(ExitCode::Internal, message)
@@ -473,6 +473,79 @@ where
         }
     }
     (collected, failure)
+}
+
+/// Renders what a lifecycle verb should leave on the operator's screen: the
+/// rows it touched under `--format json`, and the WHOLE flock as a table
+/// otherwise.
+///
+/// # Why the whole flock, and why only in a table
+///
+/// `shep start koji` used to print a one-row table containing koji. The
+/// question an operator has after starting one app is almost never "did that
+/// one app start" -- the exit code already answered that -- it is "what does
+/// the flock look like now", which is the question `shep flock` exists for
+/// and which a one-row table cannot answer. Every lifecycle verb here now
+/// prints exactly what `shep flock` would print, so the answer is the same
+/// shape whichever verb asked it.
+///
+/// `--format json` keeps the narrow payload, deliberately, and this is the
+/// one place the two surfaces diverge on purpose. A script that runs
+/// `shep stop web --format json` asked about `web` and wants the rows for
+/// `web`; widening its `data` to the whole flock would break every consumer
+/// reading `data[0]` to learn what it just stopped, for no gain -- a script
+/// that wants the flock has `shep flock --format json`. So the rule is: the
+/// human surface answers "what now", the machine surface answers "what did I
+/// just touch".
+///
+/// # The cost
+///
+/// One extra `ListFlock` round trip per lifecycle verb in table form. The
+/// reply a lifecycle verb gets back carries only the rows it touched, and
+/// widening those responses would be a wire change -- a bigger decision than
+/// this behaviour needs, and one that would still leave `delete` unable to
+/// describe a flock it had just removed rows from. A fresh listing needs no
+/// protocol change and is the same request `shep flock` already makes.
+///
+/// # Dogs
+///
+/// Routed through [`emit_flock`], not [`emit`], so a dog renders through the
+/// dogs table with its `SOURCE` column rather than through the sheep table
+/// with an ID, a face, and a `FOLD` and `SMIT` it can never fill.
+/// `shep restart log-rotate` used to draw the same dog in two shapes
+/// depending on which verb asked.
+///
+/// # Errors
+///
+/// Never returns a listing failure as this verb's failure. The verb already
+/// did its work and already reported its own outcome; failing the command
+/// because the receipt could not be fetched would turn a successful restart
+/// into a non-zero exit. An unreachable or unrecognised listing prints
+/// nothing extra and reports success, the same call [`flock_now`] makes for
+/// its own reasons.
+async fn render_outcome<T: Render>(
+    client: &Client,
+    streams: &mut Streams<'_>,
+    command: &str,
+    narrow: T,
+) -> ExitCode {
+    if streams.fmt == Format::Json {
+        return write_outcome(emit(
+            &mut *streams.out,
+            streams.fmt,
+            command,
+            narrow,
+            streams.style,
+        ));
+    }
+    let listing = flock_now(client).await;
+    write_outcome(emit_flock(
+        &mut *streams.out,
+        streams.fmt,
+        command,
+        listing,
+        streams.style,
+    ))
 }
 
 /// Renders `err` and returns the exit code `start` reports it as.
@@ -748,14 +821,14 @@ pub async fn start(
             &mut started,
         )
         .await;
-        if !started.is_empty() {
-            let wrote = write_outcome(emit(
-                &mut *streams.out,
-                streams.fmt,
-                "start",
-                FlockRows(started),
-                streams.style,
-            ));
+        // Printed whenever the verb did its work, not only when it touched a row.
+        // `shep start koji` against a koji that is already online starts nothing
+        // and succeeds, and the flock is still the answer to what happens next --
+        // before this it printed the notice and no table at all. A verb that
+        // FAILED still leaves stdout empty, which is the discipline `cli_e2e`'s
+        // `assert_json_error` pins crate-wide.
+        if !started.is_empty() || code == ExitCode::Success {
+            let wrote = render_outcome(client, streams, "start", FlockRows(started)).await;
             if wrote != ExitCode::Success {
                 return wrote;
             }
@@ -785,14 +858,14 @@ pub async fn start(
     // One table for the whole invocation, matching `stop` and `restart`. A
     // header per target would be the only place in the CLI where asking for
     // three things prints three tables.
-    if !started.is_empty() {
-        let wrote = write_outcome(emit(
-            &mut *streams.out,
-            streams.fmt,
-            "start",
-            FlockRows(started),
-            streams.style,
-        ));
+    // Printed whenever the verb did its work, not only when it touched a row.
+    // `shep start koji` against a koji that is already online starts nothing
+    // and succeeds, and the flock is still the answer to what happens next --
+    // before this it printed the notice and no table at all. A verb that
+    // FAILED still leaves stdout empty, which is the discipline `cli_e2e`'s
+    // `assert_json_error` pins crate-wide.
+    if !started.is_empty() || failure.is_none() {
+        let wrote = render_outcome(client, streams, "start", FlockRows(started)).await;
         if wrote != ExitCode::Success {
             return wrote;
         }
@@ -955,14 +1028,9 @@ pub async fn stop(client: &Client, streams: &mut Streams<'_>, args: &SelectorArg
         },
     )
     .await;
-    if !procs.is_empty() {
-        let wrote = write_outcome(emit(
-            &mut *streams.out,
-            streams.fmt,
-            "stop",
-            FlockRows(procs),
-            streams.style,
-        ));
+    // See `start`'s own note: printed whenever the verb did its work.
+    if !procs.is_empty() || failure.is_none() {
+        let wrote = render_outcome(client, streams, "stop", FlockRows(procs)).await;
         if wrote != ExitCode::Success {
             return wrote;
         }
@@ -1008,14 +1076,8 @@ pub async fn restart(client: &Client, streams: &mut Streams<'_>, args: &Selector
     // the operator reads them from `shep flock`. Consistency across verbs is
     // worth more here than this verb keeping its table on the one path where
     // it has bad news to deliver.
-    if !procs.is_empty() && failed.is_empty() {
-        let wrote = write_outcome(emit(
-            &mut *streams.out,
-            streams.fmt,
-            "restart",
-            FlockRows(procs),
-            streams.style,
-        ));
+    if (!procs.is_empty() || failure.is_none()) && failed.is_empty() {
+        let wrote = render_outcome(client, streams, "restart", FlockRows(procs)).await;
         if wrote != ExitCode::Success {
             return wrote;
         }
@@ -1060,14 +1122,9 @@ pub async fn reload(client: &Client, streams: &mut Streams<'_>, args: &SelectorA
         },
     )
     .await;
-    if !procs.is_empty() {
-        let wrote = write_outcome(emit(
-            &mut *streams.out,
-            streams.fmt,
-            "reload",
-            FlockRows(procs),
-            streams.style,
-        ));
+    // See `start`'s own note: printed whenever the verb did its work.
+    if !procs.is_empty() || failure.is_none() {
+        let wrote = render_outcome(client, streams, "reload", FlockRows(procs)).await;
         if wrote != ExitCode::Success {
             return wrote;
         }
@@ -1093,14 +1150,28 @@ pub async fn delete(client: &Client, streams: &mut Streams<'_>, args: &SelectorA
         },
     )
     .await;
-    if !ids.is_empty() {
-        let wrote = write_outcome(emit(
-            &mut *streams.out,
-            streams.fmt,
-            "delete",
-            DeletedIds(ids),
-            streams.style,
-        ));
+    // See `start`'s own note: printed whenever the verb did its work. The
+    // aside below is guarded separately -- there is nothing to name when
+    // nothing was deleted.
+    if !ids.is_empty() || failure.is_none() {
+        // The listing this prints no longer holds what was deleted, so the
+        // ids go to stderr rather than being lost. Named as ids and not as
+        // names because ids are all `Response::Deleted` carries, and inventing
+        // the names would need a second listing taken before the delete.
+        let count = ids.len();
+        let listed = ids
+            .iter()
+            .map(u32::to_string)
+            .collect::<Vec<String>>()
+            .join(", ");
+        if count > 0 && streams.fmt != Format::Json {
+            let message = match count {
+                1 => format!("deleted 1 sheep, id {listed}"),
+                n => format!("deleted {n} sheep, ids {listed}"),
+            };
+            streams.aside("delete", &message);
+        }
+        let wrote = render_outcome(client, streams, "delete", DeletedIds(ids)).await;
         if wrote != ExitCode::Success {
             return wrote;
         }
@@ -1539,6 +1610,153 @@ mod tests {
         assert!(
             !String::from_utf8_lossy(&err).contains("zeus-auth\" does not"),
             "and must not be reported as an unresolvable target"
+        );
+    }
+
+    /// The flock a `render_outcome` test hands the fake: two sheep the verb
+    /// did not touch, one it did, and a dog.
+    ///
+    /// The names are chosen so the narrow payload and the full listing cannot
+    /// be confused for one another: a test that asserted "the output mentions
+    /// koji" would pass on the one-row table this change replaces, so every
+    /// assertion below is on the exact SET of rows.
+    fn a_flock_with_a_dog() -> Vec<shep_core::protocol::ProcessInfo> {
+        use shep_core::protocol::{DogSource, ProcessInfo};
+        use shep_core::status::ProcStatus;
+        vec![
+            ProcessInfo::builder(0, "golbat", ProcStatus::Online).build(),
+            ProcessInfo::builder(1, "koji", ProcStatus::Stopped).build(),
+            ProcessInfo::builder(2, "rotom", ProcStatus::Online).build(),
+            ProcessInfo::builder(3, "log-rotate", ProcStatus::Online)
+                .dog(Some(DogSource::Adopted {
+                    path: "/usr/local/bin/shep-log-rotate".to_string(),
+                }))
+                .build(),
+        ]
+    }
+
+    /// fails if a lifecycle verb prints only the rows it touched.
+    ///
+    /// `shep start koji` printed a one-row table containing koji. The question
+    /// after starting one app is "what does the flock look like now", which a
+    /// one-row table cannot answer.
+    ///
+    /// The narrow payload handed in is koji ALONE, and the armed listing has
+    /// four entries, so the two are distinguishable by row count as well as by
+    /// content -- a build that kept rendering the narrow payload prints one
+    /// row and fails on the first assertion rather than passing on a
+    /// coincidence of names.
+    #[tokio::test]
+    async fn a_lifecycle_verb_renders_the_whole_flock_as_a_table() {
+        use shep_client::testing::fake_client_on;
+        use shep_core::protocol::ProcessInfo;
+        use shep_core::status::ProcStatus;
+
+        let dir = tempfile::tempdir().unwrap();
+        let (client, daemon) = fake_client_on(&dir.path().join("s.sock")).await;
+        daemon.reply_to_list(a_flock_with_a_dog());
+
+        let mut out = Vec::new();
+        let mut err = Vec::new();
+        let touched = vec![ProcessInfo::builder(1, "koji", ProcStatus::Stopped).build()];
+        let code = {
+            let mut streams = Streams {
+                out: &mut out,
+                err: &mut err,
+                style: crate::style::Presentation::BARE,
+                fmt: Format::Table,
+            };
+            render_outcome(&client, &mut streams, "stop", FlockRows(touched)).await
+        };
+
+        assert_eq!(code, ExitCode::Success);
+        let printed = String::from_utf8(out).unwrap();
+        // Split at the caption rather than filtering the whole output: the two
+        // tables have different columns, so a NAME read from the wrong one is
+        // a different field. This is also what proves the dog is in the SECOND
+        // table and not merely somewhere on the page.
+        let (sheep, dogs) = printed
+            .split_once("\nDogs\n")
+            .unwrap_or_else(|| panic!("the dogs table needs its own caption: {printed}"));
+        let sheep_names: Vec<&str> = sheep
+            .lines()
+            .filter_map(|line| line.split_whitespace().nth(1))
+            .filter(|word| *word != "NAME")
+            .collect();
+        assert_eq!(
+            sheep_names,
+            vec!["golbat", "koji", "rotom"],
+            "every sheep, not only the one that was stopped, and no dog among \
+             them: {printed}"
+        );
+        let dog_names: Vec<&str> = dogs
+            .lines()
+            .filter_map(|line| line.split_whitespace().next())
+            .filter(|word| *word != "NAME")
+            .collect();
+        assert_eq!(
+            dog_names,
+            vec!["log-rotate"],
+            "the dog renders through the dogs table: {printed}"
+        );
+        assert!(
+            dogs.contains("SOURCE") && dogs.contains("adopted"),
+            "with the SOURCE column the sheep table has not: {printed}"
+        );
+    }
+
+    /// fails if `--format json` is widened to the whole flock, or if it pays
+    /// for a listing it does not render.
+    ///
+    /// The machine surface answers a different question from the human one. A
+    /// script that runs `shep stop koji --format json` asked about koji and
+    /// reads `data[0]` to learn what it stopped; handing it four rows, three
+    /// of which it never asked about, breaks it silently.
+    ///
+    /// `list_flock_count` is the second half and is not decoration: it is what
+    /// proves the JSON path SKIPS the listing rather than fetching one and
+    /// discarding it. Without it a build that always asked and then chose what
+    /// to print would pass.
+    #[tokio::test]
+    async fn the_json_surface_keeps_the_rows_the_verb_touched() {
+        use shep_client::testing::fake_client_on;
+        use shep_core::protocol::ProcessInfo;
+        use shep_core::status::ProcStatus;
+
+        let dir = tempfile::tempdir().unwrap();
+        let (client, daemon) = fake_client_on(&dir.path().join("s.sock")).await;
+        daemon.reply_to_list(a_flock_with_a_dog());
+
+        let mut out = Vec::new();
+        let mut err = Vec::new();
+        let touched = vec![ProcessInfo::builder(1, "koji", ProcStatus::Stopped).build()];
+        let code = {
+            let mut streams = Streams {
+                out: &mut out,
+                err: &mut err,
+                style: crate::style::Presentation::BARE,
+                fmt: Format::Json,
+            };
+            render_outcome(&client, &mut streams, "stop", FlockRows(touched)).await
+        };
+
+        assert_eq!(code, ExitCode::Success);
+        let envelope: serde_json::Value = serde_json::from_slice(&out).unwrap();
+        let names: Vec<&str> = envelope["data"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|row| row["name"].as_str().unwrap())
+            .collect();
+        assert_eq!(
+            names,
+            vec!["koji"],
+            "only what the verb touched: {envelope}"
+        );
+        assert_eq!(
+            daemon.list_flock_count(),
+            0,
+            "and no listing was fetched to build it"
         );
     }
 

--- a/crates/shep-cli/src/commands/lifecycle.rs
+++ b/crates/shep-cli/src/commands/lifecycle.rs
@@ -537,8 +537,23 @@ fn flock_matches(selector: &ProcessSelector, flock: &[ProcessInfo]) -> Vec<Proce
 /// `shep start fold:typo` reports "no sheep is in a fold called typo" or the
 /// baffling "fold:typo is not a sheep, a fold, `-`, a recognised Flockfile, or
 /// an existing path" that sent an operator looking for a file by that name.
-fn selector_miss(target: &str, selector: &ProcessSelector) -> Option<String> {
+fn selector_miss(
+    target: &str,
+    selector: &ProcessSelector,
+    flock: &[ProcessInfo],
+) -> Option<String> {
     match selector {
+        // Phrased off the SHEEP count, never off `flock.is_empty()`.
+        // `flock_matches` passes a dog by for every wildcard, so `all`
+        // matching nothing means there are no sheep -- which is not the same
+        // as an empty flock, and saying "the flock is empty" while
+        // `shep flock` prints dog rows on the same machine is a plain
+        // contradiction an operator would have to reconcile themselves.
+        ProcessSelector::All if flock.iter().any(|info| info.dog.is_some()) => Some(
+            "no sheep in the flock; there is nothing to start. The dogs listed \
+             by `shep dogs` are not sheep and `all` never reaches them"
+                .to_string(),
+        ),
         ProcessSelector::All => Some("the flock is empty; there is nothing to start".to_string()),
         ProcessSelector::Fold(fold) => Some(format!("no sheep is in a fold called {fold}")),
         ProcessSelector::Regex(_) => Some(format!("no sheep matched {target}")),
@@ -1094,7 +1109,7 @@ async fn start_one(
             // Held for the failure path below rather than reported here: the
             // token may still name a Flockfile or a path, and only if it names
             // neither does the shape it was written in decide the message.
-            missed = selector_miss(token, &selector);
+            missed = selector_miss(token, &selector, &flock);
             listing = Some(flock);
         }
     }
@@ -2107,23 +2122,67 @@ mod tests {
     /// tier.
     #[test]
     fn a_selector_that_matched_nothing_is_reported_as_a_selector() {
-        let miss = |target: &str| selector_miss(target, &ProcessSelector::parse(target).unwrap());
+        let miss = |target: &str, flock: &[shep_core::protocol::ProcessInfo]| {
+            selector_miss(target, &ProcessSelector::parse(target).unwrap(), flock)
+        };
+        let empty: [shep_core::protocol::ProcessInfo; 0] = [];
 
         assert_eq!(
-            miss("fold:typo").as_deref(),
+            miss("fold:typo", &empty).as_deref(),
             Some("no sheep is in a fold called typo")
         );
-        assert_eq!(miss("zz-*").as_deref(), Some("no sheep matched zz-*"));
         assert_eq!(
-            miss("all").as_deref(),
+            miss("zz-*", &empty).as_deref(),
+            Some("no sheep matched zz-*")
+        );
+        assert_eq!(
+            miss("all", &empty).as_deref(),
             Some("the flock is empty; there is nothing to start")
         );
         assert_eq!(
-            miss("koji"),
+            miss("koji", &empty),
             None,
             "a bare name may still be a file, so the unresolvable message stands"
         );
-        assert_eq!(miss("11"), None, "and so may a bare id");
+        assert_eq!(miss("11", &empty), None, "and so may a bare id");
+    }
+
+    /// fails if `shep start all` calls a flock empty while it holds dogs.
+    ///
+    /// `flock_matches` passes a dog by for every wildcard, so `all` matching
+    /// nothing means there are no SHEEP. Reading that as an empty flock made
+    /// `shep start all` print "the flock is empty" on a machine where
+    /// `shep flock` was printing dog rows at the same moment, which is a
+    /// contradiction an operator has to reconcile on their own.
+    ///
+    /// Both halves in one case, because a build that always says "no sheep"
+    /// and a build that always says "empty" each pass one of them.
+    #[test]
+    fn an_all_that_matched_nothing_counts_sheep_and_not_dogs() {
+        use shep_core::protocol::{DogSource, ProcessInfo};
+        use shep_core::status::ProcStatus;
+
+        let all = ProcessSelector::parse("all").unwrap();
+        let dogs_only = [ProcessInfo::builder(0, "log-rotate", ProcStatus::Online)
+            .dog(Some(DogSource::BuiltIn))
+            .build()];
+
+        let said = selector_miss("all", &all, &dogs_only).expect("a miss is reported");
+        assert!(
+            said.starts_with("no sheep in the flock"),
+            "a flock holding only dogs is not empty: {said}"
+        );
+        assert!(
+            said.contains("`shep dogs`"),
+            "and it says where the rows an operator can see came from: {said}"
+        );
+
+        let empty: [ProcessInfo; 0] = [];
+        assert_eq!(
+            selector_miss("all", &all, &empty).as_deref(),
+            Some("the flock is empty; there is nothing to start"),
+            "with nothing registered at all, empty is the honest word"
+        );
     }
 
     /// fails if `shep start fold:typo` exits anything but 3, or if it reaches

--- a/crates/shep-cli/src/commands/lifecycle.rs
+++ b/crates/shep-cli/src/commands/lifecycle.rs
@@ -15,7 +15,8 @@ use std::time::Duration;
 
 use shep_client::{Client, START_DEADLINE};
 use shep_core::config::{AppConfig, FlockFormat, Flockfile, FlockfileError};
-use shep_core::protocol::{Request, Response, SelectorSpec};
+use shep_core::protocol::{ProcessInfo, Request, Response, SelectorSpec};
+use shep_core::selector::ProcessSelector;
 
 use crate::cli::Format;
 use crate::cli::{SelectorArgs, StartArgs, StockArgs};
@@ -45,8 +46,8 @@ pub enum TargetError {
     },
     /// The source read fine but failed Flockfile validation.
     Flockfile(FlockfileError),
-    /// `target` was not `-`, had no recognised Flockfile extension, and did
-    /// not name an existing path.
+    /// `target` named nothing at any tier of `start`'s precedence: no sheep
+    /// by id or name, no fold, no Flockfile, and no path on disk.
     Unresolvable {
         /// The raw target string, verbatim, so the reported message names
         /// exactly what was tried.
@@ -85,7 +86,8 @@ impl std::fmt::Display for TargetError {
             Self::Flockfile(err) => write!(f, "{err}"),
             Self::Unresolvable { target } => write!(
                 f,
-                "{target} is not `-`, a recognised Flockfile, or an existing path"
+                "{target} is not a sheep, a fold, `-`, a recognised Flockfile, or an \
+                 existing path"
             ),
             Self::UnknownFlockfileFormat { path } => write!(
                 f,
@@ -475,6 +477,94 @@ where
     (collected, failure)
 }
 
+/// Which sheep in `flock` a `start` target names, under the precedence
+/// [`start_one`] documents.
+///
+/// # The two tiers this function is
+///
+/// A `Name` token is tried as an exact sheep name first and as a FOLD name
+/// second, which is what makes `shep start backed` reach a fold called
+/// `backed` without the `fold:` prefix. Every other selector form means one
+/// thing already and is matched as itself.
+///
+/// # Dogs
+///
+/// A wildcard passes a dog by; an exact name or id reaches it. The same rule
+/// [`ProcessSelector::is_exact`] states for the daemon's own matching, and for
+/// the same reason: a dog is a process an operator installed, not a member of
+/// the flock `all` means. The fold fallback counts as a wildcard even though
+/// it came from a `Name` token, because the operator named a group rather than
+/// a process.
+fn flock_matches(selector: &ProcessSelector, flock: &[ProcessInfo]) -> Vec<ProcessInfo> {
+    let sheep_only = |flock: &[ProcessInfo], keep: &dyn Fn(&ProcessInfo) -> bool| {
+        flock
+            .iter()
+            .filter(|info| info.dog.is_none())
+            .filter(|info| keep(info))
+            .cloned()
+            .collect::<Vec<ProcessInfo>>()
+    };
+    match selector {
+        ProcessSelector::Name(wanted) => {
+            let named: Vec<ProcessInfo> = flock
+                .iter()
+                .filter(|info| &info.name == wanted)
+                .cloned()
+                .collect();
+            if !named.is_empty() {
+                return named;
+            }
+            sheep_only(flock, &|info| info.fold.as_deref() == Some(wanted.as_str()))
+        }
+        ProcessSelector::Id(wanted) => flock
+            .iter()
+            .filter(|info| info.id == *wanted)
+            .cloned()
+            .collect(),
+        other => sheep_only(flock, &|info| {
+            other.matches(&info.name, info.id, info.fold.as_deref())
+        }),
+    }
+}
+
+/// Whether `target` carries a marker that makes it unmistakably a selector,
+/// and so what to say when it matched nothing.
+///
+/// Only the message differs. `start` still falls through to the Flockfile and
+/// path tiers for every token, because a marker being present does not make a
+/// file of that name stop existing -- `/srv/app/` parses as a `/regex/` and is
+/// also a real directory somebody might type. What this decides is whether
+/// `shep start fold:typo` reports "no sheep is in a fold called typo" or the
+/// baffling "fold:typo is not a sheep, a fold, `-`, a recognised Flockfile, or
+/// an existing path" that sent an operator looking for a file by that name.
+fn selector_miss(target: &str, selector: &ProcessSelector) -> Option<String> {
+    match selector {
+        ProcessSelector::All => Some("the flock is empty; there is nothing to start".to_string()),
+        ProcessSelector::Fold(fold) => Some(format!("no sheep is in a fold called {fold}")),
+        ProcessSelector::Regex(_) => Some(format!("no sheep matched {target}")),
+        // A bare name or id carries no marker, so it may equally have been
+        // meant as a filename. The unresolvable message names every tier.
+        ProcessSelector::Name(_) | ProcessSelector::Id(_) => None,
+    }
+}
+
+/// Whether `target` could name a sheep or a fold at all.
+///
+/// A sheep name may not contain a path separator and may not be `.` or `..`
+/// (`shep_core::config::normalize`), so a token carrying one cannot be a
+/// sheep however the flock is configured. Making that a rule rather than a
+/// coincidence is what gives an operator whose fold shares a name with a file
+/// a way to say which they meant: `./backed` is the file, always.
+///
+/// Applied to the `Name` form only. `/regex/`, `fold:`, `all` and a glob are
+/// markers rather than names, and `/web/` legitimately contains slashes.
+fn is_reachable_as_a_name(selector: &ProcessSelector) -> bool {
+    match selector {
+        ProcessSelector::Name(name) => !name.contains(['/', '\\']) && name != "." && name != "..",
+        _ => true,
+    }
+}
+
 /// Renders what a lifecycle verb should leave on the operator's screen: the
 /// rows it touched under `--format json`, and the WHOLE flock as a table
 /// otherwise.
@@ -584,29 +674,95 @@ fn fail_target(streams: &mut Streams<'_>, err: &TargetError) -> ExitCode {
 /// the identical broken script reported `error[spawn_failed]` -- reproduced
 /// live and fixed here, since this is the one place that turns a `Restart`
 /// answer into `start`'s own exit code.
+fn is_live(info: &ProcessInfo) -> bool {
+    use shep_core::status::ProcStatus;
+    matches!(
+        info.status,
+        ProcStatus::Online | ProcStatus::Starting | ProcStatus::Stopping
+    )
+}
+
+/// Brings every sheep in `matched` up, and reports the ones that were already
+/// up rather than replacing them.
+///
+/// `selector` is the operator's own token when the match came from the
+/// selector tier, and `None` when it came from a path or Flockfile that
+/// resolved to apps the flock already has. The distinction is the difference
+/// between a suggestion that works and one that does not: `shep restart
+/// fold:backed` is a command, and `shep restart ./rotom.sh` is not, because
+/// `restart` takes selectors and a path is not one. So a single sheep is
+/// always named by its own name, and a group falls back to listing the names
+/// when there is no selector to quote.
+///
+/// The already-up set gets ONE notice however large it is. `shep start all`
+/// against a healthy thirteen-app flock would otherwise print thirteen
+/// notices saying the same thing.
+///
+/// Respawns are issued per NAME, not per row: `Request::Restart` with a name
+/// selector reaches every instance of a clustered app, so a fold holding a
+/// four-instance app would otherwise send the same request four times.
+async fn resume_all(
+    client: &Client,
+    streams: &mut Streams<'_>,
+    selector: Option<&str>,
+    matched: &[ProcessInfo],
+    started: &mut Vec<ProcessInfo>,
+) -> ExitCode {
+    let (live, asleep): (Vec<&ProcessInfo>, Vec<&ProcessInfo>) =
+        matched.iter().partition(|info| is_live(info));
+
+    match live.as_slice() {
+        [] => {}
+        [one] => {
+            let message = format!(
+                "{} is already {}; `shep restart {}` replaces it.",
+                one.name, one.status, one.name
+            );
+            streams.aside("start", &message);
+        }
+        several => {
+            let names: Vec<&str> = unique_names(several);
+            let retype = selector.map_or_else(|| names.join(" "), str::to_string);
+            let message = format!(
+                "{} are already running; `shep restart {retype}` replaces them.",
+                names.join(", ")
+            );
+            streams.aside("start", &message);
+        }
+    }
+
+    for name in unique_names(&asleep) {
+        let code = resume(client, streams, name, started).await;
+        if code != ExitCode::Success {
+            return code;
+        }
+    }
+    ExitCode::Success
+}
+
+/// Every distinct name in `infos`, in the order they appear.
+///
+/// The listing is already sorted by name, so this is a scan rather than a set.
+fn unique_names<'a>(infos: &[&'a ProcessInfo]) -> Vec<&'a str> {
+    let mut names: Vec<&str> = Vec::with_capacity(infos.len());
+    for info in infos {
+        if names.last() != Some(&info.name.as_str()) {
+            names.push(&info.name);
+        }
+    }
+    names
+}
+
 async fn resume(
     client: &Client,
     streams: &mut Streams<'_>,
-    existing: &shep_core::protocol::ProcessInfo,
+    name: &str,
     started: &mut Vec<shep_core::protocol::ProcessInfo>,
 ) -> ExitCode {
-    use shep_core::status::ProcStatus;
-
-    if matches!(
-        existing.status,
-        ProcStatus::Online | ProcStatus::Starting | ProcStatus::Stopping
-    ) {
-        let message = format!(
-            "{} is already {}; `shep restart {}` replaces it.",
-            existing.name, existing.status, existing.name
-        );
-        streams.aside("start", &message);
-        return ExitCode::Success;
-    }
     let (procs, failure) = request_each(
         client,
         streams,
-        &[SelectorSpec::Name(existing.name.clone())],
+        &[SelectorSpec::Name(name.to_string())],
         None,
         |selector| Request::Restart { selector },
         |response| match response {
@@ -626,8 +782,7 @@ async fn resume(
     // does: an error on stderr and nothing on stdout.
     if any_restart_failed(&procs) {
         let message = format!(
-            "{} could not be started; see `shep bleats {}` or its log files for why",
-            existing.name, existing.name
+            "{name} could not be started; see `shep bleats {name}` or its log files for why"
         );
         return streams.fail(ExitCode::SpawnFailed, &message);
     }
@@ -899,23 +1054,47 @@ async fn start_one(
     // directory's Flockfile". The caller does the discovery, because the
     // no-target-and-no-Flockfile case never reaches here: it brings a
     // shepherd up and stops.
-    // A target naming a sheep the flock already has is that sheep, not a new
-    // one. Checked before the path arms below, or `shep start zeus-auth` on a
-    // registered-but-stopped sheep is read as a filename, fails to resolve,
-    // and reports that nothing by that name is on disk -- while the sheep sits
-    // in the listing.
     //
-    // Only when the target is not itself a readable target: an explicit path
-    // or Flockfile still means what it says, so `shep start ./server.js` is
-    // never diverted by a coincidence of names.
-    let mut listing: Option<Vec<shep_core::protocol::ProcessInfo>> = None;
-    if let Some(name) = target {
-        let is_path_like = name == "-" || args.flockfile || Path::new(name).exists();
-        if !is_path_like {
+    // Everything from here to `resolve_target` is the precedence in
+    // `StartArgs::targets`' own help: a sheep by id or name, then a fold, then
+    // a Flockfile, then a path. Each tier claims the token only if the token
+    // actually resolves there, so a name the flock does not have still reaches
+    // the file of that name.
+    //
+    // `-` and `--flockfile` skip the flock entirely. Both say outright that
+    // the token is a source to read, and neither has ever meant anything else.
+    let mut listing: Option<Vec<ProcessInfo>> = None;
+    let mut missed: Option<String> = None;
+    if let Some(token) = target
+        && token != "-"
+        && !args.flockfile
+    {
+        // Parsed client-side, exactly as every selector-taking verb does, so a
+        // malformed one is a local usage error rather than a round trip. This
+        // is also what makes `shep start fold:backed` and `shep start all`
+        // work at all: `start` used to take a different argument grammar from
+        // every other lifecycle verb, so folds were actionable everywhere
+        // except the verb that creates things.
+        let selector = match parse_selector(streams, token) {
+            Ok(selector) => selector,
+            Err(code) => return code,
+        };
+        if is_reachable_as_a_name(&selector) {
             let flock = flock_now(client).await;
-            if let Some(existing) = flock.iter().find(|info| info.name == name) {
-                return resume(client, streams, existing, started).await;
+            let matched = flock_matches(&selector, &flock);
+            if !matched.is_empty() {
+                // No `report_config_drift` on this path, and that is not an
+                // omission: drift is a comparison between a config the
+                // operator just supplied and the one the flock stores. A
+                // selector supplies no config -- `shep start fold:backed`
+                // names sheep, not a Flockfile -- so there is nothing to
+                // compare and nothing that could have been silently ignored.
+                return resume_all(client, streams, Some(token), &matched, started).await;
             }
+            // Held for the failure path below rather than reported here: the
+            // token may still name a Flockfile or a path, and only if it names
+            // neither does the shape it was written in decide the message.
+            missed = selector_miss(token, &selector);
             listing = Some(flock);
         }
     }
@@ -942,6 +1121,16 @@ async fn start_one(
 
     let mut apps = match resolve_target(target, args.name.as_deref(), &stdin, args.flockfile) {
         Ok(apps) => apps,
+        // The last tier refused too, so the token named nothing anywhere. A
+        // token written unmistakably as a selector is reported as one -- `shep
+        // start fold:typo` says no sheep is in a fold called typo, rather than
+        // reporting that no file called `fold:typo` is on disk, which is the
+        // answer to a question nobody asked. Exit 3, matching what every other
+        // verb returns for a selector that matched nothing.
+        Err(TargetError::Unresolvable { .. }) if missed.is_some() => {
+            let message = missed.unwrap_or_default();
+            return streams.fail(ExitCode::NotFound, &message);
+        }
         Err(err) => return fail_target(streams, &err),
     };
 
@@ -981,8 +1170,13 @@ async fn start_one(
     // and gets a wall of restart output should read why none of it applied
     // at the top of the run rather than under it.
     report_config_drift(client, streams, &resumed).await;
-    for (_, existing) in &resumed {
-        let code = resume(client, streams, existing, started).await;
+    if !resumed.is_empty() {
+        // `None`, not the operator's token: this arm reached the flock through
+        // a Flockfile or a path, so there is no selector to quote back in the
+        // "already running" notice. `shep restart ./rotom.sh` is not a
+        // command. See `resume_all`'s own doc.
+        let existing: Vec<ProcessInfo> = resumed.iter().map(|(_, info)| info.clone()).collect();
+        let code = resume_all(client, streams, None, &existing, started).await;
         if code != ExitCode::Success {
             return code;
         }
@@ -1760,6 +1954,224 @@ mod tests {
         );
     }
 
+    /// A flock in which every tier of `start`'s precedence has something to
+    /// find, and each tier's answer is distinguishable from the others'.
+    ///
+    /// `golbat` and `koji` are in the fold `backed`; `rotom` is not in any
+    /// fold; `log-rotate` is a dog. The name `backed` is a fold and NOT a
+    /// sheep, which is the whole point: a build that only ever matched names
+    /// finds nothing for it.
+    fn a_foldable_flock() -> Vec<shep_core::protocol::ProcessInfo> {
+        use shep_core::protocol::{DogSource, ProcessInfo};
+        use shep_core::status::ProcStatus;
+        vec![
+            ProcessInfo::builder(0, "golbat", ProcStatus::Stopped)
+                .fold(Some("backed".to_string()))
+                .build(),
+            ProcessInfo::builder(1, "koji", ProcStatus::Stopped)
+                .fold(Some("backed".to_string()))
+                .build(),
+            ProcessInfo::builder(2, "rotom", ProcStatus::Stopped).build(),
+            ProcessInfo::builder(3, "log-rotate", ProcStatus::Online)
+                .dog(Some(DogSource::BuiltIn))
+                .build(),
+        ]
+    }
+
+    /// The names `flock_matches` picks, so a case below reads as the rule it
+    /// is about rather than as a fold of `ProcessInfo` fields.
+    fn matched_names(target: &str) -> Vec<String> {
+        let selector = ProcessSelector::parse(target).expect("the fixture uses valid selectors");
+        flock_matches(&selector, &a_foldable_flock())
+            .into_iter()
+            .map(|info| info.name)
+            .collect()
+    }
+
+    /// The precedence `StartArgs::targets`' own help states, one case per
+    /// tier, driven through the function that decides it.
+    ///
+    /// `shep stop fold:backed` already worked and `shep start fold:backed`
+    /// refused with "backed is not `-`, a recognised Flockfile, or an existing
+    /// path", because `start` took a different argument grammar from every
+    /// other lifecycle verb. Folds were actionable everywhere except the verb
+    /// that creates things.
+    #[test]
+    fn a_start_target_walks_the_precedence() {
+        assert_eq!(
+            matched_names("koji"),
+            vec!["koji"],
+            "tier 1: a sheep by name"
+        );
+        assert_eq!(matched_names("1"), vec!["koji"], "tier 1: a sheep by id");
+        assert_eq!(
+            matched_names("fold:backed"),
+            vec!["golbat", "koji"],
+            "tier 2: a fold, named as one"
+        );
+        assert_eq!(
+            matched_names("backed"),
+            vec!["golbat", "koji"],
+            "tier 2: the same fold, named bare"
+        );
+        assert!(
+            matched_names("nosuchthing").is_empty(),
+            "and a token that is none of those falls through to the file tiers"
+        );
+    }
+
+    /// fails if a name that is BOTH a sheep and a fold resolves to the fold.
+    ///
+    /// The order is name before fold, and this is the only fixture that can
+    /// tell the two apart: `a_start_target_walks_the_precedence`'s `backed` is
+    /// a fold and not a sheep, so it would pass under either order.
+    #[test]
+    fn a_sheep_outranks_a_fold_of_the_same_name() {
+        use shep_core::protocol::ProcessInfo;
+        use shep_core::status::ProcStatus;
+
+        let flock = vec![
+            ProcessInfo::builder(0, "backed", ProcStatus::Stopped).build(),
+            ProcessInfo::builder(1, "koji", ProcStatus::Stopped)
+                .fold(Some("backed".to_string()))
+                .build(),
+        ];
+        let selector = ProcessSelector::parse("backed").unwrap();
+        let names: Vec<String> = flock_matches(&selector, &flock)
+            .into_iter()
+            .map(|info| info.name)
+            .collect();
+        assert_eq!(names, vec!["backed"], "the sheep, not the fold it names");
+    }
+
+    /// fails if a wildcard sweeps up a dog.
+    ///
+    /// The same rule `ProcessSelector::is_exact` states for the daemon's own
+    /// matching: a dog is a process an operator installed, not a member of the
+    /// flock `all` means, so `shep start all` must pass it by while
+    /// `shep start log-rotate` still reaches it. The fold fallback counts as a
+    /// wildcard even though the token was a bare name, because the operator
+    /// named a group.
+    #[test]
+    fn a_wildcard_passes_a_dog_by_and_an_exact_name_reaches_it() {
+        assert_eq!(
+            matched_names("all"),
+            vec!["golbat", "koji", "rotom"],
+            "no dog in the sweep"
+        );
+        assert_eq!(
+            matched_names("log-rotate"),
+            vec!["log-rotate"],
+            "but naming it outright reaches it"
+        );
+    }
+
+    /// fails if a token carrying a path separator is tried as a sheep or a
+    /// fold.
+    ///
+    /// This is the escape hatch, and it has to be a rule rather than a
+    /// coincidence: somebody whose fold shares a name with a file in the
+    /// current directory needs a way to say which they meant, and the
+    /// precedence alone gives them none. A sheep name may never contain a path
+    /// separator (`shep_core::config::normalize`), so `./backed` is always the
+    /// file.
+    ///
+    /// `/web/` is in the same case for the opposite reason: it is full of
+    /// slashes and is a regex, not a name, so the rule is on the PARSED form
+    /// rather than on the raw token.
+    #[test]
+    fn a_token_with_a_path_separator_is_never_a_name() {
+        let path = ProcessSelector::parse("./backed").unwrap();
+        assert!(
+            !is_reachable_as_a_name(&path),
+            "./backed can only be a file"
+        );
+        let bare = ProcessSelector::parse("backed").unwrap();
+        assert!(is_reachable_as_a_name(&bare), "backed may be either");
+        let regex = ProcessSelector::parse("/web/").unwrap();
+        assert!(
+            is_reachable_as_a_name(&regex),
+            "a regex is not a name, so the separator rule does not apply to it"
+        );
+    }
+
+    /// fails if `shep start fold:typo` reports that no FILE called `fold:typo`
+    /// is on disk.
+    ///
+    /// That was the error Rin actually hit, and it sent her looking for a file
+    /// she had never asked about. A token written unmistakably as a selector
+    /// is reported as one; a bare name or id carries no marker and may equally
+    /// have been meant as a filename, so it keeps the message that names every
+    /// tier.
+    #[test]
+    fn a_selector_that_matched_nothing_is_reported_as_a_selector() {
+        let miss = |target: &str| selector_miss(target, &ProcessSelector::parse(target).unwrap());
+
+        assert_eq!(
+            miss("fold:typo").as_deref(),
+            Some("no sheep is in a fold called typo")
+        );
+        assert_eq!(miss("zz-*").as_deref(), Some("no sheep matched zz-*"));
+        assert_eq!(
+            miss("all").as_deref(),
+            Some("the flock is empty; there is nothing to start")
+        );
+        assert_eq!(
+            miss("koji"),
+            None,
+            "a bare name may still be a file, so the unresolvable message stands"
+        );
+        assert_eq!(miss("11"), None, "and so may a bare id");
+    }
+
+    /// fails if `shep start fold:typo` exits anything but 3, or if it reaches
+    /// the daemon with a `Start`.
+    ///
+    /// Driven through the VERB rather than through `selector_miss`, because
+    /// the mapping from "matched nothing" to an exit code lives in `start_one`
+    /// and a unit test of the message alone cannot see it. Exit 3 is what
+    /// `shep stop fold:typo` already returns, which is the consistency this
+    /// whole change is about.
+    #[tokio::test]
+    async fn a_start_on_an_empty_fold_exits_not_found_without_a_start_request() {
+        use shep_client::testing::fake_client_on;
+
+        let dir = tempfile::tempdir().unwrap();
+        let (client, daemon) = fake_client_on(&dir.path().join("s.sock")).await;
+        daemon.reply_to_list(a_foldable_flock());
+
+        let mut out = Vec::new();
+        let mut err = Vec::new();
+        let code = {
+            let mut streams = Streams {
+                out: &mut out,
+                err: &mut err,
+                style: crate::style::Presentation::BARE,
+                fmt: Format::Table,
+            };
+            start(
+                &client,
+                &mut streams,
+                &start_args("fold:typo"),
+                None,
+                &BTreeMap::new(),
+            )
+            .await
+        };
+
+        assert_eq!(code, ExitCode::NotFound);
+        let said = String::from_utf8(err).unwrap();
+        assert!(
+            said.contains("no sheep is in a fold called typo"),
+            "the refusal names the fold, not a file: {said}"
+        );
+        assert!(
+            !said.contains("existing path"),
+            "and never mentions a path nobody asked about: {said}"
+        );
+        assert!(out.is_empty(), "stdout stays empty on a failure");
+    }
+
     /// A sheep that is already up is reported, never restarted. Someone who
     /// typed `start` did not ask for their live service to be replaced, and
     /// `restart` is right there.
@@ -1827,17 +2239,20 @@ mod tests {
             .await
         };
         assert_eq!(code, ExitCode::Usage);
-        // One request, and it is the flock lookup: a target is a sheep's name
-        // before it is a filename, so `start` has to ask before it can say
-        // the target resolves to nothing. What must never reach the daemon is
-        // a `Start` carrying an app built from an unresolvable target.
-        let asked = envelopes
-            .try_recv()
-            .expect("the flock is consulted before the target is read as a path");
-        assert_eq!(asked.body, Request::ListFlock);
+        // NOTHING reaches the daemon. `./does-not-exist` carries a path
+        // separator, and a sheep name may never contain one
+        // (`shep_core::config::normalize`), so the token cannot be a sheep or
+        // a fold and `start` skips the flock lookup rather than asking a
+        // question whose answer it already knows. A target with no separator
+        // does ask -- `a_target_naming_a_stopped_sheep_is_acted_on_not_
+        // resolved_as_a_path` is the case that proves it.
+        //
+        // What must never reach the daemon either way is a `Start` carrying an
+        // app built from an unresolvable target.
         assert!(
             envelopes.try_recv().is_err(),
-            "and nothing else: an unresolvable target must not become a Start"
+            "a target that can only be a path costs no round trip, and an \
+             unresolvable one must never become a Start"
         );
         assert!(String::from_utf8(err).unwrap().contains("./does-not-exist"));
     }

--- a/crates/shep-cli/src/commands/lifecycle.rs
+++ b/crates/shep-cli/src/commands/lifecycle.rs
@@ -755,13 +755,28 @@ async fn resume_all(
     ExitCode::Success
 }
 
-/// Every distinct name in `infos`, in the order they appear.
+/// Every distinct name in `infos`, in the order they first appear.
 ///
-/// The listing is already sorted by name, so this is a scan rather than a set.
+/// Order-INDEPENDENT, and that is the whole of it. This compared each name
+/// against the previous one alone, which drops a duplicate only when the two
+/// are adjacent, and so was correct only for a caller handing over a
+/// name-sorted slice. One caller does not: `start_one`'s Flockfile and path
+/// arm builds its set from the resolved apps in the file's own order, so two
+/// instances of one app listed either side of a third produced a SECOND
+/// `Request::Restart` and restarted that app twice in one invocation.
+///
+/// The selector arm did hand over sorted rows, but only because the daemon
+/// sorts its listing that way -- a cross-version assumption about a peer,
+/// not an invariant this function can hold itself. Both callers are now safe
+/// regardless.
+///
+/// A `Vec` scan rather than a `HashSet`: this runs over the sheep one
+/// selector matched, which is tens of rows, and it has to preserve first-seen
+/// order for the notice it feeds.
 fn unique_names<'a>(infos: &[&'a ProcessInfo]) -> Vec<&'a str> {
     let mut names: Vec<&str> = Vec::with_capacity(infos.len());
     for info in infos {
-        if names.last() != Some(&info.name.as_str()) {
+        if !names.contains(&info.name.as_str()) {
             names.push(&info.name);
         }
     }
@@ -2145,6 +2160,37 @@ mod tests {
             "a bare name may still be a file, so the unresolvable message stands"
         );
         assert_eq!(miss("11", &empty), None, "and so may a bare id");
+    }
+
+    /// fails if a name repeated NON-ADJACENTLY produces two respawns.
+    ///
+    /// `unique_names` compared each name against the previous one only, which
+    /// drops a duplicate solely when the two sit next to each other. That is
+    /// true of a name-sorted listing and NOT true of `start_one`'s Flockfile
+    /// and path arm, which builds its set from the resolved apps in the file's
+    /// own order. Two instances of one app listed either side of a third then
+    /// produced a second `Request::Restart` and restarted that app twice in
+    /// one invocation.
+    ///
+    /// The fixture is `web`, `api`, `web` precisely because a sorted one
+    /// cannot exhibit it: sorted, the two `web` rows are adjacent and the old
+    /// code was already correct. First-seen order is asserted too, since the
+    /// notice this feeds reads as a list.
+    #[test]
+    fn unique_names_drops_a_duplicate_that_is_not_adjacent() {
+        use shep_core::status::ProcStatus;
+
+        let rows = [
+            ProcessInfo::builder(0, "web", ProcStatus::Stopped).build(),
+            ProcessInfo::builder(1, "api", ProcStatus::Stopped).build(),
+            ProcessInfo::builder(2, "web", ProcStatus::Stopped).build(),
+        ];
+        let borrowed: Vec<&ProcessInfo> = rows.iter().collect();
+        assert_eq!(
+            unique_names(&borrowed),
+            vec!["web", "api"],
+            "one entry per name, in the order each was first seen"
+        );
     }
 
     /// fails if `shep start all` calls a flock empty while it holds dogs.

--- a/crates/shep-cli/src/commands/lifecycle.rs
+++ b/crates/shep-cli/src/commands/lifecycle.rs
@@ -1883,9 +1883,11 @@ mod tests {
             "every sheep, not only the one that was stopped, and no dog among \
              them: {printed}"
         );
+        // Column 1, not 0: the dogs table leads with ID now, exactly as the
+        // sheep table does.
         let dog_names: Vec<&str> = dogs
             .lines()
-            .filter_map(|line| line.split_whitespace().next())
+            .filter_map(|line| line.split_whitespace().nth(1))
             .filter(|word| *word != "NAME")
             .collect();
         assert_eq!(

--- a/crates/shep-cli/src/commands/query.rs
+++ b/crates/shep-cli/src/commands/query.rs
@@ -130,7 +130,7 @@ pub fn flock_from_roll(streams: &mut Streams<'_>, paths: &ShepPaths) -> ExitCode
         .ok()
         .and_then(|bytes| serde_json::from_slice::<FlockSnapshot>(&bytes).ok());
 
-    let sheep: Vec<RolledSheep> = saved
+    let mut sheep: Vec<RolledSheep> = saved
         .map(|roll| {
             roll.apps
                 .into_iter()
@@ -142,6 +142,12 @@ pub fn flock_from_roll(streams: &mut Streams<'_>, paths: &ShepPaths) -> ExitCode
                 .collect()
         })
         .unwrap_or_default();
+    // The roll is stored in whatever order it was written, which is neither
+    // meaningful nor stable. Name is the whole key here: a roll holds one
+    // entry per APP, not per instance, so there are no two rows to break a
+    // tie between and no id to break it with. Same first key as every other
+    // listing shep prints (`shep_core::protocol::sort_flock`).
+    sheep.sort_unstable_by(|a, b| a.name.cmp(&b.name));
 
     if streams.fmt == Format::Table {
         let _ = writeln!(

--- a/crates/shep-cli/src/lookout/app.rs
+++ b/crates/shep-cli/src/lookout/app.rs
@@ -1089,8 +1089,17 @@ impl App {
         }
     }
 
-    /// The ids the table draws, in id order: the whole flock, or whatever the
-    /// filter leaves of it.
+    /// The ids the table draws, in name-then-id order: the whole flock, or
+    /// whatever the filter leaves of it.
+    ///
+    /// The order is the one every operator-facing shep listing takes
+    /// ([`shep_core::protocol::sort_flock`]'s own doc). `flock` is a
+    /// `BTreeMap<u32, Row>`, so iterating it is id order, which is why the
+    /// sequence is materialised and re-keyed here rather than taken from the
+    /// map. That matters more in this pane than anywhere else: the table
+    /// repolls every two seconds, so a key that is not total would let two
+    /// instances of one app swap places under the operator's cursor between
+    /// refreshes. `(name, id)` is total, since no two sheep share both.
     ///
     /// [`Self::rows`], [`Self::select_at`], [`Self::select_by`],
     /// [`Self::reseat`] and [`Self::selected_index`] all read this sequence
@@ -1105,10 +1114,14 @@ impl App {
     /// [`Self::filter`].
     fn visible_ids(&self) -> impl Iterator<Item = u32> + '_ {
         let needle = self.filter.to_lowercase();
-        self.flock.iter().filter_map(move |(id, row)| {
-            let shown = needle.is_empty() || row.info.name.to_lowercase().contains(&needle);
-            shown.then_some(*id)
-        })
+        let mut visible: Vec<(&str, u32)> = self
+            .flock
+            .iter()
+            .filter(|(_, row)| needle.is_empty() || row.info.name.to_lowercase().contains(&needle))
+            .map(|(id, row)| (row.info.name.as_str(), *id))
+            .collect();
+        visible.sort_unstable();
+        visible.into_iter().map(|(_name, id)| id)
     }
 
     /// How many rows the table draws.
@@ -1204,8 +1217,8 @@ impl App {
         Effect::RefreshSelected
     }
 
-    /// The flock the table draws, in id order: the whole flock, or whatever
-    /// the filter leaves of it. See [`Self::all_rows`] for the unfiltered
+    /// The flock the table draws, in name-then-id order: the whole flock, or
+    /// whatever the filter leaves of it. See [`Self::all_rows`] for the unfiltered
     /// sequence a pane describing the machine as a whole, not the table's
     /// current view, needs instead.
     #[must_use]
@@ -1217,6 +1230,10 @@ impl App {
 
     /// Every sheep the shepherd last reported, in id order, whatever the
     /// filter hides.
+    ///
+    /// Id order, unlike [`Self::rows`]: nothing renders this sequence as a
+    /// list. The host strip sums it, and a sum does not care what order it
+    /// arrives in.
     ///
     /// The host strip reads this rather than [`Self::rows`]: Phase 16 review
     /// Important #4 caught `flock cpu`/`flock mem` silently summing the FILTERED
@@ -1473,7 +1490,12 @@ mod tests {
     }
 
     /// `started()`'s three sheep with the gate open and the cursor parked in
-    /// the middle, on `api` at id 2.
+    /// the middle, on `web` at id 1.
+    ///
+    /// The table reads by name (`App::visible_ids`), so the middle row is the
+    /// middle NAME: `api` 2, `web` 1, `worker` 3. The ids are deliberately
+    /// left disagreeing with the display order, so a test that walks the
+    /// cursor and then asserts an id cannot pass by reading the map.
     ///
     /// Mid-list on purpose. Half the tests below assert that a stray `j` did
     /// NOT move the cursor, and a cursor already clamped at either end would
@@ -1511,8 +1533,8 @@ mod tests {
         );
         let armed = app.action().expect("armed");
         assert_eq!(armed.verb, ActionVerb::Stop);
-        assert_eq!(armed.id, 2);
-        assert_eq!(armed.name, "api");
+        assert_eq!(armed.id, 1);
+        assert_eq!(armed.name, "web");
         assert!(!armed.sent, "nothing has gone out");
     }
 
@@ -1631,7 +1653,7 @@ mod tests {
         app.update(Msg::Key(KeyPress::Action(ActionVerb::Stop)));
         app.update(Msg::Event(BusEvent::Process {
             event: ProcessEventKind::Delete,
-            info: sheep(2, "api", ProcStatus::Stopped),
+            info: sheep(1, "web", ProcStatus::Stopped),
             manually: true,
             at_ms: 0,
         }));
@@ -1872,12 +1894,12 @@ mod tests {
     fn a_deleted_selection_falls_to_the_row_that_took_its_place() {
         let (mut app, t0) = started();
         app.update(Msg::Key(KeyPress::SelectDown));
-        assert_eq!(app.selected(), Some(2), "api, at index 1");
+        assert_eq!(app.selected(), Some(1), "web, at index 1 by name");
 
-        // api dies; web and worker remain. Index 1 is now worker.
+        // web dies; api and worker remain. Index 1 is now worker.
         app.update(Msg::Snapshot {
             rows: vec![
-                sheep(1, "web", ProcStatus::Online),
+                sheep(2, "api", ProcStatus::Online),
                 sheep(3, "worker", ProcStatus::Online),
             ],
             at: t0,
@@ -1888,10 +1910,10 @@ mod tests {
         app.update(Msg::Key(KeyPress::SelectLast));
         assert_eq!(app.selected(), Some(3));
         app.update(Msg::Snapshot {
-            rows: vec![sheep(1, "web", ProcStatus::Online)],
+            rows: vec![sheep(2, "api", ProcStatus::Online)],
             at: t0,
         });
-        assert_eq!(app.selected(), Some(1));
+        assert_eq!(app.selected(), Some(2));
 
         // An empty flock selects nothing at all, rather than an id that is gone.
         app.update(Msg::Snapshot {
@@ -2028,7 +2050,7 @@ mod tests {
             Effect::None,
             "no file is read once the link is lost"
         );
-        assert_eq!(app.selected(), Some(2), "but the cursor moved anyway");
+        assert_eq!(app.selected(), Some(1), "but the cursor moved anyway");
         assert_eq!(app.update(Msg::Key(KeyPress::SelectLast)), Effect::None);
         assert_eq!(app.selected(), Some(3));
     }
@@ -2508,11 +2530,19 @@ mod tests {
     /// A dashboard whose filter is set without any keymap involved. Task 2
     /// wires `/` to this; this task proves the sequence underneath it.
     ///
-    /// Four sheep, two of which contain `web`: `web` at id 1 and `web-worker`
-    /// at id 3, with `api` at id 2 sitting BETWEEN them in the map. The gap is
-    /// deliberate. It is what makes `j` stepping over a hidden row a
+    /// Four sheep, two of which contain `web`: `api-web` at id 1 and
+    /// `web-worker` at id 4, with `cron` and `queue` sitting BETWEEN them. The
+    /// gap is deliberate. It is what makes `j` stepping over a hidden row a
     /// falsifiable claim rather than one a contiguous fixture would pass by
     /// accident.
+    ///
+    /// The names are what they are because the table reads by NAME. The old
+    /// fixture was `web` 1, `api` 2, `web-worker` 3, `cron` 4, which put the
+    /// gap in the id order alone: sorted by name, `web` and `web-worker` are
+    /// adjacent and nothing can ever sit between them that the query `web`
+    /// does not also match. Every "stepped over a hidden row" test here would
+    /// have gone on passing over a contiguous pair. `api-web` sorts before
+    /// `cron`, which is what puts two hidden rows back in the middle.
     fn filtered(query: &str) -> App {
         let t0 = Instant::now();
         let mut app = App::new(
@@ -2523,15 +2553,65 @@ mod tests {
         );
         app.update(Msg::Snapshot {
             rows: vec![
-                sheep(1, "web", ProcStatus::Online),
-                sheep(2, "api", ProcStatus::Online),
-                sheep(3, "web-worker", ProcStatus::Online),
-                sheep(4, "cron", ProcStatus::Online),
+                sheep(1, "api-web", ProcStatus::Online),
+                sheep(2, "cron", ProcStatus::Online),
+                sheep(3, "queue", ProcStatus::Online),
+                sheep(4, "web-worker", ProcStatus::Online),
             ],
             at: t0,
         });
         app.set_filter(query.to_string());
         app
+    }
+
+    /// fails if the table draws in id order, or if two instances of one app
+    /// are left in an order the map decides.
+    ///
+    /// `flock` is a `BTreeMap<u32, Row>`, so a build that simply iterates it
+    /// draws by id. The fixture makes those two answers impossible to
+    /// confuse: by id it is `web` 0, `api` 1, `web` 2; by name and then id it
+    /// is `api` 1, `web` 0, `web` 2.
+    ///
+    /// The two `web` rows carry the clustered-app case, but be clear about
+    /// what they can and cannot catch here, because it is not what the
+    /// equivalent test in `shep-core` catches. Measured with the tiebreak
+    /// removed (`sort_by(|a, b| a.0.cmp(b.0))`, a STABLE name-only key): this
+    /// test still passed. `flock` is a `BTreeMap<u32, Row>`, so the rows
+    /// arrive in id order already and a stable name sort leaves them in it.
+    /// The tiebreak is unfalsifiable from this pane, and pretending otherwise
+    /// is how a test comes to assert something nothing could break. What this
+    /// DOES catch, measured with the sort deleted outright, is the whole
+    /// defect: the rows came back `web` 0, `api` 1, `web` 2, straight off the
+    /// map.
+    ///
+    /// The key stays `(name, id)` regardless, because the reason it is total
+    /// does not depend on where the rows came from, and because this pane
+    /// repolls every two seconds -- a key that is not total is what would let
+    /// two rows swap places under the operator's cursor.
+    #[test]
+    fn the_table_draws_by_name_then_by_id() {
+        let t0 = Instant::now();
+        let mut app = App::new(
+            Palette::detect(None, None, None),
+            Control::ReadOnly,
+            "/home/rin/.shep".to_string(),
+            t0,
+        );
+        app.update(Msg::Snapshot {
+            rows: vec![
+                sheep(0, "web", ProcStatus::Online),
+                sheep(1, "api", ProcStatus::Online),
+                sheep(2, "web", ProcStatus::Online),
+            ],
+            at: t0,
+        });
+
+        let drawn: Vec<(&str, u32)> = app
+            .rows()
+            .iter()
+            .map(|row| (row.info.name.as_str(), row.info.id))
+            .collect();
+        assert_eq!(drawn, vec![("api", 1), ("web", 0), ("web", 2)]);
     }
 
     /// fails if the table stops narrowing, or if the flock's real size stops
@@ -2542,7 +2622,7 @@ mod tests {
     #[test]
     fn a_filter_narrows_the_rows_and_leaves_the_real_size_readable() {
         let app = filtered("web");
-        assert_eq!(app.rows().len(), 2, "web and web-worker");
+        assert_eq!(app.rows().len(), 2, "api-web and web-worker");
         assert_eq!(app.flock_len(), 4, "the flock did not get smaller");
     }
 
@@ -2553,7 +2633,7 @@ mod tests {
     #[test]
     fn the_filter_matches_a_substring_and_not_a_whole_name() {
         assert_eq!(filtered("wor").rows().len(), 1, "web-worker, by its middle");
-        assert_eq!(filtered("w").rows().len(), 2);
+        assert_eq!(filtered("w").rows().len(), 2, "api-web, by its own middle");
     }
 
     /// fails if either `to_lowercase` is dropped. Both directions, because
@@ -2587,11 +2667,15 @@ mod tests {
     #[test]
     fn j_and_k_step_only_over_visible_rows() {
         let mut app = filtered("web");
-        assert_eq!(app.selected(), Some(1), "the first visible sheep");
+        assert_eq!(app.selected(), Some(1), "api-web, the first visible sheep");
         app.update(Msg::Key(KeyPress::SelectDown));
-        assert_eq!(app.selected(), Some(3), "web-worker, skipping api at id 2");
+        assert_eq!(
+            app.selected(),
+            Some(4),
+            "web-worker, skipping the hidden cron and queue"
+        );
         app.update(Msg::Key(KeyPress::SelectDown));
-        assert_eq!(app.selected(), Some(3), "clamped at the last visible row");
+        assert_eq!(app.selected(), Some(4), "clamped at the last visible row");
         app.update(Msg::Key(KeyPress::SelectUp));
         assert_eq!(app.selected(), Some(1));
     }
@@ -2601,7 +2685,7 @@ mod tests {
     fn select_last_lands_on_the_last_visible_row() {
         let mut app = filtered("web");
         app.update(Msg::Key(KeyPress::SelectLast));
-        assert_eq!(app.selected(), Some(3), "web-worker, not cron at id 4");
+        assert_eq!(app.selected(), Some(4), "web-worker, not queue at id 3");
     }
 
     /// fails if a filter that hides the selection snaps to row 0, or drops the
@@ -2613,11 +2697,11 @@ mod tests {
     fn a_filter_that_hides_the_selection_clamps_to_the_nearest_visible_row() {
         let mut app = filtered("");
         app.update(Msg::Key(KeyPress::SelectLast));
-        assert_eq!(app.selected(), Some(4), "cron, position 3 of 4");
+        assert_eq!(app.selected(), Some(4), "web-worker, position 3 of 4");
         app.set_filter("web".to_string());
         assert_eq!(
             app.selected(),
-            Some(3),
+            Some(4),
             "position 3 clamps to the last visible row, which is web-worker"
         );
     }
@@ -2648,10 +2732,10 @@ mod tests {
         let t1 = Instant::now();
         app.update(Msg::Snapshot {
             rows: vec![
-                sheep(1, "web", ProcStatus::Online),
-                sheep(2, "api", ProcStatus::Online),
-                sheep(3, "web-worker", ProcStatus::Online),
-                sheep(4, "cron", ProcStatus::Online),
+                sheep(1, "api-web", ProcStatus::Online),
+                sheep(2, "cron", ProcStatus::Online),
+                sheep(3, "queue", ProcStatus::Online),
+                sheep(4, "web-worker", ProcStatus::Online),
             ],
             at: t1,
         });

--- a/crates/shep-cli/src/lookout/frames.rs
+++ b/crates/shep-cli/src/lookout/frames.rs
@@ -386,6 +386,29 @@ pub fn scene(which: Scene) -> (&'static str, Buffer) {
     (which.label(), scene_with(which, Duration::from_secs(600)))
 }
 
+/// Parks the gallery's cursor on the sheep with id `id`.
+///
+/// `SelectDown` moves one VISIBLE row, and the table reads by name, so the
+/// number of presses a given sheep needs is a fact about the fixture's names
+/// rather than about its ids. Walking until the id matches keeps a scene
+/// describing the sheep its assertions name, whatever the ordering rule is.
+///
+/// # Panics
+///
+/// If `id` is not in the flock, or is hidden by a filter. Gallery scaffolding:
+/// a scene that silently described a different sheep than the one its own
+/// assertions name is the failure this exists to make loud.
+#[track_caller]
+fn select_id(app: &mut App, id: u32) {
+    for _ in 0..=app.flock_len() {
+        if app.selected() == Some(id) {
+            return;
+        }
+        app.update(Msg::Key(KeyPress::SelectDown));
+    }
+    panic!("the gallery cannot park its cursor on id {id}");
+}
+
 /// One scene, `age` after its opening snapshot.
 ///
 /// The parameter exists for one test:
@@ -534,10 +557,16 @@ fn scene_with(which: Scene, age: Duration) -> Buffer {
         now: t0 + Duration::from_secs(7),
     });
 
-    // Onto `api`, id 2, in both flocks — the third row of each. A fresh
-    // snapshot selects the FIRST id, so without this every "sheep 2  api"
-    // and "bleats  api" assertion below is asserting about `web` at id 0 and
-    // failing for a reason that has nothing to do with the pane.
+    // Onto `api`, id 2, in both flocks. A fresh snapshot selects the first
+    // VISIBLE row, so without this every "sheep 2  api" and "bleats  api"
+    // assertion below is asserting about whichever sheep the table happens to
+    // draw first, and failing for a reason that has nothing to do with the
+    // pane.
+    //
+    // Walked by id rather than by a fixed number of `j`s. The table reads by
+    // name, so which row `api` occupies is decided by what the other five
+    // sheep are called; two `SelectDown`s used to land on it only because the
+    // table read by id and `api` held id 2.
     //
     // The four excluded scenes have either no flock (`Empty`) or no pane
     // below the table to describe (`Narrow`, `TooNarrow`, `TableOnly`), so
@@ -546,15 +575,12 @@ fn scene_with(which: Scene, age: Duration) -> Buffer {
         which,
         Scene::Empty | Scene::Narrow | Scene::TooNarrow | Scene::TableOnly
     ) {
-        app.update(Msg::Key(KeyPress::SelectDown));
-        app.update(Msg::Key(KeyPress::SelectDown));
+        select_id(&mut app, 2);
     }
 
-    // `LambsUnknown` wants `cron`, id 4 — two rows further down than `api`,
-    // where the block above already parked the cursor.
+    // `LambsUnknown` wants `cron`, id 4, instead.
     if which == Scene::LambsUnknown {
-        app.update(Msg::Key(KeyPress::SelectDown));
-        app.update(Msg::Key(KeyPress::SelectDown));
+        select_id(&mut app, 4);
     }
 
     match which {

--- a/crates/shep-cli/src/lookout/snapshots/shep__lookout__frames__tests__acting.snap
+++ b/crates/shep-cli/src/lookout/snapshots/shep__lookout__frames__tests__acting.snap
@@ -1,17 +1,18 @@
 ---
 source: crates/shep-cli/src/lookout/frames.rs
+assertion_line: 1599
 expression: render_text(&buffer)
 ---
 shep lookout   /home/rin/.shep                                                        6 in the flock
 host  load 2.31 4.10 3.88 / 10 cores   host mem 12.4G / 32.0G   flock cpu 14.7%   flock mem 716.0M …
   ID    NAME               STATUS           PID      RESTARTS  EXIT       CPU     MEM       UPTIME  
 ────────────────────────────────────────────────────────────────────────────────────────────────────
-  0     web                online           48211    0         -          3.4%    182.0M    1h 25m  
-  1     web                online           48212    0         -          2.9%    178.0M    1h 26m  
 > 2     api                online           48219    1         -          7.1%    241.0M    1h 28m  
   3     billing-reconcil…  online           48230    0         -          0.8%    96.0M     1h 29m  
   4     cron               online           48233    0         -          0.1%    8.0M      1h 31m  
   5     metrics            online           48240    0         -          0.4%    11.0M     1h 32m  
+  0     web                online           48211    0         -          3.4%    182.0M    1h 25m  
+  1     web                online           48212    0         -          2.9%    178.0M    1h 26m  
                                                                                                     
                                                                                                     
                                                                                                     

--- a/crates/shep-cli/src/lookout/snapshots/shep__lookout__frames__tests__action_accepted.snap
+++ b/crates/shep-cli/src/lookout/snapshots/shep__lookout__frames__tests__action_accepted.snap
@@ -1,17 +1,18 @@
 ---
 source: crates/shep-cli/src/lookout/frames.rs
+assertion_line: 1599
 expression: render_text(&buffer)
 ---
 shep lookout   /home/rin/.shep                                                        6 in the flock
 host  load 2.31 4.10 3.88 / 10 cores   host mem 12.4G / 32.0G   flock cpu 14.7%   flock mem 716.0M …
   ID    NAME               STATUS           PID      RESTARTS  EXIT       CPU     MEM       UPTIME  
 ────────────────────────────────────────────────────────────────────────────────────────────────────
-  0     web                online           48211    0         -          3.4%    182.0M    1h 25m  
-  1     web                online           48212    0         -          2.9%    178.0M    1h 26m  
 > 2     api                online           48299    2         -          7.1%    241.0M    1h 18m  
   3     billing-reconcil…  online           48230    0         -          0.8%    96.0M     1h 29m  
   4     cron               online           48233    0         -          0.1%    8.0M      1h 31m  
   5     metrics            online           48240    0         -          0.4%    11.0M     1h 32m  
+  0     web                online           48211    0         -          3.4%    182.0M    1h 25m  
+  1     web                online           48212    0         -          2.9%    178.0M    1h 26m  
                                                                                                     
                                                                                                     
                                                                                                     

--- a/crates/shep-cli/src/lookout/snapshots/shep__lookout__frames__tests__action_refused.snap
+++ b/crates/shep-cli/src/lookout/snapshots/shep__lookout__frames__tests__action_refused.snap
@@ -1,16 +1,17 @@
 ---
 source: crates/shep-cli/src/lookout/frames.rs
+assertion_line: 1599
 expression: render_text(&buffer)
 ---
 shep lookout   /home/rin/.shep                                                        5 in the flock
 host  load 2.31 4.10 3.88 / 10 cores   host mem 12.4G / 32.0G   flock cpu 7.6%   flock mem 475.0M  …
   ID    NAME               STATUS           PID      RESTARTS  EXIT       CPU     MEM       UPTIME  
 ────────────────────────────────────────────────────────────────────────────────────────────────────
-  0     web                online           48211    0         -          3.4%    182.0M    1h 25m  
-  1     web                online           48212    0         -          2.9%    178.0M    1h 26m  
 > 3     billing-reconcil…  online           48230    0         -          0.8%    96.0M     1h 29m  
   4     cron               online           48233    0         -          0.1%    8.0M      1h 31m  
   5     metrics            online           48240    0         -          0.4%    11.0M     1h 32m  
+  0     web                online           48211    0         -          3.4%    182.0M    1h 25m  
+  1     web                online           48212    0         -          2.9%    178.0M    1h 26m  
                                                                                                     
                                                                                                     
                                                                                                     

--- a/crates/shep-cli/src/lookout/snapshots/shep__lookout__frames__tests__action_refused_offline.snap
+++ b/crates/shep-cli/src/lookout/snapshots/shep__lookout__frames__tests__action_refused_offline.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/shep-cli/src/lookout/frames.rs
+assertion_line: 1599
 expression: render_text(&buffer)
 ---
 shep lookout   /home/rin/.shep                                                        6 in the flock
@@ -7,12 +8,12 @@ the shepherd stopped answering — reconnecting (attempt 3)
 host  load 2.31 4.10 3.88 / 10 cores   host mem 12.4G / 32.0G   flock cpu 14.7%   flock mem 716.0M …
   ID    NAME               STATUS           PID      RESTARTS  EXIT       CPU     MEM       UPTIME  
 ────────────────────────────────────────────────────────────────────────────────────────────────────
-  0     web                online           48211    0         -          3.4%    182.0M    1h 25m  
-  1     web                online           48212    0         -          2.9%    178.0M    1h 26m  
 > 2     api                online           48219    1         -          7.1%    241.0M    1h 28m  
   3     billing-reconcil…  online           48230    0         -          0.8%    96.0M     1h 29m  
   4     cron               online           48233    0         -          0.1%    8.0M      1h 31m  
   5     metrics            online           48240    0         -          0.4%    11.0M     1h 32m  
+  0     web                online           48211    0         -          3.4%    182.0M    1h 25m  
+  1     web                online           48212    0         -          2.9%    178.0M    1h 26m  
                                                                                                     
                                                                                                     
 the shepherd stopped answering — reconnecting (attempt 3)                            control enabled

--- a/crates/shep-cli/src/lookout/snapshots/shep__lookout__frames__tests__confirm.snap
+++ b/crates/shep-cli/src/lookout/snapshots/shep__lookout__frames__tests__confirm.snap
@@ -1,17 +1,18 @@
 ---
 source: crates/shep-cli/src/lookout/frames.rs
+assertion_line: 1599
 expression: render_text(&buffer)
 ---
 shep lookout   /home/rin/.shep                                                        6 in the flock
 host  load 2.31 4.10 3.88 / 10 cores   host mem 12.4G / 32.0G   flock cpu 14.7%   flock mem 716.0M …
   ID    NAME               STATUS           PID      RESTARTS  EXIT       CPU     MEM       UPTIME  
 ────────────────────────────────────────────────────────────────────────────────────────────────────
-  0     web                online           48211    0         -          3.4%    182.0M    1h 25m  
-  1     web                online           48212    0         -          2.9%    178.0M    1h 26m  
 > 2     api                online           48219    1         -          7.1%    241.0M    1h 28m  
   3     billing-reconcil…  online           48230    0         -          0.8%    96.0M     1h 29m  
   4     cron               online           48233    0         -          0.1%    8.0M      1h 31m  
   5     metrics            online           48240    0         -          0.4%    11.0M     1h 32m  
+  0     web                online           48211    0         -          3.4%    182.0M    1h 25m  
+  1     web                online           48212    0         -          2.9%    178.0M    1h 26m  
                                                                                                     
                                                                                                     
                                                                                                     

--- a/crates/shep-cli/src/lookout/snapshots/shep__lookout__frames__tests__cramped.snap
+++ b/crates/shep-cli/src/lookout/snapshots/shep__lookout__frames__tests__cramped.snap
@@ -1,17 +1,18 @@
 ---
 source: crates/shep-cli/src/lookout/frames.rs
+assertion_line: 1599
 expression: render_text(&buffer)
 ---
 shep lookout   /h… 6 in the flock
 host  load 2.31 4.10 3.88 / 10 c…
   ID    NAME      STATUS         
 ─────────────────────────────────
-  0     web       online         
-  1     web       online         
 > 2     api       online         
   3     billing…  online         
   4     cron      online         
   5     metrics   online         
+  0     web       online         
+  1     web       online         
                                  
                                  
                                  

--- a/crates/shep-cli/src/lookout/snapshots/shep__lookout__frames__tests__errored.snap
+++ b/crates/shep-cli/src/lookout/snapshots/shep__lookout__frames__tests__errored.snap
@@ -1,18 +1,18 @@
 ---
 source: crates/shep-cli/src/lookout/frames.rs
-assertion_line: 1573
+assertion_line: 1599
 expression: render_text(&buffer)
 ---
 shep lookout   /home/rin/.shep                                                                            6 in the flock
 host  load 2.31 4.10 3.88 / 10 cores   host mem 12.4G / 32.0G   flock cpu 6.7%   flock mem 371.0M   up 6d 3h            
   ID    NAME        STATUS           PID      RESTARTS  EXIT       CPU     MEM       UPTIME    FOLD        SMIT         
 ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-  0     web         online           48211    0         -          3.4%    182.0M    1h 25m    edge        -            
-  1     web         online           48212    0         -          2.9%    178.0M    1h 26m    edge        -            
 > 2     api         errored          -        14        1          -       -         1h 18m    edge        -            
   3     billing-r…  waiting-restart  -        3         1          -       -         1h 19m    -           -            
   4     cron        stopped          -        0         SIGTERM    -       -         1h 21m    -           -            
   5     metrics     online           48240    0         -          0.4%    11.0M     1h 32m    -           -            
+  0     web         online           48211    0         -          3.4%    182.0M    1h 25m    edge        -            
+  1     web         online           48212    0         -          2.9%    178.0M    1h 26m    edge        -            
                                                                                                                         
                                                                                                                         
                                                                                                                         

--- a/crates/shep-cli/src/lookout/snapshots/shep__lookout__frames__tests__feed_gap.snap
+++ b/crates/shep-cli/src/lookout/snapshots/shep__lookout__frames__tests__feed_gap.snap
@@ -1,18 +1,18 @@
 ---
 source: crates/shep-cli/src/lookout/frames.rs
-assertion_line: 1573
+assertion_line: 1599
 expression: render_text(&buffer)
 ---
 shep lookout   /home/rin/.shep                                                                            6 in the flock
 host  load 2.31 4.10 3.88 / 10 cores   host mem 12.4G / 32.0G   flock cpu 14.7%   flock mem 716.0M   up 6d 3h           
   ID    NAME        STATUS           PID      RESTARTS  EXIT       CPU     MEM       UPTIME    FOLD        SMIT         
 ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-  0     web         online           48211    0         -          3.4%    182.0M    1h 25m    edge        -            
-  1     web         online           48212    0         -          2.9%    178.0M    1h 26m    edge        -            
 > 2     api         online           48219    1         -          7.1%    241.0M    1h 28m    edge        -            
   3     billing-r…  online           48230    0         -          0.8%    96.0M     1h 29m    -           -            
   4     cron        online           48233    0         -          0.1%    8.0M      1h 31m    -           -            
   5     metrics     online           48240    0         -          0.4%    11.0M     1h 32m    -           -            
+  0     web         online           48211    0         -          3.4%    182.0M    1h 25m    edge        -            
+  1     web         online           48212    0         -          2.9%    178.0M    1h 26m    edge        -            
                                                                                                                         
                                                                                                                         
                                                                                                                         

--- a/crates/shep-cli/src/lookout/snapshots/shep__lookout__frames__tests__feed_missing.snap
+++ b/crates/shep-cli/src/lookout/snapshots/shep__lookout__frames__tests__feed_missing.snap
@@ -1,18 +1,18 @@
 ---
 source: crates/shep-cli/src/lookout/frames.rs
-assertion_line: 1573
+assertion_line: 1599
 expression: render_text(&buffer)
 ---
 shep lookout   /home/rin/.shep                                                                            6 in the flock
 host  load 2.31 4.10 3.88 / 10 cores   host mem 12.4G / 32.0G   flock cpu 14.7%   flock mem 716.0M   up 6d 3h           
   ID    NAME        STATUS           PID      RESTARTS  EXIT       CPU     MEM       UPTIME    FOLD        SMIT         
 ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-  0     web         online           48211    0         -          3.4%    182.0M    1h 25m    edge        -            
-  1     web         online           48212    0         -          2.9%    178.0M    1h 26m    edge        -            
 > 2     api         online           48219    1         -          7.1%    241.0M    1h 28m    edge        -            
   3     billing-r…  online           48230    0         -          0.8%    96.0M     1h 29m    -           -            
   4     cron        online           48233    0         -          0.1%    8.0M      1h 31m    -           -            
   5     metrics     online           48240    0         -          0.4%    11.0M     1h 32m    -           -            
+  0     web         online           48211    0         -          3.4%    182.0M    1h 25m    edge        -            
+  1     web         online           48212    0         -          2.9%    178.0M    1h 26m    edge        -            
                                                                                                                         
                                                                                                                         
                                                                                                                         

--- a/crates/shep-cli/src/lookout/snapshots/shep__lookout__frames__tests__filter_active.snap
+++ b/crates/shep-cli/src/lookout/snapshots/shep__lookout__frames__tests__filter_active.snap
@@ -1,13 +1,14 @@
 ---
 source: crates/shep-cli/src/lookout/frames.rs
+assertion_line: 1599
 expression: render_text(&buffer)
 ---
 shep lookout   /home/rin/.shep                                                   2 of 6 in the flock
 host  load 2.31 4.10 3.88 / 10 cores   host mem 12.4G / 32.0G   flock cpu 14.7%   flock mem 716.0M …
   ID    NAME               STATUS           PID      RESTARTS  EXIT       CPU     MEM       UPTIME  
 ────────────────────────────────────────────────────────────────────────────────────────────────────
-  0     web                online           48211    0         -          3.4%    182.0M    1h 25m  
-> 1     web                online           48212    0         -          2.9%    178.0M    1h 26m  
+> 0     web                online           48211    0         -          3.4%    182.0M    1h 25m  
+  1     web                online           48212    0         -          2.9%    178.0M    1h 26m  
                                                                                                     
                                                                                                     
                                                                                                     

--- a/crates/shep-cli/src/lookout/snapshots/shep__lookout__frames__tests__filter_editing.snap
+++ b/crates/shep-cli/src/lookout/snapshots/shep__lookout__frames__tests__filter_editing.snap
@@ -1,13 +1,14 @@
 ---
 source: crates/shep-cli/src/lookout/frames.rs
+assertion_line: 1599
 expression: render_text(&buffer)
 ---
 shep lookout   /home/rin/.shep                                                   2 of 6 in the flock
 host  load 2.31 4.10 3.88 / 10 cores   host mem 12.4G / 32.0G   flock cpu 14.7%   flock mem 716.0M …
   ID    NAME               STATUS           PID      RESTARTS  EXIT       CPU     MEM       UPTIME  
 ────────────────────────────────────────────────────────────────────────────────────────────────────
-  0     web                online           48211    0         -          3.4%    182.0M    1h 25m  
-> 1     web                online           48212    0         -          2.9%    178.0M    1h 26m  
+> 0     web                online           48211    0         -          3.4%    182.0M    1h 25m  
+  1     web                online           48212    0         -          2.9%    178.0M    1h 26m  
                                                                                                     
                                                                                                     
                                                                                                     

--- a/crates/shep-cli/src/lookout/snapshots/shep__lookout__frames__tests__frozen.snap
+++ b/crates/shep-cli/src/lookout/snapshots/shep__lookout__frames__tests__frozen.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/shep-cli/src/lookout/frames.rs
-assertion_line: 1573
+assertion_line: 1599
 expression: render_text(&buffer)
 ---
 shep lookout   /home/rin/.shep                                                                            6 in the flock
@@ -8,12 +8,12 @@ the shepherd has died — these values are frozen as of 2026-08-14 14:32:07
 host  load 2.31 4.10 3.88 / 10 cores   host mem 12.4G / 32.0G   flock cpu 6.7%   flock mem 371.0M   up 6d 3h            
   ID    NAME        STATUS           PID      RESTARTS  EXIT       CPU     MEM       UPTIME    FOLD        SMIT         
 ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-  0     web         online           48211    0         -          3.4%    182.0M    1h 15m    edge        -            
-  1     web         online           48212    0         -          2.9%    178.0M    1h 16m    edge        -            
 > 2     api         errored          -        14        1          -       -         1h 18m    edge        -            
   3     billing-r…  waiting-restart  -        3         1          -       -         1h 19m    -           -            
   4     cron        stopped          -        0         SIGTERM    -       -         1h 21m    -           -            
   5     metrics     online           48240    0         -          0.4%    11.0M     1h 22m    -           -            
+  0     web         online           48211    0         -          3.4%    182.0M    1h 15m    edge        -            
+  1     web         online           48212    0         -          2.9%    178.0M    1h 16m    edge        -            
                                                                                                                         
                                                                                                                         
                                                                                                                         

--- a/crates/shep-cli/src/lookout/snapshots/shep__lookout__frames__tests__healthy_wide.snap
+++ b/crates/shep-cli/src/lookout/snapshots/shep__lookout__frames__tests__healthy_wide.snap
@@ -1,18 +1,18 @@
 ---
 source: crates/shep-cli/src/lookout/frames.rs
-assertion_line: 1573
+assertion_line: 1599
 expression: render_text(&buffer)
 ---
 shep lookout   /home/rin/.shep                                                                            6 in the flock
 host  load 2.31 4.10 3.88 / 10 cores   host mem 12.4G / 32.0G   flock cpu 14.7%   flock mem 716.0M   up 6d 3h           
   ID    NAME        STATUS           PID      RESTARTS  EXIT       CPU     MEM       UPTIME    FOLD        SMIT         
 ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-  0     web         online           48211    0         -          3.4%    182.0M    1h 25m    edge        -            
-  1     web         online           48212    0         -          2.9%    178.0M    1h 26m    edge        -            
 > 2     api         online           48219    1         -          7.1%    241.0M    1h 28m    edge        -            
   3     billing-r…  online           48230    0         -          0.8%    96.0M     1h 29m    -           -            
   4     cron        online           48233    0         -          0.1%    8.0M      1h 31m    -           -            
   5     metrics     online           48240    0         -          0.4%    11.0M     1h 32m    -           -            
+  0     web         online           48211    0         -          3.4%    182.0M    1h 25m    edge        -            
+  1     web         online           48212    0         -          2.9%    178.0M    1h 26m    edge        -            
                                                                                                                         
                                                                                                                         
                                                                                                                         

--- a/crates/shep-cli/src/lookout/snapshots/shep__lookout__frames__tests__host_unknown.snap
+++ b/crates/shep-cli/src/lookout/snapshots/shep__lookout__frames__tests__host_unknown.snap
@@ -1,18 +1,18 @@
 ---
 source: crates/shep-cli/src/lookout/frames.rs
-assertion_line: 1573
+assertion_line: 1599
 expression: render_text(&buffer)
 ---
 shep lookout   /home/rin/.shep                                                                            6 in the flock
 host  usage is not available on this platform   flock cpu 14.7%   flock mem 716.0M                                      
   ID    NAME        STATUS           PID      RESTARTS  EXIT       CPU     MEM       UPTIME    FOLD        SMIT         
 ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-  0     web         online           48211    0         -          3.4%    182.0M    1h 25m    edge        -            
-  1     web         online           48212    0         -          2.9%    178.0M    1h 26m    edge        -            
 > 2     api         online           48219    1         -          7.1%    241.0M    1h 28m    edge        -            
   3     billing-r…  online           48230    0         -          0.8%    96.0M     1h 29m    -           -            
   4     cron        online           48233    0         -          0.1%    8.0M      1h 31m    -           -            
   5     metrics     online           48240    0         -          0.4%    11.0M     1h 32m    -           -            
+  0     web         online           48211    0         -          3.4%    182.0M    1h 25m    edge        -            
+  1     web         online           48212    0         -          2.9%    178.0M    1h 26m    edge        -            
                                                                                                                         
                                                                                                                         
                                                                                                                         

--- a/crates/shep-cli/src/lookout/snapshots/shep__lookout__frames__tests__lambs.snap
+++ b/crates/shep-cli/src/lookout/snapshots/shep__lookout__frames__tests__lambs.snap
@@ -1,18 +1,18 @@
 ---
 source: crates/shep-cli/src/lookout/frames.rs
-assertion_line: 1573
+assertion_line: 1599
 expression: render_text(&buffer)
 ---
 shep lookout   /home/rin/.shep                                                                            6 in the flock
 host  load 2.31 4.10 3.88 / 10 cores   host mem 12.4G / 32.0G   flock cpu 14.7%   flock mem 716.0M   up 6d 3h           
   ID    NAME        STATUS           PID      RESTARTS  EXIT       CPU     MEM       UPTIME    FOLD        SMIT         
 ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-  0     web         online           48211    0         -          3.4%    182.0M    1h 25m    edge        -            
-  1     web         online           48212    0         -          2.9%    178.0M    1h 26m    edge        -            
 > 2     api         online           48219    1         -          7.1%    241.0M    1h 28m    edge        -            
   3     billing-r…  online           48230    0         -          0.8%    96.0M     1h 29m    -           -            
   4     cron        online           48233    0         -          0.1%    8.0M      1h 31m    -           -            
   5     metrics     online           48240    0         -          0.4%    11.0M     1h 32m    -           -            
+  0     web         online           48211    0         -          3.4%    182.0M    1h 25m    edge        -            
+  1     web         online           48212    0         -          2.9%    178.0M    1h 26m    edge        -            
                                                                                                                         
                                                                                                                         
                                                                                                                         

--- a/crates/shep-cli/src/lookout/snapshots/shep__lookout__frames__tests__lambs_unknown.snap
+++ b/crates/shep-cli/src/lookout/snapshots/shep__lookout__frames__tests__lambs_unknown.snap
@@ -1,18 +1,18 @@
 ---
 source: crates/shep-cli/src/lookout/frames.rs
-assertion_line: 1573
+assertion_line: 1599
 expression: render_text(&buffer)
 ---
 shep lookout   /home/rin/.shep                                                                            6 in the flock
 host  load 2.31 4.10 3.88 / 10 cores   host mem 12.4G / 32.0G   flock cpu 6.7%   flock mem 371.0M   up 6d 3h            
   ID    NAME        STATUS           PID      RESTARTS  EXIT       CPU     MEM       UPTIME    FOLD        SMIT         
 ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-  0     web         online           48211    0         -          3.4%    182.0M    1h 25m    edge        -            
-  1     web         online           48212    0         -          2.9%    178.0M    1h 26m    edge        -            
   2     api         errored          -        14        1          -       -         1h 18m    edge        -            
   3     billing-r…  waiting-restart  -        3         1          -       -         1h 19m    -           -            
 > 4     cron        stopped          -        0         SIGTERM    -       -         1h 21m    -           -            
   5     metrics     online           48240    0         -          0.4%    11.0M     1h 32m    -           -            
+  0     web         online           48211    0         -          3.4%    182.0M    1h 25m    edge        -            
+  1     web         online           48212    0         -          2.9%    178.0M    1h 26m    edge        -            
                                                                                                                         
                                                                                                                         
                                                                                                                         

--- a/crates/shep-cli/src/lookout/snapshots/shep__lookout__frames__tests__narrow.snap
+++ b/crates/shep-cli/src/lookout/snapshots/shep__lookout__frames__tests__narrow.snap
@@ -1,17 +1,18 @@
 ---
 source: crates/shep-cli/src/lookout/frames.rs
+assertion_line: 1599
 expression: render_text(&buffer)
 ---
 shep lookout   /home/rin/.shep       6 in the flock
 host  load 2.31 4.10 3.88 / 10 cores   host mem 12…
   ID    NAME      STATUS           CPU     UPTIME  
 ───────────────────────────────────────────────────
-> 0     web       online           3.4%    1h 25m  
-  1     web       online           2.9%    1h 26m  
-  2     api       online           7.1%    1h 28m  
+> 2     api       online           7.1%    1h 28m  
   3     billing…  online           0.8%    1h 29m  
   4     cron      online           0.1%    1h 31m  
   5     metrics   online           0.4%    1h 32m  
+  0     web       online           3.4%    1h 25m  
+  1     web       online           2.9%    1h 26m  
                                                    
                                                    
                                                    

--- a/crates/shep-cli/src/lookout/snapshots/shep__lookout__frames__tests__no_detail.snap
+++ b/crates/shep-cli/src/lookout/snapshots/shep__lookout__frames__tests__no_detail.snap
@@ -1,18 +1,18 @@
 ---
 source: crates/shep-cli/src/lookout/frames.rs
-assertion_line: 1573
+assertion_line: 1599
 expression: render_text(&buffer)
 ---
 shep lookout   /home/rin/.shep                                                                            6 in the flock
 host  load 2.31 4.10 3.88 / 10 cores   host mem 12.4G / 32.0G   flock cpu 14.7%   flock mem 716.0M   up 6d 3h           
   ID    NAME        STATUS           PID      RESTARTS  EXIT       CPU     MEM       UPTIME    FOLD        SMIT         
 ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-  0     web         online           48211    0         -          3.4%    182.0M    1h 25m    edge        -            
-  1     web         online           48212    0         -          2.9%    178.0M    1h 26m    edge        -            
 > 2     api         online           48219    1         -          7.1%    241.0M    1h 28m    edge        -            
   3     billing-r…  online           48230    0         -          0.8%    96.0M     1h 29m    -           -            
   4     cron        online           48233    0         -          0.1%    8.0M      1h 31m    -           -            
   5     metrics     online           48240    0         -          0.4%    11.0M     1h 32m    -           -            
+  0     web         online           48211    0         -          3.4%    182.0M    1h 25m    edge        -            
+  1     web         online           48212    0         -          2.9%    178.0M    1h 26m    edge        -            
                                                                                                                         
                                                                                                                         
 ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

--- a/crates/shep-cli/src/lookout/snapshots/shep__lookout__frames__tests__refused.snap
+++ b/crates/shep-cli/src/lookout/snapshots/shep__lookout__frames__tests__refused.snap
@@ -1,18 +1,18 @@
 ---
 source: crates/shep-cli/src/lookout/frames.rs
-assertion_line: 1573
+assertion_line: 1599
 expression: render_text(&buffer)
 ---
 shep lookout   /home/rin/.shep                                                                            6 in the flock
 host  load 2.31 4.10 3.88 / 10 cores   host mem 12.4G / 32.0G   flock cpu 14.7%   flock mem 716.0M   up 6d 3h           
   ID    NAME        STATUS           PID      RESTARTS  EXIT       CPU     MEM       UPTIME    FOLD        SMIT         
 ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-  0     web         online           48211    0         -          3.4%    182.0M    1h 25m    edge        -            
-  1     web         online           48212    0         -          2.9%    178.0M    1h 26m    edge        -            
 > 2     api         online           48219    1         -          7.1%    241.0M    1h 28m    edge        -            
   3     billing-r…  online           48230    0         -          0.8%    96.0M     1h 29m    -           -            
   4     cron        online           48233    0         -          0.1%    8.0M      1h 31m    -           -            
   5     metrics     online           48240    0         -          0.4%    11.0M     1h 32m    -           -            
+  0     web         online           48211    0         -          3.4%    182.0M    1h 25m    edge        -            
+  1     web         online           48212    0         -          2.9%    178.0M    1h 26m    edge        -            
                                                                                                                         
                                                                                                                         
                                                                                                                         

--- a/crates/shep-cli/src/lookout/snapshots/shep__lookout__frames__tests__retrying.snap
+++ b/crates/shep-cli/src/lookout/snapshots/shep__lookout__frames__tests__retrying.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/shep-cli/src/lookout/frames.rs
-assertion_line: 1573
+assertion_line: 1599
 expression: render_text(&buffer)
 ---
 shep lookout   /home/rin/.shep                                                                            6 in the flock
@@ -8,12 +8,12 @@ the shepherd stopped answering — reconnecting (attempt 3)
 host  load 2.31 4.10 3.88 / 10 cores   host mem 12.4G / 32.0G   flock cpu 14.7%   flock mem 716.0M   up 6d 3h           
   ID    NAME        STATUS           PID      RESTARTS  EXIT       CPU     MEM       UPTIME    FOLD        SMIT         
 ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-  0     web         online           48211    0         -          3.4%    182.0M    1h 25m    edge        -            
-  1     web         online           48212    0         -          2.9%    178.0M    1h 26m    edge        -            
 > 2     api         online           48219    1         -          7.1%    241.0M    1h 28m    edge        -            
   3     billing-r…  online           48230    0         -          0.8%    96.0M     1h 29m    -           -            
   4     cron        online           48233    0         -          0.1%    8.0M      1h 31m    -           -            
   5     metrics     online           48240    0         -          0.4%    11.0M     1h 32m    -           -            
+  0     web         online           48211    0         -          3.4%    182.0M    1h 25m    edge        -            
+  1     web         online           48212    0         -          2.9%    178.0M    1h 26m    edge        -            
                                                                                                                         
                                                                                                                         
                                                                                                                         

--- a/crates/shep-cli/src/lookout/snapshots/shep__lookout__frames__tests__table_only.snap
+++ b/crates/shep-cli/src/lookout/snapshots/shep__lookout__frames__tests__table_only.snap
@@ -1,17 +1,17 @@
 ---
 source: crates/shep-cli/src/lookout/frames.rs
-assertion_line: 1573
+assertion_line: 1599
 expression: render_text(&buffer)
 ---
 shep lookout   /home/rin/.shep                                                                            6 in the flock
   ID    NAME        STATUS           PID      RESTARTS  EXIT       CPU     MEM       UPTIME    FOLD        SMIT         
 ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-> 0     web         online           48211    0         -          3.4%    182.0M    1h 25m    edge        -            
-  1     web         online           48212    0         -          2.9%    178.0M    1h 26m    edge        -            
-  2     api         online           48219    1         -          7.1%    241.0M    1h 28m    edge        -            
+> 2     api         online           48219    1         -          7.1%    241.0M    1h 28m    edge        -            
   3     billing-r…  online           48230    0         -          0.8%    96.0M     1h 29m    -           -            
   4     cron        online           48233    0         -          0.1%    8.0M      1h 31m    -           -            
   5     metrics     online           48240    0         -          0.4%    11.0M     1h 32m    -           -            
+  0     web         online           48211    0         -          3.4%    182.0M    1h 25m    edge        -            
+  1     web         online           48212    0         -          2.9%    178.0M    1h 26m    edge        -            
                                                                                                                         
                                                                                                                         
 q quit   j/k select   g/G first/last   r refresh   / filter                                                    read-only

--- a/crates/shep-cli/src/lookout/view/fixtures.rs
+++ b/crates/shep-cli/src/lookout/view/fixtures.rs
@@ -133,24 +133,41 @@ pub fn with_no_selection() -> App {
     app_with(Vec::new(), plain())
 }
 
-/// A TWO-sheep dashboard with the selection on `info`, which sorts second.
+/// A TWO-sheep dashboard with the selection walked onto `info`.
 ///
 /// Two, and the selection not on row 0, on purpose: Task 7's first mutation
 /// replaces `selected_row()` with `rows().first()`, and a one-sheep fixture
-/// would make that mutation invisible.
+/// would make that mutation invisible. Both properties are ASSERTED below
+/// rather than assumed, which is the whole reason this walks the cursor
+/// instead of pressing `j` once.
 pub fn with_selection(info: ProcessInfo) -> App {
     with_selection_and_palette(info, plain())
 }
 
 /// The same, at a given palette.
+///
+/// The decoy is `!decoy` rather than `decoy` because the table reads by NAME:
+/// with an ordinary name the decoy sorts wherever the alphabet puts it, and
+/// this fixture is used with sheep called `api`, `cron` and `gateway`. It used
+/// to press `j` once and trust `info` to be row 1, which was true only while
+/// the table read by id and the decoy held id 0. `!` sorts below every ASCII
+/// letter and digit, so the decoy is row 0 whatever the sheep under test is
+/// called.
 pub fn with_selection_and_palette(info: ProcessInfo, palette: Palette) -> App {
     assert!(
         info.id > 0,
         "the decoy takes id 0, so the sheep under test cannot"
     );
-    let decoy = ProcessInfo::builder(0, "decoy", ProcStatus::Online).build();
+    let wanted = info.id;
+    let decoy = ProcessInfo::builder(0, "!decoy", ProcStatus::Online).build();
     let mut app = app_with(vec![decoy, info], palette);
     app.update(Msg::Key(KeyPress::SelectDown));
+    assert_eq!(
+        app.selected(),
+        Some(wanted),
+        "the sheep under test must end up selected, and on row 1: the mutation \
+         this fixture exists to catch reads row 0 instead"
+    );
     app
 }
 
@@ -328,10 +345,23 @@ fn named_flock() -> Vec<ProcessInfo> {
 
 /// [`filtered_app`]'s four sheep with the gate open and the cursor on `api`
 /// at id 2, which is the sheep every action assertion in this file names.
+///
+/// The cursor is WALKED to `api` rather than moved a fixed number of rows.
+/// The table reads by name, so which row `api` occupies is decided by what
+/// the other three sheep happen to be called; this used to press `j` once and
+/// land on `api` only because the table read by id and `api` held id 2. A
+/// fixture that silently selects a different sheep than its doc claims is
+/// worse than one that fails, so the walk asserts it arrived.
 pub fn allowed_app() -> App {
     let mut app = app_with(named_flock(), plain());
     app.set_control_for_tests(Control::Allowed);
-    app.update(Msg::Key(KeyPress::SelectDown));
+    for _ in 0..named_flock().len() {
+        if app.selected() == Some(2) {
+            break;
+        }
+        app.update(Msg::Key(KeyPress::SelectDown));
+    }
+    assert_eq!(app.selected(), Some(2), "the cursor must end up on api");
     app
 }
 

--- a/crates/shep-cli/src/output/mod.rs
+++ b/crates/shep-cli/src/output/mod.rs
@@ -214,7 +214,7 @@ pub trait Render: Serialize {
     /// written that way first, and the mutation that deleted it killed no
     /// test: every table in the crate that can actually render a `-` already
     /// overrides this and reaches the rule through [`rows::Paint::Default`],
-    /// and the five that do not override it cannot produce a dash at all. A
+    /// and the seven that do not override it cannot produce a dash at all. A
     /// default nothing reaches is a path that rots unwatched, so the rule
     /// lives in `paint` alone, where it is exercised.
     ///

--- a/crates/shep-cli/src/output/mod.rs
+++ b/crates/shep-cli/src/output/mod.rs
@@ -204,9 +204,34 @@ pub trait Render: Serialize {
     fn rows(&self) -> Vec<Vec<String>>;
     /// The rows as this presentation wants them rendered.
     ///
-    /// Defaults to [`Self::rows`]: most payloads have nothing to dress up.
-    /// [`rows::FlockRows`] overrides it because its STATUS cell is the one
-    /// place a face and a colour belong. Only ever called from `table_of`'s
+    /// Defaults to [`Self::rows`]: a table with nothing to dress up says so
+    /// by not implementing this. An impl that wants colour overrides it and
+    /// calls [`rows::paint`], which keys each cell's treatment on the
+    /// column's NAME.
+    ///
+    /// The default deliberately does NOT apply the `-` placeholder rule, even
+    /// though that rule holds for every table that has a placeholder. It was
+    /// written that way first, and the mutation that deleted it killed no
+    /// test: every table in the crate that can actually render a `-` already
+    /// overrides this and reaches the rule through [`rows::Paint::Default`],
+    /// and the five that do not override it cannot produce a dash at all. A
+    /// default nothing reaches is a path that rots unwatched, so the rule
+    /// lives in `paint` alone, where it is exercised.
+    ///
+    /// # Why by name, and never by index
+    ///
+    /// This used to be `FlockRows`' own method, painting `row[0]`, `row[4]`,
+    /// `row[9]` and `row[10]` by hardcoded index. An index is a fact about
+    /// one table's column ORDER, so reordering its columns silently
+    /// repoints every one of them: the wrong cells get painted, nothing
+    /// fails to compile, and no test catches it -- a snapshot pins whatever
+    /// was accepted into it, and only a human looking at a rendered table
+    /// would notice RESTARTS had started wearing the memory ramp. Reordering
+    /// the dogs table is what made that concrete. Keyed on the name, one
+    /// place says RESTARTS is coloured by `restarts_role`, and every table
+    /// carrying a RESTARTS column gets it wherever the column sits.
+    ///
+    /// Only ever called from `table_of`'s
     /// boxed path — the plain path keeps calling [`render_table`], which
     /// keeps calling [`Self::rows`], and that is what makes `bare` provably
     /// byte-identical rather than merely intended to be.
@@ -214,9 +239,9 @@ pub trait Render: Serialize {
     /// `status_word` is a plain parameter rather than a field on
     /// `Presentation`: it is `table_of`'s own per-attempt retry knob (spec
     /// §2's word-drops-before-a-column rule), never a fact resolved once at
-    /// the seam the way every `Presentation` field is. Only
-    /// [`rows::FlockRows`] reads it; every other default impl ignores it,
-    /// so the retry `table_of` makes is a harmless no-op for anything else.
+    /// the seam the way every `Presentation` field is. Only a STATUS column
+    /// reads it, so the retry `table_of` makes is a harmless no-op for a
+    /// table that has none.
     fn rows_for(&self, _presentation: Presentation, _status_word: bool) -> Vec<Vec<String>> {
         self.rows()
     }
@@ -830,9 +855,37 @@ mod tests {
         assert!(!sheep_table.contains("bark"), "a dog is not a sheep");
         assert!(dogs_table.contains("bark"));
         assert!(!dogs_table.contains("web"));
+        // The dogs table DOES carry an ID column, and its columns line up
+        // with the sheep table's for every header the two share. It used to
+        // lead with NAME and put SOURCE second, so the two tables printed one
+        // under the other disagreed on the position of every column after the
+        // first. `DogRows`' own doc carries the ruling.
         assert!(
-            !dogs_table.starts_with("ID"),
-            "the dogs table has no ID column"
+            dogs_table.starts_with("ID"),
+            "the dogs table leads with ID, as the sheep table does: {dogs_table}"
+        );
+        let shared: Vec<&str> = dogs_table
+            .lines()
+            .next()
+            .unwrap()
+            .split_whitespace()
+            .take(9)
+            .collect();
+        assert_eq!(
+            shared,
+            [
+                "ID", "NAME", "STATUS", "PID", "RESTARTS", "EXIT", "CPU", "MEM", "UPTIME"
+            ],
+            "the nine shared columns, in the sheep table's own order"
+        );
+        assert!(
+            dogs_table
+                .lines()
+                .next()
+                .unwrap()
+                .trim_end()
+                .ends_with("SOURCE"),
+            "and this table's own column last"
         );
     }
 

--- a/crates/shep-cli/src/output/rows.rs
+++ b/crates/shep-cli/src/output/rows.rs
@@ -111,7 +111,7 @@ impl Render for FlockRows {
             Self::headers(),
             presentation,
             status_word,
-            |header, index| process_info_paint(header, &self.0[index]),
+            |header, _cell, index| process_info_paint(header, &self.0[index]),
         )
     }
 
@@ -250,6 +250,21 @@ pub(super) enum Paint {
 /// row longer than its header list is malformed, `render_table` has its own
 /// guard for that, and painting past the last header would be inventing a
 /// column name to key on.
+///
+/// # Why `paint_of` is handed the cell and not the row
+///
+/// Every rule in this module decides a column from its OWN value: SOURCE from
+/// the source text, OUTCOME from the outcome kind, RESULT from the result
+/// word. Handing the closure the whole row let those rules reach the deciding
+/// value by index -- `row[1]`, `row[2]`, `row[3]` -- which is the exact
+/// coupling keying on the header name exists to remove, just moved one level
+/// in. Reordering `DogEnabledRow::headers` would have repointed them with
+/// nothing failing to compile.
+///
+/// So the closure gets `(header, cell, index)` and there is no row to index
+/// into. `index` remains only for the rules keyed off the SOURCE STRUCT
+/// rather than the rendered text ([`process_info_paint`] reads a
+/// `ProcessInfo`), and it addresses the payload, never a sibling cell.
 pub(super) fn paint<F>(
     mut rows: Vec<Vec<String>>,
     headers: &[&'static str],
@@ -258,11 +273,11 @@ pub(super) fn paint<F>(
     paint_of: F,
 ) -> Vec<Vec<String>>
 where
-    F: Fn(&str, usize) -> Paint,
+    F: Fn(&str, &str, usize) -> Paint,
 {
     for (index, row) in rows.iter_mut().enumerate() {
         for (cell, header) in row.iter_mut().zip(headers) {
-            match paint_of(header, index) {
+            match paint_of(header, cell, index) {
                 Paint::Status(status) => *cell = status_cell(status, presentation, status_word),
                 Paint::Role(role) => colour_cell(cell, role, presentation),
                 Paint::Default => mute_a_dash(cell, presentation),
@@ -336,11 +351,14 @@ fn source_role(source: &DogSource) -> Role {
 /// The treatment the four dog-action rows wear: `enable`, `disable`, `adopt`
 /// and `rehome`, which share the columns `NAME SOURCE SHEPHERD STATUS`.
 ///
-/// Keyed off the RENDERED row rather than off the struct, unlike
+/// Keyed off the RENDERED cell rather than off the struct, unlike
 /// [`process_info_paint`]. The four types carry `source` as a `DogSource`, an
-/// `Option<DogSource>` and a `status` as free text, so reading the cells back
-/// is what lets one function serve all four instead of four near-identical
-/// ones differing only in how they reach the same two facts.
+/// `Option<DogSource>` and a `status` as free text, so reading the rendered
+/// text back is what lets one function serve all four instead of four
+/// near-identical ones differing only in how they reach the same two facts.
+///
+/// `cell` is the cell of the column named by `header`, never a sibling: see
+/// [`paint`]'s own doc for why this takes a cell rather than a row.
 ///
 /// SOURCE takes [`source_role`], the same trust distinction the dogs table
 /// draws. `rehome`'s can be absent, which renders `-` and reaches the dash
@@ -356,14 +374,14 @@ fn source_role(source: &DogSource) -> Role {
 /// would be a second decoration repeating its neighbour. That is the same
 /// reasoning `lookout/theme.rs` gives for keeping a face out of its own flock
 /// pane.
-fn dog_action_paint(header: &str, row: &[String]) -> Paint {
+fn dog_action_paint(header: &str, cell: &str) -> Paint {
     match header {
-        "SOURCE" => match row[1].as_str() {
+        "SOURCE" => match cell {
             "built-in" => Paint::Role(Role::Ink3),
             "-" => Paint::Default,
             _ => Paint::Role(Role::Butter),
         },
-        "STATUS" => status_named_by(&row[3]).map_or(Paint::Default, Paint::Status),
+        "STATUS" => status_named_by(cell).map_or(Paint::Default, Paint::Status),
         _ => Paint::Default,
     }
 }
@@ -404,10 +422,13 @@ fn outcome_role(kind: &str) -> Role {
 /// is free-form explanatory text of unbounded length, it is only ever present
 /// when OUTCOME has already said what happened, and colouring a whole
 /// sentence the colour of the word beside it is decoration.
-fn reply_paint(header: &str, row: &[String]) -> Paint {
+///
+/// `cell` is the cell of the column named by `header`, never a sibling: see
+/// [`paint`]'s own doc for why this takes a cell rather than a row.
+fn reply_paint(header: &str, cell: &str) -> Paint {
     match header {
         "ID" => Paint::Role(Role::Ink3),
-        "OUTCOME" => Paint::Role(outcome_role(&row[2])),
+        "OUTCOME" => Paint::Role(outcome_role(cell)),
         _ => Paint::Default,
     }
 }
@@ -731,7 +752,7 @@ impl Render for DogRows {
             Self::headers(),
             presentation,
             status_word,
-            |header, index| process_info_paint(header, &self.0[index]),
+            |header, _cell, index| process_info_paint(header, &self.0[index]),
         )
     }
 
@@ -918,7 +939,7 @@ impl Render for DogEnabledRow {
             Self::headers(),
             presentation,
             status_word,
-            |header, index| dog_action_paint(header, &rows[index]),
+            |header, cell, _index| dog_action_paint(header, cell),
         )
     }
 
@@ -996,7 +1017,7 @@ impl Render for DogDisabledRow {
             Self::headers(),
             presentation,
             status_word,
-            |header, index| dog_action_paint(header, &rows[index]),
+            |header, cell, _index| dog_action_paint(header, cell),
         )
     }
 
@@ -1066,7 +1087,7 @@ impl Render for DogAdoptedRow {
             Self::headers(),
             presentation,
             status_word,
-            |header, index| dog_action_paint(header, &rows[index]),
+            |header, cell, _index| dog_action_paint(header, cell),
         )
     }
 
@@ -1144,7 +1165,7 @@ impl Render for DogRehomedRow {
             Self::headers(),
             presentation,
             status_word,
-            |header, index| dog_action_paint(header, &rows[index]),
+            |header, cell, _index| dog_action_paint(header, cell),
         )
     }
 
@@ -1237,7 +1258,7 @@ impl Render for FlushedRows {
             Self::headers(),
             presentation,
             status_word,
-            |header, index| process_info_paint(header, &self.0[index]),
+            |header, _cell, index| process_info_paint(header, &self.0[index]),
         )
     }
 
@@ -1357,7 +1378,7 @@ impl Render for EmptiedFiles {
             Self::headers(),
             presentation,
             status_word,
-            |header, index| match (header, rows[index][2].as_str()) {
+            |header, cell, _index| match (header, cell) {
                 ("RESULT", "emptied") => Paint::Role(Role::Meadow),
                 ("RESULT", _) => Paint::Role(Role::Ink3),
                 _ => Paint::Default,
@@ -1472,7 +1493,7 @@ impl Render for KillRow {
             Self::headers(),
             presentation,
             status_word,
-            |header, _index| match header {
+            |header, _cell, _index| match header {
                 "SOCKET_REMOVED" if removed => Paint::Role(Role::Meadow),
                 "SOCKET_REMOVED" => Paint::Role(Role::Butter),
                 _ => Paint::Default,
@@ -1682,7 +1703,7 @@ impl Render for ImportRows {
             Self::headers(),
             presentation,
             status_word,
-            |header, index| match (header, rows[index][3].as_str()) {
+            |header, cell, _index| match (header, cell) {
                 ("REUSE_PORT", "true") => Paint::Role(Role::Butter),
                 _ => Paint::Default,
             },
@@ -1781,7 +1802,7 @@ impl Render for StartupSteps {
             Self::headers(),
             presentation,
             status_word,
-            |header, index| match (header, rows[index][2].as_str()) {
+            |header, cell, _index| match (header, cell) {
                 ("RESULT", "ok") => Paint::Role(Role::Meadow),
                 ("RESULT", "absent") => Paint::Role(Role::Ink3),
                 ("RESULT", _) => Paint::Role(Role::Bark),
@@ -1896,7 +1917,7 @@ impl Render for TriggeredRows {
             Self::headers(),
             presentation,
             status_word,
-            |header, index| reply_paint(header, &rows[index]),
+            |header, cell, _index| reply_paint(header, cell),
         )
     }
 
@@ -2034,7 +2055,7 @@ impl Render for SignalledRows {
             Self::headers(),
             presentation,
             status_word,
-            |header, index| reply_paint(header, &rows[index]),
+            |header, cell, _index| reply_paint(header, cell),
         )
     }
 
@@ -2118,7 +2139,7 @@ impl Render for SentLineRows {
             Self::headers(),
             presentation,
             status_word,
-            |header, index| reply_paint(header, &rows[index]),
+            |header, cell, _index| reply_paint(header, cell),
         )
     }
 
@@ -2216,10 +2237,10 @@ impl Render for BarkRows {
             Self::headers(),
             presentation,
             status_word,
-            |header, index| match header {
-                "SINKS" if rows[index][4] == "-" => Paint::Default,
-                "SINKS" if rows[index][4].contains("(failed)") => Paint::Role(Role::Bark),
-                "SINKS" => Paint::Role(Role::Meadow),
+            |header, cell, _index| match (header, cell) {
+                ("SINKS", "-") => Paint::Default,
+                ("SINKS", sinks) if sinks.contains("(failed)") => Paint::Role(Role::Bark),
+                ("SINKS", _) => Paint::Role(Role::Meadow),
                 _ => Paint::Default,
             },
         )
@@ -3848,7 +3869,7 @@ pub(crate) mod tests {
 
         let mut cells: Vec<String> = DogRows(vec![dog.clone()]).rows().remove(0);
         cells.reverse();
-        let painted_rows = paint(vec![cells], &backwards, coloured(), true, |header, _| {
+        let painted_rows = paint(vec![cells], &backwards, coloured(), true, |header, _, _| {
             process_info_paint(header, &dog)
         });
 
@@ -3869,6 +3890,113 @@ pub(crate) mod tests {
         );
         assert_eq!(painted_rows[0][at("NAME")], "log-rotate", "still plain");
         assert_eq!(painted_rows[0][at("UPTIME")], "41s", "still plain");
+    }
+
+    /// The same reversed-header proof, pointed at every painter that is NOT
+    /// [`process_info_paint`].
+    ///
+    /// The sibling of `a_columns_colour_follows_its_name_and_not_its_position`
+    /// and the reason it needed one. That test covered `process_info_paint`
+    /// alone, while `dog_action_paint`, `reply_paint` and the four inline
+    /// closures each dispatched on the header NAME and then read the deciding
+    /// value at a fixed index -- `row[1]`, `row[3]`, `row[2]`, `rows[i][4]`.
+    /// Reordering `DogEnabledRow::headers` would have repointed all of them
+    /// with nothing failing to compile and nothing here to notice, which is
+    /// the exact defect the by-name rule exists to remove, moved one level
+    /// in.
+    ///
+    /// `paint` now hands each rule its OWN cell, so there is no row to index
+    /// into and the class of bug is gone by construction rather than by
+    /// inspection. This is what says so: every table below is painted through
+    /// a REVERSED header list, so every column sits somewhere it never sits
+    /// in life, and each still wears its own rule.
+    #[test]
+    fn every_painter_follows_the_column_name_and_not_the_position() {
+        /// Paints `rows` through `T`'s headers in reverse, and hands back a
+        /// lookup from column name to painted cell.
+        fn reversed<T: Render>(row: Vec<String>, paint_of: fn(&str, &str) -> Paint) -> Vec<String> {
+            let backwards: Vec<&'static str> = T::headers().iter().copied().rev().collect();
+            let mut cells = row;
+            cells.reverse();
+            let mut painted = paint(
+                vec![cells],
+                &backwards,
+                coloured(),
+                true,
+                |header, cell, _index| paint_of(header, cell),
+            )
+            .remove(0);
+            painted.reverse();
+            painted
+        }
+        let at =
+            |headers: &[&'static str], name: &str| headers.iter().position(|h| *h == name).unwrap();
+
+        // --- the four dog-action rows, through `dog_action_paint` ---------
+        let adopted = DogAdoptedRow {
+            name: "log-rotate".to_string(),
+            source: DogSource::Adopted {
+                path: "/usr/local/bin/shep-log-rotate".to_string(),
+            },
+            shepherd_acted: true,
+            status: "online".to_string(),
+        };
+        let cells = reversed::<DogAdoptedRow>(adopted.rows().remove(0), dog_action_paint);
+        let h = DogAdoptedRow::headers();
+        assert_eq!(
+            cells[at(h, "SOURCE")],
+            painted("adopted", Role::Butter),
+            "SOURCE decided from SOURCE, wherever it sits"
+        );
+        assert_eq!(
+            cells[at(h, "STATUS")],
+            painted("(o.o) online", Role::Meadow),
+            "STATUS decided from STATUS"
+        );
+        assert_eq!(cells[at(h, "NAME")], "log-rotate", "NAME untouched");
+        assert_eq!(cells[at(h, "SHEPHERD")], "true", "SHEPHERD untouched");
+
+        // --- the three reply tables, through `reply_paint` ----------------
+        let reply = TriggeredRows(vec![ActionReply {
+            id: 0,
+            name: "web".to_string(),
+            outcome: ActionOutcome::TimedOut,
+        }]);
+        let cells = reversed::<TriggeredRows>(reply.rows().remove(0), reply_paint);
+        let h = TriggeredRows::headers();
+        assert_eq!(cells[at(h, "ID")], painted("0", Role::Ink3));
+        assert_eq!(cells[at(h, "OUTCOME")], painted("timed_out", Role::Bark));
+        assert_eq!(
+            cells[at(h, "DETAIL")],
+            "no reply within the app's own action_timeout",
+            "DETAIL untouched, and never mistaken for the OUTCOME beside it"
+        );
+
+        // --- the inline closures, which now share the same shape ----------
+        // Each of these decides its own column from its own cell, so driving
+        // them reversed proves the same property the two above do.
+        let emptied = EmptiedFiles(vec![EmptiedFile {
+            stream: "stdout",
+            file: "/logs/shepd.out.log".to_string(),
+            result: "emptied",
+        }])
+        .rows_for(coloured(), true);
+        assert_eq!(
+            emptied[0][at(EmptiedFiles::headers(), "RESULT")],
+            painted("emptied", Role::Meadow)
+        );
+
+        let steps = StartupSteps(vec![StartupStep {
+            action: "ran",
+            target: "launchctl load".to_string(),
+            result: "permission denied".to_string(),
+        }])
+        .rows_for(coloured(), true);
+        assert_eq!(
+            steps[0][at(StartupSteps::headers(), "RESULT")],
+            painted("permission denied", Role::Bark),
+            "an unrecognised RESULT is the failure line"
+        );
     }
 
     /// fails if SOURCE stops drawing the one trust distinction in the crate.

--- a/crates/shep-cli/src/output/rows.rs
+++ b/crates/shep-cli/src/output/rows.rs
@@ -106,19 +106,13 @@ impl Render for FlockRows {
     /// it on `Presentation` would have made it crate-wide state that ~100
     /// call sites construct for a question only this one method ever asks.
     fn rows_for(&self, presentation: Presentation, status_word: bool) -> Vec<Vec<String>> {
-        let mut rows = self.rows();
-        for (row, p) in rows.iter_mut().zip(&self.0) {
-            row[2] = status_cell(p.status, presentation, status_word);
-            colour_cell(&mut row[0], Role::Ink3, presentation);
-            mute_a_dash(&mut row[3], presentation);
-            colour_cell(&mut row[4], restarts_role(p.restarts), presentation);
-            colour_cell(&mut row[5], exit_role(p.pid, p.last_exit), presentation);
-            colour_cell(&mut row[6], cpu_role(p.cpu_percent), presentation);
-            colour_cell(&mut row[7], mem_role(p.memory_bytes), presentation);
-            colour_cell(&mut row[9], Role::Ink3, presentation);
-            mute_a_dash(&mut row[10], presentation);
-        }
-        rows
+        paint(
+            self.rows(),
+            Self::headers(),
+            presentation,
+            status_word,
+            |header, index| process_info_paint(header, &self.0[index]),
+        )
     }
 
     /// # Panics
@@ -229,6 +223,195 @@ fn status_cell(status: ProcStatus, presentation: Presentation, status_word: bool
     text
 }
 
+/// What one cell should become, decided from its column's NAME.
+///
+/// Three answers and no more, because a fourth would be a way to paint a cell
+/// without saying which rule painted it.
+#[derive(Debug, Clone, Copy)]
+pub(super) enum Paint {
+    /// Nothing of this cell's own. The `-` placeholder rule still applies,
+    /// which is the one treatment every table in the crate shares.
+    Default,
+    /// Wrap the cell in this role's span.
+    Role(Role),
+    /// Replace the cell with [`status_cell`]: the face, the word, and the
+    /// role the status wears. The only variant that changes CONTENT rather
+    /// than only colour, which is why STATUS cannot be expressed as a role.
+    Status(ProcStatus),
+}
+
+/// Paints one table's cells, asking `paint_of` for each by COLUMN NAME.
+///
+/// The single seam every colouring impl goes through. See
+/// [`Render::rows_for`](super::Render::rows_for) for why a name and never an
+/// index.
+///
+/// `zip` against `headers` deliberately stops at the shorter of the two: a
+/// row longer than its header list is malformed, `render_table` has its own
+/// guard for that, and painting past the last header would be inventing a
+/// column name to key on.
+pub(super) fn paint<F>(
+    mut rows: Vec<Vec<String>>,
+    headers: &[&'static str],
+    presentation: Presentation,
+    status_word: bool,
+    paint_of: F,
+) -> Vec<Vec<String>>
+where
+    F: Fn(&str, usize) -> Paint,
+{
+    for (index, row) in rows.iter_mut().enumerate() {
+        for (cell, header) in row.iter_mut().zip(headers) {
+            match paint_of(header, index) {
+                Paint::Status(status) => *cell = status_cell(status, presentation, status_word),
+                Paint::Role(role) => colour_cell(cell, role, presentation),
+                Paint::Default => mute_a_dash(cell, presentation),
+            }
+        }
+    }
+    rows
+}
+
+/// The treatment every column read off a [`ProcessInfo`] wears, wherever it
+/// appears.
+///
+/// Shared by `FlockRows`, `DogRows` and `FlushedRows`, which between them
+/// carry different subsets of these columns in different orders. That is the
+/// whole point: the sheep table and the dogs table now agree column for
+/// column, and neither impl restates a single rule.
+///
+/// A column absent from this match wears [`Paint::Default`], which is right
+/// for the three that genuinely have nothing to report: NAME and UPTIME (no
+/// state, and no threshold anyone agreed on), and OUT_FILE/ERR_FILE, which
+/// are the subject of `flush`'s table rather than a reading about it.
+fn process_info_paint(header: &str, p: &ProcessInfo) -> Paint {
+    match header {
+        // Chrome. Both are stable labels an operator reads past rather than
+        // reads, so they are muted for the same reason: an unchanging value
+        // must not draw the eye away from one that moves.
+        "ID" | "FOLD" => Paint::Role(Role::Ink3),
+        "STATUS" => Paint::Status(p.status),
+        "RESTARTS" => Paint::Role(restarts_role(p.restarts)),
+        "EXIT" => Paint::Role(exit_role(p.pid, p.last_exit)),
+        "CPU" => Paint::Role(cpu_role(p.cpu_percent)),
+        "MEM" => Paint::Role(mem_role(p.memory_bytes)),
+        "SOURCE" => p
+            .dog
+            .as_ref()
+            .map_or(Paint::Default, |source| Paint::Role(source_role(source))),
+        // PID and SMIT reach the dash rule, which is all either needs: a real
+        // pid and a real smit are both plain, and an absent one is muted.
+        _ => Paint::Default,
+    }
+}
+
+/// [`Role`] for a SOURCE cell: the only column in the crate carrying a TRUST
+/// distinction.
+///
+/// `built-in` is shep running its own code -- `metrics`, `bark` -- and is the
+/// unremarkable case, so it is muted like every other label that never needs
+/// a second look.
+///
+/// `adopted` is a third-party binary running at the daemon's own trust level,
+/// from a path an operator supplied, with no sandboxing beyond it. That is
+/// worth knowing at a glance and it is not a fault: the operator chose it
+/// deliberately. `Role::Butter` is exactly that distinction everywhere else
+/// in this module -- the same role a restart count above zero wears.
+///
+/// `unknown` -- a `DogSource` variant this client predates -- takes Butter
+/// too, and NOT `Role::Bark`. It is tempting to paint it as a fault, since it
+/// is the one value where shep cannot say what is running at its own trust
+/// level. But the dog is very often perfectly healthy and the real cause is a
+/// client older than its daemon; painting a working dog red is the same
+/// mistake `mem_role`'s own doc refuses when it declines a third tier. Both
+/// non-built-in values answer the question the column exists to answer --
+/// shep's own code, or something else -- and that is the line Rin drew.
+fn source_role(source: &DogSource) -> Role {
+    match source {
+        DogSource::BuiltIn => Role::Ink3,
+        _ => Role::Butter,
+    }
+}
+
+/// The treatment the four dog-action rows wear: `enable`, `disable`, `adopt`
+/// and `rehome`, which share the columns `NAME SOURCE SHEPHERD STATUS`.
+///
+/// Keyed off the RENDERED row rather than off the struct, unlike
+/// [`process_info_paint`]. The four types carry `source` as a `DogSource`, an
+/// `Option<DogSource>` and a `status` as free text, so reading the cells back
+/// is what lets one function serve all four instead of four near-identical
+/// ones differing only in how they reach the same two facts.
+///
+/// SOURCE takes [`source_role`], the same trust distinction the dogs table
+/// draws. `rehome`'s can be absent, which renders `-` and reaches the dash
+/// rule instead.
+///
+/// STATUS is coloured only when it NAMES a status. The field holds either a
+/// real `ProcStatus` rendering or a sentence saying why no shepherd answered,
+/// and a sentence has no role to wear; painting one would be decoration.
+///
+/// SHEPHERD is left plain, and it was the closest call here. `false` is worth
+/// knowing -- the config changed and nothing is running yet -- but the STATUS
+/// cell beside it already says exactly that in a whole sentence, so a colour
+/// would be a second decoration repeating its neighbour. That is the same
+/// reasoning `lookout/theme.rs` gives for keeping a face out of its own flock
+/// pane.
+fn dog_action_paint(header: &str, row: &[String]) -> Paint {
+    match header {
+        "SOURCE" => match row[1].as_str() {
+            "built-in" => Paint::Role(Role::Ink3),
+            "-" => Paint::Default,
+            _ => Paint::Role(Role::Butter),
+        },
+        "STATUS" => status_named_by(&row[3]).map_or(Paint::Default, Paint::Status),
+        _ => Paint::Default,
+    }
+}
+
+/// [`Role`] for one OUTCOME cell, over the eleven kinds the three per-sheep
+/// reply tables between them produce (`trigger`, `signal`, `whisper`).
+///
+/// One function rather than three, because no two of the three vocabularies
+/// share a kind with a different meaning, and because the four tiers answer
+/// the same question every time: did it work, is there nothing to report, is
+/// there a gap the operator can close, or did it fail.
+///
+/// - `Meadow` -- it worked.
+/// - `Ink3` -- nothing to report. `skipped` is a reload drainee and
+///   `not_running` is a sheep with no live process; neither is a failure and
+///   neither is news, which is what a muted cell says everywhere else here.
+/// - `Butter` -- a gap the operator can close. `no_channel` and `no_stdin`
+///   each name the config field that would have opened one.
+/// - `Bark` -- it failed. Reserved for exactly that, as everywhere else.
+///
+/// An unrecognised kind takes `Butter` rather than `Bark`: it means this
+/// client is older than the daemon, not that anything is broken. The same
+/// call [`source_role`] makes for its own `unknown`.
+fn outcome_role(kind: &str) -> Role {
+    match kind {
+        "replied" | "delivered" | "sent" => Role::Meadow,
+        "skipped" | "not_running" => Role::Ink3,
+        "timed_out" | "failed" | "not_written" => Role::Bark,
+        _ => Role::Butter,
+    }
+}
+
+/// The treatment the three per-sheep reply tables wear. They share the
+/// columns `ID NAME OUTCOME DETAIL` exactly.
+///
+/// ID is muted, the same chrome call [`process_info_paint`] makes for the
+/// same column name. OUTCOME takes [`outcome_role`]. DETAIL is left plain: it
+/// is free-form explanatory text of unbounded length, it is only ever present
+/// when OUTCOME has already said what happened, and colouring a whole
+/// sentence the colour of the word beside it is decoration.
+fn reply_paint(header: &str, row: &[String]) -> Paint {
+    match header {
+        "ID" => Paint::Role(Role::Ink3),
+        "OUTCOME" => Paint::Role(outcome_role(&row[2])),
+        _ => Paint::Default,
+    }
+}
+
 /// The [`ProcStatus`] a free-text STATUS cell is naming, if it is naming one.
 ///
 /// The dog-action rows ([`DogEnabledRow`] and its three siblings) carry
@@ -257,10 +440,12 @@ fn status_named_by(text: &str) -> Option<ProcStatus> {
 /// Colours a cell [`Role::Ink3`] when it holds the `-` placeholder, and
 /// leaves it alone otherwise.
 ///
-/// `FlockRows` applies this to PID and SMIT; the rule is that an absent value
-/// must not compete with a real one, and it is the same rule wherever a table
-/// prints a dash. Factored out because seven tables now want it.
-fn mute_a_dash(cell: &mut String, presentation: Presentation) {
+/// The rule is that an absent value must not compete with a real one, and it
+/// holds wherever a table prints a dash. It is [`Render::rows_for`]'s own
+/// default now, so every table in the crate gets it without asking and no
+/// impl has to remember; [`Paint::Default`] is what an impl returns to say
+/// "this cell has nothing of its own to say, apply the dash rule".
+pub(super) fn mute_a_dash(cell: &mut String, presentation: Presentation) {
     if cell == "-" {
         colour_cell(cell, Role::Ink3, presentation);
     }
@@ -272,7 +457,7 @@ fn mute_a_dash(cell: &mut String, presentation: Presentation) {
 /// dresses up (STATUS included, through [`status_cell`] above) goes through
 /// the identical wrap rather than each cell reimplementing the same two
 /// lines.
-fn colour_cell(cell: &mut String, role: Role, presentation: Presentation) {
+pub(super) fn colour_cell(cell: &mut String, role: Role, presentation: Presentation) {
     if !presentation.colour {
         return;
     }
@@ -452,14 +637,37 @@ fn signal_label(raw: i32) -> String {
 }
 
 /// The dogs half of a flock listing: the `ProcessInfo`s whose `dog` marker
-/// is set, rendered by where they came from rather than by their place in
-/// the flock.
+/// is set.
 ///
-/// No `ID` column, and that is the point of the split rather than an
-/// omission: ids reflect spawn order across one registry, so a dog booted
-/// alongside the flock lands among the sheep's numbers. Nobody sees that,
-/// because the two populations are never rendered together — which is what
-/// makes the shared id space cost nothing at the surface.
+/// # The columns line up with the sheep table
+///
+/// Every column the two tables share sits in the same ORDER, and each
+/// table's own columns come last:
+///
+/// ```text
+/// common:  ID  NAME  STATUS  PID  RESTARTS  EXIT  CPU  MEM  UPTIME
+/// sheep:   ... + FOLD  SMIT
+/// dogs:    ... + SOURCE
+/// ```
+///
+/// So an operator reading one table has learned the other. This used to have
+/// `SOURCE` second and no `ID` or `EXIT` at all, so the two tables printed
+/// under one `shep flock` disagreed on the position of every column after
+/// the first.
+///
+/// `ID` was left out deliberately once, on the grounds that ids reflect
+/// spawn order across the one registry so a dog booted alongside the flock
+/// lands among the sheep's numbers. Rin's ruling is that lining the tables
+/// up is worth more: the id is real, it is what `shep stop <id>` takes, and
+/// hiding it made the two tables look like different kinds of thing.
+/// `EXIT` joins for the same reason and needs no wire change either -- a dog
+/// exits exactly as a sheep does, and `last_exit` was already on the
+/// `ProcessInfo` this builds from, unrendered.
+///
+/// `FOLD` and `SMIT` stay off, and that is a different kind of absence: they
+/// are IMPOSSIBLE rather than empty. A dog belongs to no fold, and a smit is
+/// a mark a dog paints on a sheep, never one anything paints on a dog. A
+/// column that is structurally `-` on every row teaches nothing.
 #[derive(Debug, Serialize)]
 #[serde(transparent)]
 pub struct DogRows(pub Vec<ProcessInfo>);
@@ -479,7 +687,7 @@ fn dog_source_label(source: &DogSource) -> &'static str {
 impl Render for DogRows {
     fn headers() -> &'static [&'static str] {
         &[
-            "NAME", "SOURCE", "STATUS", "PID", "RESTARTS", "CPU", "MEM", "UPTIME",
+            "ID", "NAME", "STATUS", "PID", "RESTARTS", "EXIT", "CPU", "MEM", "UPTIME", "SOURCE",
         ]
     }
 
@@ -488,7 +696,17 @@ impl Render for DogRows {
             .iter()
             .map(|p| {
                 vec![
+                    p.id.to_string(),
                     p.name.clone(),
+                    p.status.to_string(),
+                    p.pid.map_or_else(|| "-".to_string(), |pid| pid.to_string()),
+                    p.restarts.to_string(),
+                    exit_cell(p.pid, p.last_exit),
+                    p.cpu_percent
+                        .map_or_else(|| "-".to_string(), |cpu| format!("{cpu:.1}%")),
+                    p.memory_bytes
+                        .map_or_else(|| "-".to_string(), super::human_bytes),
+                    super::human_duration(p.uptime_ms),
                     // Never the adopted path — see `Self::JSON_ONLY`'s
                     // sibling reasoning on `FlockRows` for why a path stays
                     // out of the table. `None` reads as `-`: this row only
@@ -498,44 +716,23 @@ impl Render for DogRows {
                     p.dog.as_ref().map_or("-".to_string(), |source| {
                         dog_source_label(source).to_string()
                     }),
-                    p.status.to_string(),
-                    p.pid.map_or_else(|| "-".to_string(), |pid| pid.to_string()),
-                    p.restarts.to_string(),
-                    p.cpu_percent
-                        .map_or_else(|| "-".to_string(), |cpu| format!("{cpu:.1}%")),
-                    p.memory_bytes
-                        .map_or_else(|| "-".to_string(), super::human_bytes),
-                    super::human_duration(p.uptime_ms),
                 ]
             })
             .collect()
     }
 
-    /// The same treatment `FlockRows` gives its own columns, on the five this
-    /// table shares with it, so the same dog reads the same way under
-    /// `shep dogs` as a sheep does under `shep flock`.
-    ///
-    /// STATUS takes the face and the colour ([`status_cell`]); RESTARTS,
-    /// CPU and MEM take the same three ramps; a `-` in PID is muted.
-    ///
-    /// SOURCE is muted throughout rather than ramped. It says where a
-    /// binary came from, never whether the dog is healthy, which is exactly
-    /// the role FOLD plays in the sheep table -- and this table's own
-    /// `PRIORITIES` already treats the two as the same kind of column.
-    ///
-    /// NAME and UPTIME stay plain, matching `FlockRows`: a name has no state
-    /// to report, and an uptime has no threshold anyone agreed on.
+    /// [`process_info_paint`], the same function `FlockRows` uses. Nine of
+    /// this table's ten columns are shared with that one and now wear
+    /// identical treatments; SOURCE is the tenth and is the only rule
+    /// neither table states twice.
     fn rows_for(&self, presentation: Presentation, status_word: bool) -> Vec<Vec<String>> {
-        let mut rows = self.rows();
-        for (row, p) in rows.iter_mut().zip(&self.0) {
-            colour_cell(&mut row[1], Role::Ink3, presentation);
-            row[2] = status_cell(p.status, presentation, status_word);
-            mute_a_dash(&mut row[3], presentation);
-            colour_cell(&mut row[4], restarts_role(p.restarts), presentation);
-            colour_cell(&mut row[5], cpu_role(p.cpu_percent), presentation);
-            colour_cell(&mut row[6], mem_role(p.memory_bytes), presentation);
-        }
-        rows
+        paint(
+            self.rows(),
+            Self::headers(),
+            presentation,
+            status_word,
+            |header, index| process_info_paint(header, &self.0[index]),
+        )
     }
 
     /// # Panics
@@ -543,62 +740,53 @@ impl Render for DogRows {
     #[track_caller]
     fn json_key_for(header: &str) -> &'static str {
         match header {
+            "ID" => "id",
             "NAME" => "name",
-            "SOURCE" => "dog",
             "STATUS" => "status",
             "PID" => "pid",
             "RESTARTS" => "restarts",
+            "EXIT" => "last_exit",
             "CPU" => "cpu_percent",
             "MEM" => "memory_bytes",
             "UPTIME" => "uptime_ms",
+            "SOURCE" => "dog",
             other => panic!("DogRows::headers() does not include {other:?}"),
         }
     }
 
     const JSON_ONLY: &'static [&'static str] = &[
-        // Ids reflect spawn order across the one registry shared with the
-        // sheep half; a dog booted alongside the flock lands among the
-        // sheep's own numbers. No column, because the two populations are
-        // never rendered together for that number to be compared against —
-        // see this type's own doc comment.
-        "id",
         // Fold membership is a sheep concept — a dog is supervised, never
-        // grouped for a selector to match by fold.
+        // grouped for a selector to match by fold. Structurally absent, not
+        // merely empty, which is why it stays out of the table even now that
+        // the two tables otherwise line up.
         "fold",
         // Same reason `FlockRows` keeps them out of its own table: absolute
         // paths, often longer than every other column put together. They
         // ride the JSON so a programmatic consumer can still find them.
-        "out_file",
-        "err_file",
+        "out_file", "err_file",
         // Always `null` here: only `Describe` walks for lambs, and this
         // table renders `ListFlock`'s dog half. A dog is one process by
         // contract, so a lamb tree for one is not a rendering this table
         // needs to grow to cover.
         "lambs",
-        // No EXIT column here (task 49): the task that added `last_exit`
-        // scoped the new table column to `shep flock`'s own sheep table.
-        // Rides the JSON anyway, same as every other field on this wire, so
-        // a consumer switching on `ProcessInfo` shape alone still sees it.
-        "last_exit",
-        // A dog paints smits; nothing paints one on a dog. Always `null`
-        // here, and in the JSON for the same shape-consistency reason as the
-        // rest of this list.
+        // A dog paints smits; nothing paints one on a dog. Structurally
+        // absent, like `fold` above, and in the JSON for the same
+        // shape-consistency reason as the rest of this list.
         "smit",
     ];
 
-    // Parallel to `headers()` above: `["NAME", "SOURCE", "STATUS", "PID",
-    // "RESTARTS", "CPU", "MEM", "UPTIME"]`. NAME and STATUS are what
-    // identify a row -- the same floor `FlockRows` uses for its own
-    // ID/NAME/STATUS -- so they sit at `0`. The five columns this table
-    // shares with `FlockRows` (UPTIME, PID, MEM, RESTARTS, CPU) keep that
-    // table's own drop order exactly, so an operator who has learned one
-    // table's behaviour is not surprised by the other. SOURCE is the one
-    // column this table has that `FlockRows` does not: it says where the
-    // binary came from, not whether the dog is healthy, so it is the least
-    // essential column here -- the same role `FOLD` plays for the flock --
-    // and drops first. `dog_priorities_line_up_with_dog_headers` (below)
-    // pins both the length and which two columns sit at `0`.
-    const PRIORITIES: &'static [u8] = &[0, 6, 0, 2, 4, 5, 3, 1];
+    // Parallel to `headers()` above: `["ID", "NAME", "STATUS", "PID",
+    // "RESTARTS", "EXIT", "CPU", "MEM", "UPTIME", "SOURCE"]`. Now that the
+    // columns line up with the sheep table, so do their drop priorities:
+    // every one of the nine shared columns carries the exact number
+    // `FlockRows` gives it, so a narrowing terminal takes the two tables
+    // apart in the same order and an operator who has learned one is not
+    // surprised by the other. SOURCE takes `7`, the slot `FOLD` holds over
+    // there, for the reason that made them the same kind of column before
+    // this reorder: it says where the binary came from, not whether the dog
+    // is healthy. `dog_priorities_line_up_with_dog_headers` (below) pins
+    // both the length and which three columns sit at `0`.
+    const PRIORITIES: &'static [u8] = &[0, 0, 0, 2, 4, 6, 5, 3, 1, 7];
 }
 
 /// One sheep's lamb tree, as `describe`'s second table.
@@ -614,15 +802,14 @@ impl Render for DogRows {
 #[derive(Debug, Serialize)]
 pub struct LambRows(pub Vec<Lamb>);
 
-/// `LambRows` gets NO colour, and that is a decision rather than an
-/// omission.
+/// No colour, and that is a decision rather than an omission.
 ///
-/// Both its columns are identity: which process, and what it is running. A
-/// lamb has no status, no restart count, no resource reading, and no
-/// placeholder -- `pid` is a real number on every row and `name` is a real
-/// string. There is nothing here for a colour to carry, and the rule is that
-/// every colour carries information. Muting one of two columns would just be
-/// picking one to look faded.
+/// Both columns are identity: which process, and what it is running. A lamb
+/// has no status, no restart count, no resource reading, and no placeholder
+/// -- `pid` is a real number on every row and `name` is a real string. There
+/// is nothing here for a colour to carry, and the rule is that every colour
+/// carries information. Muting one of two columns would just be picking one
+/// to look faded.
 impl Render for LambRows {
     fn headers() -> &'static [&'static str] {
         &["PID", "NAME"]
@@ -725,13 +912,14 @@ impl Render for DogEnabledRow {
     ///
     /// NAME stays plain, matching every other table in this module.
     fn rows_for(&self, presentation: Presentation, status_word: bool) -> Vec<Vec<String>> {
-        let mut rows = self.rows();
-        let row = &mut rows[0];
-        colour_cell(&mut row[1], Role::Ink3, presentation);
-        if let Some(status) = status_named_by(&row[3]) {
-            row[3] = status_cell(status, presentation, status_word);
-        }
-        rows
+        let rows = self.rows();
+        paint(
+            rows.clone(),
+            Self::headers(),
+            presentation,
+            status_word,
+            |header, index| dog_action_paint(header, &rows[index]),
+        )
     }
 
     /// # Panics
@@ -802,13 +990,14 @@ impl Render for DogDisabledRow {
 
     /// Same treatment, same reasoning, as [`DogEnabledRow::rows_for`].
     fn rows_for(&self, presentation: Presentation, status_word: bool) -> Vec<Vec<String>> {
-        let mut rows = self.rows();
-        let row = &mut rows[0];
-        colour_cell(&mut row[1], Role::Ink3, presentation);
-        if let Some(status) = status_named_by(&row[3]) {
-            row[3] = status_cell(status, presentation, status_word);
-        }
-        rows
+        let rows = self.rows();
+        paint(
+            rows.clone(),
+            Self::headers(),
+            presentation,
+            status_word,
+            |header, index| dog_action_paint(header, &rows[index]),
+        )
     }
 
     /// # Panics
@@ -871,13 +1060,14 @@ impl Render for DogAdoptedRow {
 
     /// Same treatment, same reasoning, as [`DogEnabledRow::rows_for`].
     fn rows_for(&self, presentation: Presentation, status_word: bool) -> Vec<Vec<String>> {
-        let mut rows = self.rows();
-        let row = &mut rows[0];
-        colour_cell(&mut row[1], Role::Ink3, presentation);
-        if let Some(status) = status_named_by(&row[3]) {
-            row[3] = status_cell(status, presentation, status_word);
-        }
-        rows
+        let rows = self.rows();
+        paint(
+            rows.clone(),
+            Self::headers(),
+            presentation,
+            status_word,
+            |header, index| dog_action_paint(header, &rows[index]),
+        )
     }
 
     /// # Panics
@@ -948,13 +1138,14 @@ impl Render for DogRehomedRow {
 
     /// Same treatment, same reasoning, as [`DogEnabledRow::rows_for`].
     fn rows_for(&self, presentation: Presentation, status_word: bool) -> Vec<Vec<String>> {
-        let mut rows = self.rows();
-        let row = &mut rows[0];
-        colour_cell(&mut row[1], Role::Ink3, presentation);
-        if let Some(status) = status_named_by(&row[3]) {
-            row[3] = status_cell(status, presentation, status_word);
-        }
-        rows
+        let rows = self.rows();
+        paint(
+            rows.clone(),
+            Self::headers(),
+            presentation,
+            status_word,
+            |header, index| dog_action_paint(header, &rows[index]),
+        )
     }
 
     /// # Panics
@@ -1030,30 +1221,24 @@ impl Render for FlushedRows {
             .collect()
     }
 
-    /// Two of the four columns, and no more, because two of them have
-    /// nothing to say.
+    /// [`process_info_paint`] again, which for this table's four columns
+    /// comes out as: ID muted like every other id, NAME plain, and both path
+    /// columns left to the dash rule.
     ///
-    /// ID is muted, exactly as `FlockRows` mutes its own: it never changes
-    /// and it is chrome beside the thing this table is about.
-    ///
-    /// A `-` in either path column is muted, the placeholder rule this
-    /// module applies everywhere. A real path is left plain: it is the
-    /// subject of the table rather than a reading about it, there is no
-    /// threshold to ramp against and no fault to mark, and colouring the
-    /// widest column on the row for no information would be exactly the
-    /// decoration the rule forbids.
-    ///
-    /// No STATUS column here at all -- see this type's own doc for why
-    /// `flush` renders the files rather than the lifecycle -- so there is no
-    /// face and no status colour to give.
-    fn rows_for(&self, presentation: Presentation, _status_word: bool) -> Vec<Vec<String>> {
-        let mut rows = self.rows();
-        for row in &mut rows {
-            colour_cell(&mut row[0], Role::Ink3, presentation);
-            mute_a_dash(&mut row[2], presentation);
-            mute_a_dash(&mut row[3], presentation);
-        }
-        rows
+    /// A real path is deliberately plain. It is the subject of the table
+    /// rather than a reading about it, there is no threshold to ramp against
+    /// and no fault to mark, and colouring the widest column on the row for
+    /// no information is exactly the decoration the rule forbids. No STATUS
+    /// column here at all -- see this type's own doc for why `flush` renders
+    /// the files rather than the lifecycle.
+    fn rows_for(&self, presentation: Presentation, status_word: bool) -> Vec<Vec<String>> {
+        paint(
+            self.rows(),
+            Self::headers(),
+            presentation,
+            status_word,
+            |header, index| process_info_paint(header, &self.0[index]),
+        )
     }
 
     /// # Panics
@@ -1160,6 +1345,26 @@ impl Render for EmptiedFiles {
             .collect()
     }
 
+    /// RESULT alone. `emptied` means a file was truncated; `absent` means
+    /// there was none to truncate, which is the state `flush` was asked to
+    /// produce rather than a failure, so it is muted rather than marked.
+    /// STREAM is one of two fixed words and FILE is a path; neither varies
+    /// in a way a colour could carry.
+    fn rows_for(&self, presentation: Presentation, status_word: bool) -> Vec<Vec<String>> {
+        let rows = self.rows();
+        paint(
+            rows.clone(),
+            Self::headers(),
+            presentation,
+            status_word,
+            |header, index| match (header, rows[index][2].as_str()) {
+                ("RESULT", "emptied") => Paint::Role(Role::Meadow),
+                ("RESULT", _) => Paint::Role(Role::Ink3),
+                _ => Paint::Default,
+            },
+        )
+    }
+
     /// # Panics
     /// If `header` is not one of `Self::headers()`'s own values.
     #[track_caller]
@@ -1198,6 +1403,14 @@ impl Render for EmptiedFiles {
 #[serde(transparent)]
 pub struct DeletedIds(pub Vec<u32>);
 
+/// No colour, and NOT the muted ID every other table gives that column.
+///
+/// An ID is chrome elsewhere because it sits beside content and must not draw
+/// the eye away from it. Here it is the only column and it is the content, so
+/// muting it would fade the whole table and distinguish nothing. The same
+/// header can want different treatment when it is the entire row, which is
+/// the one place keying on the column name needs a deliberate exception
+/// rather than a shared rule.
 impl Render for DeletedIds {
     fn headers() -> &'static [&'static str] {
         &["ID"]
@@ -1244,6 +1457,27 @@ impl Render for KillRow {
 
     fn rows(&self) -> Vec<Vec<String>> {
         vec![vec![self.pid.to_string(), self.socket_removed.to_string()]]
+    }
+
+    /// SOCKET_REMOVED alone, and it earns a colour where most booleans in
+    /// this module do not: `false` means the socket file outlived the
+    /// daemon, which is exactly what the next boot has to contend with.
+    /// `Butter` and not `Bark` -- a leftover to clear is not a crash. PID
+    /// belongs to a process that has just gone away; there is nothing left
+    /// to say about it.
+    fn rows_for(&self, presentation: Presentation, status_word: bool) -> Vec<Vec<String>> {
+        let removed = self.socket_removed;
+        paint(
+            self.rows(),
+            Self::headers(),
+            presentation,
+            status_word,
+            |header, _index| match header {
+                "SOCKET_REMOVED" if removed => Paint::Role(Role::Meadow),
+                "SOCKET_REMOVED" => Paint::Role(Role::Butter),
+                _ => Paint::Default,
+            },
+        )
     }
 
     /// # Panics
@@ -1300,6 +1534,29 @@ impl Render for RolledSheepRows {
             .collect()
     }
 
+    /// STATUS gets the face and the role every other STATUS column in this
+    /// module gets, which is the whole point of keying the treatment on the
+    /// column NAME: the same header means the same thing everywhere.
+    ///
+    /// It is a constant here -- `query.rs` writes the literal `stopped` on
+    /// every row, because nothing in a saved roll is running -- so the colour
+    /// draws no comparison BETWEEN rows. It still carries the fact, and a
+    /// reader who has learned `(-.-)` elsewhere reads this table without
+    /// being told. INSTANCES is a count with no threshold anyone agreed on.
+    fn rows_for(&self, presentation: Presentation, status_word: bool) -> Vec<Vec<String>> {
+        let rows = self.rows();
+        paint(
+            rows.clone(),
+            Self::headers(),
+            presentation,
+            status_word,
+            |header, index| match header {
+                "STATUS" => status_named_by(&rows[index][2]).map_or(Paint::Default, Paint::Status),
+                _ => Paint::Default,
+            },
+        )
+    }
+
     /// # Panics
     /// If `header` is not one of [`Self::headers`]'s own values.
     #[track_caller]
@@ -1341,6 +1598,9 @@ pub struct SavedRollRow {
     pub apps: u32,
 }
 
+/// No colour. A path and a count, both of them the report itself rather than
+/// a reading about it: no state, no threshold, and no outcome. Nothing here
+/// for a colour to carry.
 impl Render for SavedRollRow {
     fn headers() -> &'static [&'static str] {
         &["FILE", "APPS"]
@@ -1414,6 +1674,27 @@ impl Render for ImportRows {
                 ]
             })
             .collect()
+    }
+
+    /// REUSE_PORT alone, and only when it is `true`. This type's own doc
+    /// calls it "the column an operator scans for at a glance": a `true`
+    /// means the imported app relied on pm2 binding the port for it, shep
+    /// binds nothing, and the app itself has to set `SO_REUSEPORT`. That is
+    /// work the operator has to do, so it takes the same `Butter` a restart
+    /// count above zero takes. A `false` is the ordinary case and says
+    /// nothing.
+    fn rows_for(&self, presentation: Presentation, status_word: bool) -> Vec<Vec<String>> {
+        let rows = self.rows();
+        paint(
+            rows.clone(),
+            Self::headers(),
+            presentation,
+            status_word,
+            |header, index| match (header, rows[index][3].as_str()) {
+                ("REUSE_PORT", "true") => Paint::Role(Role::Butter),
+                _ => Paint::Default,
+            },
+        )
     }
 
     /// # Panics
@@ -1490,6 +1771,31 @@ impl Render for StartupSteps {
                 ]
             })
             .collect()
+    }
+
+    /// RESULT alone, over its three shapes. `ok` worked. `absent` is an
+    /// `unstartup` that found no unit to remove, which is the state it was
+    /// asked to produce rather than a failure (that field's own doc says
+    /// so), so it is muted. Anything else is the failure in one line, and a
+    /// half-installed unit is exactly what this verb's table exists to
+    /// catch, so it takes `Bark`.
+    ///
+    /// ACTION is one of three fixed words and TARGET is a path or a command;
+    /// neither varies in a way a colour could carry.
+    fn rows_for(&self, presentation: Presentation, status_word: bool) -> Vec<Vec<String>> {
+        let rows = self.rows();
+        paint(
+            rows.clone(),
+            Self::headers(),
+            presentation,
+            status_word,
+            |header, index| match (header, rows[index][2].as_str()) {
+                ("RESULT", "ok") => Paint::Role(Role::Meadow),
+                ("RESULT", "absent") => Paint::Role(Role::Ink3),
+                ("RESULT", _) => Paint::Role(Role::Bark),
+                _ => Paint::Default,
+            },
+        )
     }
 
     /// # Panics
@@ -1588,6 +1894,18 @@ impl Render for TriggeredRows {
                 ]
             })
             .collect()
+    }
+
+    /// [`reply_paint`], shared with the other two per-sheep reply tables.
+    fn rows_for(&self, presentation: Presentation, status_word: bool) -> Vec<Vec<String>> {
+        let rows = self.rows();
+        paint(
+            rows.clone(),
+            Self::headers(),
+            presentation,
+            status_word,
+            |header, index| reply_paint(header, &rows[index]),
+        )
     }
 
     /// # Panics
@@ -1716,6 +2034,18 @@ impl Render for SignalledRows {
             .collect()
     }
 
+    /// [`reply_paint`], shared with the other two per-sheep reply tables.
+    fn rows_for(&self, presentation: Presentation, status_word: bool) -> Vec<Vec<String>> {
+        let rows = self.rows();
+        paint(
+            rows.clone(),
+            Self::headers(),
+            presentation,
+            status_word,
+            |header, index| reply_paint(header, &rows[index]),
+        )
+    }
+
     /// # Panics
     /// If `header` is not one of `Self::headers()`'s own values.
     #[track_caller]
@@ -1786,6 +2116,18 @@ impl Render for SentLineRows {
                 ]
             })
             .collect()
+    }
+
+    /// [`reply_paint`], shared with the other two per-sheep reply tables.
+    fn rows_for(&self, presentation: Presentation, status_word: bool) -> Vec<Vec<String>> {
+        let rows = self.rows();
+        paint(
+            rows.clone(),
+            Self::headers(),
+            presentation,
+            status_word,
+            |header, index| reply_paint(header, &rows[index]),
+        )
     }
 
     /// # Panics
@@ -1862,6 +2204,33 @@ impl Render for BarkRows {
                 ]
             })
             .collect()
+    }
+
+    /// SINKS alone. A bark that reached every sink it was configured for is
+    /// `Meadow`; one where any sink refused carries `(failed)` in the cell
+    /// ([`sinks_cell`]) and is `Bark`, which is a real delivery failure and
+    /// the reason an operator reads this table at all. A bark with no sinks
+    /// renders `-` and reaches the dash rule.
+    ///
+    /// WHEN is left plain even though it is the same shape of column ID is,
+    /// and the difference is worth stating: an id never changes and is read
+    /// past, while a timestamp is the thing an operator scans an alert feed
+    /// BY. Muting it would fade the column doing the most work. RULE,
+    /// SUBJECT and MESSAGE are the record itself.
+    fn rows_for(&self, presentation: Presentation, status_word: bool) -> Vec<Vec<String>> {
+        let rows = self.rows();
+        paint(
+            rows.clone(),
+            Self::headers(),
+            presentation,
+            status_word,
+            |header, index| match header {
+                "SINKS" if rows[index][4] == "-" => Paint::Default,
+                "SINKS" if rows[index][4].contains("(failed)") => Paint::Role(Role::Bark),
+                "SINKS" => Paint::Role(Role::Meadow),
+                _ => Paint::Default,
+            },
+        )
     }
 
     /// # Panics
@@ -1956,6 +2325,8 @@ pub struct KvEntry {
 #[serde(transparent)]
 pub struct KvRows(pub Vec<KvEntry>);
 
+/// No colour. The store is opaque to shep: a key and a value are operator
+/// data, and shep has no opinion about either that a colour could express.
 impl Render for KvRows {
     fn headers() -> &'static [&'static str] {
         &["KEY", "VALUE"]
@@ -2002,6 +2373,13 @@ impl Render for KvRows {
 #[serde(transparent)]
 pub struct AvailableDogRows(pub Vec<AvailableDog>);
 
+/// No colour, and CATEGORY is the near miss worth naming. It is an
+/// organisational label, which is the shape `FOLD` and `SOURCE` both get
+/// muted for. But those two are muted so they recede behind a STATUS column
+/// beside them, and this table has no status and describes nothing that is
+/// running: it is a catalogue of dogs an operator could adopt. With no signal
+/// column for chrome to recede behind, muting one of four would be picking a
+/// column to look faded rather than telling anyone anything.
 impl Render for AvailableDogRows {
     fn headers() -> &'static [&'static str] {
         &["NAME", "PACKAGE", "CATEGORY", "DESCRIPTION"]
@@ -2074,6 +2452,17 @@ pub struct KvUnsetRow {
     pub removed: u32,
 }
 
+/// No colour, for [`DeletedIds`]' reason and one of its own.
+///
+/// One column, which is also the whole content: muting it would fade the
+/// entire table and distinguish nothing, since there is no second column for
+/// a muted one to recede behind.
+///
+/// `removed` is also a COUNT rather than an outcome, and it is `1` on every
+/// single-key `unset` -- a key that was not there exits `NotFound` before
+/// this is ever built (see the field's own doc). So the only value a colour
+/// could distinguish is `--all` against an already-empty store, and `0`
+/// reads as `0`.
 impl Render for KvUnsetRow {
     fn headers() -> &'static [&'static str] {
         &["REMOVED"]
@@ -2393,13 +2782,15 @@ pub(crate) mod tests {
     /// JSON value is the tagged `DogSource` object (`{"kind": "built_in"}`
     /// or `{"kind": "adopted", "path": ...}`), not a plain string this
     /// gate's cell comparison knows how to stringify — the test above pins
-    /// that mapping instead.
+    /// that mapping instead. `EXIT` joins for exactly the reason
+    /// `flock_rows_do_not_drift` gives for its own: `last_exit` is a nested
+    /// object, not a scalar.
     #[test]
     fn dog_rows_do_not_drift() {
         assert_no_drift(
             &DogRows(vec![dog_info("metrics", DogSource::BuiltIn)]),
             |j| &j[0],
-            &["UPTIME", "CPU", "MEM", "SOURCE"],
+            &["UPTIME", "CPU", "MEM", "SOURCE", "EXIT"],
         );
     }
 
@@ -3142,7 +3533,7 @@ pub(crate) mod tests {
     #[test]
     fn priorities_line_up_with_headers_for_every_render_impl() {
         assert_priorities_match_headers::<FlockRows>(&["ID", "NAME", "STATUS"]);
-        assert_priorities_match_headers::<DogRows>(&["NAME", "STATUS"]);
+        assert_priorities_match_headers::<DogRows>(&["ID", "NAME", "STATUS"]);
         assert_priorities_match_headers::<LambRows>(&["PID", "NAME"]);
         assert_priorities_match_headers::<DogEnabledRow>(&["NAME", "STATUS"]);
         assert_priorities_match_headers::<DogDisabledRow>(&["NAME", "STATUS"]);
@@ -3372,6 +3763,267 @@ pub(crate) mod tests {
             .build()
     }
 
+    /// fails if the two tables stop agreeing on their shared columns, in
+    /// order.
+    ///
+    /// This is the property Rin asked for, and it is checked as a property
+    /// rather than by pinning two header lists: a list would pass by being
+    /// edited to match whatever the code now does, which is exactly how the
+    /// two drifted apart in the first place.
+    #[test]
+    fn the_sheep_and_dog_tables_share_a_column_order() {
+        let sheep = FlockRows::headers();
+        let dogs = DogRows::headers();
+
+        let common = [
+            "ID", "NAME", "STATUS", "PID", "RESTARTS", "EXIT", "CPU", "MEM", "UPTIME",
+        ];
+        assert_eq!(
+            &sheep[..common.len()],
+            &common,
+            "the sheep table leads with them"
+        );
+        assert_eq!(&dogs[..common.len()], &common, "and so does the dogs table");
+
+        assert_eq!(
+            &sheep[common.len()..],
+            &["FOLD", "SMIT"],
+            "the sheep table's own"
+        );
+        assert_eq!(&dogs[common.len()..], &["SOURCE"], "the dogs table's own");
+
+        // FOLD and SMIT are absent from the dogs table because they are
+        // IMPOSSIBLE for a dog, not because they are empty: a dog belongs to
+        // no fold, and a smit is a mark a dog paints ON a sheep.
+        assert!(
+            DogRows::JSON_ONLY.contains(&"fold") && DogRows::JSON_ONLY.contains(&"smit"),
+            "both still ride the JSON, with a reason recorded beside them"
+        );
+    }
+
+    /// fails if a shared column wears a different treatment in the two
+    /// tables.
+    ///
+    /// The two are painted by ONE function keyed on the column name, so this
+    /// is what says that function is actually reached from both rather than
+    /// reimplemented once each. It compares the painted CELLS, not the roles,
+    /// so it also catches a table that read the right rule off the wrong
+    /// column.
+    #[test]
+    fn a_shared_column_is_painted_the_same_in_both_tables() {
+        let mut as_sheep = sample_dog(ProcStatus::Online, Some(14_110));
+        as_sheep.dog = None;
+        let sheep = FlockRows(vec![as_sheep]).rows_for(coloured(), true);
+        let dogs =
+            DogRows(vec![sample_dog(ProcStatus::Online, Some(14_110))]).rows_for(coloured(), true);
+
+        for (index, header) in FlockRows::headers().iter().enumerate() {
+            let Some(there) = DogRows::headers().iter().position(|h| h == header) else {
+                continue;
+            };
+            assert_eq!(
+                sheep[0][index], dogs[0][there],
+                "{header} renders differently in the two tables"
+            );
+        }
+    }
+
+    /// fails if the colouring goes back to being keyed on a column's INDEX.
+    ///
+    /// The mechanism this guards is invisible in a diff and invisible in a
+    /// snapshot. `rows_for` used to paint `row[4]` with the restart ramp
+    /// because RESTARTS was the fifth column; move a column and that index
+    /// silently points somewhere else, nothing fails to compile, and the
+    /// wrong cell wears the ramp.
+    ///
+    /// # Why this drives a REVERSED header list
+    ///
+    /// Asserting against the real `FlockRows`/`DogRows` cannot catch it. The
+    /// reorder left the two tables sharing indices 0 through 8 exactly, so on
+    /// those columns a positional build and a name-keyed one paint
+    /// identically and only SOURCE tells them apart. A test that looked
+    /// convincing while resting on one column is the shape of test this
+    /// branch has already found three of.
+    ///
+    /// So this drives [`paint`] over a header list in REVERSE, which no real
+    /// table uses, and asserts every column still wears its own rule. Under
+    /// any index-keyed rule every one of these lands somewhere else.
+    #[test]
+    fn a_columns_colour_follows_its_name_and_not_its_position() {
+        let dog = sample_dog(ProcStatus::Online, Some(14_110));
+        let forwards = DogRows::headers();
+        let backwards: Vec<&'static str> = forwards.iter().copied().rev().collect();
+
+        let mut cells: Vec<String> = DogRows(vec![dog.clone()]).rows().remove(0);
+        cells.reverse();
+        let painted_rows = paint(vec![cells], &backwards, coloured(), true, |header, _| {
+            process_info_paint(header, &dog)
+        });
+
+        let at = |name: &str| backwards.iter().position(|h| *h == name).unwrap();
+        // Every one of these indices differs from the one the same column has
+        // in the real table, which is what makes the assertions load-bearing.
+        assert_eq!(painted_rows[0][at("ID")], painted("9", Role::Ink3));
+        assert_eq!(painted_rows[0][at("RESTARTS")], painted("4", Role::Butter));
+        assert_eq!(painted_rows[0][at("MEM")], painted("3.0M", Role::Meadow));
+        assert_eq!(painted_rows[0][at("CPU")], painted("0.0%", Role::Ink3));
+        assert_eq!(
+            painted_rows[0][at("SOURCE")],
+            painted("adopted", Role::Butter)
+        );
+        assert_eq!(
+            painted_rows[0][at("STATUS")],
+            painted("(o.o) online", Role::Meadow)
+        );
+        assert_eq!(painted_rows[0][at("NAME")], "log-rotate", "still plain");
+        assert_eq!(painted_rows[0][at("UPTIME")], "41s", "still plain");
+    }
+
+    /// fails if SOURCE stops drawing the one trust distinction in the crate.
+    ///
+    /// `adopted` is a third-party binary running at the daemon's own trust
+    /// level from an operator-supplied path; `built-in` is shep running its
+    /// own code. Those must not look identical, which is what they did.
+    ///
+    /// `unknown` is deliberately Butter and NOT Bark: a `DogSource` this
+    /// client predates means the client is older than its daemon, and the dog
+    /// is very often perfectly healthy. Painting a working dog red is the
+    /// mistake `mem_role`'s own doc refuses when it declines a third tier.
+    #[test]
+    fn source_draws_the_trust_line_and_never_paints_a_working_dog_red() {
+        assert_eq!(source_role(&DogSource::BuiltIn), Role::Ink3);
+        assert_eq!(
+            source_role(&DogSource::Adopted {
+                path: "/usr/local/bin/shep-log-rotate".to_string()
+            }),
+            Role::Butter
+        );
+        assert_ne!(
+            source_role(&DogSource::BuiltIn),
+            source_role(&DogSource::Adopted {
+                path: "/x".to_string()
+            }),
+            "shep's own code and a third-party binary must not look the same"
+        );
+    }
+
+    /// fails if an outcome kind lands in the wrong tier.
+    ///
+    /// One function serves `trigger`, `signal` and `whisper`, so this covers
+    /// all eleven kinds the three produce. The `Bark` tier is the one that
+    /// matters most and the one most easily over-applied: `skipped` and
+    /// `not_running` are NOT failures, and an unrecognised kind is a version
+    /// gap rather than a fault.
+    #[test]
+    fn an_outcome_lands_in_the_tier_its_kind_calls_for() {
+        for worked in ["replied", "delivered", "sent"] {
+            assert_eq!(outcome_role(worked), Role::Meadow, "{worked}");
+        }
+        for quiet in ["skipped", "not_running"] {
+            assert_eq!(outcome_role(quiet), Role::Ink3, "{quiet}");
+        }
+        for failed in ["timed_out", "failed", "not_written"] {
+            assert_eq!(outcome_role(failed), Role::Bark, "{failed}");
+        }
+        for gap in ["no_channel", "no_stdin"] {
+            assert_eq!(outcome_role(gap), Role::Butter, "{gap}");
+        }
+        assert_eq!(
+            outcome_role("unknown"),
+            Role::Butter,
+            "a kind this client predates is a version gap, not a fault"
+        );
+    }
+
+    /// fails if the reply tables stop colouring their OUTCOME, or start
+    /// colouring their DETAIL.
+    ///
+    /// Driven through a real `TriggeredRows` rather than through
+    /// `outcome_role`, so it covers the wiring as well as the tiers. DETAIL
+    /// is free-form text that only exists when OUTCOME has already said what
+    /// happened; colouring a whole sentence the colour of the word beside it
+    /// is decoration.
+    #[test]
+    fn a_reply_table_colours_its_outcome_and_leaves_its_detail_alone() {
+        let rows = TriggeredRows(vec![
+            ActionReply {
+                id: 0,
+                name: "web".to_string(),
+                outcome: ActionOutcome::Replied {
+                    body: "swept 3".to_string(),
+                },
+            },
+            ActionReply {
+                id: 1,
+                name: "api".to_string(),
+                outcome: ActionOutcome::TimedOut,
+            },
+        ])
+        .rows_for(coloured(), true);
+
+        assert_eq!(rows[0][0], painted("0", Role::Ink3), "ID is chrome");
+        assert_eq!(rows[0][1], "web", "NAME is plain");
+        assert_eq!(rows[0][2], painted("replied", Role::Meadow));
+        assert_eq!(rows[0][3], "swept 3", "DETAIL carries no colour");
+        assert_eq!(rows[1][2], painted("timed_out", Role::Bark));
+        assert_eq!(
+            rows[1][3], "no reply within the app's own action_timeout",
+            "and neither does a failure's DETAIL"
+        );
+    }
+
+    /// fails if the `-` placeholder rule stops reaching a column whose own
+    /// rule declined to paint it.
+    ///
+    /// `BarkRows` returns [`Paint::Default`] for a SINKS cell holding `-`,
+    /// rather than one of the two roles it gives a real sink list, and
+    /// `Paint::Default` is what carries the placeholder rule. So this pins
+    /// the handoff: a column CAN have a rule of its own and still fall back
+    /// to the shared one for the value that has nothing to say.
+    ///
+    /// An earlier version of this test claimed it proved the rule reached a
+    /// table stating no rule at all, which was simply false -- `BarkRows` has
+    /// its own `rows_for`. The mutation that deleted the trait default killed
+    /// nothing, which is how the wrong target was found.
+    #[test]
+    fn a_placeholder_falls_back_to_the_shared_rule() {
+        let rows = BarkRows(vec![Bark {
+            at_ms: 0,
+            rule: "restart-storm".to_string(),
+            subject: "web".to_string(),
+            message: "restarted 5 times".to_string(),
+            sinks: Vec::new(),
+        }])
+        .rows_for(coloured(), true);
+        assert_eq!(rows[0][4], painted("-", Role::Ink3), "no sinks reads as -");
+    }
+
+    /// fails if a bark that failed to deliver reads the same as one that
+    /// delivered.
+    ///
+    /// A refused sink is the reason an operator reads this table at all: the
+    /// alert did not arrive. `sinks_cell` already appends `(failed)`, so the
+    /// colour agrees with the text rather than replacing it.
+    #[test]
+    fn a_bark_whose_sink_refused_is_marked() {
+        let bark = |error: Option<String>| Bark {
+            at_ms: 0,
+            rule: "restart-storm".to_string(),
+            subject: "web".to_string(),
+            message: "restarted 5 times".to_string(),
+            sinks: vec![SinkOutcome {
+                sink: "ops".to_string(),
+                error,
+            }],
+        };
+        let delivered = BarkRows(vec![bark(None)]).rows_for(coloured(), true);
+        assert_eq!(delivered[0][4], painted("ops", Role::Meadow));
+
+        let refused =
+            BarkRows(vec![bark(Some("connection refused".to_string()))]).rows_for(coloured(), true);
+        assert_eq!(refused[0][4], painted("ops(failed)", Role::Bark));
+    }
+
     /// fails if the dogs table stops matching the flock table on the five
     /// columns the two share, or if it starts colouring a column that has
     /// nothing to say.
@@ -3385,8 +4037,10 @@ pub(crate) mod tests {
             DogRows(vec![sample_dog(ProcStatus::Online, Some(14_110))]).rows_for(coloured(), true);
         let row = &rows[0];
 
-        assert_eq!(row[0], "log-rotate", "NAME is plain, as in the flock table");
-        assert_eq!(row[1], painted("adopted", Role::Ink3), "SOURCE is chrome");
+        // Cell by cell, in the order the columns now sit, which is the sheep
+        // table's order for all nine shared columns.
+        assert_eq!(row[0], painted("9", Role::Ink3), "ID is chrome");
+        assert_eq!(row[1], "log-rotate", "NAME is plain, as in the flock table");
         assert_eq!(
             row[2],
             painted("(o.o) online", Role::Meadow),
@@ -3394,9 +4048,15 @@ pub(crate) mod tests {
         );
         assert_eq!(row[3], "14110", "a real PID is left plain");
         assert_eq!(row[4], painted("4", Role::Butter), "RESTARTS above zero");
-        assert_eq!(row[5], painted("0.0%", Role::Ink3), "idle CPU is not news");
-        assert_eq!(row[6], painted("3.0M", Role::Meadow), "MEM below the ramp");
-        assert_eq!(row[7], "41s", "UPTIME is plain, as in the flock table");
+        assert_eq!(row[5], painted("-", Role::Ink3), "EXIT: still running");
+        assert_eq!(row[6], painted("0.0%", Role::Ink3), "idle CPU is not news");
+        assert_eq!(row[7], painted("3.0M", Role::Meadow), "MEM below the ramp");
+        assert_eq!(row[8], "41s", "UPTIME is plain, as in the flock table");
+        assert_eq!(
+            row[9],
+            painted("adopted", Role::Butter),
+            "SOURCE carries the trust distinction, and sits last"
+        );
     }
 
     /// fails if a stopped dog's `-` placeholders stop being muted, or if its
@@ -3412,8 +4072,8 @@ pub(crate) mod tests {
 
         assert_eq!(row[2], painted("(-.-) stopped", Role::Ink3));
         assert_eq!(row[3], painted("-", Role::Ink3), "PID");
-        assert_eq!(row[5], painted("-", Role::Ink3), "CPU");
-        assert_eq!(row[6], painted("-", Role::Ink3), "MEM");
+        assert_eq!(row[6], painted("-", Role::Ink3), "CPU");
+        assert_eq!(row[7], painted("-", Role::Ink3), "MEM");
     }
 
     /// fails if a dog-action row colours a STATUS cell holding a SENTENCE.
@@ -3435,7 +4095,11 @@ pub(crate) mod tests {
             status: "online".to_string(),
         };
         let row = &acted.rows_for(coloured(), true)[0];
-        assert_eq!(row[1], painted("adopted", Role::Ink3), "SOURCE is chrome");
+        assert_eq!(
+            row[1],
+            painted("adopted", Role::Butter),
+            "SOURCE says this is not shep's own code"
+        );
         assert_eq!(row[3], painted("(o.o) online", Role::Meadow));
 
         let sentence = "no shepherd running; the config was written";

--- a/crates/shep-cli/src/output/rows.rs
+++ b/crates/shep-cli/src/output/rows.rs
@@ -1522,6 +1522,21 @@ pub struct RolledSheep {
 #[derive(Debug, Serialize)]
 pub struct RolledSheepRows(pub Vec<RolledSheep>);
 
+/// No colour, including on STATUS, which is the one place in this module a
+/// STATUS column goes unpainted.
+///
+/// It was painted first, on the reasoning that keying treatments by column
+/// NAME is exactly so the same header means the same thing everywhere. That
+/// reasoning is right in general and wrong here, because this column is a
+/// CONSTANT: `commands::query`'s `flock_from_roll` writes the literal
+/// `stopped` on every row, since nothing in a saved roll is running by
+/// definition. A colour identical on every row of every rendering of this
+/// table distinguishes nothing, and the rule the colour work runs on is that
+/// a colour carries information or the column does not get one. Rin's call,
+/// and it is the same call `AvailableDogRows` gets for CATEGORY.
+///
+/// INSTANCES is a count with no threshold anyone agreed on, and NAME is
+/// identity.
 impl Render for RolledSheepRows {
     fn headers() -> &'static [&'static str] {
         &["NAME", "INSTANCES", "STATUS"]
@@ -1532,29 +1547,6 @@ impl Render for RolledSheepRows {
             .iter()
             .map(|s| vec![s.name.clone(), s.instances.to_string(), s.status.to_owned()])
             .collect()
-    }
-
-    /// STATUS gets the face and the role every other STATUS column in this
-    /// module gets, which is the whole point of keying the treatment on the
-    /// column NAME: the same header means the same thing everywhere.
-    ///
-    /// It is a constant here -- `query.rs` writes the literal `stopped` on
-    /// every row, because nothing in a saved roll is running -- so the colour
-    /// draws no comparison BETWEEN rows. It still carries the fact, and a
-    /// reader who has learned `(-.-)` elsewhere reads this table without
-    /// being told. INSTANCES is a count with no threshold anyone agreed on.
-    fn rows_for(&self, presentation: Presentation, status_word: bool) -> Vec<Vec<String>> {
-        let rows = self.rows();
-        paint(
-            rows.clone(),
-            Self::headers(),
-            presentation,
-            status_word,
-            |header, index| match header {
-                "STATUS" => status_named_by(&rows[index][2]).map_or(Paint::Default, Paint::Status),
-                _ => Paint::Default,
-            },
-        )
     }
 
     /// # Panics

--- a/crates/shep-cli/src/output/rows.rs
+++ b/crates/shep-cli/src/output/rows.rs
@@ -110,17 +110,13 @@ impl Render for FlockRows {
         for (row, p) in rows.iter_mut().zip(&self.0) {
             row[2] = status_cell(p.status, presentation, status_word);
             colour_cell(&mut row[0], Role::Ink3, presentation);
-            if row[3] == "-" {
-                colour_cell(&mut row[3], Role::Ink3, presentation);
-            }
+            mute_a_dash(&mut row[3], presentation);
             colour_cell(&mut row[4], restarts_role(p.restarts), presentation);
             colour_cell(&mut row[5], exit_role(p.pid, p.last_exit), presentation);
             colour_cell(&mut row[6], cpu_role(p.cpu_percent), presentation);
             colour_cell(&mut row[7], mem_role(p.memory_bytes), presentation);
             colour_cell(&mut row[9], Role::Ink3, presentation);
-            if row[10] == "-" {
-                colour_cell(&mut row[10], Role::Ink3, presentation);
-            }
+            mute_a_dash(&mut row[10], presentation);
         }
         rows
     }
@@ -194,11 +190,17 @@ impl Render for FlockRows {
     const PRIORITIES: &'static [u8] = &[0, 0, 0, 2, 4, 6, 5, 3, 1, 7, 8];
 }
 
-/// One sheep's STATUS cell, per spec §2 -- the only place in this module a
-/// face or a colour belongs, and the only STATUS cell any `Render` impl in
-/// this crate dresses up: `DogRows`/`DogEnabledRow`/`DogDisabledRow` render
-/// their own STATUS text unchanged, because a dog is not a sheep and this
-/// feature was never about giving one a face.
+/// One STATUS cell, per spec §2 -- the only place in this module a face or a
+/// colour for a status is decided, and now shared by every table with a
+/// STATUS column rather than by `FlockRows` alone.
+///
+/// It used to be `FlockRows`' own, on the grounds that a dog is not a sheep
+/// and the feature was never about giving one a face. That left seven of the
+/// eight tables in this module plain while one was coloured, so the same dog
+/// read one way under `shep dogs` and another under `shep flock`. Rin's
+/// ruling is that the treatment extends: a dog is supervised exactly as a
+/// sheep is, and `vocabulary.rs` stays the single source for the faces and
+/// the status-to-role mapping rather than growing a second set for dogs.
 ///
 /// - `presentation.level.sheep()` decides whether a face appears at all
 ///   ([`vocabulary::face`], always exactly 5 columns).
@@ -225,6 +227,43 @@ fn status_cell(status: ProcStatus, presentation: Presentation, status_word: bool
     };
     colour_cell(&mut text, vocabulary::role_of(status), presentation);
     text
+}
+
+/// The [`ProcStatus`] a free-text STATUS cell is naming, if it is naming one.
+///
+/// The dog-action rows ([`DogEnabledRow`] and its three siblings) carry
+/// `status` as a `String`, because it holds either a real status rendering or
+/// a sentence saying why no shepherd answered. A sentence has no role, so
+/// this is what keeps colour off it: a cell that names a status is coloured
+/// like one, and a cell that explains something is left alone.
+///
+/// Matched against each variant's own [`fmt::Display`](std::fmt::Display)
+/// rather than against a second table of strings, so this cannot drift from
+/// the rendering it is inverting. What it CAN miss is a variant added to
+/// `ProcStatus` and not added to `EVERY` below, which
+/// `every_status_is_recognised_by_its_own_rendering` is the guard for.
+fn status_named_by(text: &str) -> Option<ProcStatus> {
+    const EVERY: [ProcStatus; 6] = [
+        ProcStatus::Starting,
+        ProcStatus::Online,
+        ProcStatus::Stopping,
+        ProcStatus::Stopped,
+        ProcStatus::Errored,
+        ProcStatus::WaitingRestart,
+    ];
+    EVERY.into_iter().find(|status| status.to_string() == text)
+}
+
+/// Colours a cell [`Role::Ink3`] when it holds the `-` placeholder, and
+/// leaves it alone otherwise.
+///
+/// `FlockRows` applies this to PID and SMIT; the rule is that an absent value
+/// must not compete with a real one, and it is the same rule wherever a table
+/// prints a dash. Factored out because seven tables now want it.
+fn mute_a_dash(cell: &mut String, presentation: Presentation) {
+    if cell == "-" {
+        colour_cell(cell, Role::Ink3, presentation);
+    }
 }
 
 /// Wraps `cell` in [`crate::output::paint::style_for`]'s span for `role`, or
@@ -472,6 +511,33 @@ impl Render for DogRows {
             .collect()
     }
 
+    /// The same treatment `FlockRows` gives its own columns, on the five this
+    /// table shares with it, so the same dog reads the same way under
+    /// `shep dogs` as a sheep does under `shep flock`.
+    ///
+    /// STATUS takes the face and the colour ([`status_cell`]); RESTARTS,
+    /// CPU and MEM take the same three ramps; a `-` in PID is muted.
+    ///
+    /// SOURCE is muted throughout rather than ramped. It says where a
+    /// binary came from, never whether the dog is healthy, which is exactly
+    /// the role FOLD plays in the sheep table -- and this table's own
+    /// `PRIORITIES` already treats the two as the same kind of column.
+    ///
+    /// NAME and UPTIME stay plain, matching `FlockRows`: a name has no state
+    /// to report, and an uptime has no threshold anyone agreed on.
+    fn rows_for(&self, presentation: Presentation, status_word: bool) -> Vec<Vec<String>> {
+        let mut rows = self.rows();
+        for (row, p) in rows.iter_mut().zip(&self.0) {
+            colour_cell(&mut row[1], Role::Ink3, presentation);
+            row[2] = status_cell(p.status, presentation, status_word);
+            mute_a_dash(&mut row[3], presentation);
+            colour_cell(&mut row[4], restarts_role(p.restarts), presentation);
+            colour_cell(&mut row[5], cpu_role(p.cpu_percent), presentation);
+            colour_cell(&mut row[6], mem_role(p.memory_bytes), presentation);
+        }
+        rows
+    }
+
     /// # Panics
     /// If `header` is not one of `Self::headers()`'s own values.
     #[track_caller]
@@ -548,6 +614,15 @@ impl Render for DogRows {
 #[derive(Debug, Serialize)]
 pub struct LambRows(pub Vec<Lamb>);
 
+/// `LambRows` gets NO colour, and that is a decision rather than an
+/// omission.
+///
+/// Both its columns are identity: which process, and what it is running. A
+/// lamb has no status, no restart count, no resource reading, and no
+/// placeholder -- `pid` is a real number on every row and `name` is a real
+/// string. There is nothing here for a colour to carry, and the rule is that
+/// every colour carries information. Muting one of two columns would just be
+/// picking one to look faded.
 impl Render for LambRows {
     fn headers() -> &'static [&'static str] {
         &["PID", "NAME"]
@@ -627,6 +702,38 @@ impl Render for DogEnabledRow {
         ]]
     }
 
+    /// The dog-action rows' shared treatment, spelled out here once and
+    /// pointed at from the other three.
+    ///
+    /// SOURCE is muted, the same call `DogRows` makes: it says where the
+    /// binary came from, never whether anything is healthy.
+    ///
+    /// STATUS is coloured only when it NAMES a status. This field holds
+    /// either a real `ProcStatus` rendering or a sentence saying why no
+    /// shepherd answered ([`Self::status`]'s own doc), and a sentence has no
+    /// role to wear -- colouring it would be decoration, which is the one
+    /// thing the rule here forbids. [`status_named_by`] is what tells the two
+    /// apart.
+    ///
+    /// SHEPHERD is left plain deliberately, and it was the closest call in
+    /// this table. `false` is worth knowing -- it means the config changed
+    /// and nothing is running yet -- but the STATUS cell beside it already
+    /// says so in a whole sentence, so a colour here would be a second
+    /// decoration saying what the text already says. That is the same
+    /// reasoning `lookout/theme.rs` gives for not putting a face in its own
+    /// flock pane.
+    ///
+    /// NAME stays plain, matching every other table in this module.
+    fn rows_for(&self, presentation: Presentation, status_word: bool) -> Vec<Vec<String>> {
+        let mut rows = self.rows();
+        let row = &mut rows[0];
+        colour_cell(&mut row[1], Role::Ink3, presentation);
+        if let Some(status) = status_named_by(&row[3]) {
+            row[3] = status_cell(status, presentation, status_word);
+        }
+        rows
+    }
+
     /// # Panics
     /// If `header` is not one of `Self::headers()`'s own values.
     #[track_caller]
@@ -693,6 +800,17 @@ impl Render for DogDisabledRow {
         ]]
     }
 
+    /// Same treatment, same reasoning, as [`DogEnabledRow::rows_for`].
+    fn rows_for(&self, presentation: Presentation, status_word: bool) -> Vec<Vec<String>> {
+        let mut rows = self.rows();
+        let row = &mut rows[0];
+        colour_cell(&mut row[1], Role::Ink3, presentation);
+        if let Some(status) = status_named_by(&row[3]) {
+            row[3] = status_cell(status, presentation, status_word);
+        }
+        rows
+    }
+
     /// # Panics
     /// If `header` is not one of `Self::headers()`'s own values.
     #[track_caller]
@@ -749,6 +867,17 @@ impl Render for DogAdoptedRow {
             self.shepherd_acted.to_string(),
             self.status.clone(),
         ]]
+    }
+
+    /// Same treatment, same reasoning, as [`DogEnabledRow::rows_for`].
+    fn rows_for(&self, presentation: Presentation, status_word: bool) -> Vec<Vec<String>> {
+        let mut rows = self.rows();
+        let row = &mut rows[0];
+        colour_cell(&mut row[1], Role::Ink3, presentation);
+        if let Some(status) = status_named_by(&row[3]) {
+            row[3] = status_cell(status, presentation, status_word);
+        }
+        rows
     }
 
     /// # Panics
@@ -815,6 +944,17 @@ impl Render for DogRehomedRow {
             self.shepherd_acted.to_string(),
             self.status.clone(),
         ]]
+    }
+
+    /// Same treatment, same reasoning, as [`DogEnabledRow::rows_for`].
+    fn rows_for(&self, presentation: Presentation, status_word: bool) -> Vec<Vec<String>> {
+        let mut rows = self.rows();
+        let row = &mut rows[0];
+        colour_cell(&mut row[1], Role::Ink3, presentation);
+        if let Some(status) = status_named_by(&row[3]) {
+            row[3] = status_cell(status, presentation, status_word);
+        }
+        rows
     }
 
     /// # Panics
@@ -888,6 +1028,32 @@ impl Render for FlushedRows {
                 ]
             })
             .collect()
+    }
+
+    /// Two of the four columns, and no more, because two of them have
+    /// nothing to say.
+    ///
+    /// ID is muted, exactly as `FlockRows` mutes its own: it never changes
+    /// and it is chrome beside the thing this table is about.
+    ///
+    /// A `-` in either path column is muted, the placeholder rule this
+    /// module applies everywhere. A real path is left plain: it is the
+    /// subject of the table rather than a reading about it, there is no
+    /// threshold to ramp against and no fault to mark, and colouring the
+    /// widest column on the row for no information would be exactly the
+    /// decoration the rule forbids.
+    ///
+    /// No STATUS column here at all -- see this type's own doc for why
+    /// `flush` renders the files rather than the lifecycle -- so there is no
+    /// face and no status colour to give.
+    fn rows_for(&self, presentation: Presentation, _status_word: bool) -> Vec<Vec<String>> {
+        let mut rows = self.rows();
+        for row in &mut rows {
+            colour_cell(&mut row[0], Role::Ink3, presentation);
+            mute_a_dash(&mut row[2], presentation);
+            mute_a_dash(&mut row[3], presentation);
+        }
+        rows
     }
 
     /// # Panics
@@ -3152,6 +3318,240 @@ pub(crate) mod tests {
                 })
             ),
             Role::Bark
+        );
+    }
+
+    // --- Colour: the seven tables that are not the flock listing ---------
+    //
+    // Colour was commissioned as "colour the flock table" and delivered
+    // exactly that, so `colour_cell` appeared in one of the eight `Render`
+    // impls in this module and nowhere else. These pin what each of the
+    // other seven now does AND what it deliberately does not, because
+    // "nothing is coloured" and "everything is coloured" are both wrong and
+    // a presence check alone cannot tell either from the rule.
+    //
+    // Every assertion below compares against the exact painted string rather
+    // than looking for an escape byte. A presence check would pass on a cell
+    // painted the WRONG role, which is the failure that matters here: a
+    // healthy dog painted `Bark` reads as broken.
+
+    /// The 256-colour presentation these cases render at.
+    fn coloured() -> Presentation {
+        use crate::style::StyleLevel;
+        Presentation::new(
+            StyleLevel::Full,
+            None,
+            Some(std::ffi::OsStr::new("xterm-256color")),
+            None,
+            200,
+        )
+    }
+
+    /// `text` as `colour_cell` would paint it for `role`. Built through
+    /// `paint::style_for`, the same function the renderer calls, so this
+    /// compares the ROLE and not merely the presence of an escape.
+    fn painted(text: &str, role: Role) -> String {
+        let mut cell = text.to_string();
+        colour_cell(&mut cell, role, coloured());
+        cell
+    }
+
+    /// One dog, with readings chosen so every ramp lands on a known side:
+    /// four restarts (above zero), 0.0% CPU (idle, which is muted rather
+    /// than green), and 3 MiB (below the MEM boundary).
+    fn sample_dog(status: ProcStatus, pid: Option<u32>) -> ProcessInfo {
+        ProcessInfo::builder(9, "log-rotate", status)
+            .pid(pid)
+            .restarts(4)
+            .uptime_ms(41_000)
+            .cpu_percent(pid.map(|_| 0.0))
+            .memory_bytes(pid.map(|_| 3 * 1024 * 1024))
+            .dog(Some(DogSource::Adopted {
+                path: "/usr/local/bin/shep-log-rotate".to_string(),
+            }))
+            .build()
+    }
+
+    /// fails if the dogs table stops matching the flock table on the five
+    /// columns the two share, or if it starts colouring a column that has
+    /// nothing to say.
+    ///
+    /// The same dog used to read one way under `shep dogs` and another under
+    /// `shep flock`, because only one of the two tables had ever been
+    /// coloured.
+    #[test]
+    fn the_dogs_table_is_coloured_by_the_flock_tables_own_rules() {
+        let rows =
+            DogRows(vec![sample_dog(ProcStatus::Online, Some(14_110))]).rows_for(coloured(), true);
+        let row = &rows[0];
+
+        assert_eq!(row[0], "log-rotate", "NAME is plain, as in the flock table");
+        assert_eq!(row[1], painted("adopted", Role::Ink3), "SOURCE is chrome");
+        assert_eq!(
+            row[2],
+            painted("(o.o) online", Role::Meadow),
+            "STATUS takes the face and the role, from vocabulary.rs"
+        );
+        assert_eq!(row[3], "14110", "a real PID is left plain");
+        assert_eq!(row[4], painted("4", Role::Butter), "RESTARTS above zero");
+        assert_eq!(row[5], painted("0.0%", Role::Ink3), "idle CPU is not news");
+        assert_eq!(row[6], painted("3.0M", Role::Meadow), "MEM below the ramp");
+        assert_eq!(row[7], "41s", "UPTIME is plain, as in the flock table");
+    }
+
+    /// fails if a stopped dog's `-` placeholders stop being muted, or if its
+    /// STATUS stops carrying the role a stopped sheep's does.
+    ///
+    /// The sibling of the case above, and it exists because that one cannot
+    /// reach the placeholder branch: a running dog has a real PID, CPU and
+    /// MEM in every cell.
+    #[test]
+    fn a_stopped_dogs_placeholders_are_muted() {
+        let rows = DogRows(vec![sample_dog(ProcStatus::Stopped, None)]).rows_for(coloured(), true);
+        let row = &rows[0];
+
+        assert_eq!(row[2], painted("(-.-) stopped", Role::Ink3));
+        assert_eq!(row[3], painted("-", Role::Ink3), "PID");
+        assert_eq!(row[5], painted("-", Role::Ink3), "CPU");
+        assert_eq!(row[6], painted("-", Role::Ink3), "MEM");
+    }
+
+    /// fails if a dog-action row colours a STATUS cell holding a SENTENCE.
+    ///
+    /// `DogEnabledRow::status` is a `String` carrying either a real status
+    /// rendering or a sentence saying why no shepherd answered. A sentence
+    /// has no role, so painting it would be decoration, which the governing
+    /// rule forbids. Both halves are asserted in one case because a build
+    /// that coloured everything and a build that coloured nothing each pass
+    /// one half.
+    #[test]
+    fn a_dog_action_row_colours_a_status_and_never_a_sentence() {
+        let acted = DogEnabledRow {
+            name: "log-rotate".to_string(),
+            source: DogSource::Adopted {
+                path: "/usr/local/bin/shep-log-rotate".to_string(),
+            },
+            shepherd_acted: true,
+            status: "online".to_string(),
+        };
+        let row = &acted.rows_for(coloured(), true)[0];
+        assert_eq!(row[1], painted("adopted", Role::Ink3), "SOURCE is chrome");
+        assert_eq!(row[3], painted("(o.o) online", Role::Meadow));
+
+        let sentence = "no shepherd running; the config was written";
+        let unacted = DogEnabledRow {
+            name: "log-rotate".to_string(),
+            source: DogSource::BuiltIn,
+            shepherd_acted: false,
+            status: sentence.to_string(),
+        };
+        let row = &unacted.rows_for(coloured(), true)[0];
+        assert_eq!(row[3], sentence, "a sentence is left exactly as it was");
+    }
+
+    /// fails if the SHEPHERD column starts carrying a colour, or if NAME
+    /// does.
+    ///
+    /// Deliberate, and it was the closest call in that table. `false` is
+    /// worth knowing, but the STATUS cell beside it already says so in a
+    /// whole sentence, and a colour that repeats its neighbour is
+    /// decoration.
+    #[test]
+    fn a_dog_action_row_leaves_the_name_and_the_shepherd_column_plain() {
+        let row = &DogDisabledRow {
+            name: "log-rotate".to_string(),
+            source: DogSource::BuiltIn,
+            shepherd_acted: false,
+            status: "no shepherd running".to_string(),
+        }
+        .rows_for(coloured(), true)[0];
+        assert_eq!(row[0], "log-rotate");
+        assert_eq!(row[2], "false");
+    }
+
+    /// fails if `rehome`'s own `-` SOURCE stops being muted.
+    ///
+    /// `DogRehomedRow` is the only one of the four whose SOURCE can be
+    /// absent, and it reaches the same muting either way -- it is chrome
+    /// when it says `adopted` and a placeholder when it says `-`.
+    #[test]
+    fn a_rehomed_row_with_nothing_to_forget_still_mutes_its_source() {
+        let row = &DogRehomedRow {
+            name: "metrics".to_string(),
+            source: None,
+            shepherd_acted: true,
+            status: "stopped".to_string(),
+        }
+        .rows_for(coloured(), true)[0];
+        assert_eq!(row[1], painted("-", Role::Ink3));
+        assert_eq!(row[3], painted("(-.-) stopped", Role::Ink3));
+    }
+
+    /// fails if `flush`'s table stops muting its ID, or starts colouring a
+    /// real path.
+    ///
+    /// A path is the SUBJECT of this table rather than a reading about it:
+    /// no threshold to ramp against, no fault to mark, and the widest column
+    /// on the row. Only the `-` a peer daemon predating the field produces
+    /// is muted.
+    #[test]
+    fn a_flushed_row_mutes_its_id_and_its_dash_and_leaves_a_path_alone() {
+        let mut without = sample_info(1, "cron", 0);
+        without.out_file = None;
+        without.err_file = None;
+        let rows =
+            FlushedRows(vec![sample_info(0, "web", 60_000), without]).rows_for(coloured(), true);
+
+        assert_eq!(rows[0][0], painted("0", Role::Ink3), "ID is chrome");
+        assert_eq!(rows[0][1], "web", "NAME is plain");
+        assert_eq!(
+            rows[0][2], "/logs/web-0-out.log",
+            "a real path carries no colour"
+        );
+        assert_eq!(rows[1][2], painted("-", Role::Ink3), "the placeholder does");
+        assert_eq!(rows[1][3], painted("-", Role::Ink3));
+    }
+
+    /// fails if `LambRows` grows a colour.
+    ///
+    /// Both its columns are identity and neither has a state, a reading or a
+    /// placeholder, so there is nothing for a colour to carry. Pinned rather
+    /// than left implicit because "this one is deliberately plain" and "this
+    /// one was forgotten" look identical in a diff, and the second is
+    /// exactly what happened to the other seven tables.
+    #[test]
+    fn lamb_rows_carry_no_colour_at_all() {
+        let rows = LambRows(vec![Lamb::new(48_302, "node")]).rows_for(coloured(), true);
+        assert_eq!(rows[0], vec!["48302".to_string(), "node".to_string()]);
+    }
+
+    /// fails if a `ProcStatus` variant is added without being added to
+    /// `status_named_by`'s own list.
+    ///
+    /// That list is what decides whether a dog-action row's STATUS cell is
+    /// coloured, and a variant missing from it would silently render plain
+    /// rather than fail to compile. Driven off `Display`, so it also fails
+    /// if the two ever disagree.
+    #[test]
+    fn every_status_is_recognised_by_its_own_rendering() {
+        for status in [
+            ProcStatus::Starting,
+            ProcStatus::Online,
+            ProcStatus::Stopping,
+            ProcStatus::Stopped,
+            ProcStatus::Errored,
+            ProcStatus::WaitingRestart,
+        ] {
+            assert_eq!(
+                status_named_by(&status.to_string()),
+                Some(status),
+                "{status} is not recognised by its own rendering"
+            );
+        }
+        assert_eq!(
+            status_named_by("no shepherd running"),
+            None,
+            "and a sentence is not mistaken for one"
         );
     }
 

--- a/crates/shep-cli/tests/cli_e2e.rs
+++ b/crates/shep-cli/tests/cli_e2e.rs
@@ -1510,6 +1510,79 @@ fn a_second_command_reuses_the_daemon_rather_than_spawning_a_second() {
     graceful_kill(home);
 }
 
+/// A lifecycle verb prints the whole flock, not only the sheep it touched.
+///
+/// `shep start koji` used to print a one-row table containing koji, which
+/// cannot answer the question an operator actually has after a lifecycle
+/// command: what does the flock look like now.
+///
+/// Driven over the real binary against a real daemon, because the unit tests
+/// for this behaviour drive `render_outcome` directly and so cannot say
+/// whether any verb is wired to it. The mutation they cannot catch is the one
+/// that matters most: a `stop` still calling `emit` with its own rows.
+///
+/// Three sheep and a stop of ONE, so the narrow answer and the full one differ
+/// by row count as well as by content. The name assertion is on the exact set
+/// -- a `contains("alpha")` would pass on the one-row table this replaces,
+/// since the row it prints is alpha's.
+///
+/// The `--format json` half is asserted in the same case, and it is not
+/// padding: the two surfaces answer different questions on purpose, so a
+/// change that widened both would fix the complaint and silently break every
+/// script reading `data[0]`.
+#[test]
+fn a_lifecycle_verb_prints_the_whole_flock_and_json_still_prints_what_it_touched() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path();
+    let script = write_test_script(&dir);
+    let mut guard = DaemonGuard::default();
+
+    for name in ["alpha", "gamma", "beta"] {
+        let started = shep(home)
+            .arg("start")
+            .arg(&script)
+            .arg("--name")
+            .arg(name)
+            .output()
+            .unwrap();
+        guard.adopt_home(home);
+        assert_success(&started);
+    }
+
+    let stopped = shep(home).arg("stop").arg("alpha").output().unwrap();
+    assert_success(&stopped);
+    let printed = String::from_utf8(stopped.stdout).unwrap();
+    let named: Vec<&str> = printed
+        .lines()
+        .filter_map(|line| line.split_whitespace().nth(1))
+        .filter(|word| *word != "NAME")
+        .collect();
+    assert_eq!(
+        named,
+        ["alpha", "beta", "gamma"],
+        "stopping one sheep prints the whole flock, in name order: {printed}"
+    );
+
+    let json = shep(home)
+        .arg("--format")
+        .arg("json")
+        .arg("stop")
+        .arg("beta")
+        .output()
+        .unwrap();
+    assert_success(&json);
+    let envelope: serde_json::Value = serde_json::from_slice(&json.stdout).unwrap();
+    let rows = envelope["data"].as_array().unwrap();
+    let names: Vec<&str> = rows.iter().map(|r| r["name"].as_str().unwrap()).collect();
+    assert_eq!(
+        names,
+        ["beta"],
+        "the machine surface still answers what it touched: {envelope}"
+    );
+
+    graceful_kill(home);
+}
+
 // --- Case 3 --------------------------------------------------------------
 
 /// Two concurrent `shep start` invocations against a cold `$SHEP_HOME`

--- a/crates/shep-core/CHANGELOG.md
+++ b/crates/shep-core/CHANGELOG.md
@@ -29,6 +29,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   daemon that predates the request answers its existing "does not implement
   that request" error, and every previously pinned wire fixture is unchanged.
 
+- Add `protocol::sort_flock`, the one ordering rule every operator-facing
+  listing takes: by name, then by id. An id is assigned at registration, so
+  ordering by it sorts the flock by an accident of history rather than by
+  anything an operator is looking for, and it is not stable -- a `delete all`
+  followed by a fresh start moved a real thirteen-app flock from ids 0-10 to
+  11-21 with nothing about the apps having changed. The id keeps its other
+  job: it is still how one instance of a clustered app is addressed. It stops
+  being a sort key and stays an addressing key.
+
 ## [0.1.1] - 2026-08-26
 
 ### Additions

--- a/crates/shep-core/src/protocol/mod.rs
+++ b/crates/shep-core/src/protocol/mod.rs
@@ -18,7 +18,7 @@ pub use request::{
     ActionOutcome, ActionReply, DogSectionToml, DogSource, Envelope, ExitInfo, Hello, HelloAck,
     HelloReply, Lamb, LineOutcome, LineReply, ProcessInfo, ProcessInfoBuilder, Reply, Request,
     Response, RpcError, RpcErrorCode, SelectorSpec, SheepDrift, SignalOutcome, SignalReply, Smit,
-    SmitError,
+    SmitError, sort_flock,
 };
 pub use wire::{MAX_FRAME_BYTES, WireError, codec, decode_frame, encode_frame};
 

--- a/crates/shep-core/src/protocol/request.rs
+++ b/crates/shep-core/src/protocol/request.rs
@@ -710,12 +710,15 @@ pub struct ProcessInfo {
 /// still how an operator addresses one instance at `shep stop 11`. It stops
 /// being a sort key and stays an addressing key.
 ///
-/// The daemon's own `snapshot_all` sorts the richer `(name, instance, id)`,
-/// which agrees with this one on every listing where the ids were handed out
-/// in instance order and is strictly more stable where a reload has given a
-/// slot a fresh id. [`ProcessInfo`] carries no instance number, so this is
-/// the finest key expressible over a listing that has already crossed the
-/// wire.
+/// This is the ONLY ordering rule in shep, and the daemon's own
+/// `snapshot_all` calls this function rather than restating it. It used to
+/// sort the richer `(name, instance, id)`, which is strictly more stable
+/// where a reload has given a slot a fresh id -- and which was a second rule
+/// no listing that has crossed the wire could reproduce, since
+/// [`ProcessInfo`] carries no instance number. The two agreed until a reload
+/// churned an id and then disagreed, so `ListFlock` could order a reloaded
+/// app differently from the `Restart` reply printed a second earlier. One
+/// rule everywhere is worth more than a finer one in half the places.
 pub fn sort_flock(listing: &mut [ProcessInfo]) {
     listing.sort_unstable_by(|a, b| (a.name.as_str(), a.id).cmp(&(b.name.as_str(), b.id)));
 }

--- a/crates/shep-core/src/protocol/request.rs
+++ b/crates/shep-core/src/protocol/request.rs
@@ -688,6 +688,38 @@ pub struct ProcessInfo {
     pub smit: Option<String>,
 }
 
+/// Orders one flock listing the way every operator-facing surface presents
+/// one: by name, then by id.
+///
+/// # Why name first
+///
+/// An id is assigned at registration, so ordering by it sorts the flock by
+/// an accident of history rather than by anything an operator is looking
+/// for. It is not stable either: a `delete all` followed by a fresh start
+/// moved a real thirteen-app flock from ids 0-10 to 11-21 with nothing
+/// about the apps having changed. A name is what an operator scans a long
+/// listing for, and it survives that churn.
+///
+/// # Why id breaks the tie
+///
+/// A name is unique to an APP, not to a sheep: an app stocked to four
+/// instances puts four rows under one name. Name alone is therefore not a
+/// total order, and an unstable sort would let those four shuffle between
+/// refreshes — visible in `shep flock` and worse in `shep lookout`, which
+/// repolls every two seconds. The id keeps its other job unchanged: it is
+/// still how an operator addresses one instance at `shep stop 11`. It stops
+/// being a sort key and stays an addressing key.
+///
+/// The daemon's own `snapshot_all` sorts the richer `(name, instance, id)`,
+/// which agrees with this one on every listing where the ids were handed out
+/// in instance order and is strictly more stable where a reload has given a
+/// slot a fresh id. [`ProcessInfo`] carries no instance number, so this is
+/// the finest key expressible over a listing that has already crossed the
+/// wire.
+pub fn sort_flock(listing: &mut [ProcessInfo]) {
+    listing.sort_unstable_by(|a, b| (a.name.as_str(), a.id).cmp(&(b.name.as_str(), b.id)));
+}
+
 impl ProcessInfo {
     /// Starts a builder for one sheep's row.
     ///
@@ -2493,6 +2525,36 @@ mod tests {
         assert_eq!(
             format!("{response:?}"),
             "DogSection { toml: DogSectionToml(<70 bytes>) }"
+        );
+    }
+
+    /// The fixture is built so the two candidate orders CANNOT agree: read
+    /// by id it is `web/1, api/2, web/0`, read by name it is
+    /// `api, web, web`. A listing that happened to be alphabetical already,
+    /// or whose ids happened to ascend with its names, would pass under
+    /// either rule and prove nothing.
+    ///
+    /// The two `web` rows are the tiebreak half, and they are the reason a
+    /// multi-instance fixture is required: their ids are seeded out of order
+    /// (1 before 0), so a sort keyed on name alone would leave them as it
+    /// found them and fail the last assertion while passing the first.
+    #[test]
+    fn a_listing_sorts_by_name_then_by_id() {
+        let mut listing = vec![
+            ProcessInfo::builder(1, "web", ProcStatus::Online).build(),
+            ProcessInfo::builder(2, "api", ProcStatus::Online).build(),
+            ProcessInfo::builder(0, "web", ProcStatus::Online).build(),
+        ];
+        sort_flock(&mut listing);
+
+        let seen: Vec<(&str, u32)> = listing
+            .iter()
+            .map(|info| (info.name.as_str(), info.id))
+            .collect();
+        assert_eq!(
+            seen,
+            vec![("api", 2), ("web", 0), ("web", 1)],
+            "name first, then id inside a name"
         );
     }
 }

--- a/crates/shep-core/src/protocol/request.rs
+++ b/crates/shep-core/src/protocol/request.rs
@@ -1174,8 +1174,10 @@ pub enum Response {
     /// listed here as the no-op success it is, so this carries the same
     /// matches `Describe` would.
     Reloading(Vec<ProcessInfo>),
-    /// Answer to `Scale` — the app's instances that will REMAIN, one row each,
-    /// in instance-slot order.
+    /// Answer to `Scale` — the app's instances that will REMAIN, one row
+    /// each, by name and then by id ([`sort_flock`]). Every row shares one
+    /// name here, so that is id order in practice; it is stated as the shared
+    /// rule rather than as this reply's own so the two cannot drift.
     ///
     /// Scaling up, these are the instances that exist, the new ones included,
     /// and the answer is complete.

--- a/crates/shep-daemon/CHANGELOG.md
+++ b/crates/shep-daemon/CHANGELOG.md
@@ -111,10 +111,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Every reply carrying a listing now comes back in the same order the flock
   listing does: by name, then by id. `ListFlock`, `Describe` and `Mustered`
-  already grouped by name; `Stop`, `Restart`, `Delete`, `Scale`, `Reopen`,
-  `Flush`, `Trigger`, `Signal` and `SendLine` came back by id, so one session
-  against one flock printed two different orders. Wire-observable, and so
-  visible under `--format json` as well as in a table.
+  already grouped by name; `Start`, `Stop`, `Restart`, `Reload`, `Scale`,
+  `Reopen`, `Flush`, `Trigger`, `Signal` and `SendLine` came back in whatever
+  order they were assembled, so one session against one flock printed two
+  different orders. Wire-observable, and so visible under `--format json` as
+  well as in a table. `Delete` is not in that list and never was: it answers
+  with ids alone, which the daemon already sorts.
+
+- `snapshot_all` takes the shared rule rather than a finer one of its own. It
+  sorted `(name, instance, id)`, which is more stable across a reload and
+  which no listing that has crossed the wire can reproduce, since
+  `ProcessInfo` carries no instance number. The two agreed until a reload
+  churned an id and then diverged, so `ListFlock` could order a reloaded app
+  differently from the `Restart` reply printed a second earlier -- the very
+  inconsistency this change exists to end, one layer down. It now calls
+  `sort_flock`, so the two cannot drift.
 
 ### Additions
 

--- a/crates/shep-daemon/CHANGELOG.md
+++ b/crates/shep-daemon/CHANGELOG.md
@@ -109,6 +109,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   shell inherits that shell's PATH, which measured two kilobytes and buried
   the sentence that mattered.
 
+- Every reply carrying a listing now comes back in the same order the flock
+  listing does: by name, then by id. `ListFlock`, `Describe` and `Mustered`
+  already grouped by name; `Stop`, `Restart`, `Delete`, `Scale`, `Reopen`,
+  `Flush`, `Trigger`, `Signal` and `SendLine` came back by id, so one session
+  against one flock printed two different orders. Wire-observable, and so
+  visible under `--format json` as well as in a table.
+
 ### Additions
 
 - Add `SupervisorError::CannotStart`, a `Start` batch refused before anything

--- a/crates/shep-daemon/src/supervisor.rs
+++ b/crates/shep-daemon/src/supervisor.rs
@@ -48,7 +48,7 @@ use shep_core::config::{AppConfig, ResolvedApp, normalize};
 use shep_core::paths::ShepPaths;
 use shep_core::protocol::{
     ActionOutcome, ActionReply, BusEvent, DogSource, ExitInfo, LineOutcome, LineReply,
-    ProcessEventKind, ProcessInfo, SheepDrift, SignalOutcome, SignalReply, Smit,
+    ProcessEventKind, ProcessInfo, SheepDrift, SignalOutcome, SignalReply, Smit, sort_flock,
 };
 use shep_core::selector::ProcessSelector;
 use shep_core::signals::OperatorSignal;
@@ -3130,7 +3130,7 @@ impl<R: ProcessRunner> Actor<R> {
         }
 
         if remaining.is_empty() {
-            results.sort_unstable_by_key(|info| info.id);
+            sort_flock(&mut results);
             send_reply(reply, Ok(results));
             return;
         }
@@ -3454,7 +3454,7 @@ impl<R: ProcessRunner> Actor<R> {
                     .map(|slot| to_info(&slot.entry, &self.smits))
             })
             .collect();
-        instances.sort_unstable_by_key(|info| info.id);
+        sort_flock(&mut instances);
         // `Ok` even when `failure` is set, and that is deliberate: see
         // `Scaled`'s own doc. The caller records `app` unconditionally and
         // turns `shortfall` into the operator's error; an `Err` here would
@@ -4407,10 +4407,17 @@ impl<R: ProcessRunner> Actor<R> {
         // reopens: `HashMap` iteration order is arbitrary, and pump failures
         // are reported in the order they are collected, so an unsorted pump
         // set would make a multi-pump failure message read differently run to
-        // run. `matched` needs no such step — it is built in the id order
-        // `matching_ids` answers in, and a caller reading the reply as a
-        // table wants a stable order over `list`'s own (name-grouped) one.
+        // run. Id order, deliberately, unlike `matched` below: this sequence
+        // is never rendered, it only fixes the order failures are collected
+        // in, and any total order does that job.
         pumps.sort_unstable_by_key(|(info, _)| info.id);
+        // `matched` IS rendered -- it is the table `shep reopen` prints -- so
+        // it takes the one order every operator-facing listing takes. It
+        // arrives here in the id order `matching_ids` answers in; an earlier
+        // version of this comment claimed that was already `list`'s order,
+        // which was never true (`snapshot_all` groups by name) and is what
+        // let two orders ship side by side.
+        sort_flock(&mut matched);
         spawn_reopen_task(matched, pumps, reply);
     }
 
@@ -4501,12 +4508,14 @@ impl<R: ProcessRunner> Actor<R> {
         // Sorted for the reason `handle_reopen` sorts: `HashMap` iteration
         // order is arbitrary, and pump failures are reported in the order
         // they are collected, so an unsorted flush set would make a
-        // multi-pump failure message read differently run to run. Neither
-        // `matched` nor `paths` needs the step — the first is built in the id
-        // order `matching_ids` answers in, which is `list`'s and so the one a
-        // caller rendering the reply as a table wants, and the second is a
-        // `BTreeSet` already.
+        // multi-pump failure message read differently run to run. `paths`
+        // needs no such step, being a `BTreeSet` already.
         pumps.sort_unstable_by_key(|&(id, _)| id);
+        // `matched` is the table `shep empty` prints, so it takes the
+        // operator-facing order rather than the id order `matching_ids`
+        // hands it over in. See `handle_reopen` for the stale claim this
+        // replaces.
+        sort_flock(&mut matched);
         let pumps = pumps.into_iter().map(|(_, log_ctl)| log_ctl).collect();
         spawn_flush_task(matched, pumps, paths, reply);
     }
@@ -5474,7 +5483,7 @@ impl<R: ProcessRunner> Actor<R> {
             }
             if self.pending[i].remaining.is_empty() {
                 let mut pending = self.pending.remove(i);
-                pending.results.sort_unstable_by_key(|info| info.id);
+                sort_flock(&mut pending.results);
                 if matches!(pending.reply, ReplyKind::Shutdown(_)) {
                     shutdown_completed = true;
                 }
@@ -5900,7 +5909,13 @@ fn spawn_trigger_task(
         // The refusals were collected in id order and the waits were armed in
         // it, but a wait's row is appended when it settles, so this is what
         // the answer's order actually rests on.
-        rows.sort_unstable_by_key(|row| row.id);
+        // Keyed the way every operator-facing table shep prints is keyed
+        // (`sort_flock`'s own doc): by name, with the id breaking the tie
+        // between two instances of one app. This table carries an ID and a
+        // NAME column just as a flock listing does, so an operator who runs
+        // `shep flock` and then `shep trigger` should not have to read two
+        // orders.
+        rows.sort_unstable_by(|a, b| (a.name.as_str(), a.id).cmp(&(b.name.as_str(), b.id)));
         let _ = reply.send(Ok(rows));
     });
 }
@@ -5937,7 +5952,8 @@ fn spawn_signal_task(
             };
             rows.push(SignalReply { id, name, outcome });
         }
-        rows.sort_unstable_by_key(|row| row.id);
+        // Name then id, per `spawn_trigger_task`'s own note.
+        rows.sort_unstable_by(|a, b| (a.name.as_str(), a.id).cmp(&(b.name.as_str(), b.id)));
         let _ = reply.send(Ok(rows));
     });
 }
@@ -5995,7 +6011,8 @@ fn spawn_send_line_task(
             ))
             .await,
         );
-        rows.sort_unstable_by_key(|row| row.id);
+        // Name then id, per `spawn_trigger_task`'s own note.
+        rows.sort_unstable_by(|a, b| (a.name.as_str(), a.id).cmp(&(b.name.as_str(), b.id)));
         let _ = reply.send(Ok(rows));
     });
 }
@@ -12150,16 +12167,25 @@ mod tests {
     /// every row assertion below — which is what the `try_recv` between the
     /// two settlements is for.
     ///
-    /// The id order and the order the rows are produced in genuinely differ,
-    /// so the final sort is load-bearing rather than incidental: the refused
-    /// sheep is collected before either wait is even armed, and the two waits
-    /// settle in the order the app and the clock decide. Delete the sort and
-    /// the rows come back `[1, 0, 2]`.
+    /// The three sheep are named so that NO two of the candidate orders
+    /// agree, which is what makes the final sort load-bearing rather than
+    /// incidental. Ids are `web` 0, `zeus` 1, `worker` 2. The rows are
+    /// PRODUCED as `[1, 0, 2]` -- the refused sheep is collected before
+    /// either wait is armed, and the two waits settle in the order the app
+    /// and the clock decide. Sorted by id they would be `[0, 1, 2]`. Sorted
+    /// the way shep actually sorts a listing, by name then id, they are
+    /// `[0, 2, 1]`: web, worker, zeus. Delete the sort and this fails; key it
+    /// on the id instead and it fails differently.
+    ///
+    /// The sheep was called `api` until the ordering rule changed, and that
+    /// name made the fixture unable to fail: `api, web, worker` is what the
+    /// rows settle in AND what name order asks for, so a build with no sort
+    /// at all would have passed.
     #[tokio::test(start_paused = true)]
     async fn a_trigger_answers_every_sheep_it_matched_before_it_answers_at_all() {
         let dir = tempfile::tempdir().unwrap();
         let (mut actor, mut mailbox, mut child_rx) = actor_with_an_open_channel(&dir);
-        register_sheep(&mut actor, &dir, "api", None);
+        register_sheep(&mut actor, &dir, "zeus", None);
         let (silent_tx, mut silent_rx) = mpsc::channel(16);
         register_sheep(&mut actor, &dir, "worker", Some(silent_tx));
 
@@ -12199,8 +12225,8 @@ mod tests {
                         body: "swept 3".to_string()
                     }
                 ),
-                row(1, "api", ActionOutcome::NoChannel),
                 row(2, "worker", ActionOutcome::TimedOut),
+                row(1, "zeus", ActionOutcome::NoChannel),
             ])
         );
     }
@@ -12231,6 +12257,7 @@ mod tests {
         assert_eq!(
             triggered(answer).await,
             Ok(vec![
+                row(1, "api", ActionOutcome::NoChannel),
                 row(
                     0,
                     "web",
@@ -12238,7 +12265,6 @@ mod tests {
                         body: "swept 3".to_string()
                     }
                 ),
-                row(1, "api", ActionOutcome::NoChannel),
             ])
         );
         assert!(

--- a/crates/shep-daemon/src/supervisor.rs
+++ b/crates/shep-daemon/src/supervisor.rs
@@ -2467,6 +2467,11 @@ impl<R: ProcessRunner> Actor<R> {
         if !failures.is_empty() {
             return Err(SupervisorError::SpawnFailed(failures.join("; ")));
         }
+        // The table `shep start` prints. `results` is built in the order the
+        // caller supplied its apps and then instance by instance within each,
+        // which is the Flockfile's order rather than the one every other
+        // listing takes.
+        sort_flock(&mut results);
         Ok(results)
     }
 
@@ -3526,7 +3531,7 @@ impl<R: ProcessRunner> Actor<R> {
             return;
         }
 
-        let accepted: Vec<ProcessInfo> = matched
+        let mut accepted: Vec<ProcessInfo> = matched
             .iter()
             .map(|id| {
                 let slot = self
@@ -3536,6 +3541,10 @@ impl<R: ProcessRunner> Actor<R> {
                 to_info(&slot.entry, &self.smits)
             })
             .collect();
+        // The table `shep reload` prints, so it takes the one order every
+        // operator-facing listing takes. It arrives in the id order
+        // `matching_ids` answers in, which is not that order.
+        sort_flock(&mut accepted);
 
         // Grouped by app because a reload runs one instance of an app at a
         // time, and ordered by instance slot because that is the order an
@@ -5631,12 +5640,29 @@ impl<R: ProcessRunner> Actor<R> {
 
     /// Full flock listing, grouped by app name.
     ///
-    /// Sorted on `(name, instance, id)`, not id: sorting by id scatters a
-    /// clustered app's instances across the table, and grouping by name is
-    /// what makes a four-instance app read as one thing at a glance.
-    /// `instance` keeps a clustered app's slots in their own order once
-    /// grouped, and `id` breaks the tie a reload creates, where a
-    /// replacement takes the drainee's slot number with a fresh id.
+    /// Sorted by [`sort_flock`], the one rule every operator-facing listing
+    /// in shep takes: name, then id. Sorting by id alone scatters a clustered
+    /// app's instances across the table, and grouping by name is what makes a
+    /// four-instance app read as one thing at a glance.
+    ///
+    /// # Why not `(name, instance, id)`
+    ///
+    /// It used to sort on that, and the extra key was a real refinement:
+    /// `instance` keeps a clustered app's slots in their own order, where
+    /// `id` breaks the tie a reload creates by giving a replacement a fresh
+    /// id at the drainee's slot number.
+    ///
+    /// It was also a SECOND rule. `ProcessInfo` carries no instance number,
+    /// so no listing that has crossed the wire can reproduce it, and
+    /// `sort_flock` -- which every lifecycle reply now takes -- cannot. The
+    /// two agree on any flock whose ids were handed out in instance order and
+    /// diverge exactly once a reload has churned one, so `ListFlock` could
+    /// order a reloaded app differently from the `Restart` reply printed a
+    /// second earlier. That is the inconsistency this whole change exists to
+    /// end, reintroduced one layer down.
+    ///
+    /// So the finer key goes and the shared one stays, by calling the shared
+    /// function rather than restating it: the two cannot drift.
     ///
     /// Applied here once rather than once per verb: this is the single
     /// function every listing reply is built from — `ListFlock`, `Describe`,
@@ -5644,18 +5670,13 @@ impl<R: ProcessRunner> Actor<R> {
     /// anywhere else would leave the metrics dog and bark reading a
     /// different order from the operator, or duplicate the rule per verb.
     fn snapshot_all(&self) -> Vec<ProcessInfo> {
-        let mut entries: Vec<&ProcessEntry> = self.sheep.values().map(|slot| &slot.entry).collect();
-        entries.sort_unstable_by(|a, b| {
-            (a.spec.config().name.as_str(), a.instance, a.id).cmp(&(
-                b.spec.config().name.as_str(),
-                b.instance,
-                b.id,
-            ))
-        });
-        entries
-            .into_iter()
-            .map(|entry| to_info(entry, &self.smits))
-            .collect()
+        let mut listing: Vec<ProcessInfo> = self
+            .sheep
+            .values()
+            .map(|slot| to_info(&slot.entry, &self.smits))
+            .collect();
+        sort_flock(&mut listing);
+        listing
     }
 
     /// Broadcasts one lifecycle transition. Send failures (no receivers)

--- a/crates/shep-daemon/src/supervisor.rs
+++ b/crates/shep-daemon/src/supervisor.rs
@@ -1161,8 +1161,14 @@ impl SupervisorHandle {
     }
 
     /// Sends `action` over the shepherd channel of every sheep matching
-    /// `selector` and answers with one id-sorted row per match, carrying what
-    /// each app said back or why nothing came.
+    /// `selector` and answers with one row per match, carrying what each app
+    /// said back or why nothing came.
+    ///
+    /// Rows come back in the one order every operator-facing listing takes: by name, then
+    /// by id (`shep_core::protocol::sort_flock`). They were id-sorted until
+    /// that rule was made the only one; this table carries an ID and a NAME
+    /// column exactly as a flock listing does, so an operator reading both in
+    /// one session should not have to read two orders.
     ///
     /// Answers on completion rather than on acceptance: an action has no
     /// floor on how long it takes, so an acceptance would tell a caller
@@ -1216,8 +1222,8 @@ impl SupervisorHandle {
     }
 
     /// Delivers `sig` to the OWN process of every sheep matching `selector` —
-    /// never its process group — and answers with one id-sorted row per
-    /// match.
+    /// never its process group — and answers with one row per match, in the one order every operator-facing listing takes: by name, then
+    /// by id (`shep_core::protocol::sort_flock`).
     ///
     /// Unlike [`Self::trigger`], there is nothing to wait out: a `kill(2)`
     /// either returns or does not, so this answers as soon as every matched
@@ -1245,8 +1251,9 @@ impl SupervisorHandle {
         rx.await.map_err(|_| SupervisorError::EngineStopped)?
     }
 
-    /// Writes `line` to every matched sheep's stdin, and answers with one
-    /// id-sorted row per match.
+    /// Writes `line` to every matched sheep's stdin, and answers with one row
+    /// per match, in the one order every operator-facing listing takes: by name, then
+    /// by id (`shep_core::protocol::sort_flock`).
     ///
     /// Unlike [`Self::signal`], each write can genuinely wait — a pipe write
     /// blocks until the app reads — so the reply is bounded per sheep at
@@ -1288,8 +1295,14 @@ impl SupervisorHandle {
         rx.await.map_err(|_| SupervisorError::EngineStopped)
     }
 
-    /// Full flock listing, grouped by app name (each app's instances kept
-    /// in their own instance-slot order, ties from a reload broken by id).
+    /// Full flock listing, by name and then by id
+    /// (`shep_core::protocol::sort_flock`, which `snapshot_all` calls).
+    ///
+    /// It used to keep each app's instances in their own instance-slot order
+    /// with reload ties broken by id. That is a finer key and no listing that
+    /// has crossed the wire can reproduce it, since `ProcessInfo` carries no
+    /// instance number, so it was dropped for the one rule every reply now
+    /// shares. See `snapshot_all` for the whole of that reasoning.
     ///
     /// Convenience over `Self::list_checked` for callers that don't need
     /// to distinguish "actor gone" from "empty flock" — mainly tests.
@@ -1925,8 +1938,12 @@ enum ReplyKind {
 /// turns on whether the request was fully satisfied.
 #[derive(Debug)]
 pub(crate) struct Scaled {
-    /// The app's surviving instances, in instance-slot order. On a partial
-    /// scale-up this is what came up, never the count asked for.
+    /// The app's surviving instances, by name and then by id
+    /// (`shep_core::protocol::sort_flock`). Every row here shares one name,
+    /// so in practice that is id order -- but it is the shared rule that says
+    /// so, not a rule of this reply's own, which is what stops the two
+    /// drifting. On a partial scale-up this is what came up, never the count
+    /// asked for.
     pub(crate) instances: Vec<ProcessInfo>,
     /// The app's config as it now stands, with the ACHIEVED `instances` count.
     pub(crate) app: ResolvedApp,
@@ -5985,7 +6002,7 @@ type LineWait = (u32, String, oneshot::Receiver<Result<(), RunnerError>>);
 
 /// Awaits every write's acknowledgement, each under its own
 /// [`STDIN_WRITE_TIMEOUT`], and answers `reply` with `settled` and the results
-/// in id order.
+/// by name and then by id, the order `spawn_trigger_task`'s own note gives.
 ///
 /// The waits run CONCURRENTLY — `join_all`, not a `for` loop. Unlike
 /// `spawn_trigger_task`, whose per-row waits carry no shared bound, every wait

--- a/docs/lookout/frames.ansi
+++ b/docs/lookout/frames.ansi
@@ -32,12 +32,12 @@ shep lookout   /home/rin/.shep                                                  
 [0m[38;5;245mhost  load 2.31 4.10 3.88 / 10 cores   host mem 12.4G / 32.0G   flock cpu 14.7%   flock mem 716.0M   up 6d 3h           [0m
   [0m[38;5;245mID    NAME        STATUS           PID      RESTARTS  EXIT       CPU     MEM       UPTIME    FOLD        SMIT         [0m
 [0m[38;5;245m────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────[0m
-  0     web         [0m[38;5;29monline         [0m  48211    0         -          3.4%    182.0M    1h 25m    edge        -            [0m
-  1     web         [0m[38;5;29monline         [0m  48212    0         -          2.9%    178.0M    1h 26m    edge        -            [0m
 > 2     api         [0m[38;5;29monline         [0m  48219    1         -          7.1%    241.0M    1h 28m    edge        -            [0m
   3     billing-r…  [0m[38;5;29monline         [0m  48230    0         -          0.8%    96.0M     1h 29m    -           -            [0m
   4     cron        [0m[38;5;29monline         [0m  48233    0         -          0.1%    8.0M      1h 31m    -           -            [0m
   5     metrics     [0m[38;5;29monline         [0m  48240    0         -          0.4%    11.0M     1h 32m    -           -            [0m
+  0     web         [0m[38;5;29monline         [0m  48211    0         -          3.4%    182.0M    1h 25m    edge        -            [0m
+  1     web         [0m[38;5;29monline         [0m  48212    0         -          2.9%    178.0M    1h 26m    edge        -            [0m
                                                                                                                         [0m
                                                                                                                         [0m
                                                                                                                         [0m
@@ -67,12 +67,12 @@ shep lookout   /home/rin/.shep                                                  
 [0m[38;5;245mhost  load 2.31 4.10 3.88 / 10 cores   host mem 12.4G / 32.0G   flock cpu 6.7%   flock mem 371.0M   up 6d 3h            [0m
   [0m[38;5;245mID    NAME        STATUS           PID      RESTARTS  EXIT       CPU     MEM       UPTIME    FOLD        SMIT         [0m
 [0m[38;5;245m────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────[0m
-  0     web         [0m[38;5;29monline         [0m  48211    0         -          3.4%    182.0M    1h 25m    edge        -            [0m
-  1     web         [0m[38;5;29monline         [0m  48212    0         -          2.9%    178.0M    1h 26m    edge        -            [0m
 > 2     api         [0m[38;5;166merrored        [0m  -        14        1          -       -         1h 18m    edge        -            [0m
   3     billing-r…  [0m[38;5;221mwaiting-restart[0m  -        3         1          -       -         1h 19m    -           -            [0m
   4     cron        [0m[38;5;245mstopped        [0m  -        0         SIGTERM    -       -         1h 21m    -           -            [0m
   5     metrics     [0m[38;5;29monline         [0m  48240    0         -          0.4%    11.0M     1h 32m    -           -            [0m
+  0     web         [0m[38;5;29monline         [0m  48211    0         -          3.4%    182.0M    1h 25m    edge        -            [0m
+  1     web         [0m[38;5;29monline         [0m  48212    0         -          2.9%    178.0M    1h 26m    edge        -            [0m
                                                                                                                         [0m
                                                                                                                         [0m
                                                                                                                         [0m
@@ -135,12 +135,12 @@ shep lookout   /home/rin/.shep      [0m[38;5;245m 6 in the flock[0m
 [0m[38;5;245mhost  load 2.31 4.10 3.88 / 10 cores   host mem 12…[0m
   [0m[38;5;245mID    NAME      STATUS           CPU     UPTIME  [0m
 [0m[38;5;245m───────────────────────────────────────────────────[0m
-> 0     web       [0m[38;5;29monline         [0m  3.4%    1h 25m  [0m
-  1     web       [0m[38;5;29monline         [0m  2.9%    1h 26m  [0m
-  2     api       [0m[38;5;29monline         [0m  7.1%    1h 28m  [0m
+> 2     api       [0m[38;5;29monline         [0m  7.1%    1h 28m  [0m
   3     billing…  [0m[38;5;29monline         [0m  0.8%    1h 29m  [0m
   4     cron      [0m[38;5;29monline         [0m  0.1%    1h 31m  [0m
   5     metrics   [0m[38;5;29monline         [0m  0.4%    1h 32m  [0m
+  0     web       [0m[38;5;29monline         [0m  3.4%    1h 25m  [0m
+  1     web       [0m[38;5;29monline         [0m  2.9%    1h 26m  [0m
                                                    [0m
                                                    [0m
                                                    [0m
@@ -168,12 +168,12 @@ shep lookout   /home/rin/.shep                                                  
 [0m[38;5;245mhost  load 2.31 4.10 3.88 / 10 cores   host mem 12.4G / 32.0G   flock cpu 14.7%   flock mem 716.0M   up 6d 3h           [0m
   [0m[38;5;245mID    NAME        STATUS           PID      RESTARTS  EXIT       CPU     MEM       UPTIME    FOLD        SMIT         [0m
 [0m[38;5;245m────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────[0m
-  0     web         [0m[38;5;29monline         [0m  48211    0         -          3.4%    182.0M    1h 25m    edge        -            [0m
-  1     web         [0m[38;5;29monline         [0m  48212    0         -          2.9%    178.0M    1h 26m    edge        -            [0m
 > 2     api         [0m[38;5;29monline         [0m  48219    1         -          7.1%    241.0M    1h 28m    edge        -            [0m
   3     billing-r…  [0m[38;5;29monline         [0m  48230    0         -          0.8%    96.0M     1h 29m    -           -            [0m
   4     cron        [0m[38;5;29monline         [0m  48233    0         -          0.1%    8.0M      1h 31m    -           -            [0m
   5     metrics     [0m[38;5;29monline         [0m  48240    0         -          0.4%    11.0M     1h 32m    -           -            [0m
+  0     web         [0m[38;5;29monline         [0m  48211    0         -          3.4%    182.0M    1h 25m    edge        -            [0m
+  1     web         [0m[38;5;29monline         [0m  48212    0         -          2.9%    178.0M    1h 26m    edge        -            [0m
                                                                                                                         [0m
                                                                                                                         [0m
                                                                                                                         [0m
@@ -203,12 +203,12 @@ shep lookout   /home/rin/.shep                                                  
 [0m[38;5;245mhost  load 2.31 4.10 3.88 / 10 cores   host mem 12.4G / 32.0G   flock cpu 6.7%   flock mem 371.0M   up 6d 3h            [0m
   [0m[38;5;245mID    NAME        STATUS           PID      RESTARTS  EXIT       CPU     MEM       UPTIME    FOLD        SMIT         [0m
 [0m[38;5;245m────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────[0m
-  0     web         [0m[38;5;29monline         [0m  48211    0         -          3.4%    182.0M    1h 15m    edge        -            [0m
-  1     web         [0m[38;5;29monline         [0m  48212    0         -          2.9%    178.0M    1h 16m    edge        -            [0m
 > 2     api         [0m[38;5;166merrored        [0m  -        14        1          -       -         1h 18m    edge        -            [0m
   3     billing-r…  [0m[38;5;221mwaiting-restart[0m  -        3         1          -       -         1h 19m    -           -            [0m
   4     cron        [0m[38;5;245mstopped        [0m  -        0         SIGTERM    -       -         1h 21m    -           -            [0m
   5     metrics     [0m[38;5;29monline         [0m  48240    0         -          0.4%    11.0M     1h 22m    -           -            [0m
+  0     web         [0m[38;5;29monline         [0m  48211    0         -          3.4%    182.0M    1h 15m    edge        -            [0m
+  1     web         [0m[38;5;29monline         [0m  48212    0         -          2.9%    178.0M    1h 16m    edge        -            [0m
                                                                                                                         [0m
                                                                                                                         [0m
                                                                                                                         [0m
@@ -237,12 +237,12 @@ shep lookout   /home/rin/.shep                                                  
 [0m[38;5;245mhost  load 2.31 4.10 3.88 / 10 cores   host mem 12.4G / 32.0G   flock cpu 14.7%   flock mem 716.0M   up 6d 3h           [0m
   [0m[38;5;245mID    NAME        STATUS           PID      RESTARTS  EXIT       CPU     MEM       UPTIME    FOLD        SMIT         [0m
 [0m[38;5;245m────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────[0m
-  0     web         [0m[38;5;29monline         [0m  48211    0         -          3.4%    182.0M    1h 25m    edge        -            [0m
-  1     web         [0m[38;5;29monline         [0m  48212    0         -          2.9%    178.0M    1h 26m    edge        -            [0m
 > 2     api         [0m[38;5;29monline         [0m  48219    1         -          7.1%    241.0M    1h 28m    edge        -            [0m
   3     billing-r…  [0m[38;5;29monline         [0m  48230    0         -          0.8%    96.0M     1h 29m    -           -            [0m
   4     cron        [0m[38;5;29monline         [0m  48233    0         -          0.1%    8.0M      1h 31m    -           -            [0m
   5     metrics     [0m[38;5;29monline         [0m  48240    0         -          0.4%    11.0M     1h 32m    -           -            [0m
+  0     web         [0m[38;5;29monline         [0m  48211    0         -          3.4%    182.0M    1h 25m    edge        -            [0m
+  1     web         [0m[38;5;29monline         [0m  48212    0         -          2.9%    178.0M    1h 26m    edge        -            [0m
                                                                                                                         [0m
                                                                                                                         [0m
                                                                                                                         [0m
@@ -272,8 +272,8 @@ shep lookout   /home/rin/.shep                                                  
 [0m[38;5;245mhost  load 2.31 4.10 3.88 / 10 cores   host mem 12.4G / 32.0G   flock cpu 14.7%   flock mem 716.0M …[0m
   [0m[38;5;245mID    NAME               STATUS           PID      RESTARTS  EXIT       CPU     MEM       UPTIME  [0m
 [0m[38;5;245m────────────────────────────────────────────────────────────────────────────────────────────────────[0m
-  0     web                [0m[38;5;29monline         [0m  48211    0         -          3.4%    182.0M    1h 25m  [0m
-> 1     web                [0m[38;5;29monline         [0m  48212    0         -          2.9%    178.0M    1h 26m  [0m
+> 0     web                [0m[38;5;29monline         [0m  48211    0         -          3.4%    182.0M    1h 25m  [0m
+  1     web                [0m[38;5;29monline         [0m  48212    0         -          2.9%    178.0M    1h 26m  [0m
                                                                                                     [0m
                                                                                                     [0m
                                                                                                     [0m
@@ -291,8 +291,8 @@ shep lookout   /home/rin/.shep                                                  
 [0m[38;5;245mhost  load 2.31 4.10 3.88 / 10 cores   host mem 12.4G / 32.0G   flock cpu 14.7%   flock mem 716.0M …[0m
   [0m[38;5;245mID    NAME               STATUS           PID      RESTARTS  EXIT       CPU     MEM       UPTIME  [0m
 [0m[38;5;245m────────────────────────────────────────────────────────────────────────────────────────────────────[0m
-  0     web                [0m[38;5;29monline         [0m  48211    0         -          3.4%    182.0M    1h 25m  [0m
-> 1     web                [0m[38;5;29monline         [0m  48212    0         -          2.9%    178.0M    1h 26m  [0m
+> 0     web                [0m[38;5;29monline         [0m  48211    0         -          3.4%    182.0M    1h 25m  [0m
+  1     web                [0m[38;5;29monline         [0m  48212    0         -          2.9%    178.0M    1h 26m  [0m
                                                                                                     [0m
                                                                                                     [0m
                                                                                                     [0m
@@ -329,12 +329,12 @@ shep lookout   /home/rin/.shep                                                  
 [0m[38;5;245mhost  load 2.31 4.10 3.88 / 10 cores   host mem 12.4G / 32.0G   flock cpu 14.7%   flock mem 716.0M   up 6d 3h           [0m
   [0m[38;5;245mID    NAME        STATUS           PID      RESTARTS  EXIT       CPU     MEM       UPTIME    FOLD        SMIT         [0m
 [0m[38;5;245m────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────[0m
-  0     web         [0m[38;5;29monline         [0m  48211    0         -          3.4%    182.0M    1h 25m    edge        -            [0m
-  1     web         [0m[38;5;29monline         [0m  48212    0         -          2.9%    178.0M    1h 26m    edge        -            [0m
 > 2     api         [0m[38;5;29monline         [0m  48219    1         -          7.1%    241.0M    1h 28m    edge        -            [0m
   3     billing-r…  [0m[38;5;29monline         [0m  48230    0         -          0.8%    96.0M     1h 29m    -           -            [0m
   4     cron        [0m[38;5;29monline         [0m  48233    0         -          0.1%    8.0M      1h 31m    -           -            [0m
   5     metrics     [0m[38;5;29monline         [0m  48240    0         -          0.4%    11.0M     1h 32m    -           -            [0m
+  0     web         [0m[38;5;29monline         [0m  48211    0         -          3.4%    182.0M    1h 25m    edge        -            [0m
+  1     web         [0m[38;5;29monline         [0m  48212    0         -          2.9%    178.0M    1h 26m    edge        -            [0m
                                                                                                                         [0m
                                                                                                                         [0m
 [0m[38;5;245m────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────[0m
@@ -353,12 +353,12 @@ shep lookout   /home/rin/.shep                                                  
 shep lookout   /home/rin/.shep                                                                           [0m[38;5;245m 6 in the flock[0m
   [0m[38;5;245mID    NAME        STATUS           PID      RESTARTS  EXIT       CPU     MEM       UPTIME    FOLD        SMIT         [0m
 [0m[38;5;245m────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────[0m
-> 0     web         [0m[38;5;29monline         [0m  48211    0         -          3.4%    182.0M    1h 25m    edge        -            [0m
-  1     web         [0m[38;5;29monline         [0m  48212    0         -          2.9%    178.0M    1h 26m    edge        -            [0m
-  2     api         [0m[38;5;29monline         [0m  48219    1         -          7.1%    241.0M    1h 28m    edge        -            [0m
+> 2     api         [0m[38;5;29monline         [0m  48219    1         -          7.1%    241.0M    1h 28m    edge        -            [0m
   3     billing-r…  [0m[38;5;29monline         [0m  48230    0         -          0.8%    96.0M     1h 29m    -           -            [0m
   4     cron        [0m[38;5;29monline         [0m  48233    0         -          0.1%    8.0M      1h 31m    -           -            [0m
   5     metrics     [0m[38;5;29monline         [0m  48240    0         -          0.4%    11.0M     1h 32m    -           -            [0m
+  0     web         [0m[38;5;29monline         [0m  48211    0         -          3.4%    182.0M    1h 25m    edge        -            [0m
+  1     web         [0m[38;5;29monline         [0m  48212    0         -          2.9%    178.0M    1h 26m    edge        -            [0m
                                                                                                                         [0m
                                                                                                                         [0m
 [0m[38;5;245mq quit   j/k select   g/G first/last   r refresh   / filter                                                    read-only[0m
@@ -371,12 +371,12 @@ shep lookout   /home/rin/.shep                                                  
 [0m[38;5;245mhost  load 2.31 4.10 3.88 / 10 cores   host mem 12.4G / 32.0G   flock cpu 14.7%   flock mem 716.0M   up 6d 3h           [0m
   [0m[38;5;245mID    NAME        STATUS           PID      RESTARTS  EXIT       CPU     MEM       UPTIME    FOLD        SMIT         [0m
 [0m[38;5;245m────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────[0m
-  0     web         [0m[38;5;29monline         [0m  48211    0         -          3.4%    182.0M    1h 25m    edge        -            [0m
-  1     web         [0m[38;5;29monline         [0m  48212    0         -          2.9%    178.0M    1h 26m    edge        -            [0m
 > 2     api         [0m[38;5;29monline         [0m  48219    1         -          7.1%    241.0M    1h 28m    edge        -            [0m
   3     billing-r…  [0m[38;5;29monline         [0m  48230    0         -          0.8%    96.0M     1h 29m    -           -            [0m
   4     cron        [0m[38;5;29monline         [0m  48233    0         -          0.1%    8.0M      1h 31m    -           -            [0m
   5     metrics     [0m[38;5;29monline         [0m  48240    0         -          0.4%    11.0M     1h 32m    -           -            [0m
+  0     web         [0m[38;5;29monline         [0m  48211    0         -          3.4%    182.0M    1h 25m    edge        -            [0m
+  1     web         [0m[38;5;29monline         [0m  48212    0         -          2.9%    178.0M    1h 26m    edge        -            [0m
                                                                                                                         [0m
                                                                                                                         [0m
                                                                                                                         [0m
@@ -406,12 +406,12 @@ shep lookout   /home/rin/.shep                                                  
 [0m[38;5;245mhost  load 2.31 4.10 3.88 / 10 cores   host mem 12.4G / 32.0G   flock cpu 14.7%   flock mem 716.0M   up 6d 3h           [0m
   [0m[38;5;245mID    NAME        STATUS           PID      RESTARTS  EXIT       CPU     MEM       UPTIME    FOLD        SMIT         [0m
 [0m[38;5;245m────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────[0m
-  0     web         [0m[38;5;29monline         [0m  48211    0         -          3.4%    182.0M    1h 25m    edge        -            [0m
-  1     web         [0m[38;5;29monline         [0m  48212    0         -          2.9%    178.0M    1h 26m    edge        -            [0m
 > 2     api         [0m[38;5;29monline         [0m  48219    1         -          7.1%    241.0M    1h 28m    edge        -            [0m
   3     billing-r…  [0m[38;5;29monline         [0m  48230    0         -          0.8%    96.0M     1h 29m    -           -            [0m
   4     cron        [0m[38;5;29monline         [0m  48233    0         -          0.1%    8.0M      1h 31m    -           -            [0m
   5     metrics     [0m[38;5;29monline         [0m  48240    0         -          0.4%    11.0M     1h 32m    -           -            [0m
+  0     web         [0m[38;5;29monline         [0m  48211    0         -          3.4%    182.0M    1h 25m    edge        -            [0m
+  1     web         [0m[38;5;29monline         [0m  48212    0         -          2.9%    178.0M    1h 26m    edge        -            [0m
                                                                                                                         [0m
                                                                                                                         [0m
                                                                                                                         [0m
@@ -441,12 +441,12 @@ shep lookout   /h…[0m[38;5;245m 6 in the flock[0m
 [0m[38;5;245mhost  load 2.31 4.10 3.88 / 10 c…[0m
   [0m[38;5;245mID    NAME      STATUS         [0m
 [0m[38;5;245m─────────────────────────────────[0m
-  0     web       [0m[38;5;29monline         [0m
-  1     web       [0m[38;5;29monline         [0m
 > 2     api       [0m[38;5;29monline         [0m
   3     billing…  [0m[38;5;29monline         [0m
   4     cron      [0m[38;5;29monline         [0m
   5     metrics   [0m[38;5;29monline         [0m
+  0     web       [0m[38;5;29monline         [0m
+  1     web       [0m[38;5;29monline         [0m
                                  [0m
                                  [0m
                                  [0m
@@ -472,12 +472,12 @@ shep lookout   /home/rin/.shep                                                  
 [0m[38;5;245mhost  usage is not available on this platform   flock cpu 14.7%   flock mem 716.0M                                      [0m
   [0m[38;5;245mID    NAME        STATUS           PID      RESTARTS  EXIT       CPU     MEM       UPTIME    FOLD        SMIT         [0m
 [0m[38;5;245m────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────[0m
-  0     web         [0m[38;5;29monline         [0m  48211    0         -          3.4%    182.0M    1h 25m    edge        -            [0m
-  1     web         [0m[38;5;29monline         [0m  48212    0         -          2.9%    178.0M    1h 26m    edge        -            [0m
 > 2     api         [0m[38;5;29monline         [0m  48219    1         -          7.1%    241.0M    1h 28m    edge        -            [0m
   3     billing-r…  [0m[38;5;29monline         [0m  48230    0         -          0.8%    96.0M     1h 29m    -           -            [0m
   4     cron        [0m[38;5;29monline         [0m  48233    0         -          0.1%    8.0M      1h 31m    -           -            [0m
   5     metrics     [0m[38;5;29monline         [0m  48240    0         -          0.4%    11.0M     1h 32m    -           -            [0m
+  0     web         [0m[38;5;29monline         [0m  48211    0         -          3.4%    182.0M    1h 25m    edge        -            [0m
+  1     web         [0m[38;5;29monline         [0m  48212    0         -          2.9%    178.0M    1h 26m    edge        -            [0m
                                                                                                                         [0m
                                                                                                                         [0m
                                                                                                                         [0m
@@ -507,12 +507,12 @@ shep lookout   /home/rin/.shep                                                  
 [0m[38;5;245mhost  load 2.31 4.10 3.88 / 10 cores   host mem 12.4G / 32.0G   flock cpu 14.7%   flock mem 716.0M   up 6d 3h           [0m
   [0m[38;5;245mID    NAME        STATUS           PID      RESTARTS  EXIT       CPU     MEM       UPTIME    FOLD        SMIT         [0m
 [0m[38;5;245m────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────[0m
-  0     web         [0m[38;5;29monline         [0m  48211    0         -          3.4%    182.0M    1h 25m    edge        -            [0m
-  1     web         [0m[38;5;29monline         [0m  48212    0         -          2.9%    178.0M    1h 26m    edge        -            [0m
 > 2     api         [0m[38;5;29monline         [0m  48219    1         -          7.1%    241.0M    1h 28m    edge        -            [0m
   3     billing-r…  [0m[38;5;29monline         [0m  48230    0         -          0.8%    96.0M     1h 29m    -           -            [0m
   4     cron        [0m[38;5;29monline         [0m  48233    0         -          0.1%    8.0M      1h 31m    -           -            [0m
   5     metrics     [0m[38;5;29monline         [0m  48240    0         -          0.4%    11.0M     1h 32m    -           -            [0m
+  0     web         [0m[38;5;29monline         [0m  48211    0         -          3.4%    182.0M    1h 25m    edge        -            [0m
+  1     web         [0m[38;5;29monline         [0m  48212    0         -          2.9%    178.0M    1h 26m    edge        -            [0m
                                                                                                                         [0m
                                                                                                                         [0m
                                                                                                                         [0m
@@ -542,12 +542,12 @@ shep lookout   /home/rin/.shep                                                  
 [0m[38;5;245mhost  load 2.31 4.10 3.88 / 10 cores   host mem 12.4G / 32.0G   flock cpu 6.7%   flock mem 371.0M   up 6d 3h            [0m
   [0m[38;5;245mID    NAME        STATUS           PID      RESTARTS  EXIT       CPU     MEM       UPTIME    FOLD        SMIT         [0m
 [0m[38;5;245m────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────[0m
-  0     web         [0m[38;5;29monline         [0m  48211    0         -          3.4%    182.0M    1h 25m    edge        -            [0m
-  1     web         [0m[38;5;29monline         [0m  48212    0         -          2.9%    178.0M    1h 26m    edge        -            [0m
   2     api         [0m[38;5;166merrored        [0m  -        14        1          -       -         1h 18m    edge        -            [0m
   3     billing-r…  [0m[38;5;221mwaiting-restart[0m  -        3         1          -       -         1h 19m    -           -            [0m
 > 4     cron        [0m[38;5;245mstopped        [0m  -        0         SIGTERM    -       -         1h 21m    -           -            [0m
   5     metrics     [0m[38;5;29monline         [0m  48240    0         -          0.4%    11.0M     1h 32m    -           -            [0m
+  0     web         [0m[38;5;29monline         [0m  48211    0         -          3.4%    182.0M    1h 25m    edge        -            [0m
+  1     web         [0m[38;5;29monline         [0m  48212    0         -          2.9%    178.0M    1h 26m    edge        -            [0m
                                                                                                                         [0m
                                                                                                                         [0m
                                                                                                                         [0m
@@ -577,12 +577,12 @@ shep lookout   /home/rin/.shep                                                  
 [0m[38;5;245mhost  load 2.31 4.10 3.88 / 10 cores   host mem 12.4G / 32.0G   flock cpu 14.7%   flock mem 716.0M …[0m
   [0m[38;5;245mID    NAME               STATUS           PID      RESTARTS  EXIT       CPU     MEM       UPTIME  [0m
 [0m[38;5;245m────────────────────────────────────────────────────────────────────────────────────────────────────[0m
-  0     web                [0m[38;5;29monline         [0m  48211    0         -          3.4%    182.0M    1h 25m  [0m
-  1     web                [0m[38;5;29monline         [0m  48212    0         -          2.9%    178.0M    1h 26m  [0m
 > 2     api                [0m[38;5;29monline         [0m  48219    1         -          7.1%    241.0M    1h 28m  [0m
   3     billing-reconcil…  [0m[38;5;29monline         [0m  48230    0         -          0.8%    96.0M     1h 29m  [0m
   4     cron               [0m[38;5;29monline         [0m  48233    0         -          0.1%    8.0M      1h 31m  [0m
   5     metrics            [0m[38;5;29monline         [0m  48240    0         -          0.4%    11.0M     1h 32m  [0m
+  0     web                [0m[38;5;29monline         [0m  48211    0         -          3.4%    182.0M    1h 25m  [0m
+  1     web                [0m[38;5;29monline         [0m  48212    0         -          2.9%    178.0M    1h 26m  [0m
                                                                                                     [0m
                                                                                                     [0m
                                                                                                     [0m
@@ -596,12 +596,12 @@ shep lookout   /home/rin/.shep                                                  
 [0m[38;5;245mhost  load 2.31 4.10 3.88 / 10 cores   host mem 12.4G / 32.0G   flock cpu 14.7%   flock mem 716.0M …[0m
   [0m[38;5;245mID    NAME               STATUS           PID      RESTARTS  EXIT       CPU     MEM       UPTIME  [0m
 [0m[38;5;245m────────────────────────────────────────────────────────────────────────────────────────────────────[0m
-  0     web                [0m[38;5;29monline         [0m  48211    0         -          3.4%    182.0M    1h 25m  [0m
-  1     web                [0m[38;5;29monline         [0m  48212    0         -          2.9%    178.0M    1h 26m  [0m
 > 2     api                [0m[38;5;29monline         [0m  48219    1         -          7.1%    241.0M    1h 28m  [0m
   3     billing-reconcil…  [0m[38;5;29monline         [0m  48230    0         -          0.8%    96.0M     1h 29m  [0m
   4     cron               [0m[38;5;29monline         [0m  48233    0         -          0.1%    8.0M      1h 31m  [0m
   5     metrics            [0m[38;5;29monline         [0m  48240    0         -          0.4%    11.0M     1h 32m  [0m
+  0     web                [0m[38;5;29monline         [0m  48211    0         -          3.4%    182.0M    1h 25m  [0m
+  1     web                [0m[38;5;29monline         [0m  48212    0         -          2.9%    178.0M    1h 26m  [0m
                                                                                                     [0m
                                                                                                     [0m
                                                                                                     [0m
@@ -615,11 +615,11 @@ shep lookout   /home/rin/.shep                                                  
 [0m[38;5;245mhost  load 2.31 4.10 3.88 / 10 cores   host mem 12.4G / 32.0G   flock cpu 7.6%   flock mem 475.0M  …[0m
   [0m[38;5;245mID    NAME               STATUS           PID      RESTARTS  EXIT       CPU     MEM       UPTIME  [0m
 [0m[38;5;245m────────────────────────────────────────────────────────────────────────────────────────────────────[0m
-  0     web                [0m[38;5;29monline         [0m  48211    0         -          3.4%    182.0M    1h 25m  [0m
-  1     web                [0m[38;5;29monline         [0m  48212    0         -          2.9%    178.0M    1h 26m  [0m
 > 3     billing-reconcil…  [0m[38;5;29monline         [0m  48230    0         -          0.8%    96.0M     1h 29m  [0m
   4     cron               [0m[38;5;29monline         [0m  48233    0         -          0.1%    8.0M      1h 31m  [0m
   5     metrics            [0m[38;5;29monline         [0m  48240    0         -          0.4%    11.0M     1h 32m  [0m
+  0     web                [0m[38;5;29monline         [0m  48211    0         -          3.4%    182.0M    1h 25m  [0m
+  1     web                [0m[38;5;29monline         [0m  48212    0         -          2.9%    178.0M    1h 26m  [0m
                                                                                                     [0m
                                                                                                     [0m
                                                                                                     [0m
@@ -634,12 +634,12 @@ shep lookout   /home/rin/.shep                                                  
 [0m[38;5;245mhost  load 2.31 4.10 3.88 / 10 cores   host mem 12.4G / 32.0G   flock cpu 14.7%   flock mem 716.0M …[0m
   [0m[38;5;245mID    NAME               STATUS           PID      RESTARTS  EXIT       CPU     MEM       UPTIME  [0m
 [0m[38;5;245m────────────────────────────────────────────────────────────────────────────────────────────────────[0m
-  0     web                [0m[38;5;29monline         [0m  48211    0         -          3.4%    182.0M    1h 25m  [0m
-  1     web                [0m[38;5;29monline         [0m  48212    0         -          2.9%    178.0M    1h 26m  [0m
 > 2     api                [0m[38;5;29monline         [0m  48299    2         -          7.1%    241.0M    1h 18m  [0m
   3     billing-reconcil…  [0m[38;5;29monline         [0m  48230    0         -          0.8%    96.0M     1h 29m  [0m
   4     cron               [0m[38;5;29monline         [0m  48233    0         -          0.1%    8.0M      1h 31m  [0m
   5     metrics            [0m[38;5;29monline         [0m  48240    0         -          0.4%    11.0M     1h 32m  [0m
+  0     web                [0m[38;5;29monline         [0m  48211    0         -          3.4%    182.0M    1h 25m  [0m
+  1     web                [0m[38;5;29monline         [0m  48212    0         -          2.9%    178.0M    1h 26m  [0m
                                                                                                     [0m
                                                                                                     [0m
                                                                                                     [0m
@@ -654,12 +654,12 @@ shep lookout   /home/rin/.shep                                                  
 [0m[38;5;245mhost  load 2.31 4.10 3.88 / 10 cores   host mem 12.4G / 32.0G   flock cpu 14.7%   flock mem 716.0M …[0m
   [0m[38;5;245mID    NAME               STATUS           PID      RESTARTS  EXIT       CPU     MEM       UPTIME  [0m
 [0m[38;5;245m────────────────────────────────────────────────────────────────────────────────────────────────────[0m
-  0     web                [0m[38;5;29monline         [0m  48211    0         -          3.4%    182.0M    1h 25m  [0m
-  1     web                [0m[38;5;29monline         [0m  48212    0         -          2.9%    178.0M    1h 26m  [0m
 > 2     api                [0m[38;5;29monline         [0m  48219    1         -          7.1%    241.0M    1h 28m  [0m
   3     billing-reconcil…  [0m[38;5;29monline         [0m  48230    0         -          0.8%    96.0M     1h 29m  [0m
   4     cron               [0m[38;5;29monline         [0m  48233    0         -          0.1%    8.0M      1h 31m  [0m
   5     metrics            [0m[38;5;29monline         [0m  48240    0         -          0.4%    11.0M     1h 32m  [0m
+  0     web                [0m[38;5;29monline         [0m  48211    0         -          3.4%    182.0M    1h 25m  [0m
+  1     web                [0m[38;5;29monline         [0m  48212    0         -          2.9%    178.0M    1h 26m  [0m
                                                                                                     [0m
                                                                                                     [0m
 [0m[38;5;166mthe shepherd stopped answering — reconnecting (attempt 3)                           [0m[38;5;245m control enabled[0m

--- a/docs/lookout/frames.txt
+++ b/docs/lookout/frames.txt
@@ -32,12 +32,12 @@ shep lookout   /home/rin/.shep                                                  
 host  load 2.31 4.10 3.88 / 10 cores   host mem 12.4G / 32.0G   flock cpu 14.7%   flock mem 716.0M   up 6d 3h           
   ID    NAME        STATUS           PID      RESTARTS  EXIT       CPU     MEM       UPTIME    FOLD        SMIT         
 ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-  0     web         online           48211    0         -          3.4%    182.0M    1h 25m    edge        -            
-  1     web         online           48212    0         -          2.9%    178.0M    1h 26m    edge        -            
 > 2     api         online           48219    1         -          7.1%    241.0M    1h 28m    edge        -            
   3     billing-r…  online           48230    0         -          0.8%    96.0M     1h 29m    -           -            
   4     cron        online           48233    0         -          0.1%    8.0M      1h 31m    -           -            
   5     metrics     online           48240    0         -          0.4%    11.0M     1h 32m    -           -            
+  0     web         online           48211    0         -          3.4%    182.0M    1h 25m    edge        -            
+  1     web         online           48212    0         -          2.9%    178.0M    1h 26m    edge        -            
                                                                                                                         
                                                                                                                         
                                                                                                                         
@@ -66,12 +66,12 @@ shep lookout   /home/rin/.shep                                                  
 host  load 2.31 4.10 3.88 / 10 cores   host mem 12.4G / 32.0G   flock cpu 6.7%   flock mem 371.0M   up 6d 3h            
   ID    NAME        STATUS           PID      RESTARTS  EXIT       CPU     MEM       UPTIME    FOLD        SMIT         
 ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-  0     web         online           48211    0         -          3.4%    182.0M    1h 25m    edge        -            
-  1     web         online           48212    0         -          2.9%    178.0M    1h 26m    edge        -            
 > 2     api         errored          -        14        1          -       -         1h 18m    edge        -            
   3     billing-r…  waiting-restart  -        3         1          -       -         1h 19m    -           -            
   4     cron        stopped          -        0         SIGTERM    -       -         1h 21m    -           -            
   5     metrics     online           48240    0         -          0.4%    11.0M     1h 32m    -           -            
+  0     web         online           48211    0         -          3.4%    182.0M    1h 25m    edge        -            
+  1     web         online           48212    0         -          2.9%    178.0M    1h 26m    edge        -            
                                                                                                                         
                                                                                                                         
                                                                                                                         
@@ -132,12 +132,12 @@ shep lookout   /home/rin/.shep       6 in the flock
 host  load 2.31 4.10 3.88 / 10 cores   host mem 12…
   ID    NAME      STATUS           CPU     UPTIME  
 ───────────────────────────────────────────────────
-> 0     web       online           3.4%    1h 25m  
-  1     web       online           2.9%    1h 26m  
-  2     api       online           7.1%    1h 28m  
+> 2     api       online           7.1%    1h 28m  
   3     billing…  online           0.8%    1h 29m  
   4     cron      online           0.1%    1h 31m  
   5     metrics   online           0.4%    1h 32m  
+  0     web       online           3.4%    1h 25m  
+  1     web       online           2.9%    1h 26m  
                                                    
                                                    
                                                    
@@ -163,12 +163,12 @@ the shepherd stopped answering — reconnecting (attempt 3)
 host  load 2.31 4.10 3.88 / 10 cores   host mem 12.4G / 32.0G   flock cpu 14.7%   flock mem 716.0M   up 6d 3h           
   ID    NAME        STATUS           PID      RESTARTS  EXIT       CPU     MEM       UPTIME    FOLD        SMIT         
 ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-  0     web         online           48211    0         -          3.4%    182.0M    1h 25m    edge        -            
-  1     web         online           48212    0         -          2.9%    178.0M    1h 26m    edge        -            
 > 2     api         online           48219    1         -          7.1%    241.0M    1h 28m    edge        -            
   3     billing-r…  online           48230    0         -          0.8%    96.0M     1h 29m    -           -            
   4     cron        online           48233    0         -          0.1%    8.0M      1h 31m    -           -            
   5     metrics     online           48240    0         -          0.4%    11.0M     1h 32m    -           -            
+  0     web         online           48211    0         -          3.4%    182.0M    1h 25m    edge        -            
+  1     web         online           48212    0         -          2.9%    178.0M    1h 26m    edge        -            
                                                                                                                         
                                                                                                                         
                                                                                                                         
@@ -197,12 +197,12 @@ the shepherd has died — these values are frozen as of 2026-08-14 14:32:07
 host  load 2.31 4.10 3.88 / 10 cores   host mem 12.4G / 32.0G   flock cpu 6.7%   flock mem 371.0M   up 6d 3h            
   ID    NAME        STATUS           PID      RESTARTS  EXIT       CPU     MEM       UPTIME    FOLD        SMIT         
 ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-  0     web         online           48211    0         -          3.4%    182.0M    1h 15m    edge        -            
-  1     web         online           48212    0         -          2.9%    178.0M    1h 16m    edge        -            
 > 2     api         errored          -        14        1          -       -         1h 18m    edge        -            
   3     billing-r…  waiting-restart  -        3         1          -       -         1h 19m    -           -            
   4     cron        stopped          -        0         SIGTERM    -       -         1h 21m    -           -            
   5     metrics     online           48240    0         -          0.4%    11.0M     1h 22m    -           -            
+  0     web         online           48211    0         -          3.4%    182.0M    1h 15m    edge        -            
+  1     web         online           48212    0         -          2.9%    178.0M    1h 16m    edge        -            
                                                                                                                         
                                                                                                                         
                                                                                                                         
@@ -230,12 +230,12 @@ shep lookout   /home/rin/.shep                                                  
 host  load 2.31 4.10 3.88 / 10 cores   host mem 12.4G / 32.0G   flock cpu 14.7%   flock mem 716.0M   up 6d 3h           
   ID    NAME        STATUS           PID      RESTARTS  EXIT       CPU     MEM       UPTIME    FOLD        SMIT         
 ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-  0     web         online           48211    0         -          3.4%    182.0M    1h 25m    edge        -            
-  1     web         online           48212    0         -          2.9%    178.0M    1h 26m    edge        -            
 > 2     api         online           48219    1         -          7.1%    241.0M    1h 28m    edge        -            
   3     billing-r…  online           48230    0         -          0.8%    96.0M     1h 29m    -           -            
   4     cron        online           48233    0         -          0.1%    8.0M      1h 31m    -           -            
   5     metrics     online           48240    0         -          0.4%    11.0M     1h 32m    -           -            
+  0     web         online           48211    0         -          3.4%    182.0M    1h 25m    edge        -            
+  1     web         online           48212    0         -          2.9%    178.0M    1h 26m    edge        -            
                                                                                                                         
                                                                                                                         
                                                                                                                         
@@ -264,8 +264,8 @@ shep lookout   /home/rin/.shep                                                  
 host  load 2.31 4.10 3.88 / 10 cores   host mem 12.4G / 32.0G   flock cpu 14.7%   flock mem 716.0M …
   ID    NAME               STATUS           PID      RESTARTS  EXIT       CPU     MEM       UPTIME  
 ────────────────────────────────────────────────────────────────────────────────────────────────────
-  0     web                online           48211    0         -          3.4%    182.0M    1h 25m  
-> 1     web                online           48212    0         -          2.9%    178.0M    1h 26m  
+> 0     web                online           48211    0         -          3.4%    182.0M    1h 25m  
+  1     web                online           48212    0         -          2.9%    178.0M    1h 26m  
                                                                                                     
                                                                                                     
                                                                                                     
@@ -282,8 +282,8 @@ shep lookout   /home/rin/.shep                                                  
 host  load 2.31 4.10 3.88 / 10 cores   host mem 12.4G / 32.0G   flock cpu 14.7%   flock mem 716.0M …
   ID    NAME               STATUS           PID      RESTARTS  EXIT       CPU     MEM       UPTIME  
 ────────────────────────────────────────────────────────────────────────────────────────────────────
-  0     web                online           48211    0         -          3.4%    182.0M    1h 25m  
-> 1     web                online           48212    0         -          2.9%    178.0M    1h 26m  
+> 0     web                online           48211    0         -          3.4%    182.0M    1h 25m  
+  1     web                online           48212    0         -          2.9%    178.0M    1h 26m  
                                                                                                     
                                                                                                     
                                                                                                     
@@ -318,12 +318,12 @@ shep lookout   /home/rin/.shep                                                  
 host  load 2.31 4.10 3.88 / 10 cores   host mem 12.4G / 32.0G   flock cpu 14.7%   flock mem 716.0M   up 6d 3h           
   ID    NAME        STATUS           PID      RESTARTS  EXIT       CPU     MEM       UPTIME    FOLD        SMIT         
 ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-  0     web         online           48211    0         -          3.4%    182.0M    1h 25m    edge        -            
-  1     web         online           48212    0         -          2.9%    178.0M    1h 26m    edge        -            
 > 2     api         online           48219    1         -          7.1%    241.0M    1h 28m    edge        -            
   3     billing-r…  online           48230    0         -          0.8%    96.0M     1h 29m    -           -            
   4     cron        online           48233    0         -          0.1%    8.0M      1h 31m    -           -            
   5     metrics     online           48240    0         -          0.4%    11.0M     1h 32m    -           -            
+  0     web         online           48211    0         -          3.4%    182.0M    1h 25m    edge        -            
+  1     web         online           48212    0         -          2.9%    178.0M    1h 26m    edge        -            
                                                                                                                         
                                                                                                                         
 ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
@@ -341,12 +341,12 @@ q quit   j/k select   g/G first/last   r refresh   / filter                     
 shep lookout   /home/rin/.shep                                                                            6 in the flock
   ID    NAME        STATUS           PID      RESTARTS  EXIT       CPU     MEM       UPTIME    FOLD        SMIT         
 ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-> 0     web         online           48211    0         -          3.4%    182.0M    1h 25m    edge        -            
-  1     web         online           48212    0         -          2.9%    178.0M    1h 26m    edge        -            
-  2     api         online           48219    1         -          7.1%    241.0M    1h 28m    edge        -            
+> 2     api         online           48219    1         -          7.1%    241.0M    1h 28m    edge        -            
   3     billing-r…  online           48230    0         -          0.8%    96.0M     1h 29m    -           -            
   4     cron        online           48233    0         -          0.1%    8.0M      1h 31m    -           -            
   5     metrics     online           48240    0         -          0.4%    11.0M     1h 32m    -           -            
+  0     web         online           48211    0         -          3.4%    182.0M    1h 25m    edge        -            
+  1     web         online           48212    0         -          2.9%    178.0M    1h 26m    edge        -            
                                                                                                                         
                                                                                                                         
 q quit   j/k select   g/G first/last   r refresh   / filter                                                    read-only
@@ -358,12 +358,12 @@ shep lookout   /home/rin/.shep                                                  
 host  load 2.31 4.10 3.88 / 10 cores   host mem 12.4G / 32.0G   flock cpu 14.7%   flock mem 716.0M   up 6d 3h           
   ID    NAME        STATUS           PID      RESTARTS  EXIT       CPU     MEM       UPTIME    FOLD        SMIT         
 ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-  0     web         online           48211    0         -          3.4%    182.0M    1h 25m    edge        -            
-  1     web         online           48212    0         -          2.9%    178.0M    1h 26m    edge        -            
 > 2     api         online           48219    1         -          7.1%    241.0M    1h 28m    edge        -            
   3     billing-r…  online           48230    0         -          0.8%    96.0M     1h 29m    -           -            
   4     cron        online           48233    0         -          0.1%    8.0M      1h 31m    -           -            
   5     metrics     online           48240    0         -          0.4%    11.0M     1h 32m    -           -            
+  0     web         online           48211    0         -          3.4%    182.0M    1h 25m    edge        -            
+  1     web         online           48212    0         -          2.9%    178.0M    1h 26m    edge        -            
                                                                                                                         
                                                                                                                         
                                                                                                                         
@@ -392,12 +392,12 @@ shep lookout   /home/rin/.shep                                                  
 host  load 2.31 4.10 3.88 / 10 cores   host mem 12.4G / 32.0G   flock cpu 14.7%   flock mem 716.0M   up 6d 3h           
   ID    NAME        STATUS           PID      RESTARTS  EXIT       CPU     MEM       UPTIME    FOLD        SMIT         
 ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-  0     web         online           48211    0         -          3.4%    182.0M    1h 25m    edge        -            
-  1     web         online           48212    0         -          2.9%    178.0M    1h 26m    edge        -            
 > 2     api         online           48219    1         -          7.1%    241.0M    1h 28m    edge        -            
   3     billing-r…  online           48230    0         -          0.8%    96.0M     1h 29m    -           -            
   4     cron        online           48233    0         -          0.1%    8.0M      1h 31m    -           -            
   5     metrics     online           48240    0         -          0.4%    11.0M     1h 32m    -           -            
+  0     web         online           48211    0         -          3.4%    182.0M    1h 25m    edge        -            
+  1     web         online           48212    0         -          2.9%    178.0M    1h 26m    edge        -            
                                                                                                                         
                                                                                                                         
                                                                                                                         
@@ -426,12 +426,12 @@ shep lookout   /h… 6 in the flock
 host  load 2.31 4.10 3.88 / 10 c…
   ID    NAME      STATUS         
 ─────────────────────────────────
-  0     web       online         
-  1     web       online         
 > 2     api       online         
   3     billing…  online         
   4     cron      online         
   5     metrics   online         
+  0     web       online         
+  1     web       online         
                                  
                                  
                                  
@@ -456,12 +456,12 @@ shep lookout   /home/rin/.shep                                                  
 host  usage is not available on this platform   flock cpu 14.7%   flock mem 716.0M                                      
   ID    NAME        STATUS           PID      RESTARTS  EXIT       CPU     MEM       UPTIME    FOLD        SMIT         
 ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-  0     web         online           48211    0         -          3.4%    182.0M    1h 25m    edge        -            
-  1     web         online           48212    0         -          2.9%    178.0M    1h 26m    edge        -            
 > 2     api         online           48219    1         -          7.1%    241.0M    1h 28m    edge        -            
   3     billing-r…  online           48230    0         -          0.8%    96.0M     1h 29m    -           -            
   4     cron        online           48233    0         -          0.1%    8.0M      1h 31m    -           -            
   5     metrics     online           48240    0         -          0.4%    11.0M     1h 32m    -           -            
+  0     web         online           48211    0         -          3.4%    182.0M    1h 25m    edge        -            
+  1     web         online           48212    0         -          2.9%    178.0M    1h 26m    edge        -            
                                                                                                                         
                                                                                                                         
                                                                                                                         
@@ -490,12 +490,12 @@ shep lookout   /home/rin/.shep                                                  
 host  load 2.31 4.10 3.88 / 10 cores   host mem 12.4G / 32.0G   flock cpu 14.7%   flock mem 716.0M   up 6d 3h           
   ID    NAME        STATUS           PID      RESTARTS  EXIT       CPU     MEM       UPTIME    FOLD        SMIT         
 ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-  0     web         online           48211    0         -          3.4%    182.0M    1h 25m    edge        -            
-  1     web         online           48212    0         -          2.9%    178.0M    1h 26m    edge        -            
 > 2     api         online           48219    1         -          7.1%    241.0M    1h 28m    edge        -            
   3     billing-r…  online           48230    0         -          0.8%    96.0M     1h 29m    -           -            
   4     cron        online           48233    0         -          0.1%    8.0M      1h 31m    -           -            
   5     metrics     online           48240    0         -          0.4%    11.0M     1h 32m    -           -            
+  0     web         online           48211    0         -          3.4%    182.0M    1h 25m    edge        -            
+  1     web         online           48212    0         -          2.9%    178.0M    1h 26m    edge        -            
                                                                                                                         
                                                                                                                         
                                                                                                                         
@@ -524,12 +524,12 @@ shep lookout   /home/rin/.shep                                                  
 host  load 2.31 4.10 3.88 / 10 cores   host mem 12.4G / 32.0G   flock cpu 6.7%   flock mem 371.0M   up 6d 3h            
   ID    NAME        STATUS           PID      RESTARTS  EXIT       CPU     MEM       UPTIME    FOLD        SMIT         
 ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-  0     web         online           48211    0         -          3.4%    182.0M    1h 25m    edge        -            
-  1     web         online           48212    0         -          2.9%    178.0M    1h 26m    edge        -            
   2     api         errored          -        14        1          -       -         1h 18m    edge        -            
   3     billing-r…  waiting-restart  -        3         1          -       -         1h 19m    -           -            
 > 4     cron        stopped          -        0         SIGTERM    -       -         1h 21m    -           -            
   5     metrics     online           48240    0         -          0.4%    11.0M     1h 32m    -           -            
+  0     web         online           48211    0         -          3.4%    182.0M    1h 25m    edge        -            
+  1     web         online           48212    0         -          2.9%    178.0M    1h 26m    edge        -            
                                                                                                                         
                                                                                                                         
                                                                                                                         
@@ -558,12 +558,12 @@ shep lookout   /home/rin/.shep                                                  
 host  load 2.31 4.10 3.88 / 10 cores   host mem 12.4G / 32.0G   flock cpu 14.7%   flock mem 716.0M …
   ID    NAME               STATUS           PID      RESTARTS  EXIT       CPU     MEM       UPTIME  
 ────────────────────────────────────────────────────────────────────────────────────────────────────
-  0     web                online           48211    0         -          3.4%    182.0M    1h 25m  
-  1     web                online           48212    0         -          2.9%    178.0M    1h 26m  
 > 2     api                online           48219    1         -          7.1%    241.0M    1h 28m  
   3     billing-reconcil…  online           48230    0         -          0.8%    96.0M     1h 29m  
   4     cron               online           48233    0         -          0.1%    8.0M      1h 31m  
   5     metrics            online           48240    0         -          0.4%    11.0M     1h 32m  
+  0     web                online           48211    0         -          3.4%    182.0M    1h 25m  
+  1     web                online           48212    0         -          2.9%    178.0M    1h 26m  
                                                                                                     
                                                                                                     
                                                                                                     
@@ -576,12 +576,12 @@ shep lookout   /home/rin/.shep                                                  
 host  load 2.31 4.10 3.88 / 10 cores   host mem 12.4G / 32.0G   flock cpu 14.7%   flock mem 716.0M …
   ID    NAME               STATUS           PID      RESTARTS  EXIT       CPU     MEM       UPTIME  
 ────────────────────────────────────────────────────────────────────────────────────────────────────
-  0     web                online           48211    0         -          3.4%    182.0M    1h 25m  
-  1     web                online           48212    0         -          2.9%    178.0M    1h 26m  
 > 2     api                online           48219    1         -          7.1%    241.0M    1h 28m  
   3     billing-reconcil…  online           48230    0         -          0.8%    96.0M     1h 29m  
   4     cron               online           48233    0         -          0.1%    8.0M      1h 31m  
   5     metrics            online           48240    0         -          0.4%    11.0M     1h 32m  
+  0     web                online           48211    0         -          3.4%    182.0M    1h 25m  
+  1     web                online           48212    0         -          2.9%    178.0M    1h 26m  
                                                                                                     
                                                                                                     
                                                                                                     
@@ -594,11 +594,11 @@ shep lookout   /home/rin/.shep                                                  
 host  load 2.31 4.10 3.88 / 10 cores   host mem 12.4G / 32.0G   flock cpu 7.6%   flock mem 475.0M  …
   ID    NAME               STATUS           PID      RESTARTS  EXIT       CPU     MEM       UPTIME  
 ────────────────────────────────────────────────────────────────────────────────────────────────────
-  0     web                online           48211    0         -          3.4%    182.0M    1h 25m  
-  1     web                online           48212    0         -          2.9%    178.0M    1h 26m  
 > 3     billing-reconcil…  online           48230    0         -          0.8%    96.0M     1h 29m  
   4     cron               online           48233    0         -          0.1%    8.0M      1h 31m  
   5     metrics            online           48240    0         -          0.4%    11.0M     1h 32m  
+  0     web                online           48211    0         -          3.4%    182.0M    1h 25m  
+  1     web                online           48212    0         -          2.9%    178.0M    1h 26m  
                                                                                                     
                                                                                                     
                                                                                                     
@@ -612,12 +612,12 @@ shep lookout   /home/rin/.shep                                                  
 host  load 2.31 4.10 3.88 / 10 cores   host mem 12.4G / 32.0G   flock cpu 14.7%   flock mem 716.0M …
   ID    NAME               STATUS           PID      RESTARTS  EXIT       CPU     MEM       UPTIME  
 ────────────────────────────────────────────────────────────────────────────────────────────────────
-  0     web                online           48211    0         -          3.4%    182.0M    1h 25m  
-  1     web                online           48212    0         -          2.9%    178.0M    1h 26m  
 > 2     api                online           48299    2         -          7.1%    241.0M    1h 18m  
   3     billing-reconcil…  online           48230    0         -          0.8%    96.0M     1h 29m  
   4     cron               online           48233    0         -          0.1%    8.0M      1h 31m  
   5     metrics            online           48240    0         -          0.4%    11.0M     1h 32m  
+  0     web                online           48211    0         -          3.4%    182.0M    1h 25m  
+  1     web                online           48212    0         -          2.9%    178.0M    1h 26m  
                                                                                                     
                                                                                                     
                                                                                                     
@@ -631,12 +631,12 @@ the shepherd stopped answering — reconnecting (attempt 3)
 host  load 2.31 4.10 3.88 / 10 cores   host mem 12.4G / 32.0G   flock cpu 14.7%   flock mem 716.0M …
   ID    NAME               STATUS           PID      RESTARTS  EXIT       CPU     MEM       UPTIME  
 ────────────────────────────────────────────────────────────────────────────────────────────────────
-  0     web                online           48211    0         -          3.4%    182.0M    1h 25m  
-  1     web                online           48212    0         -          2.9%    178.0M    1h 26m  
 > 2     api                online           48219    1         -          7.1%    241.0M    1h 28m  
   3     billing-reconcil…  online           48230    0         -          0.8%    96.0M     1h 29m  
   4     cron               online           48233    0         -          0.1%    8.0M      1h 31m  
   5     metrics            online           48240    0         -          0.4%    11.0M     1h 32m  
+  0     web                online           48211    0         -          3.4%    182.0M    1h 25m  
+  1     web                online           48212    0         -          2.9%    178.0M    1h 26m  
                                                                                                     
                                                                                                     
 the shepherd stopped answering — reconnecting (attempt 3)                            control enabled

--- a/web/src/data/cli-reference.generated.txt
+++ b/web/src/data/cli-reference.generated.txt
@@ -73,11 +73,23 @@ Usage: shep start [OPTIONS] [TARGETS]...
 
 Arguments:
   [TARGETS]...
-          Script paths, Flockfiles, names the flock already has, or `-` to read Flockfile JSON from
-          stdin
+          Selectors, script paths, Flockfiles, or `-` to read Flockfile JSON from stdin
           
-          Omit them to start the Flockfile in the current directory, or, when there is none, to
-          bring a shepherd up with nothing running yet.
+          A target is resolved in four tiers and the first one that matches wins: a sheep the flock
+          already has, by id or by name; then a fold, written either as `fold:<name>` or as the bare
+          fold name; then a Flockfile, by its extension; then a path on disk, started as a script.
+          
+          So `shep start backed` starts the fold `backed` even when a file called `backed` is
+          sitting in the current directory. Write `./backed` to mean the file: a sheep name may
+          never contain a path separator, so a target carrying one is always a path.
+          
+          The wildcard selectors work here too, and mean what they mean everywhere else: `all`,
+          `/regex/`, and glob patterns such as `web-*`. They reach only sheep the flock already has,
+          since there is nothing to register. A sheep already running is reported and left alone;
+          `restart` is the verb that replaces one.
+          
+          Omit the targets to start the Flockfile in the current directory, or, when there is none,
+          to bring a shepherd up with nothing running yet.
           
           Several are started in turn, not atomically: if the second fails the first is already up,
           and the exit code is the first failure. `--name` is refused with more than one, since a

--- a/web/src/data/cli-reference.generated.txt
+++ b/web/src/data/cli-reference.generated.txt
@@ -1,5 +1,5 @@
 @@VERSION@@
-shep 0.1.6
+shep 0.1.7
 @@TOPLEVEL@@
 A process manager for your flock
 

--- a/web/src/pages/docs/dogs.astro
+++ b/web/src/pages/docs/dogs.astro
@@ -81,18 +81,25 @@ NAME     SOURCE    SHEPHERD  STATUS
 metrics  built-in  true      online
 
 $ shep dogs
-NAME     SOURCE    STATUS  PID    RESTARTS  CPU  MEM   UPTIME
-metrics  built-in  online  39950  0         -    9.8M  1s
+ID  NAME     STATUS  PID    RESTARTS  EXIT  CPU  MEM    UPTIME  SOURCE
+1   metrics  online  49313  0         -     -    10.9M  2s      built-in
 
 $ shep flock
-ID  NAME  STATUS  PID    RESTARTS  CPU  MEM   UPTIME  FOLD
-0   web   online  39899  0         -    3.0M  5s      -
+ID  NAME  STATUS  PID    RESTARTS  EXIT  CPU  MEM   UPTIME  FOLD  SMIT
+0   web   online  49290  0         -     -    3.0M  2s      -     -
 
 Dogs
-NAME     SOURCE    STATUS  PID    RESTARTS  CPU  MEM   UPTIME
-metrics  built-in  online  39950  0         -    9.8M  1s
+ID  NAME     STATUS  PID    RESTARTS  EXIT  CPU  MEM    UPTIME  SOURCE
+1   metrics  online  49313  0         -     -    10.9M  2s      built-in
 
 $ shep disable metrics`}</CodeBlock>
+    <p class="fine">
+      The dogs table shares its column order with the sheep table above it,
+      so a dog and a sheep read the same way. <code>SOURCE</code> is the one
+      column only dogs have, and <code>FOLD</code>/<code>SMIT</code> the two
+      only sheep have. See <a href="/docs/output#the-dogs-table">terminal
+      output</a>.
+    </p>
     <p class="fine">
       Running <code>enable</code> and <code>adopt</code> at once from a
       provisioning script is safe: each takes an exclusive lock on{" "}

--- a/web/src/pages/docs/folds.astro
+++ b/web/src/pages/docs/folds.astro
@@ -87,12 +87,12 @@ error[not_found]: the daemon reported NotFound: selector matched no registered s
 
     <h2>Selecting one from any verb</h2>
     <p>
-      Every verb that takes a selector (<code>stop</code>,
-      <code>restart</code>, <code>delete</code>, <code>bleats</code>,
-      <code>trigger</code>, and the rest) accepts
-      <code>fold:&lt;name&gt;</code> in place of a name, an id, a
-      <code>/regex/</code>, or <code>all</code>. It reaches every sheep
-      carrying that fold in one call:
+      Every verb accepts <code>fold:&lt;name&gt;</code> in place of a name,
+      an id, a <code>/regex/</code>, a glob, or <code>all</code>. That is
+      <code>stop</code>, <code>restart</code>, <code>reload</code>,
+      <code>delete</code>, <code>bleats</code>, <code>trigger</code>,
+      <code>start</code>, and the rest. It reaches every sheep carrying that
+      fold in one call:
     </p>
     <CodeBlock>{`$ shep stop fold:backend
 ID  NAME    STATUS   PID    RESTARTS  EXIT     CPU  MEM    UPTIME  FOLD     SMIT
@@ -103,6 +103,47 @@ ID  NAME    STATUS   PID    RESTARTS  EXIT     CPU  MEM    UPTIME  FOLD     SMIT
       The listing is the whole flock, not just the fold. Every lifecycle verb
       prints it that way, so <code>cron</code> is there and still online. See
       <a href="/docs/output#after-a-lifecycle-command">terminal output</a>.
+    </p>
+
+    <h2>Folds on <code>start</code></h2>
+    <p>
+      <code>shep start</code> takes selectors like every other verb, and it
+      also takes the things only it can take: a script path, a Flockfile, or
+      <code>-</code> for Flockfile JSON on stdin. That makes some targets
+      ambiguous, so it resolves one in a fixed order and the first tier that
+      matches wins.
+    </p>
+    <div class="rows">
+      <div class="row"><span>1. a sheep</span><span>by id or by name</span></div>
+      <div class="row"><span>2. a fold</span><span><code>fold:backed</code>, or just <code>backed</code></span></div>
+      <div class="row"><span>3. a Flockfile</span><span>by its extension</span></div>
+      <div class="row"><span>4. a path</span><span>started as a script</span></div>
+    </div>
+    <p>
+      So <code>shep start backed</code> starts the fold even when a file
+      called <code>backed</code> is sitting right there in the current
+      directory. Write <code>./backed</code> when you mean the file. That
+      works whatever your sheep are called: a sheep name may never contain a
+      path separator, so a target carrying one is always a path.
+    </p>
+    <p>
+      Only sheep the flock already has can be reached this way. A fold is a
+      field on a registered sheep, so there is nothing for a fold to
+      register. A sheep that is already running is reported and left alone;
+      <code>restart</code> is the verb that replaces one.
+    </p>
+    <CodeBlock>{`$ shep start fold:backed
+ID  NAME    STATUS  PID    RESTARTS  EXIT  CPU  MEM    UPTIME  FOLD    SMIT
+0   golbat  online  19303  1         -     -    32.0K  0s      backed  -
+1   koji    online  19304  1         -     -    32.0K  0s      backed  -
+2   rotom   online  19260  0         -     -    32.0K  0s      front   -
+
+$ shep start fold:typo
+error[not_found]: no sheep is in a fold called typo`}</CodeBlock>
+    <p>
+      A selector that matched nothing is <code>not_found</code>, exit 3, the
+      same as everywhere else. It does not fall back to looking for a file
+      called <code>fold:typo</code>.
     </p>
 
     <Callout variant="note">

--- a/web/src/pages/docs/folds.astro
+++ b/web/src/pages/docs/folds.astro
@@ -95,9 +95,15 @@ error[not_found]: the daemon reported NotFound: selector matched no registered s
       carrying that fold in one call:
     </p>
     <CodeBlock>{`$ shep stop fold:backend
-ID  NAME    STATUS   PID  RESTARTS  CPU  MEM  UPTIME  FOLD
-0   web     stopped  -    0         -    -    0s      backend
-1   worker  stopped  -    0         -    -    0s      backend`}</CodeBlock>
+ID  NAME    STATUS   PID    RESTARTS  EXIT     CPU  MEM    UPTIME  FOLD     SMIT
+2   cron    online   16564  0         -        -    32.0K  0s      -        -
+0   web     stopped  -      0         SIGTERM  -    -      0s      backend  -
+1   worker  stopped  -      0         SIGTERM  -    -      0s      backend  -`}</CodeBlock>
+    <p>
+      The listing is the whole flock, not just the fold. Every lifecycle verb
+      prints it that way, so <code>cron</code> is there and still online. See
+      <a href="/docs/output#after-a-lifecycle-command">terminal output</a>.
+    </p>
 
     <Callout variant="note">
       Selector parsing checks shapes in a fixed order, and it matters if a

--- a/web/src/pages/docs/output.astro
+++ b/web/src/pages/docs/output.astro
@@ -94,6 +94,66 @@ import CodeBlock from "../../components/docs/CodeBlock.astro";
       on that same row says it never started at all.
     </p>
 
+    <h2>After a lifecycle command</h2>
+    <p>
+      <code>start</code>, <code>stop</code>, <code>restart</code>,
+      <code>reload</code>, <code>delete</code> and <code>stock</code> all
+      print the whole flock afterwards, not only the sheep they touched. The
+      question after starting one app is usually what everything else is
+      doing, and the exit code already said whether the one you named worked.
+    </p>
+    <CodeBlock label="shep restart golbat">{`┌────┬────────┬─────────┬───────┬──────────┬─────────┬─────┬────────┬────────┬────────┬──────┐
+│ ID │ NAME   │ STATUS  │ PID   │ RESTARTS │ EXIT    │ CPU │ MEM    │ UPTIME │ FOLD   │ SMIT │
+├────┼────────┼─────────┼───────┼──────────┼─────────┼─────┼────────┼────────┼────────┼──────┤
+│ 4  │ golbat │ online  │ 14459 │ 5        │ -       │ -   │ 416.0K │ 0s     │ backed │ -    │
+│ 5  │ koji   │ stopped │ -     │ 2        │ SIGTERM │ -   │ -      │ 0s     │ backed │ -    │
+└────┴────────┴─────────┴───────┴──────────┴─────────┴─────┴────────┴────────┴────────┴──────┘
+
+Dogs
+┌────────────┬─────────┬────────┬───────┬──────────┬──────┬──────┬────────┐
+│ NAME       │ SOURCE  │ STATUS │ PID   │ RESTARTS │ CPU  │ MEM  │ UPTIME │
+├────────────┼─────────┼────────┼───────┼──────────┼──────┼──────┼────────┤
+│ log-rotate │ adopted │ online │ 14110 │ 1        │ 0.0% │ 6.6M │ 41s    │
+└────────────┴─────────┴────────┴───────┴──────────┴──────┴──────┴────────┘`}</CodeBlock>
+    <p>
+      That is the same output <code>shep flock</code> gives, dogs table and
+      all. A dog has no fold and no id you would ever type, so it gets the
+      dogs table with its own <code>SOURCE</code> column rather than a row in
+      the sheep table. <code>shep restart log-rotate</code> and
+      <code>shep flock</code> draw it the same way.
+    </p>
+    <p>
+      <code>delete</code> is the one verb whose listing cannot show what it
+      did, since the rows are gone. It names the ids it removed on stderr and
+      prints what is left on stdout.
+    </p>
+    <CodeBlock label="shep delete rotom">{`notice[delete]: deleted 1 sheep, id 6`}</CodeBlock>
+    <Callout variant="note">
+      <code>--format json</code> is not widened. A script that runs
+      <code>shep stop web --format json</code> asked about
+      <code>web</code>, so <code>data</code> holds the rows for
+      <code>web</code>. Use <code>shep flock --format json</code> when you
+      want the flock.
+    </Callout>
+
+    <h2>Row order</h2>
+    <p>
+      Every listing shep prints is sorted by name, then by id. That covers
+      <code>shep flock</code>, every lifecycle verb above,
+      <code>shep lookout</code>, and the tables
+      <code>signal</code>, <code>whisper</code> and <code>trigger</code>
+      print.
+    </p>
+    <p>
+      Ids are handed out in registration order, which is a fact about your
+      shell history rather than about the flock, and they move: a
+      <code>delete all</code> followed by a fresh start renumbers everything.
+      Names do not. The id breaks ties, so the four instances of an app
+      stocked to four stay in a fixed order instead of shuffling between
+      refreshes, and it is still what you type at
+      <code>shep stop 11</code>.
+    </p>
+
     <h2>Narrow windows</h2>
     <p>
       The table measures your terminal and drops columns until it fits,

--- a/web/src/pages/docs/output.astro
+++ b/web/src/pages/docs/output.astro
@@ -97,39 +97,77 @@ import CodeBlock from "../../components/docs/CodeBlock.astro";
     <h2>The dogs table</h2>
     <p>
       Dogs get their own table, under a <code>Dogs</code> caption, wherever
-      one appears beside a flock listing. It carries the columns a dog can
-      actually fill: no <code>ID</code> and no <code>FOLD</code>, since a dog
-      is supervised rather than grouped, and a <code>SOURCE</code> column the
-      sheep table has no use for.
+      one appears beside a flock listing. Every column the two tables share
+      sits in the same place, and each table's own columns come last:
     </p>
-    <CodeBlock label="shep dogs">{`┌────────────┬─────────┬──────────────┬──────┬──────────┬─────┬──────┬────────┐
-│ NAME       │ SOURCE  │ STATUS       │ PID  │ RESTARTS │ CPU │ MEM  │ UPTIME │
-├────────────┼─────────┼──────────────┼──────┼──────────┼─────┼──────┼────────┤
-│ log-rotate │ adopted │ (o.o) online │ 7868 │ 0        │ -   │ 6.6M │ 2s     │
-└────────────┴─────────┴──────────────┴──────┴──────────┴─────┴──────┴────────┘`}</CodeBlock>
+    <div class="rows">
+      <div class="row"><span>both</span><span><code>ID NAME STATUS PID RESTARTS EXIT CPU MEM UPTIME</code></span></div>
+      <div class="row"><span>sheep only</span><span><code>FOLD SMIT</code></span></div>
+      <div class="row"><span>dogs only</span><span><code>SOURCE</code></span></div>
+    </div>
+    <CodeBlock label="shep flock">{`┌────┬────────┬──────────────┬───────┬──────────┬──────┬─────┬──────┬────────┬────────┬──────┐
+│ ID │ NAME   │ STATUS       │ PID   │ RESTARTS │ EXIT │ CPU │ MEM  │ UPTIME │ FOLD   │ SMIT │
+├────┼────────┼──────────────┼───────┼──────────┼──────┼─────┼──────┼────────┼────────┼──────┤
+│ 0  │ golbat │ (o.o) online │ 48182 │ 0        │ -    │ -   │ 3.0M │ 2s     │ backed │ -    │
+└────┴────────┴──────────────┴───────┴──────────┴──────┴─────┴──────┴────────┴────────┴──────┘
+
+Dogs
+┌────┬────────────┬──────────────┬───────┬──────────┬──────┬─────┬──────┬────────┬─────────┐
+│ ID │ NAME       │ STATUS       │ PID   │ RESTARTS │ EXIT │ CPU │ MEM  │ UPTIME │ SOURCE  │
+├────┼────────────┼──────────────┼───────┼──────────┼──────┼─────┼──────┼────────┼─────────┤
+│ 1  │ log-rotate │ (o.o) online │ 48207 │ 0        │ -    │ -   │ 6.6M │ 2s     │ adopted │
+└────┴────────────┴──────────────┴───────┴──────────┴──────┴─────┴──────┴────────┴─────────┘`}</CodeBlock>
     <p>
-      The colours are the flock table's, on the five columns the two share:
-      the same face and status colour, the same restart colour above zero,
-      the same two-tier ramps for CPU and MEM. <code>SOURCE</code> is muted
-      like <code>FOLD</code> is, because it says where a binary came from and
-      never whether the dog is healthy. So the same dog reads the same way
-      under <code>shep dogs</code>, under <code>shep flock</code>, and after
+      <code>FOLD</code> and <code>SMIT</code> are missing from the dogs table
+      because they are impossible for a dog rather than merely empty: a dog
+      belongs to no fold, and a smit is a mark a dog paints <em>on</em> a
+      sheep. A column that reads <code>-</code> on every row teaches nothing.
+    </p>
+    <p>
+      Colours match too, column for column. Same face and status colour, same
+      restart colour above zero, same ramps for CPU and MEM, same
+      <code>EXIT</code>. So the same dog reads the same way under
+      <code>shep dogs</code>, under <code>shep flock</code>, and after
       <code>shep restart log-rotate</code>.
+    </p>
+
+    <h3>SOURCE says whose code is running</h3>
+    <p>
+      It is the only column in shep carrying a trust distinction, so the two
+      values do not look alike. <code>built-in</code> is shep running its own
+      code, and is muted like any other label you read past.
+      <code>adopted</code> is a third-party binary running at the shepherd's
+      own trust level, from a path you supplied, with no sandbox around it.
+      That gets the same colour a restart count above zero gets: worth a
+      glance, not a fault, because you chose it.
     </p>
     <p>
       <code>enable</code>, <code>disable</code>, <code>adopt</code> and
       <code>rehome</code> print a one-row confirmation with the same
       treatment. Their <code>STATUS</code> holds either a status or a
       sentence saying why no shepherd answered, and only a status is
-      coloured; a sentence is left plain, because a colour that repeats the
+      coloured; a sentence is left plain, because a colour repeating the
       words beside it is decoration rather than information.
     </p>
+
+    <h3>Where else colour appears</h3>
+    <p>
+      Every table shep prints follows one rule: a colour carries information,
+      or the column does not get one. Beyond the flock and the dogs:
+    </p>
+    <div class="rows">
+      <div class="row"><span><code>trigger</code>, <code>signal</code>, <code>whisper</code></span><span>OUTCOME by what happened: it worked, nothing to report, a config gap you can close, or it failed</span></div>
+      <div class="row"><span><code>flush</code>, <code>startup</code></span><span>RESULT the same way. <code>absent</code> is muted, not marked: it is the state the verb was asked to produce</span></div>
+      <div class="row"><span><code>barks</code></span><span>SINKS, so an alert that failed to deliver does not read like one that arrived</span></div>
+      <div class="row"><span><code>kill</code></span><span>SOCKET_REMOVED, because a <code>false</code> is what the next boot has to contend with</span></div>
+      <div class="row"><span><code>import</code></span><span>REUSE_PORT when it is <code>true</code>, which is work you have to do</span></div>
+    </div>
     <Callout variant="note">
-      Two tables carry no colour on purpose. <code>describe</code>'s lamb
-      table is two identity columns with no state to report, and
-      <code>shep empty</code>'s table is mostly file paths, which are the
-      subject of that table rather than a reading about it. Every colour
-      shep prints carries information; none is decoration.
+      Five tables carry no colour at all, deliberately: <code>describe</code>'s
+      lamb tree, <code>delete</code>'s id list, the saved-roll summary, the KV
+      store, and <code>shep dogs --available</code>. Each is either pure data
+      shep has no opinion about, or a single column that is also the whole
+      content, where muting would fade the table and distinguish nothing.
     </Callout>
 
     <h2>After a lifecycle command</h2>
@@ -148,17 +186,16 @@ import CodeBlock from "../../components/docs/CodeBlock.astro";
 └────┴────────┴─────────┴───────┴──────────┴─────────┴─────┴────────┴────────┴────────┴──────┘
 
 Dogs
-┌────────────┬─────────┬────────┬───────┬──────────┬──────┬──────┬────────┐
-│ NAME       │ SOURCE  │ STATUS │ PID   │ RESTARTS │ CPU  │ MEM  │ UPTIME │
-├────────────┼─────────┼────────┼───────┼──────────┼──────┼──────┼────────┤
-│ log-rotate │ adopted │ online │ 14110 │ 1        │ 0.0% │ 6.6M │ 41s    │
-└────────────┴─────────┴────────┴───────┴──────────┴──────┴──────┴────────┘`}</CodeBlock>
+┌────┬────────────┬────────┬───────┬──────────┬──────┬──────┬──────┬────────┬─────────┐
+│ ID │ NAME       │ STATUS │ PID   │ RESTARTS │ EXIT │ CPU  │ MEM  │ UPTIME │ SOURCE  │
+├────┼────────────┼────────┼───────┼──────────┼──────┼──────┼──────┼────────┼─────────┤
+│ 6  │ log-rotate │ online │ 14110 │ 1        │ -    │ 0.0% │ 6.6M │ 41s    │ adopted │
+└────┴────────────┴────────┴───────┴──────────┴──────┴──────┴──────┴────────┴─────────┘`}</CodeBlock>
     <p>
       That is the same output <code>shep flock</code> gives, dogs table and
-      all. A dog has no fold and no id you would ever type, so it gets the
-      dogs table with its own <code>SOURCE</code> column rather than a row in
-      the sheep table. <code>shep restart log-rotate</code> and
-      <code>shep flock</code> draw it the same way.
+      all, so <code>shep restart log-rotate</code> and <code>shep flock</code>
+      draw the same dog the same way. See <a href="#the-dogs-table">the dogs
+      table</a> for why it is a second table rather than another row.
     </p>
     <p>
       <code>delete</code> is the one verb whose listing cannot show what it

--- a/web/src/pages/docs/output.astro
+++ b/web/src/pages/docs/output.astro
@@ -209,7 +209,7 @@ Dogs
       did, since the rows are gone. It names the ids it removed on stderr and
       prints what is left on stdout.
     </p>
-    <CodeBlock label="shep delete rotom">{`notice[delete]: deleted 1 sheep, id 6`}</CodeBlock>
+    <CodeBlock label="shep delete koji">{`notice[delete]: deleted 1 sheep, id 5`}</CodeBlock>
     <Callout variant="note">
       <code>--format json</code> is not widened. A script that runs
       <code>shep stop web --format json</code> asked about

--- a/web/src/pages/docs/output.astro
+++ b/web/src/pages/docs/output.astro
@@ -163,12 +163,19 @@ Dogs
       <div class="row"><span><code>import</code></span><span>REUSE_PORT when it is <code>true</code>, which is work you have to do</span></div>
     </div>
     <Callout variant="note">
-      Five tables carry no colour at all, deliberately: <code>describe</code>'s
-      lamb tree, <code>delete</code>'s id list, the saved-roll summary, the KV
-      store, and <code>shep dogs --available</code>. Each is either pure data
-      shep has no opinion about, or a single column that is also the whole
-      content, where muting would fade the table and distinguish nothing.
+      Seven tables carry no colour at all, deliberately: <code>describe</code>'s
+      lamb tree, <code>delete</code>'s id list, <code>unset</code>'s count, the
+      two saved-roll tables, the KV store, and
+      <code>shep dogs --available</code>. Each is either pure data shep has no
+      opinion about, or a single column that is also the whole content, where
+      muting would fade the table and distinguish nothing.
     </Callout>
+    <p class="fine">
+      The roll listing is the one table with a <code>STATUS</code> column and
+      no colour on it. Everything in a saved roll is stopped by definition, so
+      the cell reads <code>stopped</code> on every row of every rendering, and
+      a colour that never varies distinguishes nothing.
+    </p>
 
     <h2>After a lifecycle command</h2>
     <p>

--- a/web/src/pages/docs/output.astro
+++ b/web/src/pages/docs/output.astro
@@ -94,6 +94,44 @@ import CodeBlock from "../../components/docs/CodeBlock.astro";
       on that same row says it never started at all.
     </p>
 
+    <h2>The dogs table</h2>
+    <p>
+      Dogs get their own table, under a <code>Dogs</code> caption, wherever
+      one appears beside a flock listing. It carries the columns a dog can
+      actually fill: no <code>ID</code> and no <code>FOLD</code>, since a dog
+      is supervised rather than grouped, and a <code>SOURCE</code> column the
+      sheep table has no use for.
+    </p>
+    <CodeBlock label="shep dogs">{`┌────────────┬─────────┬──────────────┬──────┬──────────┬─────┬──────┬────────┐
+│ NAME       │ SOURCE  │ STATUS       │ PID  │ RESTARTS │ CPU │ MEM  │ UPTIME │
+├────────────┼─────────┼──────────────┼──────┼──────────┼─────┼──────┼────────┤
+│ log-rotate │ adopted │ (o.o) online │ 7868 │ 0        │ -   │ 6.6M │ 2s     │
+└────────────┴─────────┴──────────────┴──────┴──────────┴─────┴──────┴────────┘`}</CodeBlock>
+    <p>
+      The colours are the flock table's, on the five columns the two share:
+      the same face and status colour, the same restart colour above zero,
+      the same two-tier ramps for CPU and MEM. <code>SOURCE</code> is muted
+      like <code>FOLD</code> is, because it says where a binary came from and
+      never whether the dog is healthy. So the same dog reads the same way
+      under <code>shep dogs</code>, under <code>shep flock</code>, and after
+      <code>shep restart log-rotate</code>.
+    </p>
+    <p>
+      <code>enable</code>, <code>disable</code>, <code>adopt</code> and
+      <code>rehome</code> print a one-row confirmation with the same
+      treatment. Their <code>STATUS</code> holds either a status or a
+      sentence saying why no shepherd answered, and only a status is
+      coloured; a sentence is left plain, because a colour that repeats the
+      words beside it is decoration rather than information.
+    </p>
+    <Callout variant="note">
+      Two tables carry no colour on purpose. <code>describe</code>'s lamb
+      table is two identity columns with no state to report, and
+      <code>shep empty</code>'s table is mostly file paths, which are the
+      subject of that table rather than a reading about it. Every colour
+      shep prints carries information; none is decoration.
+    </Callout>
+
     <h2>After a lifecycle command</h2>
     <p>
       <code>start</code>, <code>stop</code>, <code>restart</code>,

--- a/web/src/pages/docs/output.astro
+++ b/web/src/pages/docs/output.astro
@@ -94,7 +94,7 @@ import CodeBlock from "../../components/docs/CodeBlock.astro";
       on that same row says it never started at all.
     </p>
 
-    <h2>The dogs table</h2>
+    <h2 id="the-dogs-table">The dogs table</h2>
     <p>
       Dogs get their own table, under a <code>Dogs</code> caption, wherever
       one appears beside a flock listing. Every column the two tables share
@@ -131,7 +131,7 @@ Dogs
       <code>shep restart log-rotate</code>.
     </p>
 
-    <h3>SOURCE says whose code is running</h3>
+    <h3 id="source-says-whose-code-is-running">SOURCE says whose code is running</h3>
     <p>
       It is the only column in shep carrying a trust distinction, so the two
       values do not look alike. <code>built-in</code> is shep running its own
@@ -150,7 +150,7 @@ Dogs
       words beside it is decoration rather than information.
     </p>
 
-    <h3>Where else colour appears</h3>
+    <h3 id="where-else-colour-appears">Where else colour appears</h3>
     <p>
       Every table shep prints follows one rule: a colour carries information,
       or the column does not get one. Beyond the flock and the dogs:
@@ -177,7 +177,7 @@ Dogs
       a colour that never varies distinguishes nothing.
     </p>
 
-    <h2>After a lifecycle command</h2>
+    <h2 id="after-a-lifecycle-command">After a lifecycle command</h2>
     <p>
       <code>start</code>, <code>stop</code>, <code>restart</code>,
       <code>reload</code>, <code>delete</code> and <code>stock</code> all
@@ -218,7 +218,7 @@ Dogs
       want the flock.
     </Callout>
 
-    <h2>Row order</h2>
+    <h2 id="row-order">Row order</h2>
     <p>
       Every listing shep prints is sorted by name, then by id. That covers
       <code>shep flock</code>, every lifecycle verb above,


### PR DESCRIPTION
Four inconsistencies found by using shep on a real thirteen-app flock, plus the dogs table.

- every listing now orders by name, then by id. `shep flock` sorted by name while every other verb sorted by id, and the id is assigned by registration order so it sorts by an accident of history. Tiebreak on id because a clustered app's instances share a name
- `start`, `stop`, `restart`, `reload`, `delete` and `stock` print the whole flock. The question after starting one app is what the flock looks like now, and a one-row table cannot answer it
- `shep start` takes the selector grammar, so folds work there as they already did on `stop`. Precedence is id or name, then folds, then Flockfiles, then paths, written into the verb's help and the docs page
- the dogs table lines up with the flock: shared columns in the same order, `FOLD` and `SMIT` off it because a dog can have neither, `SOURCE` at the end
- fifteen of the twenty-two tables now carry colour, keyed by column name rather than by index

That last one was a precondition, not a tidy-up. Colour was applied by hardcoded position, so reordering a column would have silently coloured the wrong cells with nothing failing and snapshots passing whatever was accepted.

`--format json` deliberately stays narrow while the tables widen, so a script reading `data[0]` after `shep start` keeps working.

Seven tables stay plain, each with the reason on the impl. `RolledSheepRows` lost its colour again after review: its STATUS is a hardcoded `stopped`, so the colour never varied between rows, which makes it decoration.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added selector precedence for `start`, including sheep, folds, Flockfiles, and paths.
  * Expanded dog tables with IDs, exit codes, sources, and consistent status coloring.
  * Added trust-source display and broader output coloring.

* **Bug Fixes**
  * Improved lifecycle output, selector errors, restart failures, and running-sheep handling.
  * Standardized name-based ordering across listings, logs, tables, and lifecycle results.
  * Table output now shows the full flock, while JSON remains scoped to affected entries.

* **Documentation**
  * Expanded guidance for selectors, lifecycle output, dog tables, columns, ordering, and color meanings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->