### PR TITLE
v0.1.7 did not publish: release-plz needs publish = false, not just release = false

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -109,9 +109,19 @@ name = "shep-cli"
 release = false
 
 # Runnable demos for docs/humans, not a crate anyone installs. `publish =
-# false` in its own manifest already stops `cargo publish` from ever
-# reaching it; this entry says the same thing to release-plz explicitly,
-# the same defense-in-depth `shep-cli`'s entry above uses.
+# false` in its own manifest already stops `cargo publish` from ever reaching
+# it, and both keys below say so to release-plz as well.
+#
+# BOTH keys are required, and that is not belt and braces. release-plz
+# validates its own `publish` against the manifest's and refuses the whole
+# run when they disagree, so `release = false` alone left it believing this
+# crate was publishable and it failed the release for v0.1.7 with "has
+# `publish = false` ... but it has `publish = true` in the release-plz
+# configuration". `release` governs whether a crate is released; `publish` is
+# what gets checked against the manifest. `shep-cli`'s entry above needs only
+# `release = false` because its manifest sets no `publish` key at all, so
+# there is nothing for that check to disagree with.
 [[package]]
 name = "shep-examples"
 release = false
+publish = false


### PR DESCRIPTION
v0.1.7 merged and did not publish. crates.io is still on 0.1.6.

The release job failed with:

```
Package `shep-examples` has `publish = false` or `publish = []` in the
Cargo.toml, but it has `publish = true` in the release-plz configuration.
```

- `release = false` and `publish = false` are different keys to release-plz. The first says whether a crate is released, the second is the one checked against the manifest
- the examples entry set only the first, so release-plz still thought the crate was publishable, saw the manifest disagree, and refused the whole run rather than that one crate
- `shep-cli`'s entry needs only `release = false` because its manifest sets no `publish` key, so nothing can disagree

Worth knowing for the next workspace member: a crate with `publish = false` blocks every crate's release until its config entry names the same key, and no pull request can catch it. #26 was green on all 24 checks, because the release job only runs on a push to main.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified release configuration requirements to keep package settings consistent with the crate manifest.
* **Chores**
  * Updated the examples package configuration to explicitly disable publishing and releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->