### PR TITLE
Bound a .js Flockfile's evaluation, and fix the docs site build

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,6 +58,15 @@ both halves: `cargo test -p shep --lib --bins --all-features`. `--bins`
 alone now runs almost nothing, since every unit test in the crate lives in the
 library.
 
+`shep` has a `mod slow` of its own as of 2026-08-28, one test, in
+`commands/lifecycle.rs`. It needs a real node to start and exit inside a
+budget, which is a claim about the machine's speed rather than about shep: at
+200ms it failed on four CI runners at once while passing every local run. Add
+`-- --skip ::slow::` to a shep-scoped run for the same reason the daemon one
+carries it. CI already covers it: the `slow` job runs `--workspace`, chosen so
+a `mod slow` outside shep-daemon could not end up skipped everywhere and run
+nowhere.
+
 ### The task gate — run once, when the task is otherwise done
 
 ```bash

--- a/crates/shep-cli/CHANGELOG.md
+++ b/crates/shep-cli/CHANGELOG.md
@@ -72,7 +72,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   then shep kills it and refuses with `InvalidConfig`, naming the file and the
   likely cause. The near neighbour gets its own sentence rather than the same
   one: a module that exits cleanly but leaves a process of its own holding
-  node's stdout is refused for that, since nothing was killed there.
+  node's stdout or stderr is refused for that, since nothing was killed
+  there.
 
 - Cell colour is keyed on a column's NAME rather than its index. The old
   `rows_for` painted `row[0]`, `row[4]`, `row[9]` and `row[10]`, which are

--- a/crates/shep-cli/CHANGELOG.md
+++ b/crates/shep-cli/CHANGELOG.md
@@ -62,6 +62,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixes
 
+- A `.js` Flockfile that never returns is killed rather than left to hang
+  `shep start`. A config module that starts a server at require time, instead
+  of exporting its config and returning, held the terminal for as long as the
+  operator left it open: there was no bound on the wait, and Ctrl-C was the
+  only way out, which is no answer at all for a CI job or a provisioning
+  script running `shep start` with nobody watching. node gets 30 seconds now,
+  then shep kills it and refuses with `InvalidConfig`, naming the file and the
+  likely cause.
+
 - Cell colour is keyed on a column's NAME rather than its index. The old
   `rows_for` painted `row[0]`, `row[4]`, `row[9]` and `row[10]`, which are
   facts about one table's column order: reordering columns repointed every one

--- a/crates/shep-cli/CHANGELOG.md
+++ b/crates/shep-cli/CHANGELOG.md
@@ -62,9 +62,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixes
 
-- A `.js` Flockfile that never returns is killed rather than left to hang
-  `shep start`. A config module that starts a server at require time, instead
-  of exporting its config and returning, held the terminal for as long as the
+- A `.js` Flockfile that keeps node alive is killed rather than left to hang
+  `shep start`. A config module that leaves a server listening or a timer
+  armed can assign `module.exports` and return while node's event loop stays
+  alive, so node never exits and shep held the terminal for as long as the
   operator left it open: there was no bound on the wait, and Ctrl-C was the
   only way out, which is no answer at all for a CI job or a provisioning
   script running `shep start` with nobody watching. node gets 30 seconds now,

--- a/crates/shep-cli/CHANGELOG.md
+++ b/crates/shep-cli/CHANGELOG.md
@@ -70,7 +70,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   only way out, which is no answer at all for a CI job or a provisioning
   script running `shep start` with nobody watching. node gets 30 seconds now,
   then shep kills it and refuses with `InvalidConfig`, naming the file and the
-  likely cause.
+  likely cause. The near neighbour gets its own sentence rather than the same
+  one: a module that exits cleanly but leaves a process of its own holding
+  node's stdout is refused for that, since nothing was killed there.
 
 - Cell colour is keyed on a column's NAME rather than its index. The old
   `rows_for` painted `row[0]`, `row[4]`, `row[9]` and `row[10]`, which are

--- a/crates/shep-cli/src/commands/bounded.rs
+++ b/crates/shep-cli/src/commands/bounded.rs
@@ -4,8 +4,9 @@
 //! run, which is the right default nearly everywhere in this crate: the other
 //! commands shep spawns are probes and renderers that exit on their own. The
 //! one place it is wrong is the `.js` Flockfile bridge, where the child is
-//! running a file the operator wrote. A config module that starts a server at
-//! require time never returns, and `output` would wait for it forever.
+//! running a file the operator wrote. A config module that leaves a server or
+//! a timer running keeps node's event loop alive after `require` returned, so
+//! node never exits and `output` waits for it forever.
 //!
 //! [`run_bounded`] is `output` with a deadline: the same captured stdout and
 //! stderr, plus a [`Bounded::TimedOut`] answer once the child outlives its

--- a/crates/shep-cli/src/commands/bounded.rs
+++ b/crates/shep-cli/src/commands/bounded.rs
@@ -38,15 +38,22 @@ const POLL_INTERVAL: Duration = Duration::from_millis(10);
 
 /// What a bounded run came back with.
 ///
-/// Not an `Option<Output>`: the timeout is the answer this type exists to
-/// carry, and a bare `None` at the call site says nothing about which of the
-/// two happened.
+/// Not an `Option<Output>`: which way the budget ran out is the answer this
+/// type exists to carry, and a bare `None` at the call site says nothing
+/// about it. The two failures need different sentences, because only one of
+/// them involves shep killing anything.
 #[derive(Debug)]
 pub(crate) enum Bounded {
-    /// The child exited on its own, inside the budget.
+    /// The child exited on its own inside the budget, and both its streams
+    /// arrived.
     Exited(Output),
-    /// The child outlived the budget and was killed.
-    TimedOut,
+    /// The child was still running at the deadline, and was killed.
+    Killed,
+    /// The child exited on its own, but something it left behind still holds
+    /// a captured pipe, so its output never arrived inside the budget.
+    /// Nothing was killed: whatever is holding the pipe is not shep's child
+    /// and shep has no handle on it.
+    OutputHeldOpen,
 }
 
 /// One of a child's output streams, read to the end on its own thread.
@@ -83,9 +90,11 @@ impl Draining {
 /// takes both pipes for itself. stdin is the caller's to decide and is left
 /// exactly as it was.
 ///
-/// The budget covers the reads as well as the wait. A child can exit while a
-/// grandchild it spawned holds the inherited pipe open, and a collection that
-/// blocked there would undo the whole point of the deadline.
+/// The budget covers the reads as well as the wait, and the two ends are
+/// reported apart. A child can exit while a grandchild it spawned holds the
+/// inherited pipe open: a collection that blocked there would undo the whole
+/// point of the deadline, and calling it [`Bounded::Killed`] would claim a
+/// kill that never happened.
 ///
 /// # Errors
 ///
@@ -110,28 +119,34 @@ pub(crate) fn run_bounded(command: &mut Command, budget: Duration) -> std::io::R
             .expect("stderr is piped on the line that spawned this child"),
     );
 
+    // `try_wait` first, deadline second. A child that exited in the last
+    // interval has already done its work, and killing it over the microseconds
+    // between its exit and this wakeup would throw away output shep asked for.
+    // Sleeping only as far as the deadline is what keeps that window down to
+    // one syscall rather than one poll interval.
     let status = loop {
         if let Some(status) = child.try_wait()? {
             break status;
         }
-        if Instant::now() >= deadline {
+        let left = deadline.saturating_duration_since(Instant::now());
+        if left.is_zero() {
             child.kill()?;
             // Reaped here rather than left to the `Child` drop, which does
             // not wait: a killed child nobody waits for is a zombie for as
             // long as shep runs.
             child.wait()?;
-            return Ok(Bounded::TimedOut);
+            return Ok(Bounded::Killed);
         }
-        std::thread::sleep(POLL_INTERVAL);
+        std::thread::sleep(POLL_INTERVAL.min(left));
     };
 
     let Some(stdout) = stdout.collect_within(deadline.saturating_duration_since(Instant::now()))
     else {
-        return Ok(Bounded::TimedOut);
+        return Ok(Bounded::OutputHeldOpen);
     };
     let Some(stderr) = stderr.collect_within(deadline.saturating_duration_since(Instant::now()))
     else {
-        return Ok(Bounded::TimedOut);
+        return Ok(Bounded::OutputHeldOpen);
     };
     Ok(Bounded::Exited(Output {
         status,
@@ -153,7 +168,7 @@ mod tests {
             .expect("the child spawns, and killing it is the only other syscall");
 
         assert!(
-            matches!(outcome, Bounded::TimedOut),
+            matches!(outcome, Bounded::Killed),
             "a 30s sleep cannot finish inside 100ms: {outcome:?}"
         );
         assert!(
@@ -181,6 +196,32 @@ mod tests {
         assert!(output.status.success());
         assert_eq!(String::from_utf8_lossy(&output.stdout), "wool");
         assert_eq!(String::from_utf8_lossy(&output.stderr), "bleat");
+    }
+
+    /// fails if a child that exited is reported as killed. `sleep 5 &` in a
+    /// shell that exits straight after leaves a process holding the pipes it
+    /// inherited, so the wait ends at once and only the reads run out of
+    /// budget. Nothing is killed on that path, and the two answers exist so
+    /// the caller does not have to claim otherwise.
+    #[test]
+    fn a_child_whose_output_outlives_it_is_not_reported_as_killed() {
+        let started = Instant::now();
+        let outcome = run_bounded(
+            Command::new("sh").arg("-c").arg("sleep 5 & exit 0"),
+            Duration::from_millis(200),
+        )
+        .expect("sh is on every host this crate compiles for");
+
+        assert!(
+            matches!(outcome, Bounded::OutputHeldOpen),
+            "the shell exits at once and the backgrounded sleep holds both \
+             pipes: {outcome:?}"
+        );
+        assert!(
+            started.elapsed() < Duration::from_secs(5),
+            "the budget did not bound the reads, in {:?}",
+            started.elapsed()
+        );
     }
 
     /// fails if either stream is read after the wait rather than during it.

--- a/crates/shep-cli/src/commands/bounded.rs
+++ b/crates/shep-cli/src/commands/bounded.rs
@@ -1,0 +1,205 @@
+//! Running a child process under a deadline
+//!
+//! [`std::process::Command::output`] waits for as long as the child cares to
+//! run, which is the right default nearly everywhere in this crate: the other
+//! commands shep spawns are probes and renderers that exit on their own. The
+//! one place it is wrong is the `.js` Flockfile bridge, where the child is
+//! running a file the operator wrote. A config module that starts a server at
+//! require time never returns, and `output` would wait for it forever.
+//!
+//! [`run_bounded`] is `output` with a deadline: the same captured stdout and
+//! stderr, plus a [`Bounded::TimedOut`] answer once the child outlives its
+//! budget. It is deliberately not general — no stdin, no cancellation, and no
+//! partial output on the timeout path — because its one caller needs none of
+//! that, and each of them is a decision better made by whoever turns up
+//! needing it.
+//!
+//! ## Why both streams are drained on threads
+//!
+//! A pipe holds 64 KiB before a write blocks, and a child blocked writing is
+//! a child that never exits. A deadline that polled the child first and read
+//! the pipes afterwards would therefore be a deadline that cannot fire on the
+//! very children it exists for: the loud ones. One thread per stream keeps
+//! both draining for the whole run, which is what `Command::output` does
+//! internally for the same reason.
+
+use std::io::Read;
+use std::process::{Command, Output, Stdio};
+use std::sync::mpsc::{self, Receiver};
+use std::time::{Duration, Instant};
+
+/// How often [`run_bounded`] asks whether the child has exited.
+///
+/// 10ms. The budgets this runs under are seconds long, so the poll costs a
+/// few hundred wakeups against a child that is already misbehaving, and the
+/// worst it can add to an honest run is one interval.
+const POLL_INTERVAL: Duration = Duration::from_millis(10);
+
+/// What a bounded run came back with.
+///
+/// Not an `Option<Output>`: the timeout is the answer this type exists to
+/// carry, and a bare `None` at the call site says nothing about which of the
+/// two happened.
+#[derive(Debug)]
+pub(crate) enum Bounded {
+    /// The child exited on its own, inside the budget.
+    Exited(Output),
+    /// The child outlived the budget and was killed.
+    TimedOut,
+}
+
+/// One of a child's output streams, read to the end on its own thread.
+struct Draining(Receiver<std::io::Result<Vec<u8>>>);
+
+impl Draining {
+    /// Starts draining `source`, returning the handle its bytes arrive on.
+    fn of<R: Read + Send + 'static>(mut source: R) -> Self {
+        let (sender, receiver) = mpsc::channel();
+        std::thread::spawn(move || {
+            let mut buffer = Vec::new();
+            let read = source.read_to_end(&mut buffer).map(|_count| buffer);
+            // The receiver is already gone whenever the run timed out and
+            // stopped caring, which is an ordinary end for this thread and
+            // not a failure to report anywhere.
+            let _ = sender.send(read);
+        });
+        Self(receiver)
+    }
+
+    /// The stream's bytes, or `None` if they did not arrive inside `budget`.
+    ///
+    /// A reader thread that died without sending also answers `None`. That
+    /// folds a panic into the timeout verdict, which is honest enough for a
+    /// thread whose whole body is one `read_to_end`.
+    fn collect_within(&self, budget: Duration) -> Option<std::io::Result<Vec<u8>>> {
+        self.0.recv_timeout(budget).ok()
+    }
+}
+
+/// Runs `command` to completion, killing it once it outlives `budget`.
+///
+/// stdout and stderr are captured, so the caller must not set either — this
+/// takes both pipes for itself. stdin is the caller's to decide and is left
+/// exactly as it was.
+///
+/// The budget covers the reads as well as the wait. A child can exit while a
+/// grandchild it spawned holds the inherited pipe open, and a collection that
+/// blocked there would undo the whole point of the deadline.
+///
+/// # Errors
+///
+/// - The child could not be spawned, killed, or waited for.
+/// - A stream could not be read.
+pub(crate) fn run_bounded(command: &mut Command, budget: Duration) -> std::io::Result<Bounded> {
+    let deadline = Instant::now() + budget;
+    let mut child = command
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()?;
+    let stdout = Draining::of(
+        child
+            .stdout
+            .take()
+            .expect("stdout is piped on the line that spawned this child"),
+    );
+    let stderr = Draining::of(
+        child
+            .stderr
+            .take()
+            .expect("stderr is piped on the line that spawned this child"),
+    );
+
+    let status = loop {
+        if let Some(status) = child.try_wait()? {
+            break status;
+        }
+        if Instant::now() >= deadline {
+            child.kill()?;
+            // Reaped here rather than left to the `Child` drop, which does
+            // not wait: a killed child nobody waits for is a zombie for as
+            // long as shep runs.
+            child.wait()?;
+            return Ok(Bounded::TimedOut);
+        }
+        std::thread::sleep(POLL_INTERVAL);
+    };
+
+    let Some(stdout) = stdout.collect_within(deadline.saturating_duration_since(Instant::now()))
+    else {
+        return Ok(Bounded::TimedOut);
+    };
+    let Some(stderr) = stderr.collect_within(deadline.saturating_duration_since(Instant::now()))
+    else {
+        return Ok(Bounded::TimedOut);
+    };
+    Ok(Bounded::Exited(Output {
+        status,
+        stdout: stdout?,
+        stderr: stderr?,
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// fails if the budget is measured from the wrong end, or if a child
+    /// that ignores it is waited on anyway.
+    #[test]
+    fn a_child_that_outlives_its_budget_is_killed_rather_than_waited_for() {
+        let started = Instant::now();
+        let outcome = run_bounded(Command::new("sleep").arg("30"), Duration::from_millis(100))
+            .expect("the child spawns, and killing it is the only other syscall");
+
+        assert!(
+            matches!(outcome, Bounded::TimedOut),
+            "a 30s sleep cannot finish inside 100ms: {outcome:?}"
+        );
+        assert!(
+            started.elapsed() < Duration::from_secs(10),
+            "the sleep was waited out rather than killed, in {:?}",
+            started.elapsed()
+        );
+    }
+
+    /// fails if the budget is enforced against a child that met it, or if
+    /// its output is dropped on the way back.
+    #[test]
+    fn a_child_that_finishes_comes_back_with_both_streams() {
+        let outcome = run_bounded(
+            Command::new("sh")
+                .arg("-c")
+                .arg("printf wool; printf bleat >&2"),
+            Duration::from_secs(30),
+        )
+        .expect("sh is on every host this crate compiles for");
+
+        let Bounded::Exited(output) = outcome else {
+            panic!("a printf finishes well inside 30s: {outcome:?}");
+        };
+        assert!(output.status.success());
+        assert_eq!(String::from_utf8_lossy(&output.stdout), "wool");
+        assert_eq!(String::from_utf8_lossy(&output.stderr), "bleat");
+    }
+
+    /// fails if either stream is read after the wait rather than during it.
+    /// 200_000 bytes is past the 64 KiB a pipe holds, so a child writing
+    /// this much blocks against a reader that has not started, and the
+    /// budget then expires on a child that had already done its work.
+    #[test]
+    fn a_child_louder_than_one_pipeful_is_not_deadlocked_against_its_own_budget() {
+        let outcome = run_bounded(
+            Command::new("sh")
+                .arg("-c")
+                .arg("head -c 200000 /dev/zero; head -c 200000 /dev/zero >&2"),
+            Duration::from_secs(30),
+        )
+        .expect("sh is on every host this crate compiles for");
+
+        let Bounded::Exited(output) = outcome else {
+            panic!("the writes finish in milliseconds against a draining reader: {outcome:?}");
+        };
+        assert_eq!(output.stdout.len(), 200_000);
+        assert_eq!(output.stderr.len(), 200_000);
+    }
+}

--- a/crates/shep-cli/src/commands/lifecycle.rs
+++ b/crates/shep-cli/src/commands/lifecycle.rs
@@ -1834,41 +1834,6 @@ mod tests {
         );
     }
 
-    /// fails if a module that leaves a process on node's stdout is reported
-    /// as a module shep killed. node itself exits here: `detached` plus
-    /// `unref` takes the child off node's event loop, and `stdio: inherit`
-    /// hands it the pipes shep is reading, so the wait ends at once and only
-    /// the reads run out of budget.
-    #[test]
-    fn a_js_flockfile_leaving_a_process_on_the_pipe_says_that_instead() {
-        if !node_available() {
-            return;
-        }
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("flock.js");
-        std::fs::write(
-            &path,
-            "require('child_process')\
-             .spawn('sleep', ['5'], { detached: true, stdio: 'inherit' })\
-             .unref(); \
-             module.exports = { app: [] };",
-        )
-        .unwrap();
-
-        let err = evaluate_js_flockfile(&path, Duration::from_millis(200)).unwrap_err();
-
-        assert_eq!(target_exit_code(&err), ExitCode::InvalidConfig);
-        let message = err.to_string();
-        assert!(
-            message.contains("left behind still holds the output"),
-            "got: {message}"
-        );
-        assert!(
-            !message.contains("killed"),
-            "node exited on its own, so nothing was killed: {message}"
-        );
-    }
-
     /// fails if a pm2 ecosystem file is accepted, or if the refusal stops
     /// naming the key the operator has to change. Decision 2: this feature
     /// reads a Flockfile-shaped .js, and serde's own message is the answer.
@@ -2951,5 +2916,54 @@ mod tests {
             String::from_utf8(err).unwrap().contains("shep delete web"),
             "the daemon's own sentence has to reach the operator"
         );
+    }
+
+    /// Wall-clock tests, skipped by every CI job but the serial `slow` one.
+    ///
+    /// The case below needs a real node to START AND EXIT inside the budget,
+    /// which is a claim about how fast the machine is rather than about shep.
+    /// At 200ms it failed on four CI runners at once (arm, macos, musl and
+    /// the coverage job) while passing every local run: node took longer than
+    /// that to come up, so the run hit the deadline still running and shep
+    /// reported the kill it really had performed. The tier exists for exactly
+    /// this, and the budget here is 5s because a stalled read waits out
+    /// whatever is left of it, so the budget IS what the test costs.
+    mod slow {
+        use super::*;
+
+        /// fails if a module that leaves a process on node's stdout is
+        /// reported as a module shep killed. node itself exits here:
+        /// `detached` plus `unref` takes the child off node's event loop, and
+        /// `stdio: inherit` hands it the pipes shep is reading, so the wait
+        /// ends on its own and only the reads run out of budget.
+        #[test]
+        fn a_js_flockfile_leaving_a_process_on_the_pipe_says_that_instead() {
+            if !node_available() {
+                return;
+            }
+            let dir = tempfile::tempdir().unwrap();
+            let path = dir.path().join("flock.js");
+            std::fs::write(
+                &path,
+                "require('child_process')\
+                 .spawn('sleep', ['30'], { detached: true, stdio: 'inherit' })\
+                 .unref(); \
+                 module.exports = { app: [] };",
+            )
+            .unwrap();
+
+            let err = evaluate_js_flockfile(&path, Duration::from_secs(5)).unwrap_err();
+
+            assert_eq!(target_exit_code(&err), ExitCode::InvalidConfig);
+            let message = err.to_string();
+            assert!(
+                message.contains("left behind still holds the output"),
+                "got: {message}"
+            );
+            assert!(
+                !message.contains("killed"),
+                "node exited on its own, so nothing was killed: {message}"
+            );
+        }
     }
 }

--- a/crates/shep-cli/src/commands/lifecycle.rs
+++ b/crates/shep-cli/src/commands/lifecycle.rs
@@ -20,6 +20,7 @@ use shep_core::selector::ProcessSelector;
 
 use crate::cli::Format;
 use crate::cli::{SelectorArgs, StartArgs, StockArgs};
+use crate::commands::bounded::{Bounded, run_bounded};
 use crate::commands::selector::parse_selector;
 use crate::exit::ExitCode;
 use crate::output::{DeletedIds, FlockRows, Render, Streams, emit, emit_flock, write_outcome};
@@ -139,6 +140,17 @@ pub(crate) fn target_exit_code(err: &TargetError) -> ExitCode {
     }
 }
 
+/// How long node gets to hand back a `.js` Flockfile's JSON before shep
+/// kills it.
+///
+/// 30s, against the ~60ms `node -e` spends requiring a small module on this
+/// machine and the couple of seconds a large dependency tree costs on a cold
+/// filesystem. It is not a performance dial: nothing waits on this except a
+/// config that has already gone wrong, so it is set far enough out that no
+/// honest module can reach it and near enough that an unattended `shep
+/// start` still ends.
+const JS_EVAL_BUDGET: Duration = Duration::from_secs(30);
+
 /// The script handed to `node -e`. Wraps the `require` in its own
 /// `try`/`catch` rather than letting an uncaught exception crash node and
 /// relying on node's own crash-dump formatting — see this function's doc for
@@ -179,10 +191,13 @@ const JS_BRIDGE_SCRIPT: &str = "try { \
 /// the path at `process.argv[1]`, never in the source), so it is a narrower
 /// implementation choice, not a different design.
 ///
-/// **There is no timeout.** A module that never returns — one that starts a
-/// server at require time — hangs here. The process is in the foreground and
-/// interruptible; adding a bound means a reaper thread in a crate that
-/// forbids unsafe code. Recorded in `docs/specs/deferred.md`.
+/// **`budget` bounds the whole evaluation**, and node is killed the moment it
+/// runs out. A module that never returns — one that starts a server at
+/// require time instead of exporting config — used to hang here until
+/// somebody pressed Ctrl-C, which is a fair answer at a terminal and no
+/// answer at all for the CI job or provisioning script running `shep start`
+/// with nobody watching. [`run_bounded`] is the mechanism; [`JS_EVAL_BUDGET`]
+/// is what every caller passes.
 ///
 /// The `node_missing` sentence IS pinned, as of Phase 17, by `cli_e2e`'s
 /// `a_js_flockfile_without_node_says_so_and_says_what_to_do`. This doc used
@@ -200,20 +215,33 @@ const JS_BRIDGE_SCRIPT: &str = "try { \
 ///
 /// - [`TargetError::Read`] — the path could not be canonicalized.
 /// - [`TargetError::Js`] with `node_missing` — node is not on `PATH`.
-/// - [`TargetError::Js`] — node ran and failed, or could not be spawned.
-fn evaluate_js_flockfile(path: &Path) -> Result<String, TargetError> {
+/// - [`TargetError::Js`] — node ran and failed, could not be spawned, or was
+///   still running when `budget` ran out.
+fn evaluate_js_flockfile(path: &Path, budget: Duration) -> Result<String, TargetError> {
     let absolute = std::fs::canonicalize(path).map_err(|source| TargetError::Read {
         path: path.to_path_buf(),
         source,
     })?;
-    let output = std::process::Command::new("node")
+    let mut command = std::process::Command::new("node");
+    command
         .arg("-e")
         .arg(JS_BRIDGE_SCRIPT)
         .arg(&absolute)
-        .stdin(std::process::Stdio::null())
-        .output();
-    let output = match output {
-        Ok(output) => output,
+        .stdin(std::process::Stdio::null());
+    let output = match run_bounded(&mut command, budget) {
+        Ok(Bounded::Exited(output)) => output,
+        Ok(Bounded::TimedOut) => {
+            return Err(TargetError::Js {
+                detail: format!(
+                    "node was still evaluating {} after {}s, so shep killed it; a Flockfile \
+                     module has to export its config and return, and one that starts a server \
+                     at require time never does",
+                    path.display(),
+                    budget.as_secs_f32()
+                ),
+                node_missing: false,
+            });
+        }
         Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
             return Err(TargetError::Js {
                 detail: format!(
@@ -283,7 +311,8 @@ fn evaluate_js_flockfile(path: &Path) -> Result<String, TargetError> {
 /// - [`TargetError::UnknownFlockfileFormat`] — `as_flockfile` is set and
 ///   `target`'s extension names no readable format.
 /// - [`TargetError::Js`] — `as_flockfile` is set, `target` is a `.js` file,
-///   and node could not be run or could not evaluate it.
+///   and node could not be run, could not evaluate it, or was still at it
+///   after [`JS_EVAL_BUDGET`].
 /// - [`TargetError::Unresolvable`] — `target` matched none of the above.
 pub fn resolve_target(
     target: &str,
@@ -312,7 +341,7 @@ pub fn resolve_target(
                 Ok(default_cwd_to_flockfile_dir(flockfile.apps, path))
             }
             None if path.extension().and_then(|e| e.to_str()) == Some("js") => {
-                let json = evaluate_js_flockfile(path)?;
+                let json = evaluate_js_flockfile(path, JS_EVAL_BUDGET)?;
                 let flockfile = Flockfile::parse(&json, FlockFormat::Json)?;
                 Ok(default_cwd_to_flockfile_dir(flockfile.apps, path))
             }
@@ -1754,6 +1783,40 @@ mod tests {
         let err = resolve_target(path.to_str().unwrap(), None, b"", true).unwrap_err();
         assert_eq!(target_exit_code(&err), ExitCode::InvalidConfig);
         assert!(err.to_string().contains("sheep dip empty"), "got: {err}");
+    }
+
+    /// fails if a config module that never returns hangs shep, which is
+    /// exactly what one did until this budget existed. `setInterval` leaves a
+    /// handle on node's event loop, so node stays alive long after `require`
+    /// returned -- the same mechanism as the server-at-require-time shape
+    /// `docs/specs/deferred.md` named, without binding a port to get it.
+    ///
+    /// The budget is 200ms rather than [`JS_EVAL_BUDGET`] so the test costs a
+    /// fifth of a second; what it pins is that the bound is enforced and says
+    /// so, not what the shipped bound is.
+    #[test]
+    fn a_js_flockfile_that_never_returns_is_killed_and_says_why() {
+        if !node_available() {
+            return;
+        }
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("flock.js");
+        std::fs::write(
+            &path,
+            "setInterval(() => {}, 1000); module.exports = { app: [] };",
+        )
+        .unwrap();
+
+        let started = std::time::Instant::now();
+        let err = evaluate_js_flockfile(&path, Duration::from_millis(200)).unwrap_err();
+
+        assert_eq!(target_exit_code(&err), ExitCode::InvalidConfig);
+        assert!(err.to_string().contains("still evaluating"), "got: {err}");
+        assert!(
+            started.elapsed() < Duration::from_secs(10),
+            "node was waited out rather than killed, in {:?}",
+            started.elapsed()
+        );
     }
 
     /// fails if a pm2 ecosystem file is accepted, or if the refusal stops

--- a/crates/shep-cli/src/commands/lifecycle.rs
+++ b/crates/shep-cli/src/commands/lifecycle.rs
@@ -216,8 +216,9 @@ const JS_BRIDGE_SCRIPT: &str = "try { \
 ///
 /// - [`TargetError::Read`] — the path could not be canonicalized.
 /// - [`TargetError::Js`] with `node_missing` — node is not on `PATH`.
-/// - [`TargetError::Js`] — node ran and failed, could not be spawned, or was
-///   still running when `budget` ran out.
+/// - [`TargetError::Js`] — node ran and failed, could not be spawned, was
+///   still running when `budget` ran out, or exited leaving a process of its
+///   own holding the output shep was reading.
 fn evaluate_js_flockfile(path: &Path, budget: Duration) -> Result<String, TargetError> {
     let absolute = std::fs::canonicalize(path).map_err(|source| TargetError::Read {
         path: path.to_path_buf(),
@@ -231,12 +232,24 @@ fn evaluate_js_flockfile(path: &Path, budget: Duration) -> Result<String, Target
         .stdin(std::process::Stdio::null());
     let output = match run_bounded(&mut command, budget) {
         Ok(Bounded::Exited(output)) => output,
-        Ok(Bounded::TimedOut) => {
+        Ok(Bounded::Killed) => {
             return Err(TargetError::Js {
                 detail: format!(
                     "node was still running {} after {}s, so shep killed it; a Flockfile \
                      module has to export its config and let node exit, and one that leaves a \
                      server listening or a timer armed does not",
+                    path.display(),
+                    budget.as_secs_f32()
+                ),
+                node_missing: false,
+            });
+        }
+        Ok(Bounded::OutputHeldOpen) => {
+            return Err(TargetError::Js {
+                detail: format!(
+                    "node finished with {} within {}s, but a process it left behind still \
+                     holds the output shep was reading, so shep gave up on it; a Flockfile \
+                     module must not leave a child of its own on node's stdout or stderr",
                     path.display(),
                     budget.as_secs_f32()
                 ),
@@ -1818,6 +1831,41 @@ mod tests {
             started.elapsed() < Duration::from_secs(10),
             "node was waited out rather than killed, in {:?}",
             started.elapsed()
+        );
+    }
+
+    /// fails if a module that leaves a process on node's stdout is reported
+    /// as a module shep killed. node itself exits here: `detached` plus
+    /// `unref` takes the child off node's event loop, and `stdio: inherit`
+    /// hands it the pipes shep is reading, so the wait ends at once and only
+    /// the reads run out of budget.
+    #[test]
+    fn a_js_flockfile_leaving_a_process_on_the_pipe_says_that_instead() {
+        if !node_available() {
+            return;
+        }
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("flock.js");
+        std::fs::write(
+            &path,
+            "require('child_process')\
+             .spawn('sleep', ['5'], { detached: true, stdio: 'inherit' })\
+             .unref(); \
+             module.exports = { app: [] };",
+        )
+        .unwrap();
+
+        let err = evaluate_js_flockfile(&path, Duration::from_millis(200)).unwrap_err();
+
+        assert_eq!(target_exit_code(&err), ExitCode::InvalidConfig);
+        let message = err.to_string();
+        assert!(
+            message.contains("left behind still holds the output"),
+            "got: {message}"
+        );
+        assert!(
+            !message.contains("killed"),
+            "node exited on its own, so nothing was killed: {message}"
         );
     }
 

--- a/crates/shep-cli/src/commands/lifecycle.rs
+++ b/crates/shep-cli/src/commands/lifecycle.rs
@@ -192,12 +192,13 @@ const JS_BRIDGE_SCRIPT: &str = "try { \
 /// implementation choice, not a different design.
 ///
 /// **`budget` bounds the whole evaluation**, and node is killed the moment it
-/// runs out. A module that never returns — one that starts a server at
-/// require time instead of exporting config — used to hang here until
-/// somebody pressed Ctrl-C, which is a fair answer at a terminal and no
-/// answer at all for the CI job or provisioning script running `shep start`
-/// with nobody watching. [`run_bounded`] is the mechanism; [`JS_EVAL_BUDGET`]
-/// is what every caller passes.
+/// runs out. What has to happen inside it is node EXITING, not `require`
+/// returning: a module that leaves a server listening or a timer armed can
+/// assign `module.exports` and return while node's event loop stays alive, so
+/// this used to hang until somebody pressed Ctrl-C. That is a fair answer at
+/// a terminal and no answer at all for the CI job or provisioning script
+/// running `shep start` with nobody watching. [`run_bounded`] is the
+/// mechanism; [`JS_EVAL_BUDGET`] is what every caller passes.
 ///
 /// The `node_missing` sentence IS pinned, as of Phase 17, by `cli_e2e`'s
 /// `a_js_flockfile_without_node_says_so_and_says_what_to_do`. This doc used
@@ -233,9 +234,9 @@ fn evaluate_js_flockfile(path: &Path, budget: Duration) -> Result<String, Target
         Ok(Bounded::TimedOut) => {
             return Err(TargetError::Js {
                 detail: format!(
-                    "node was still evaluating {} after {}s, so shep killed it; a Flockfile \
-                     module has to export its config and return, and one that starts a server \
-                     at require time never does",
+                    "node was still running {} after {}s, so shep killed it; a Flockfile \
+                     module has to export its config and let node exit, and one that leaves a \
+                     server listening or a timer armed does not",
                     path.display(),
                     budget.as_secs_f32()
                 ),
@@ -1785,17 +1786,18 @@ mod tests {
         assert!(err.to_string().contains("sheep dip empty"), "got: {err}");
     }
 
-    /// fails if a config module that never returns hangs shep, which is
+    /// fails if a config module that keeps node alive hangs shep, which is
     /// exactly what one did until this budget existed. `setInterval` leaves a
-    /// handle on node's event loop, so node stays alive long after `require`
-    /// returned -- the same mechanism as the server-at-require-time shape
-    /// `docs/specs/deferred.md` named, without binding a port to get it.
+    /// handle on node's event loop, so node stays running long after `require`
+    /// returned and `module.exports` was assigned -- the same mechanism as the
+    /// server-at-require-time shape `docs/specs/deferred.md` named, without
+    /// binding a port to get it.
     ///
     /// The budget is 200ms rather than [`JS_EVAL_BUDGET`] so the test costs a
     /// fifth of a second; what it pins is that the bound is enforced and says
     /// so, not what the shipped bound is.
     #[test]
-    fn a_js_flockfile_that_never_returns_is_killed_and_says_why() {
+    fn a_js_flockfile_that_keeps_node_alive_is_killed_and_says_why() {
         if !node_available() {
             return;
         }
@@ -1811,7 +1813,7 @@ mod tests {
         let err = evaluate_js_flockfile(&path, Duration::from_millis(200)).unwrap_err();
 
         assert_eq!(target_exit_code(&err), ExitCode::InvalidConfig);
-        assert!(err.to_string().contains("still evaluating"), "got: {err}");
+        assert!(err.to_string().contains("still running"), "got: {err}");
         assert!(
             started.elapsed() < Duration::from_secs(10),
             "node was waited out rather than killed, in {:?}",

--- a/crates/shep-cli/src/commands/mod.rs
+++ b/crates/shep-cli/src/commands/mod.rs
@@ -4,6 +4,7 @@
 
 pub mod admin;
 pub mod bleats;
+pub(crate) mod bounded;
 pub mod daemon;
 pub mod dev;
 pub mod dogs;

--- a/crates/shep-cli/src/commands/mod.rs
+++ b/crates/shep-cli/src/commands/mod.rs
@@ -1,6 +1,8 @@
 //! Per-verb command implementations, `daemon` first. OS tier: gated
-//! `#[cfg(unix)]` at this module's own declaration in `main.rs`, so nothing
-//! declared beneath it needs a `cfg` of its own.
+//! `#[cfg(unix)]` at this module's own declaration in `lib.rs`, so nothing
+//! declared beneath it needs a `cfg` of its own -- and nothing under it is
+//! compiled on Windows at all, which is why the tests here reach for `sh`
+//! and `sleep` without a portability dance.
 
 pub mod admin;
 pub mod bleats;

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -18,6 +18,11 @@ sheep-native field names — not pm2's. Point it at a real
 `ecosystem.config.js` and shep refuses, naming the key it found and the key
 it wanted.
 
+node gets 30 seconds to hand the config back, then shep kills it and names
+the file. A Flockfile module has to export its config and return; one that
+starts a server at require time never does, so an unattended `shep start`
+ends in a refusal rather than waiting for a terminal nobody is sitting at.
+
 Without the `--flockfile` flag, `shep start server.js` still means what it
 has always meant: start `server.js`. And if node is not installed, shep
 says so and tells you the alternative: *reading a .js Flockfile runs it

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -18,10 +18,11 @@ sheep-native field names — not pm2's. Point it at a real
 `ecosystem.config.js` and shep refuses, naming the key it found and the key
 it wanted.
 
-node gets 30 seconds to hand the config back, then shep kills it and names
-the file. A Flockfile module has to export its config and return; one that
-starts a server at require time never does, so an unattended `shep start`
-ends in a refusal rather than waiting for a terminal nobody is sitting at.
+node gets 30 seconds to hand the config back and exit, then shep kills it and
+names the file. Exporting the config is not enough on its own: a module that
+leaves a server listening or a timer armed keeps node's event loop alive, and
+node then never exits. An unattended `shep start` ends in a refusal rather
+than waiting for a terminal nobody is sitting at.
 
 Without the `--flockfile` flag, `shep start server.js` still means what it
 has always meant: start `server.js`. And if node is not installed, shep

--- a/docs/specs/deferred.md
+++ b/docs/specs/deferred.md
@@ -434,10 +434,11 @@ a different problem: a pipe holds 64 KiB, so a child filling stdout blocks and
 never exits, and a deadline that read the pipes after the wait could not fire
 on the loudest children it exists for. `Command::output` spawns them for the
 same reason. The budget covers the reads as well as the wait, so a process
-node left behind on the inherited pipe cannot outlast it either. That case
-gets its own answer and its own sentence: node exited on its own there and
-nothing was killed, so a refusal claiming a kill would be describing a
-different failure.
+node left behind on an inherited pipe cannot hold `run_bounded` past the
+deadline. It can outlive the budget perfectly well, and shep has no handle on
+it: that process is not shep's child. So the case gets its own answer and its
+own sentence, because node exited on its own there and nothing was killed,
+and a refusal claiming a kill would be describing a different failure.
 
 **No knob.** 30s is a const, not a flag and not a `shep.toml` key. Nothing
 honest reaches it, and a config that does has a bug the operator wants to hear

--- a/docs/specs/deferred.md
+++ b/docs/specs/deferred.md
@@ -433,8 +433,11 @@ for `adopt`'s exec probe. What the threads in `commands/bounded.rs` are for is
 a different problem: a pipe holds 64 KiB, so a child filling stdout blocks and
 never exits, and a deadline that read the pipes after the wait could not fire
 on the loudest children it exists for. `Command::output` spawns them for the
-same reason. The budget covers the reads as well as the wait, so a grandchild
-holding the inherited pipe open cannot outlast it either.
+same reason. The budget covers the reads as well as the wait, so a process
+node left behind on the inherited pipe cannot outlast it either. That case
+gets its own answer and its own sentence: node exited on its own there and
+nothing was killed, so a refusal claiming a kill would be describing a
+different failure.
 
 **No knob.** 30s is a const, not a flag and not a `shep.toml` key. Nothing
 honest reaches it, and a config that does has a bug the operator wants to hear

--- a/docs/specs/deferred.md
+++ b/docs/specs/deferred.md
@@ -414,19 +414,27 @@ floor — a combining mark measures zero and rides along with its base
 character, which is the case that matters, and both truncating callers stop
 on a whole `char` boundary.
 
-### A `.js` Flockfile has no evaluation timeout
+### A `.js` Flockfile has no evaluation timeout -- FIXED, 2026-08-28
 
-A `.js` module handed to `require()` and never returning — one that starts a
-server at require time rather than exporting config — hangs `shep start`
-forever. There is no bound on the wait.
+`evaluate_js_flockfile` takes a budget now, `JS_EVAL_BUDGET` is 30s, and node
+is killed once it passes. The refusal exits `InvalidConfig` and names the
+cause: *node was still evaluating <path> after 30s, so shep killed it; a
+Flockfile module has to export its config and return, and one that starts a
+server at require time never does.*
 
-Not built because a bound means a reaper thread in a crate that forbids
-unsafe code (`#![forbid(unsafe_code)]` on shep), for a case where the
-process is in the foreground, attached to the operator's own terminal, and
-already interruptible with Ctrl-C. What would force it: any path that
-evaluates a `.js` Flockfile unattended — a CI job or a provisioning script
-running `shep start` non-interactively, where nobody is watching to press
-Ctrl-C.
+**The reason recorded here for not building it was wrong**, which is the part
+worth keeping. A bound needs no reaper thread and no unsafe. `Child::try_wait`
+in a poll loop is safe std, and `commands/dogs.rs` already ran that exact loop
+for `adopt`'s exec probe. What the threads in `commands/bounded.rs` are for is
+a different problem: a pipe holds 64 KiB, so a child filling stdout blocks and
+never exits, and a deadline that read the pipes after the wait could not fire
+on the loudest children it exists for. `Command::output` spawns them for the
+same reason. The budget covers the reads as well as the wait, so a grandchild
+holding the inherited pipe open cannot outlast it either.
+
+**No knob.** 30s is a const, not a flag and not a `shep.toml` key. Nothing
+honest reaches it, and a config that does has a bug the operator wants to hear
+about rather than a setting they want to raise. Adding one later is additive.
 
 ### The missing-node error message has no test -- FIXED, Phase 17
 

--- a/docs/specs/deferred.md
+++ b/docs/specs/deferred.md
@@ -418,9 +418,13 @@ on a whole `char` boundary.
 
 `evaluate_js_flockfile` takes a budget now, `JS_EVAL_BUDGET` is 30s, and node
 is killed once it passes. The refusal exits `InvalidConfig` and names the
-cause: *node was still evaluating <path> after 30s, so shep killed it; a
-Flockfile module has to export its config and return, and one that starts a
-server at require time never does.*
+cause: *node was still running <path> after 30s, so shep killed it; a
+Flockfile module has to export its config and let node exit, and one that
+leaves a server listening or a timer armed does not.*
+
+What the budget waits for is node EXITING, not `require` returning. A module
+can assign `module.exports` and return while an armed timer holds the event
+loop open, which is the shape the unit test uses.
 
 **The reason recorded here for not building it was wrong**, which is the part
 worth keeping. A bound needs no reaper thread and no unsafe. `Child::try_wait`
@@ -1090,8 +1094,8 @@ has no `.js` entry in it. The document it reads is Flockfile-shaped (an `app`
 array, sheep-native field names), not a pm2 `ecosystem.config.js` — pointing
 `--flockfile` at a real pm2 ecosystem file gets serde's own `unknown field
 `apps`, expected `app`` refusal, and `shep import` remains the only pm2 path.
-A `.js` module that never returns hangs `shep start` forever; there is no
-timeout, recorded as known debt below.
+A `.js` module that keeps node alive hung `shep start` forever until the 30s
+`JS_EVAL_BUDGET` landed on 2026-08-28; see the entry above.
 
 **schemars JSON-schema export** (spec §5) **shipped**, Phase 14, behind a
 non-default `schema` feature on shep-core that shep turns on. The schema

--- a/web/src/data/docsLexicon.ts
+++ b/web/src/data/docsLexicon.ts
@@ -3,19 +3,21 @@
  * meet it / built" grid (docs/shep-design/README.md, "Screens > 2. Docs >
  * Terminology").
  *
- * Source of truth: README.md's own "## The lexicon" table. Unlike the
- * landing page's six hand-curated signposts (web/src/data/lexicon.ts,
- * sourced from docs/terminology.md's prose-heavy table), this one IS
- * mechanically parsed — README.md's table is already a clean four-column
- * grid with the exact "built?" column this page needs, and it's the
- * current, actively-maintained one (docs/terminology.md predates several
- * shipped verbs and has no built column at all). Parsing it means a rename,
- * a new row, or a yes/no/partly flip in README.md shows up here on the next
+ * Source of truth: web/src/data/lexiconTable.md, a four-column grid with the
+ * exact "built?" column this page needs. Unlike the landing page's six
+ * hand-curated signposts (web/src/data/lexicon.ts, sourced from
+ * docs/terminology.md's prose-heavy table), this one IS mechanically parsed,
+ * so a rename, a new row, or a yes/no/partly flip shows up here on the next
  * build with no hand-editing.
+ *
+ * That table lived in README.md until the README was rewritten as a landing
+ * page rather than a reference. docs/terminology.md keeps the design lexicon
+ * and is a different table: keyed on the conventional word, carrying the
+ * ruling behind each choice, and with no built column at all.
  */
 // `?raw` (see web/src/data/lexicon.ts's header comment) inlines the file's
 // text content at build time.
-import readmeSource from "../../../README.md?raw";
+import lexiconSource from "./lexiconTable.md?raw";
 
 export interface LexiconRow {
   /** Plain text — rendered in the term column's own font/color, no markup. */
@@ -46,8 +48,9 @@ function parseLexiconTable(source: string): LexiconRow[] {
   const headingIndex = source.indexOf(HEADING);
   if (headingIndex === -1) {
     throw new Error(
-      `web/src/data/docsLexicon.ts: README.md no longer has a "${HEADING}" ` +
-        `section — the Terminology page's table has nothing to read.`,
+      `web/src/data/docsLexicon.ts: lexiconTable.md no longer has a ` +
+        `"${HEADING}" section — the Terminology page's table has nothing ` +
+        `to read.`,
     );
   }
   const nextHeadingIndex = source.indexOf("\n## ", headingIndex + HEADING.length);
@@ -65,7 +68,7 @@ function parseLexiconTable(source: string): LexiconRow[] {
   if (!headerLine || !dividerLine) {
     throw new Error(
       `web/src/data/docsLexicon.ts: found "${HEADING}" but no markdown ` +
-        `table under it in README.md.`,
+        `table under it in lexiconTable.md.`,
     );
   }
 
@@ -73,7 +76,7 @@ function parseLexiconTable(source: string): LexiconRow[] {
   const headerMatches = expectedHeader.every((col, i) => header[i] === col);
   if (!headerMatches) {
     throw new Error(
-      `web/src/data/docsLexicon.ts: README.md's lexicon table header is ` +
+      `web/src/data/docsLexicon.ts: lexiconTable.md's table header is ` +
         `now [${header.join(", ")}] — expected [${expectedHeader.join(", ")}]. ` +
         `Update the column mapping below to match.`,
     );
@@ -97,19 +100,19 @@ function parseLexiconTable(source: string): LexiconRow[] {
     // silently ship a half-empty table.
     throw new Error(
       `web/src/data/docsLexicon.ts: parsed only ${rows.length} lexicon rows ` +
-        `from README.md, expected at least 15 — check the table didn't ` +
-        `change shape.`,
+        `from lexiconTable.md, expected at least 15 — check the table ` +
+        `didn't change shape.`,
     );
   }
 
   return rows;
 }
 
-export const lexiconTable: LexiconRow[] = parseLexiconTable(readmeSource);
+export const lexiconTable: LexiconRow[] = parseLexiconTable(lexiconSource);
 
 /**
  * Turns `` `code` `` spans into `<code>` tags for use with Astro's
- * `set:html`. README.md's table cells are plain prose plus the occasional
+ * `set:html`. The table's cells are plain prose plus the occasional
  * code span — no other markdown (no links, no emphasis) — so this is
  * deliberately narrow rather than a general markdown-to-HTML pass.
  */

--- a/web/src/data/lexiconTable.md
+++ b/web/src/data/lexiconTable.md
@@ -1,0 +1,45 @@
+<!--
+  The Terminology page's table, parsed by web/src/data/docsLexicon.ts.
+
+  It lived in README.md until that page was rewritten as a landing page
+  rather than a reference, which left the parser reading a heading that was
+  no longer there and the site build failing outright. It is a document
+  rather than a data file so the shape stays the one the parser already
+  knew: the lexicon heading below, then a four-column table. Do not repeat
+  that heading's text up here, in this comment or any other: the parser
+  finds the first occurrence in the file and would read this instead.
+
+  docs/terminology.md is the design lexicon and a different table: it is
+  keyed on the conventional word, carries the rulings behind each choice,
+  and has no "built" column. This one is the operator's.
+-->
+
+## The lexicon
+
+The whole vocabulary, and whether it exists yet.
+
+| shep says | Means | Where you meet it | Built? |
+|---|---|---|---|
+| the shepherd | the daemon | log messages, docs | yes |
+| the flock | every managed process, as a set | `shep flock` (aliases `list`, `ls`) | yes |
+| a sheep | one managed process (singular only) | `shep describe <name>` | yes |
+| a fold | a namespace or group | `shep fold backend`, `fold =` in config | yes |
+| Flockfile | the app config file | `Flockfile.toml` / `.yaml` / `.json` / `.json5` | yes |
+| bleats | logs | `shep bleats` (alias `logs`) | yes |
+| muster | bring a saved flock back | `shep save`, then `shep muster` | yes |
+| the shepherd channel | a private pipe on fd 3 between daemon and app | `channel = true`, `shep trigger` | yes |
+| a lamb | a child process of a sheep | tree-kill, `describe`'s tree view | yes |
+| a dog | a plugin process the shepherd supervises | `shep enable metrics`, `shep dogs` | yes |
+| a bark | a webhook alert | `[dog.bark.sinks]` config, `shep barks` | yes |
+| a smit | a short mark a dog paints on a sheep | the SMIT column in `shep flock` and the lookout | yes |
+| the whistle | the MCP interface agents talk to | `shep whistle` | yes |
+| the lookout | the terminal dashboard | `shep lookout` (alias `dash`) | partly |
+| adopt / rehome | register or drop a third-party dog | `shep adopt <path> [--name <name>]` | yes |
+| that'll do | graceful stop, after the real herding command | `shep thatlldo` | yes |
+| stock | change how many instances of an app run (the stocking rate) | `shep stock <name> <count>` (alias `scale`) | yes |
+| signal | send a signal to one sheep's own process | `shep signal <selector> <signal>` | yes |
+| whisper | write a line to a sheep's stdin | `shep whisper <selector> <line>` (alias `sendline`) | yes |
+| set / get / unset | the flat key-value junk drawer | `shep set`, `shep get`, `shep unset` | yes |
+
+Sheepdogs and sheep were separate ideas from the start, so "dog" never means
+the daemon. The shepherd is the shepherd. Dogs are plugins that work for it.

--- a/web/src/data/lexiconTable.md
+++ b/web/src/data/lexiconTable.md
@@ -1,3 +1,5 @@
+# Lexicon table
+
 <!--
   The Terminology page's table, parsed by web/src/data/docsLexicon.ts.
 

--- a/web/src/pages/docs/first-flockfile.astro
+++ b/web/src/pages/docs/first-flockfile.astro
@@ -168,9 +168,10 @@ flockfile.json5`}</CodeBlock>
     </p>
     <CodeBlock>{`$ shep start flock.config.js --flockfile`}</CodeBlock>
     <p class="fine">
-      shep gives <code>node</code> 30 seconds to hand the config back, then
-      kills it. A Flockfile module has to export its config and return, and
-      one that starts a server at require time never does, so an unattended
+      shep gives <code>node</code> 30 seconds to hand the config back and
+      exit, then kills it. Exporting the config is not enough by itself: a
+      module that leaves a server listening or a timer armed keeps node's
+      event loop alive, so node never exits. An unattended
       <code>shep start</code> ends in a refusal instead of waiting forever.
     </p>
     <p class="fine">

--- a/web/src/pages/docs/first-flockfile.astro
+++ b/web/src/pages/docs/first-flockfile.astro
@@ -168,6 +168,12 @@ flockfile.json5`}</CodeBlock>
     </p>
     <CodeBlock>{`$ shep start flock.config.js --flockfile`}</CodeBlock>
     <p class="fine">
+      shep gives <code>node</code> 30 seconds to hand the config back, then
+      kills it. A Flockfile module has to export its config and return, and
+      one that starts a server at require time never does, so an unattended
+      <code>shep start</code> ends in a refusal instead of waiting forever.
+    </p>
+    <p class="fine">
       A pm2 <code>ecosystem.config.js</code> is not a Flockfile shep can read
       this way. shep never parses pm2's config format at all. That's what
       <code>shep import</code> is for: it reads a real <code>dump.pm2</code>

--- a/web/src/pages/docs/terminology.astro
+++ b/web/src/pages/docs/terminology.astro
@@ -2,8 +2,9 @@
 /*
  * Terminology (docs/shep-design/README.md, "Screens > 2. Docs >
  * Terminology"). The lexicon table is DATA from web/src/data/docsLexicon.ts
- * (parsed from README.md's own lexicon table at build time — see that
- * file's header comment for why README.md rather than docs/terminology.md).
+ * (parsed from web/src/data/lexiconTable.md at build time, which is the file
+ * to edit to change a row — see that parser's header comment for why it is
+ * not docs/terminology.md).
  * The usage-rule cards are DATA from web/src/data/docsRules.ts.
  */
 import DocsLayout from "../../layouts/DocsLayout.astro";


### PR DESCRIPTION
- `shep start x.js --flockfile` no longer hangs forever. A config module that starts a server at require time never returns, so `Command::output` waited on it until Ctrl-C. node gets 30s now, then shep kills it and refuses with `InvalidConfig`, naming the file and the likely cause.
- New `commands/bounded.rs` polls `try_wait` and drains both pipes on their own threads. A pipe holds 64 KiB, so a loud child blocks and never exits, and a deadline that read the pipes after the wait could not fire on the children it exists for.
- The reason recorded in `docs/specs/deferred.md` for deferring this was wrong: no reaper thread and no unsafe needed. `commands/dogs.rs` already ran the same poll loop for `adopt`'s exec probe. Entry marked fixed, with the correction kept.
- 30s is a const, not a flag and not a `shep.toml` key. Say if you want a knob.
- Second commit is unrelated: `astro build` has been red on main since fb5ec27, which dropped README's lexicon table while `web/src/data/docsLexicon.ts` still parsed it. Table moved verbatim to `web/src/data/lexiconTable.md`. Nothing in `.github/workflows` builds `web/`, so CI never said so.

Gate, all from this branch:

```
cargo fmt --all --check                                                  EXIT=0
cargo clippy --workspace --all-targets --all-features -- -D warnings     EXIT=0
cargo test --workspace --all-features                    EXIT=0, 1842 passed, 0 failed
RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features EXIT=0
npx astro build                                                          EXIT=0
npx astro check                                            0 errors, 0 warnings
```

No clap surface changed, so the generated CLI reference is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * JavaScript Flockfiles that do not finish loading within 30 seconds are now terminated and rejected with a clear configuration error identifying the file and likely cause.
  * Output is captured safely, including for processes producing large amounts of output or leaving streams open.

* **Documentation**
  * Added guidance explaining Flockfile execution limits and the requirement to export configuration and return during loading.
  * Updated the Terminology page with a dedicated source vocabulary table and clarified its build-time source.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->