### PR TITLE
chore: release v0.1.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2058,7 +2058,7 @@ dependencies = [
 
 [[package]]
 name = "shep"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "anstyle",
  "assert_cmd",
@@ -2096,11 +2096,11 @@ dependencies = [
 
 [[package]]
 name = "shep-cli"
-version = "0.1.7"
+version = "0.1.8"
 
 [[package]]
 name = "shep-client"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "futures-util",
  "nix 0.29.0",
@@ -2113,7 +2113,7 @@ dependencies = [
 
 [[package]]
 name = "shep-core"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "annotate-snippets",
  "anstyle",
@@ -2143,7 +2143,7 @@ dependencies = [
 
 [[package]]
 name = "shep-daemon"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "bytes",
  "chrono",
@@ -2170,7 +2170,7 @@ dependencies = [
 
 [[package]]
 name = "shep-examples"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "nix 0.29.0",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.7"
+version = "0.1.8"
 edition = "2024"
 # 1.88 forced by serde-saphyr (let-chains, stabilized 1.88) — a current dep,
 # not a future one. Also the floor for ratatui/sysinfo/rmcp in later phases.
@@ -31,9 +31,9 @@ license = "MIT OR Apache-2.0"
 # the `[package]` table — so this literal is not sourced from
 # `workspace.package.version` above and a release bump has to touch both
 # places by hand. If that drifts, `cargo-release` is the mechanical fix.
-shep-core = { path = "crates/shep-core", version = "0.1.7" }
-shep-daemon = { path = "crates/shep-daemon", version = "0.1.7" }
-shep-client = { path = "crates/shep-client", version = "0.1.7" }
+shep-core = { path = "crates/shep-core", version = "0.1.8" }
+shep-daemon = { path = "crates/shep-daemon", version = "0.1.8" }
+shep-client = { path = "crates/shep-client", version = "0.1.8" }
 serde = { version = "1", default-features = false, features = ["derive"] }
 serde_json = { version = "1", default-features = false, features = ["std"] }
 toml = { version = "0.8", default-features = false, features = ["parse", "display"] }

--- a/crates/shep-cli/CHANGELOG.md
+++ b/crates/shep-cli/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.8] - 2026-08-28
+
+
 ### Additions
 
 - The dogs table's columns line up with the sheep table's. Every column the

--- a/crates/shep-client/CHANGELOG.md
+++ b/crates/shep-client/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.8] - 2026-08-28
+
+
 ## [0.1.0] - 2026-08-26
 
 ### Additions

--- a/crates/shep-core/CHANGELOG.md
+++ b/crates/shep-core/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.8] - 2026-08-28
+
+
 ### Additions
 
 - Add `Request::ConfigDrift`, `Response::Drifted`, `SheepDrift`, and

--- a/crates/shep-daemon/CHANGELOG.md
+++ b/crates/shep-daemon/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.8] - 2026-08-28
+
+
 ### Fixes
 
 - Name the sheep and the path in a failed spawn's message. The whole error


### PR DESCRIPTION



## 🤖 New release

* `shep-core`: 0.1.7 -> 0.1.8
* `shep-daemon`: 0.1.7 -> 0.1.8
* `shep-client`: 0.1.7 -> 0.1.8
* `shep`: 0.1.7 -> 0.1.8 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `shep-core`

<blockquote>

## [0.1.8] - 2026-08-28

### Additions

- Add `Request::ConfigDrift`, `Response::Drifted`, `SheepDrift`, and
  `AppConfig::drifted_fields`. `ConfigDrift` asks which of a set of apps name
  a sheep the flock already has under a DIFFERENT config, and changes
  nothing. `Start` on an already-registered name adds instances rather than
  reconciling config, which `shep stock` depends on, so an operator who
  edited a Flockfile and re-ran `shep start` had the edit ignored with no
  error and no warning; this is what a caller asks in order to say so.
  `SheepDrift` carries the sheep's name and the names of the differing
  fields, never their values, because `AppConfig::env` holds secrets and the
  answer is printed at an operator (IR-41). `drifted_fields` compares through
  serde rather than field by field, so a field added to `AppConfig` is
  compared without a second edit, and sorts the result explicitly rather than
  leaning on `serde_json::Map` being a `BTreeMap`, which holds only while the
  additive `preserve_order` feature is off anywhere in the graph. Additive: `PROTOCOL_VERSION` stays **1**, a
  daemon that predates the request answers its existing "does not implement
  that request" error, and every previously pinned wire fixture is unchanged.

- Add `protocol::sort_flock`, the one ordering rule every operator-facing
  listing takes: by name, then by id. An id is assigned at registration, so
  ordering by it sorts the flock by an accident of history rather than by
  anything an operator is looking for, and it is not stable -- a `delete all`
  followed by a fresh start moved a real thirteen-app flock from ids 0-10 to
  11-21 with nothing about the apps having changed. The id keeps its other
  job: it is still how one instance of a clustered app is addressed. It stops
  being a sort key and stays an addressing key.
</blockquote>

## `shep-daemon`

<blockquote>

## [0.1.8] - 2026-08-28

### Fixes

- Name the sheep and the path in a failed spawn's message. The whole error
  an operator got was `process spawn failed: No such file or directory (os
  error 2)`, which on an eleven-app Flockfile said neither which app had
  failed nor which path had been tried. It now reads
  ``<name>: process spawn failed: <os error>; tried `<script>` in <cwd>``,
  with the `cwd` clause present only when the app sets one. The path is the `script`/`interpreter`
  and `cwd` as the Flockfile spells them rather than a resolution of the two,
  because that is where the edit has to be made. `shep stock`'s own partial-
  scale reply gains the path too and does not repeat the name, which it
  already opens with.

- Check every app in a `Start` batch before registering any of it, and
  register nothing if any of them fails. One app pointing at a `script` that
  does not exist used to register and start the apps ahead of it, fail on
  that one, and never reach the apps behind it, leaving a flock that matched
  neither the Flockfile nor its previous state. The error now names every app
  that failed and the path each was looked for at, rather than the first
  failure alone. Passwd resolution for `user`/`group` is hoisted into the
  same pass for the same reason.

  The refusal reaches only a `script` or `interpreter` containing a `/`. A
  path is a claim about the filesystem, which the daemon can settle and an
  operator can fix with a typo correction. A BARE command is a claim about an
  environment, and the environment that decides is the daemon's rather than
  the shell an operator tested in: a `shep startup` unit gives the shepherd
  whatever `PATH` launchd or systemd hands it, and shep's own fallback is
  `/usr/local/bin:/usr/bin:/bin`, so homebrew's `node` on Apple Silicon
  (`/opt/homebrew/bin`) and nvm's (under `$HOME`) both resolve in a terminal
  and neither resolves under the unit. A bare command that does not resolve
  is reported in the shepherd's log, naming the sheep and the program, and
  the batch goes ahead; that one app's spawn then fails exactly as it did
  before. Refusing there would keep a whole flock down at boot over one app's
  interpreter, which is worse than the partial registration being fixed.

  A filesystem error that is not "no such file" never refuses a batch either.
  `Path::exists` returns `false` on any `fs::metadata` error, so a permission
  error on an intermediate directory, an unsettled mount and a race all read
  identically to "absent"; the check now matches `ErrorKind::NotFound`
  specifically, and everything else is a suspicion the spawn reports as it
  always did.

- Keep the pre-registration refusal to the one caller it was written for.
  `do_start` is shared, so the check reached two callers that must not have
  it. A dog whose binary is missing was refused and left no trace, where it
  belongs in the dogs table as `Errored`: `spawn_fresh` registers that row on
  purpose, `shep dogs` renders it, and `dogs::spawn_dog_watch` subscribes to
  it, so an operator who enabled a broken dog needs to see it rather than
  find nothing. Worse, restoring a muster roll refused the WHOLE roll when
  one saved app's binary had gone missing, so a machine came back from a
  reboot with nothing running at all, unattended. Both now register each app
  on its own merits, via a `BatchPolicy` the call site states explicitly.
  All-or-nothing stays what `shep start` against a Flockfile does, which is
  the case the check exists for and the only one where an operator is holding
  a terminal.

  The policy governs every point `do_start` can stop at, which took three
  passes to get right: the pre-registration check, the spawn loop, and
  `user`/`group` resolution. A `PerApp` batch now survives an app whose user
  cannot be resolved, where one unresolvable name used to refuse an entire
  muster restore.

  Resolving credentials no longer builds a vector to zip against the apps.
  That pairing was safe only while a failure returned early; once a failure
  is SKIPPED, the two sequences drift, `zip` hands app 2 app 3's credentials,
  and the last app is dropped without a word. That is a privilege
  misassignment rather than a scheduling bug: the flock comes up looking
  correct with processes under identities nobody chose. Each app now carries
  its own credentials from the point of resolution, so there is no second
  sequence to keep in step.

  Under `PerApp`, an app whose credentials fail is registered `Errored` like
  an app whose spawn fails, so it is visible in `shep flock` rather than
  missing from it. It carries no identity, which is what still rules out the
  outcome that matters: a later `shep restart` resolves it afresh and meets
  the same refusal instead of coming up as the daemon. `AllOrNothing`
  registers nothing at all, as it always has. Both causes are named in the
  error either way.

  The policy governs the SPAWN loop as well as the pre-registration check.
  That loop returned on the first failure whatever the policy said, so a bad
  entry that was not last still took every app after it down: `a-good` came
  up, `b-bad` failed, and `c-good` was never registered at all. A muster roll
  is written from a `BTreeMap` and restored in that order, so this was a
  certainty whenever the broken name sorted first rather than a race. Under
  `PerApp` a failed spawn now records that app, leaves it `Errored` and
  visible, and moves to the next; the app's own remaining instances are
  skipped, since they share a binary and would only add identical wrecks to
  the listing. The error still names every app that failed, so the muster's
  existing "failed to spawn one or more apps" log keeps its meaning.

- Explain a bare program's spawn failure in the reply, not only in the log.
  When a `script` or `interpreter` with no `/` in it fails to spawn, the
  `SpawnFailed` message now carries "`node` is not on the shepherd's PATH
  (...)" in place of the bare "tried `node`" clause, so an operator at a
  terminal gets the diagnosis rather than only `No such file or directory`.
  No protocol change: `SpawnFailed` already carries free-form text. A PATH of
  more than four entries is summarised, because a daemon autostarted from a
  shell inherits that shell's PATH, which measured two kilobytes and buried
  the sentence that mattered.

- Every reply carrying a listing now comes back in the same order the flock
  listing does: by name, then by id. `ListFlock`, `Describe` and `Mustered`
  already grouped by name; `Start`, `Stop`, `Restart`, `Reload`, `Scale`,
  `Reopen`, `Flush`, `Trigger`, `Signal` and `SendLine` came back in whatever
  order they were assembled, so one session against one flock printed two
  different orders. Wire-observable, and so visible under `--format json` as
  well as in a table. `Delete` is not in that list and never was: it answers
  with ids alone, which the daemon already sorts.

- `snapshot_all` takes the shared rule rather than a finer one of its own. It
  sorted `(name, instance, id)`, which is more stable across a reload and
  which no listing that has crossed the wire can reproduce, since
  `ProcessInfo` carries no instance number. The two agreed until a reload
  churned an id and then diverged, so `ListFlock` could order a reloaded app
  differently from the `Restart` reply printed a second earlier -- the very
  inconsistency this change exists to end, one layer down. It now calls
  `sort_flock`, so the two cannot drift.

- A sheep restored from the muster roll comes back under its configured
  `user`/`group` rather than under the shepherd. `register_at_rest` records
  membership without resolving anything, and `ProcessEntry::credentials`
  spelled "nobody has looked this app up yet" and "this app asked for nobody"
  the same way, as `None`. A later `shep restart` read the second meaning and
  started the child as the daemon: no error, no warning, and nothing in `shep
  describe` to see it by. The field is now a `SpawnIdentity`, which tells the
  two apart, and every spawn path reaches a usable `Option<Credentials>`
  through one seam that resolves an unresolved entry instead of falling back.
  An app that resolved once is still settled for good, so a restart neither
  re-reads the passwd database nor changes a running app's identity underneath
  it.

- Announce a credential-refused row once, not on every restore. The
  `Errored` row a `PerApp` start leaves is registered idempotently by name, so
  a second muster restore over a flock already holding it finds the row rather
  than making one. The `ProcessEventKind::Errored` emit keyed on the row's
  STATUS, which is `Errored` whether the call created it or found it, so the
  repeat went out as a fresh transition and bark's `Trigger::GaveUp` read it as
  one, paging twice for a row that had not changed whenever the two restores
  sat further apart than its five-minute debounce. It keys on the registration now: `register_without_spawning` returns
  whether it made the row, which is a question the row itself cannot answer.

- Say why a restart produced no process. The event a failed restart emits
  carries no reason and the reply has no per-id error slot, so the shepherd's
  log was the only place to learn that a binary had been replaced mid-deploy
  or that `fork` returned `EAGAIN` -- and that path discarded the runner's
  error, leaving an `errored` row and nothing to read. The reason is now an
  argument to the one function both failure routes go through, so there is no
  way into that state without one.

### Additions

- Add `SupervisorError::CannotStart`, a command refused before it registered
  or spawned anything: a `Start` batch whose checking pass rejected an app, or
  a `shep stock` scale-UP of an app whose `user` will not resolve. A scale
  that removes instances, or that asks for the count an app already has,
  resolves nothing and cannot reach it. Separate from `SpawnFailed` because nothing was spawned,
  and an operator told "spawn failed" about a spawn that never happened is
  being pointed at the wrong place; the two also differ in what they leave
  behind, which is the part that matters operationally. It maps to the
  existing `RpcErrorCode::SpawnFailed` all the same, so exit 7 and every
  older client are unchanged: `RpcErrorCode` is versioned and a client
  predating a new code could not decode the reply at all.

- Add `ProcessRunner::preflight` and `Preflight`, what a runner can tell
  about a `SpawnSpec` before anything is spawned. Three verdicts, because a
  caller registering a batch has three different things to do with the
  answer: `Unknown` ("nothing knowable in advance", never "this will work"),
  `Impossible` (a certainty, and the only one a caller may refuse a whole
  batch over), and `Doubtful` (report it and carry on). `preflight` is
  defaulted to `Unknown`, so an out-of-tree implementor is unaffected and a
  runner that never touches the filesystem gives the honest answer.
  `TokioRunner` answers `Impossible` for a `/`-containing path that is not on
  the filesystem, `Doubtful` for a bare command missing from the `PATH` the
  child will actually be given, and `Unknown` for everything else, including
  a relative path with no `cwd` and any filesystem error other than
  `NotFound`. Existence only, never the executable bit.

- Answer `Request::ConfigDrift`: report which of a set of apps name a
  registered sheep whose stored config differs, and in which fields. Reads
  the flock and changes nothing -- it registers, spawns and records nothing,
  so it is answered during a shutdown rather than refused the way `Start` is.
  The incoming configs are re-normalized first, on the same untrusted-peer
  rule `Start` follows plus one of its own: an unnormalized config would
  report every default it did not spell out as a difference from the
  normalized copy the flock stores.

- `privilege::SpawnIdentity` — an entry's identity and whether it has been
  resolved yet, which tells "this app asked for nobody" apart from "nobody
  has asked yet". Both credential fixes above turn on that distinction.
- `fake::ScriptedRunner::spawned_as` and `spawn_count`, behind `test-fakes`.
  The fake starts no process, so it drops no privilege and changes no identity
  at all. Recording what a spawn was ASKED for is therefore the only way a test
  can assert the identity it carried rather than merely that it happened.
</blockquote>


## `shep`

<blockquote>

## [0.1.8] - 2026-08-28

### Additions

- The dogs table's columns line up with the sheep table's. Every column the
  two share sits in the same order and each table's own columns come last, so
  the dogs table gains `ID` and `EXIT` and moves `SOURCE` from second to last.
  Both fields were already on the `ProcessInfo` it builds from, so this is no
  wire change. `FOLD` and `SMIT` stay off it because they are impossible for a
  dog rather than empty.

- `SOURCE` carries the one trust distinction shep draws. `adopted` is a
  third-party binary running at the shepherd's own trust level from an
  operator-supplied path; `built-in` is shep running its own code. They no
  longer look identical.

- Colour reaches every table that has something to say with one, which is
  fifteen of the twenty-two in `output::rows`. The eight newly covered are the
  three per-sheep reply tables (`trigger`, `signal`, `whisper`), `flush`'s
  two, `startup`'s, `barks` and `kill`, plus `import`'s `REUSE_PORT`. Seven
  stay plain on purpose, each with the reason recorded on its impl.

- Colour reaches the seven `Render` impls that are not the flock table.
  `colour_cell` had only ever appeared inside `FlockRows`, so one of eight
  tables was coloured and the same dog read one way under `shep dogs` and
  another under `shep flock`. The dogs table and the `enable`/`disable`/
  `adopt`/`rehome` confirmations now take the flock table's own rules, and
  `shep empty`'s table mutes its id and its placeholders. `describe`'s lamb
  table stays plain: two identity columns with no state, no reading and no
  placeholder, so there is nothing for a colour to carry.

- `shep start` takes the selector grammar every other lifecycle verb takes:
  `all`, `fold:<name>`, `/regex/`, globs, and a bare id. `shep stop
  fold:backed` worked and `shep start fold:backed` refused with "backed is not
  `-`, a recognised Flockfile, or an existing path", because `start` alone
  took a different argument grammar. Folds were actionable everywhere except
  the verb that creates things.

- A bare token is also tried as a fold name, so `shep start backed` reaches
  the fold `backed`. The full order, first tier that matches wins: a sheep by
  id or name, then a fold, then a Flockfile, then a path on disk. Written down
  in `shep start --help` and on the folds page, since a precedence rule is
  only reasonable if the person it surprises can find out why.

- `./backed` always means the file. A sheep name may never contain a path
  separator, so a target carrying one skips the flock entirely. That is what
  gives somebody whose fold shares a name with a file a way to say which they
  meant.

### Fixes

- A `.js` Flockfile that keeps node alive is killed rather than left to hang
  `shep start`. A config module that leaves a server listening or a timer
  armed can assign `module.exports` and return while node's event loop stays
  alive, so node never exits and shep held the terminal for as long as the
  operator left it open: there was no bound on the wait, and Ctrl-C was the
  only way out, which is no answer at all for a CI job or a provisioning
  script running `shep start` with nobody watching. node gets 30 seconds now,
  then shep kills it and refuses with `InvalidConfig`, naming the file and the
  likely cause. The near neighbour gets its own sentence rather than the same
  one: a module that exits cleanly but leaves a process of its own holding
  node's stdout or stderr is refused for that, since nothing was killed
  there.

- Cell colour is keyed on a column's NAME rather than its index. The old
  `rows_for` painted `row[0]`, `row[4]`, `row[9]` and `row[10]`, which are
  facts about one table's column order: reordering columns repointed every one
  of them with nothing failing to compile and no test able to notice.

- Say so when a Flockfile app names a sheep the flock already has under a
  different config, instead of ignoring the edit in silence. `shep start` on
  a registered name adds instances rather than reconciling config, so
  changing an app's `cwd` and re-running `shep start` left it running the old
  one with nothing printed; the apps then crash-looped against a path that no
  longer applied and only a `shep delete` plus a fresh start recovered them.
  `start` now asks the daemon (`Request::ConfigDrift`) before resuming
  anything and names the sheep and every field that differs, on stderr, so
  `--format json` piping is unaffected. Reported, never applied: whether
  `start` should reconcile by default or grow an `--update` flag is a
  separate decision, and changing a running flock's `cwd` or argv underneath
  an operator would be a worse surprise than the bug being fixed. Field names
  only, never values, since `env` carries secrets.

- A selector that matched nothing is reported as a selector. `shep start
  fold:typo` said `fold:typo is not ... an existing path` and sent an operator
  looking for a file they had never asked about; it now says no sheep is in a
  fold called typo, and exits 3 like every other verb does.

- Every lifecycle verb prints the whole flock afterwards, not only the rows it
  touched. `shep start koji` printed a one-row table containing koji; the
  question an operator has after a lifecycle command is what the flock looks
  like now, which a one-row table cannot answer and which the exit code
  already covered for the sheep they named. Applies to `start`, `stop`,
  `restart`, `reload`, `delete` and `stock`. `describe` stays narrow, because
  answering about one sheep is what it is for.

- A lifecycle verb acting on a dog renders it through the dogs table rather
  than the sheep table. `shep restart log-rotate` gave it an id, a face, and a
  `FOLD` and `SMIT` a dog can never fill, while dropping the `SOURCE` column
  that says whether it was adopted or is built in. Falls out of the change
  above: the listing goes through the same renderer `shep flock` uses.

- `--format json` is deliberately NOT widened by either of those. A script
  running `shep stop web --format json` asked about `web`, so `data` still
  holds `web`'s rows; widening it would break every consumer reading
  `data[0]`. `shep flock --format json` is the way to ask for the flock.

- `shep lookout`'s flock table draws by name, then by id, rather than by id.
  It repolls every two seconds, so the tiebreak is what stops two instances of
  one app swapping places under the cursor between refreshes.

- `shep bleats` tails a flock's log files in name order, and `shep flock`
  against a stopped shepherd lists the saved roll in name order. Both used
  the order they happened to be handed.

- Table columns are padded by the columns a name draws in, not by its
  character count. A CJK or emoji glyph counts as one character and draws as
  two, so a name built from them hung over its own column and pushed every
  column after it out of line. In `shep lookout` such a name could also lose
  the `…` that says it was cut. The box-drawn table, the plain one and
  `lookout` now measure the same way.
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Release**
  - Updated the application to version 0.1.8.
  - Aligned included components to the 0.1.8 release.

- **Documentation**
  - Added 0.1.8 release entries to the changelogs.
  - Recorded the release date as August 28, 2026.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->