### PR TITLE
Make shep start act on the row you named, not every sheep sharing its name

### DIFF
--- a/crates/shep-cli/src/commands/lifecycle.rs
+++ b/crates/shep-cli/src/commands/lifecycle.rs
@@ -2645,7 +2645,7 @@ mod tests {
         use shep_client::testing::fake_client_answering;
 
         let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("s.sock");
+        let path = shep_client::testing::control_address(dir.path());
         let (client, mut envelopes) =
             fake_client_answering(&path, a_daemon_for(a_clustered_flock(&[]), &[])).await;
 
@@ -2673,7 +2673,7 @@ mod tests {
         use shep_client::testing::fake_client_answering;
 
         let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("s.sock");
+        let path = shep_client::testing::control_address(dir.path());
         let (client, mut envelopes) =
             fake_client_answering(&path, a_daemon_for(a_clustered_flock(&[0]), &[])).await;
 
@@ -2702,7 +2702,7 @@ mod tests {
         use shep_client::testing::fake_client_answering;
 
         let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("s.sock");
+        let path = shep_client::testing::control_address(dir.path());
         let (client, _envelopes) =
             fake_client_answering(&path, a_daemon_for(a_clustered_flock(&[0]), &[])).await;
 
@@ -2732,7 +2732,7 @@ mod tests {
         use shep_client::testing::fake_client_answering;
 
         let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("s.sock");
+        let path = shep_client::testing::control_address(dir.path());
         let (client, mut envelopes) =
             fake_client_answering(&path, a_daemon_for(a_clustered_flock(&[]), &[0])).await;
 
@@ -2779,7 +2779,7 @@ mod tests {
             "[[app]]\nname = \"zam\"\nscript = \"./zam\"\ninstances = 3\n",
         )
         .unwrap();
-        let socket = dir.path().join("s.sock");
+        let socket = shep_client::testing::control_address(dir.path());
         let (client, mut envelopes) =
             fake_client_answering(&socket, a_daemon_for(a_clustered_flock(&[]), &[])).await;
 

--- a/crates/shep-cli/src/commands/lifecycle.rs
+++ b/crates/shep-cli/src/commands/lifecycle.rs
@@ -1164,7 +1164,7 @@ pub async fn start(
         // before this it printed the notice and no table at all. A verb that
         // FAILED still leaves stdout empty, which is the discipline `cli_e2e`'s
         // `assert_json_error` pins crate-wide.
-        if !started.is_empty() || code == ExitCode::Success {
+        if code == ExitCode::Success {
             let wrote = render_outcome(client, streams, "start", FlockRows(started)).await;
             if wrote != ExitCode::Success {
                 return wrote;
@@ -1201,7 +1201,15 @@ pub async fn start(
     // before this it printed the notice and no table at all. A verb that
     // FAILED still leaves stdout empty, which is the discipline `cli_e2e`'s
     // `assert_json_error` pins crate-wide.
-    if !started.is_empty() || failure.is_none() {
+    //
+    // Keyed on the outcome ALONE, never on `started` being non-empty. The two
+    // agreed while a failure stopped the run, since nothing could follow one
+    // and add a row: now that every row is attempted, a fold whose second app
+    // fails and whose third comes up fine ends non-empty AND failed, and the
+    // old condition printed a table on the error path. Under `--format json`
+    // that is a data envelope beside an error envelope, which is two answers
+    // to one question and what `cli_e2e`'s `assert_json_error` refuses.
+    if failure.is_none() {
         let wrote = render_outcome(client, streams, "start", FlockRows(started)).await;
         if wrote != ExitCode::Success {
             return wrote;
@@ -2584,7 +2592,7 @@ mod tests {
 
     /// Every selector `start` sent inside a `Request::Restart`, in order.
     fn respawns(
-        envelopes: &mut tokio::sync::mpsc::Receiver<shep_core::protocol::Envelope>,
+        envelopes: &mut tokio::sync::mpsc::UnboundedReceiver<shep_core::protocol::Envelope>,
     ) -> Vec<SelectorSpec> {
         let mut sent = Vec::new();
         while let Ok(envelope) = envelopes.try_recv() {
@@ -2595,8 +2603,9 @@ mod tests {
         sent
     }
 
-    /// Runs `start` against `daemon` and hands back the code and stderr.
-    async fn start_against(client: &Client, target: &str) -> (ExitCode, String) {
+    /// Runs `start` against `daemon` and hands back the code, stdout and
+    /// stderr, in that order.
+    async fn start_against(client: &Client, target: &str) -> (ExitCode, String, String) {
         let mut out = Vec::new();
         let mut err = Vec::new();
         let code = {
@@ -2615,7 +2624,11 @@ mod tests {
             )
             .await
         };
-        (code, String::from_utf8(err).unwrap())
+        (
+            code,
+            String::from_utf8(out).unwrap(),
+            String::from_utf8(err).unwrap(),
+        )
     }
 
     /// fails if `shep start 0` respawns anything but id 0.
@@ -2636,7 +2649,7 @@ mod tests {
         let (client, mut envelopes) =
             fake_client_answering(&path, a_daemon_for(a_clustered_flock(&[]), &[])).await;
 
-        let (code, _) = start_against(&client, "0").await;
+        let (code, _, _) = start_against(&client, "0").await;
 
         assert_eq!(code, ExitCode::Success);
         assert_eq!(
@@ -2664,9 +2677,10 @@ mod tests {
         let (client, mut envelopes) =
             fake_client_answering(&path, a_daemon_for(a_clustered_flock(&[0]), &[])).await;
 
-        let (code, said) = start_against(&client, "all").await;
+        let (code, printed, said) = start_against(&client, "all").await;
 
         assert_eq!(code, ExitCode::Success);
+        let _ = printed;
         assert_eq!(
             respawns(&mut envelopes),
             vec![SelectorSpec::Id(1), SelectorSpec::Id(2)],
@@ -2692,7 +2706,7 @@ mod tests {
         let (client, _envelopes) =
             fake_client_answering(&path, a_daemon_for(a_clustered_flock(&[0]), &[])).await;
 
-        let (code, said) = start_against(&client, "0").await;
+        let (code, _, said) = start_against(&client, "0").await;
 
         assert_eq!(code, ExitCode::Success);
         assert!(
@@ -2722,7 +2736,7 @@ mod tests {
         let (client, mut envelopes) =
             fake_client_answering(&path, a_daemon_for(a_clustered_flock(&[]), &[0])).await;
 
-        let (code, said) = start_against(&client, "all").await;
+        let (code, printed, said) = start_against(&client, "all").await;
 
         assert_eq!(code, ExitCode::SpawnFailed, "the first failure is the code");
         assert_eq!(
@@ -2737,6 +2751,12 @@ mod tests {
         assert!(
             said.contains("id 0"),
             "and the failure names the row, not just the app: {said}"
+        );
+        assert!(
+            printed.is_empty(),
+            "a failed verb leaves stdout empty even though rows 1 and 2 came \
+             up, the rule `cli_e2e`'s assert_json_error pins crate-wide: \
+             {printed}"
         );
     }
 
@@ -2763,7 +2783,7 @@ mod tests {
         let (client, mut envelopes) =
             fake_client_answering(&socket, a_daemon_for(a_clustered_flock(&[]), &[])).await;
 
-        let (code, _) = start_against(&client, flockfile.to_str().unwrap()).await;
+        let (code, _, _) = start_against(&client, flockfile.to_str().unwrap()).await;
 
         assert_eq!(code, ExitCode::Success);
         assert_eq!(

--- a/crates/shep-cli/src/commands/lifecycle.rs
+++ b/crates/shep-cli/src/commands/lifecycle.rs
@@ -819,17 +819,37 @@ fn is_live(info: &ProcessInfo) -> bool {
 /// resolved to apps the flock already has. The distinction is the difference
 /// between a suggestion that works and one that does not: `shep restart
 /// fold:backed` is a command, and `shep restart ./rotom.sh` is not, because
-/// `restart` takes selectors and a path is not one. So a single sheep is
-/// always named by its own name, and a group falls back to listing the names
-/// when there is no selector to quote.
+/// `restart` takes selectors and a path is not one. So the token is quoted
+/// back whenever there is one, and a path or Flockfile falls back to listing
+/// the names.
 ///
 /// The already-up set gets ONE notice however large it is. `shep start all`
 /// against a healthy thirteen-app flock would otherwise print thirteen
 /// notices saying the same thing.
 ///
-/// Respawns are issued per NAME, not per row: `Request::Restart` with a name
-/// selector reaches every instance of a clustered app, so a fold holding a
-/// four-instance app would otherwise send the same request four times.
+/// # Respawns are issued per ROW, by id
+///
+/// They used to be issued per NAME, deduped, because `Request::Restart` with
+/// a name selector reaches every instance of a clustered app in one request
+/// and a fold holding a four-instance app would otherwise send four. The
+/// saving was real and the widening it bought was not worth it: a name
+/// selector reaches every instance whether or not this function matched them,
+/// so collapsing to names hands the daemon a WIDER set than the one the
+/// operator's own selector picked out. Two ways that bit:
+///
+/// - `shep start 0` against ten instances named `zam` restarted all ten.
+///   `Id` is the only selector form that can name a subset of one name's
+///   rows, so it was the only form the collapse could widen -- which is
+///   exactly the form an operator reaches for to name ONE of a clustered
+///   app's instances.
+/// - Worse, and for every selector form: the `live`/`asleep` partition above
+///   promises not to replace a sheep that is already up, and a name selector
+///   walked straight back over it. One online instance among nine stopped
+///   ones was restarted by the request meant for the other nine.
+///
+/// So the id of each row is what goes on the wire, and no dedup is needed --
+/// a row is one instance and appears once. The cost is the round trip the
+/// old shape was saving, one per instance rather than one per name.
 async fn resume_all(
     client: &Client,
     streams: &mut Streams<'_>,
@@ -860,8 +880,8 @@ async fn resume_all(
         }
     }
 
-    for name in unique_names(&asleep) {
-        let code = resume(client, streams, name, started).await;
+    for sheep in asleep {
+        let code = resume(client, streams, sheep, started).await;
         if code != ExitCode::Success {
             return code;
         }
@@ -871,18 +891,17 @@ async fn resume_all(
 
 /// Every distinct name in `infos`, in the order they first appear.
 ///
-/// Order-INDEPENDENT, and that is the whole of it. This compared each name
-/// against the previous one alone, which drops a duplicate only when the two
-/// are adjacent, and so was correct only for a caller handing over a
-/// name-sorted slice. One caller does not: `start_one`'s Flockfile and path
-/// arm builds its set from the resolved apps in the file's own order, so two
-/// instances of one app listed either side of a third produced a SECOND
-/// `Request::Restart` and restarted that app twice in one invocation.
+/// Feeds the already-running notice and nothing else. It used to pick the
+/// respawn targets too, and twice it was the wrong tool for that: once
+/// because it deduped by adjacency and dropped a repeat only when the two
+/// rows sat next to each other, and once because a name is simply not what
+/// the operator selected -- see [`resume_all`]. A notice reads as a list of
+/// apps, so collapsing to names is right for this and only this.
 ///
-/// The selector arm did hand over sorted rows, but only because the daemon
-/// sorts its listing that way -- a cross-version assumption about a peer,
-/// not an invariant this function can hold itself. Both callers are now safe
-/// regardless.
+/// Order-INDEPENDENT: it compares against every name kept so far, not
+/// against the previous one, so a caller handing over rows in a Flockfile's
+/// own order gets the same answer as one handing over the daemon's sorted
+/// listing.
 ///
 /// A `Vec` scan rather than a `HashSet`: this runs over the sheep one
 /// selector matched, which is tens of rows, and it has to preserve first-seen
@@ -900,13 +919,13 @@ fn unique_names<'a>(infos: &[&'a ProcessInfo]) -> Vec<&'a str> {
 async fn resume(
     client: &Client,
     streams: &mut Streams<'_>,
-    name: &str,
+    sheep: &ProcessInfo,
     started: &mut Vec<shep_core::protocol::ProcessInfo>,
 ) -> ExitCode {
     let (procs, failure) = request_each(
         client,
         streams,
-        &[SelectorSpec::Name(name.to_string())],
+        &[SelectorSpec::Id(sheep.id)],
         None,
         |selector| Request::Restart { selector },
         |response| match response {
@@ -925,8 +944,14 @@ async fn resume(
     // table on a path that is supposed to fail exactly like the by-path one
     // does: an error on stderr and nothing on stdout.
     if any_restart_failed(&procs) {
+        // Named by id as well as by name, because this now reports one ROW:
+        // four instances of one app failing used to be one message and would
+        // otherwise be four identical ones, naming a sheep the operator
+        // cannot tell apart. The id is also what makes the `bleats` suggestion
+        // reach the instance that actually failed.
+        let (name, id) = (&sheep.name, sheep.id);
         let message = format!(
-            "{name} could not be started; see `shep bleats {name}` or its log files for why"
+            "{name} (id {id}) could not be started; see `shep bleats {id}` or its log files for why"
         );
         return streams.fail(ExitCode::SpawnFailed, &message);
     }
@@ -1024,11 +1049,13 @@ async fn flock_now(client: &Client) -> Vec<shep_core::protocol::ProcessInfo> {
 /// `start` over a warning it could not compute would trade a working command
 /// for a defensive one.
 ///
-/// One request for the whole invocation, not one per app.
+/// One request for the whole invocation, not one per app. The rows beside
+/// each app go unread: drift is a comparison between two CONFIGS, and every
+/// instance of a clustered app shares one.
 async fn report_config_drift(
     client: &Client,
     streams: &mut Streams<'_>,
-    resumed: &[(AppConfig, shep_core::protocol::ProcessInfo)],
+    resumed: &[(AppConfig, Vec<shep_core::protocol::ProcessInfo>)],
 ) {
     if resumed.is_empty() {
         return;
@@ -1303,12 +1330,26 @@ async fn start_one(
         Some(flock) => flock,
         None => flock_now(client).await,
     };
-    let mut resumed = Vec::new();
+    // EVERY row the name has, not the first one. A clustered app is several
+    // rows under one name, and taking one of them as the app's stand-in meant
+    // a Flockfile naming a stopped four-instance app started instance 0 and
+    // left the other three down. Worse when instance 0 was the live one: the
+    // "already running" notice fired for the whole app and nothing started at
+    // all. Invisible while respawns went out per name, because a name
+    // selector reached the other three anyway; the moment they go out per
+    // row, the representative is all this arm would act on.
+    let mut resumed: Vec<(AppConfig, Vec<ProcessInfo>)> = Vec::new();
     let mut fresh = Vec::new();
     for app in apps {
-        match flock.iter().find(|info| info.name == app.name) {
-            Some(existing) => resumed.push((app, existing.clone())),
-            None => fresh.push(app),
+        let rows: Vec<ProcessInfo> = flock
+            .iter()
+            .filter(|info| info.name == app.name)
+            .cloned()
+            .collect();
+        if rows.is_empty() {
+            fresh.push(app);
+        } else {
+            resumed.push((app, rows));
         }
     }
     // Before the resumes below, not after: an operator who edited the file
@@ -1320,7 +1361,10 @@ async fn start_one(
         // a Flockfile or a path, so there is no selector to quote back in the
         // "already running" notice. `shep restart ./rotom.sh` is not a
         // command. See `resume_all`'s own doc.
-        let existing: Vec<ProcessInfo> = resumed.iter().map(|(_, info)| info.clone()).collect();
+        let existing: Vec<ProcessInfo> = resumed
+            .iter()
+            .flat_map(|(_, rows)| rows.iter().cloned())
+            .collect();
         let code = resume_all(client, streams, None, &existing, started).await;
         if code != ExitCode::Success {
             return code;
@@ -2477,6 +2521,184 @@ mod tests {
         assert!(
             said.contains("shep restart zeus-auth"),
             "and pointed at the verb that would replace it: {said}"
+        );
+    }
+
+    /// Ten stopped instances of one clustered app, the shape both respawn
+    /// bugs needed and the shape `a_foldable_flock` cannot show: every sheep
+    /// in it has a name of its own, so a selector naming a name and a
+    /// selector naming a row pick the same set there.
+    fn a_clustered_flock(online: &[u32]) -> Vec<ProcessInfo> {
+        use shep_core::status::ProcStatus;
+        (0..3)
+            .map(|id| {
+                let status = if online.contains(&id) {
+                    ProcStatus::Online
+                } else {
+                    ProcStatus::Stopped
+                };
+                ProcessInfo::builder(id, "zam", status).build()
+            })
+            .collect()
+    }
+
+    /// A fake that answers a `start` invocation end to end: the listing it
+    /// begins with, the respawns it decides on, the drift check, and the
+    /// second listing it renders from. `failing` names the ids to answer as
+    /// `errored`, which is how a spawn failure reaches this verb.
+    fn a_daemon_for(
+        flock: Vec<ProcessInfo>,
+        failing: &'static [u32],
+    ) -> impl Fn(&Request) -> Response + Send + 'static {
+        use shep_core::status::ProcStatus;
+        move |request| match request {
+            Request::ListFlock => Response::Flock(flock.clone()),
+            Request::ConfigDrift { .. } => Response::Drifted(Vec::new()),
+            Request::Restart { selector } => {
+                let SelectorSpec::Id(id) = selector else {
+                    // Never reached by a correct build, and asserted on
+                    // directly below -- answered rather than panicked so the
+                    // assertion that names the bug is the one that fails.
+                    return Response::Restarted(Vec::new());
+                };
+                let status = if failing.contains(id) {
+                    ProcStatus::Errored
+                } else {
+                    ProcStatus::Online
+                };
+                Response::Restarted(vec![ProcessInfo::builder(*id, "zam", status).build()])
+            }
+            _ => Response::Pong,
+        }
+    }
+
+    /// Every selector `start` sent inside a `Request::Restart`, in order.
+    fn respawns(
+        envelopes: &mut tokio::sync::mpsc::Receiver<shep_core::protocol::Envelope>,
+    ) -> Vec<SelectorSpec> {
+        let mut sent = Vec::new();
+        while let Ok(envelope) = envelopes.try_recv() {
+            if let Request::Restart { selector } = envelope.body {
+                sent.push(selector);
+            }
+        }
+        sent
+    }
+
+    /// Runs `start` against `daemon` and hands back the code and stderr.
+    async fn start_against(client: &Client, target: &str) -> (ExitCode, String) {
+        let mut out = Vec::new();
+        let mut err = Vec::new();
+        let code = {
+            let mut streams = Streams {
+                out: &mut out,
+                err: &mut err,
+                style: crate::style::Presentation::BARE,
+                fmt: Format::Table,
+            };
+            start(
+                client,
+                &mut streams,
+                &start_args(target),
+                None,
+                &BTreeMap::new(),
+            )
+            .await
+        };
+        (code, String::from_utf8(err).unwrap())
+    }
+
+    /// fails if `shep start 0` respawns anything but id 0.
+    ///
+    /// Rin's own flock: ten instances of `zam`, all stopped, and
+    /// `shep start 0` brought all ten back. `resume_all` collapsed the rows
+    /// it matched to their distinct NAMES before sending, and a name selector
+    /// reaches every instance the name has. `Id` is the only selector form
+    /// that can name a subset of one name's rows, so it was the only form the
+    /// collapse could widen -- and it is exactly the form an operator reaches
+    /// for to name one instance of a clustered app.
+    #[tokio::test]
+    async fn a_start_by_id_respawns_that_row_and_no_other() {
+        use shep_client::testing::fake_client_answering;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("s.sock");
+        let (client, mut envelopes) =
+            fake_client_answering(&path, a_daemon_for(a_clustered_flock(&[]), &[])).await;
+
+        let (code, _) = start_against(&client, "0").await;
+
+        assert_eq!(code, ExitCode::Success);
+        assert_eq!(
+            respawns(&mut envelopes),
+            vec![SelectorSpec::Id(0)],
+            "one respawn, for the row the operator named"
+        );
+    }
+
+    /// fails if `start` respawns a sheep it has just reported as already up.
+    ///
+    /// The same collapse, and the worse half of it: this one needs no `Id`
+    /// selector at all. `resume_all` partitions the rows it matched into live
+    /// and asleep precisely so that a live one is left alone -- and then sent
+    /// a NAME, which walks straight back over the row it had just set aside.
+    /// `shep start all` against a clustered app with one instance up
+    /// restarted that instance, which is the surprise `start` documents
+    /// itself as refusing to be clever about.
+    #[tokio::test]
+    async fn a_start_never_respawns_a_row_that_was_already_up() {
+        use shep_client::testing::fake_client_answering;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("s.sock");
+        let (client, mut envelopes) =
+            fake_client_answering(&path, a_daemon_for(a_clustered_flock(&[0]), &[])).await;
+
+        let (code, said) = start_against(&client, "all").await;
+
+        assert_eq!(code, ExitCode::Success);
+        assert_eq!(
+            respawns(&mut envelopes),
+            vec![SelectorSpec::Id(1), SelectorSpec::Id(2)],
+            "the two that were down, and not the one that was up"
+        );
+        assert!(said.contains("already"), "the live one is reported: {said}");
+    }
+
+    /// fails if a Flockfile naming a clustered app starts only one instance.
+    ///
+    /// This arm matched an app to the flock with a `find`, which takes the
+    /// FIRST row of a name and calls it the app. Harmless while respawns went
+    /// out per name -- the name reached the other instances anyway -- and a
+    /// silent halving the moment they go out per row. Both halves are here:
+    /// three rows respawned, and none of them skipped because the
+    /// representative happened to be the live one.
+    #[tokio::test]
+    async fn a_flockfile_naming_a_clustered_app_resumes_every_instance() {
+        use shep_client::testing::fake_client_answering;
+
+        let dir = tempfile::tempdir().unwrap();
+        let flockfile = dir.path().join("flock.toml");
+        std::fs::write(
+            &flockfile,
+            "[[app]]\nname = \"zam\"\nscript = \"./zam\"\ninstances = 3\n",
+        )
+        .unwrap();
+        let socket = dir.path().join("s.sock");
+        let (client, mut envelopes) =
+            fake_client_answering(&socket, a_daemon_for(a_clustered_flock(&[]), &[])).await;
+
+        let (code, _) = start_against(&client, flockfile.to_str().unwrap()).await;
+
+        assert_eq!(code, ExitCode::Success);
+        assert_eq!(
+            respawns(&mut envelopes),
+            vec![
+                SelectorSpec::Id(0),
+                SelectorSpec::Id(1),
+                SelectorSpec::Id(2)
+            ],
+            "every row the name has, not the first one"
         );
     }
 

--- a/crates/shep-cli/src/commands/lifecycle.rs
+++ b/crates/shep-cli/src/commands/lifecycle.rs
@@ -880,13 +880,19 @@ async fn resume_all(
         }
     }
 
+    // Every row is attempted and the FIRST failure is what the verb returns,
+    // the discipline `request_each` states for the selector-taking verbs:
+    // stopping at the first failure leaves the operator guessing which of the
+    // rest were touched. This returned early, so one app in a fold failing to
+    // spawn abandoned the fold's remaining apps in silence.
+    let mut failure: Option<ExitCode> = None;
     for sheep in asleep {
         let code = resume(client, streams, sheep, started).await;
         if code != ExitCode::Success {
-            return code;
+            failure = failure.or(Some(code));
         }
     }
-    ExitCode::Success
+    failure.unwrap_or(ExitCode::Success)
 }
 
 /// Every distinct name in `infos`, in the order they first appear.
@@ -2663,6 +2669,41 @@ mod tests {
             "the two that were down, and not the one that was up"
         );
         assert!(said.contains("already"), "the live one is reported: {said}");
+    }
+
+    /// fails if one row failing to spawn abandons the rows after it.
+    ///
+    /// `request_each` states the discipline for every selector-taking verb --
+    /// attempt them all, report the FIRST failure -- because stopping early
+    /// leaves the operator guessing which of the rest were touched.
+    /// `resume_all` returned on the first failure instead, so one app in a
+    /// fold failing to come up left the fold's remaining apps down without a
+    /// word about them.
+    #[tokio::test]
+    async fn a_row_that_cannot_spawn_does_not_abandon_the_rows_after_it() {
+        use shep_client::testing::fake_client_answering;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("s.sock");
+        let (client, mut envelopes) =
+            fake_client_answering(&path, a_daemon_for(a_clustered_flock(&[]), &[0])).await;
+
+        let (code, said) = start_against(&client, "all").await;
+
+        assert_eq!(code, ExitCode::SpawnFailed, "the first failure is the code");
+        assert_eq!(
+            respawns(&mut envelopes),
+            vec![
+                SelectorSpec::Id(0),
+                SelectorSpec::Id(1),
+                SelectorSpec::Id(2)
+            ],
+            "every row is attempted, not just the ones before the failure"
+        );
+        assert!(
+            said.contains("id 0"),
+            "and the failure names the row, not just the app: {said}"
+        );
     }
 
     /// fails if a Flockfile naming a clustered app starts only one instance.

--- a/crates/shep-cli/src/commands/lifecycle.rs
+++ b/crates/shep-cli/src/commands/lifecycle.rs
@@ -863,9 +863,13 @@ async fn resume_all(
     match live.as_slice() {
         [] => {}
         [one] => {
+            // The operator's own token, not the sheep's name: `shep start 0`
+            // asked about one instance, and answering it with `shep restart
+            // zam` would suggest a command that replaces all ten.
+            let retype = selector.unwrap_or(one.name.as_str());
             let message = format!(
-                "{} is already {}; `shep restart {}` replaces it.",
-                one.name, one.status, one.name
+                "{} is already {}; `shep restart {retype}` replaces it.",
+                one.name, one.status
             );
             streams.aside("start", &message);
         }
@@ -2669,6 +2673,36 @@ mod tests {
             "the two that were down, and not the one that was up"
         );
         assert!(said.contains("already"), "the live one is reported: {said}");
+    }
+
+    /// fails if the notice for a single live row suggests a command wider
+    /// than the one the operator typed.
+    ///
+    /// `shep start 0` against a live instance answered "`shep restart zam`
+    /// replaces it", which replaces all ten. The suggestion has to be the
+    /// operator's own token whenever there is one; only a path or Flockfile
+    /// target, which is not a selector and cannot be quoted back, falls back
+    /// to the name.
+    #[tokio::test]
+    async fn the_already_up_notice_quotes_the_operators_own_token() {
+        use shep_client::testing::fake_client_answering;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("s.sock");
+        let (client, _envelopes) =
+            fake_client_answering(&path, a_daemon_for(a_clustered_flock(&[0]), &[])).await;
+
+        let (code, said) = start_against(&client, "0").await;
+
+        assert_eq!(code, ExitCode::Success);
+        assert!(
+            said.contains("`shep restart 0`"),
+            "the one row the operator named: {said}"
+        );
+        assert!(
+            !said.contains("`shep restart zam`"),
+            "never the name, which would replace every instance of it: {said}"
+        );
     }
 
     /// fails if one row failing to spawn abandons the rows after it.

--- a/crates/shep-client/src/testing.rs
+++ b/crates/shep-client/src/testing.rs
@@ -840,10 +840,10 @@ pub async fn fake_client_answering(
     path: &Path,
     answer: impl Fn(&Request) -> Response + Send + 'static,
 ) -> (Client, mpsc::UnboundedReceiver<Envelope>) {
-    let listener = UnixListener::bind(path).unwrap();
+    let mut listener = Listener::bind(path).unwrap();
     let (tx, rx) = mpsc::unbounded_channel();
     tokio::spawn(async move {
-        let (stream, _) = listener.accept().await.unwrap();
+        let stream = listener.accept().await.unwrap();
         let mut frames = Framed::new(stream, codec());
         handshake(&mut frames, sample_ack()).await;
         while let Some(Ok(frame)) = frames.next().await {

--- a/crates/shep-client/src/testing.rs
+++ b/crates/shep-client/src/testing.rs
@@ -802,6 +802,50 @@ pub async fn fake_client_with_push(path: &Path) -> (Client, FakeDaemon) {
     fake_client_on(path).await
 }
 
+/// As [`fake_client_capturing_envelopes`], but the caller decides what each
+/// request is answered with — for a test asserting on what a MULTI-REQUEST
+/// caller puts on the wire.
+///
+/// The two existing shapes each cover one half and neither covers this.
+/// [`fake_client_capturing_envelopes`] shows the wire but answers everything
+/// `Response::Pong`, so a caller that reads its own reply and decides what to
+/// send next stalls at the first request. [`FakeDaemon`] answers a `ListFlock`
+/// or a `Describe` properly but keeps every envelope to itself, so the
+/// requests that followed cannot be asserted on at all. `shep start <name>`
+/// needs both at once: it lists the flock, decides from the listing which
+/// sheep to respawn, and the whole question is which respawns it then sends.
+/// Two bugs reached an operator's terminal in that gap, both of them a
+/// widened selector no test could see (`shep-cli`'s `resume_all`).
+///
+/// `answer` is called with each decoded [`Request`] in arrival order and may
+/// close over a counter to answer the second call differently from the first.
+/// The envelope reaches the channel BEFORE the reply is written, matching
+/// [`fake_client_capturing_envelopes`], so a test that awaits its own request
+/// future finds the envelope already queued.
+pub async fn fake_client_answering(
+    path: &Path,
+    answer: impl Fn(&Request) -> Response + Send + 'static,
+) -> (Client, mpsc::Receiver<Envelope>) {
+    let listener = UnixListener::bind(path).unwrap();
+    let (tx, rx) = mpsc::channel(SCRIPT_CHANNEL_CAPACITY);
+    tokio::spawn(async move {
+        let (stream, _) = listener.accept().await.unwrap();
+        let mut frames = Framed::new(stream, codec());
+        handshake(&mut frames, sample_ack()).await;
+        loop {
+            let envelope = read_envelope(&mut frames).await;
+            let id = envelope.id;
+            let reply = answer(&envelope.body);
+            if tx.send(envelope).await.is_err() {
+                break;
+            }
+            write_reply(&mut frames, id, reply).await;
+        }
+    });
+    let client = Client::connect(path).await.unwrap();
+    (client, rx)
+}
+
 /// Binds `path`, handshakes with [`sample_ack`], and answers every request
 /// with `Response::Pong` while forwarding each decoded [`Envelope`] onto
 /// the returned channel — for a test asserting on what a `Client` actually

--- a/crates/shep-client/src/testing.rs
+++ b/crates/shep-client/src/testing.rs
@@ -822,21 +822,37 @@ pub async fn fake_client_with_push(path: &Path) -> (Client, FakeDaemon) {
 /// The envelope reaches the channel BEFORE the reply is written, matching
 /// [`fake_client_capturing_envelopes`], so a test that awaits its own request
 /// future finds the envelope already queued.
+///
+/// UNBOUNDED, unlike every other channel in this module, and that is the
+/// difference a multi-request caller makes. A test reads these envelopes after
+/// the call it is testing has returned, so nothing drains the channel while
+/// the exchange is in flight: on a bounded channel of this module's `SCRIPT_CHANNEL_CAPACITY`
+/// the send blocks once the caller's ninth request arrives, the reply to it is
+/// never written, and the test hangs rather than failing. One `shep start` over
+/// a ten-instance app is thirteen requests. Unbounded also keeps the observer
+/// off the reply path entirely, since the send no longer awaits anything.
+///
+/// The read loop ends on a closed or unreadable connection instead of
+/// panicking there. A test drops its `Client` while this task is parked on the
+/// next frame, which is an ordinary end rather than a fault, and
+/// `read_envelope`'s `unwrap` would report it as a panic in a detached task.
 pub async fn fake_client_answering(
     path: &Path,
     answer: impl Fn(&Request) -> Response + Send + 'static,
-) -> (Client, mpsc::Receiver<Envelope>) {
+) -> (Client, mpsc::UnboundedReceiver<Envelope>) {
     let listener = UnixListener::bind(path).unwrap();
-    let (tx, rx) = mpsc::channel(SCRIPT_CHANNEL_CAPACITY);
+    let (tx, rx) = mpsc::unbounded_channel();
     tokio::spawn(async move {
         let (stream, _) = listener.accept().await.unwrap();
         let mut frames = Framed::new(stream, codec());
         handshake(&mut frames, sample_ack()).await;
-        loop {
-            let envelope = read_envelope(&mut frames).await;
+        while let Some(Ok(frame)) = frames.next().await {
+            let Ok(envelope) = decode_frame::<Envelope>(&frame) else {
+                break;
+            };
             let id = envelope.id;
             let reply = answer(&envelope.body);
-            if tx.send(envelope).await.is_err() {
+            if tx.send(envelope).is_err() {
                 break;
             }
             write_reply(&mut frames, id, reply).await;

--- a/crates/shep-client/tests/request_reply.rs
+++ b/crates/shep-client/tests/request_reply.rs
@@ -147,3 +147,35 @@ async fn every_request_carries_an_explicit_deadline_on_the_wire() {
         Some(u64::try_from(START_DEADLINE.as_millis()).unwrap())
     );
 }
+
+/// fails if a caller has to drain the envelope channel to keep getting
+/// replies.
+///
+/// `fake_client_answering` exists for a caller that sends several requests and
+/// reads the record of them afterwards, which is every test of a CLI verb that
+/// lists the flock and then acts on what it found. Nothing drains the channel
+/// while that exchange is in flight, so a bounded one of
+/// `SCRIPT_CHANNEL_CAPACITY` stops the fake at the ninth request: the send
+/// blocks, its reply is never written, and the caller waits for a deadline
+/// that has nothing behind it. Ten requests here against a capacity of eight,
+/// so a bounded channel hangs this test rather than failing it.
+#[tokio::test]
+async fn a_run_of_requests_is_answered_without_the_receiver_being_read() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("s.sock");
+    let (client, mut envelopes) =
+        shep_client::testing::fake_client_answering(&path, |_| Response::Pong).await;
+
+    for _ in 0..10 {
+        client
+            .request(Request::Ping)
+            .await
+            .expect("every request is answered, however far behind the observer is");
+    }
+
+    let mut seen = 0;
+    while envelopes.try_recv().is_ok() {
+        seen += 1;
+    }
+    assert_eq!(seen, 10, "and every envelope was still recorded");
+}

--- a/crates/shep-client/tests/request_reply.rs
+++ b/crates/shep-client/tests/request_reply.rs
@@ -162,7 +162,7 @@ async fn every_request_carries_an_explicit_deadline_on_the_wire() {
 #[tokio::test]
 async fn a_run_of_requests_is_answered_without_the_receiver_being_read() {
     let dir = tempfile::tempdir().unwrap();
-    let path = dir.path().join("s.sock");
+    let path = shep_client::testing::control_address(dir.path());
     let (client, mut envelopes) =
         shep_client::testing::fake_client_answering(&path, |_| Response::Pong).await;
 


### PR DESCRIPTION
`shep start 0` against ten instances of `x` started all ten. `start` resolved the selector to rows, collapsed those rows to names, and sent `Restart { Name(...) }`, so the daemon got a wider set than the one it had matched.

- Respawns go out one per row, by id
- `shep start all` no longer restarts an instance it just reported as already up
- One row failing to spawn no longer abandons the rows after it, the rule `stop` and `restart` already follow
- A Flockfile naming a clustered app resumes every instance, not just the first row of that name
- The already-running notice quotes the target you typed
- Spawn failures name the row: `x (id 3) could not be started`

Adds `shep_client::testing::fake_client_answering`, since nothing in the workspace could see what `start` put on the wire here. Each fix is mutation-verified: reverting it fails its own test and nothing else.

Not fixed, both flagged rather than changed:

- RESTARTS goes 0 to 1 on `shep start`, since the wire has no start-by-id for a registered sheep and `start` sends `Restart`
- `shep start 999` exits 2 where `shep stop 999` exits 3, which is deliberate and tested: a bare id may still be a filename

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

- Improved `start` behavior for clustered applications by resuming all stopped instances associated with an app.
- Preserved process selector scope when restarting instances.
- Prevented running instances from being restarted when selecting processes.
- Start operations now continue after individual failures and report failed instance IDs.
- Improved configuration-drift reporting for applications with grouped process entries.
- Prevented success output from appearing when a start operation fails.
- Improved JavaScript Flockfile execution error handling, time limits, and cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->