### PR TITLE
chore: release v0.1.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2058,7 +2058,7 @@ dependencies = [
 
 [[package]]
 name = "shep"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "anstyle",
  "assert_cmd",
@@ -2096,11 +2096,11 @@ dependencies = [
 
 [[package]]
 name = "shep-cli"
-version = "0.1.9"
+version = "0.1.10"
 
 [[package]]
 name = "shep-client"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "futures-util",
  "nix 0.29.0",
@@ -2113,7 +2113,7 @@ dependencies = [
 
 [[package]]
 name = "shep-core"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "annotate-snippets",
  "anstyle",
@@ -2143,7 +2143,7 @@ dependencies = [
 
 [[package]]
 name = "shep-daemon"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "bytes",
  "chrono",
@@ -2172,7 +2172,7 @@ dependencies = [
 
 [[package]]
 name = "shep-examples"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "nix 0.29.0",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.9"
+version = "0.1.10"
 edition = "2024"
 # 1.88 forced by serde-saphyr (let-chains, stabilized 1.88) — a current dep,
 # not a future one. Also the floor for ratatui/sysinfo/rmcp in later phases.
@@ -31,9 +31,9 @@ license = "MIT OR Apache-2.0"
 # the `[package]` table — so this literal is not sourced from
 # `workspace.package.version` above and a release bump has to touch both
 # places by hand. If that drifts, `cargo-release` is the mechanical fix.
-shep-core = { path = "crates/shep-core", version = "0.1.9" }
-shep-daemon = { path = "crates/shep-daemon", version = "0.1.9" }
-shep-client = { path = "crates/shep-client", version = "0.1.9" }
+shep-core = { path = "crates/shep-core", version = "0.1.10" }
+shep-daemon = { path = "crates/shep-daemon", version = "0.1.10" }
+shep-client = { path = "crates/shep-client", version = "0.1.10" }
 serde = { version = "1", default-features = false, features = ["derive"] }
 serde_json = { version = "1", default-features = false, features = ["std"] }
 toml = { version = "0.8", default-features = false, features = ["parse", "display"] }


### PR DESCRIPTION



## 🤖 New release

* `shep-core`: 0.1.9 -> 0.1.10 (✓ API compatible changes)
* `shep-daemon`: 0.1.9 -> 0.1.10 (✓ API compatible changes)
* `shep-client`: 0.1.9 -> 0.1.10 (✓ API compatible changes)
* `shep`: 0.1.9 -> 0.1.10 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `shep-core`

<blockquote>

## [0.1.10] - 2026-08-28

### Added

- A Flockfile app may carry a `dog` table, so a dog can configure the app it
  manages. The key must BE a table: any other type is refused at parse time
  rather than quietly ignored, which is the rule every other typed key in a
  Flockfile already follows.

### Changed

- `AppConfig::reuse_port` is accepted rather than refused, and now decides how
  a reload runs. `normalize` used to reject any Flockfile that set it, on the
  grounds that nothing read it and a config key that silently does nothing is
  worse than one that will not load. Something reads it now: an app that sets
  it gets a reload that overlaps its two instances, and a probed app that
  leaves it unset gets one that drains before it spawns. See `shep-daemon`'s
  entry for why that distinction exists.
- Every Flockfile that loads today still loads, and none of them can be
  setting `reuse_port`: `normalize` refused it, and `shep import` stopped
  writing it for cluster-mode pm2 apps before that. What DOES change for an
  existing config is the reload an app already gets. One with a
  `readiness_probe` moves from an overlapping reload to a serial one, which is
  the point of the change rather than a side effect of it; `shep-daemon`'s
  entry has the reasoning.

### Removals

- BREAKING: `NormalizeError::ReusePortUnimplemented`, with the refusal it
  reported. The enum is `#[non_exhaustive]`, so a downstream `match` already
  carries a wildcard arm and keeps compiling; a downstream that CONSTRUCTS the
  variant does not. Nothing in this workspace did, and nothing could construct
  it meaningfully now that the condition it named is gone.
</blockquote>

## `shep-daemon`

<blockquote>

## [0.1.10] - 2026-08-28

### Fixed

- A reload's readiness probe could be answered by the instance the reload was
  replacing, so a release that started and never served was verified, the
  instance that COULD serve was drained, and the reload reported success over
  a dead address. `await_ready` probes at t=0 by design, and at t=0 the
  outgoing instance is still bound to the address the probe names, because the
  drain runs only after readiness resolves. Found in production on 2026-08-28.
- A reload's replacement is no longer marked `Online` when its readiness
  deadline elapses. It used to be, whenever no old instance was left to
  abandon back to, which is where the false success above was recorded. It is
  still not killed, since with the drainee gone that would empty the instance
  slot, but it keeps `Starting` and the reload is announced as abandoned.

### Changed

- A reload now runs one of two orderings, chosen per app. An app with a
  `readiness_probe` and no `reuse_port` is replaced SERIALLY: the old instance
  drains first and the replacement is spawned into the empty slot, so the only
  process that can answer its probe is itself. The cost is a gap, the drain
  plus the replacement's start. Everything else overlaps as before: an app with
  no probe, an app using `wait_ready`, and an app whose `reuse_port` says it
  sets `SO_REUSEPORT` itself.
- An overlapping reload of a probed app asks its probe a second time once the
  drained instance is reaped, and reports the reload failed if that one does
  not pass. `SO_REUSEPORT` lets the kernel hand either instance a connection,
  so even a late probe can be answered by the one on its way out. Exact for a
  single-instance app; for a clustered one the surviving old instances can
  still answer until the last swap.
- A reload can replace an instance a previous reload left unready, which is
  what lets a rollback run at all. Without it a deploy tool would swap the
  release directory back, ask for a reload, and be told `Ok` by a daemon that
  had skipped the only instance the app had.
</blockquote>

## `shep-client`

<blockquote>

## [0.1.10] - 2026-08-28

### Added

- `testing::fake_client_answering`, a fake daemon whose reply to each request
  comes from a caller-supplied closure while every envelope is still forwarded
  to the caller. The existing fakes each did one half: one shows the wire but
  answers everything `Pong`, so a caller that reads its own reply and decides
  what to send next stalls at the first request; the other answers a
  `ListFlock` properly but keeps its envelopes to itself. A verb that lists,
  decides from the listing, and then sends needs both at once. Available under
  the `test-support` feature, like the rest of the module.
</blockquote>

## `shep`

<blockquote>

## [0.1.10] - 2026-08-28

### Fixed

- `shep start <selector>` acted on every sheep sharing a name instead of the
  rows the selector named. It resolved the selector against the listing, then
  collapsed the matched rows to their distinct NAMES before putting them on
  the wire, and a name selector reaches every instance that name has. Two ways
  that bit an operator running a clustered app: `shep start 0` against ten
  stopped instances started all ten, and `shep start all` with one instance
  online and nine stopped restarted the online one too, walking back over the
  row `resume_all` had deliberately set aside. Respawns now go out one per
  row, by id. Found on a ten-instance app.
- A sheep that could not spawn no longer abandons the rows after it. `start`
  returned on the first failure, so an app in a fold that could not start left
  every app behind it in that fold down and unmentioned. It now attempts every
  row and returns the first failing code, which is the rule the other
  selector-taking verbs already state and follow.
- The already-running notice quotes the target the operator typed. `shep start
  0` against one live instance of a ten-instance app used to answer "zam is
  already online; `shep restart zam` replaces it", suggesting a command that
  acts on all ten. A path or Flockfile target still falls back to names, since
  `shep restart ./rotom.sh` is not a command.
- A failed `shep start` prints no flock table. Its output guards keyed on
  whether any row had come up rather than on the outcome, which agreed with
  itself only while a failure stopped the run. Once every row is attempted, a
  fold whose second app fails and whose third succeeds ends both non-empty and
  failed, and under `--format json` that put a data envelope beside an error
  envelope: two answers to one question.
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).