### PR TITLE
a_clustered_flock builds three instances, not ten

### DIFF
--- a/crates/shep-cli/src/commands/lifecycle.rs
+++ b/crates/shep-cli/src/commands/lifecycle.rs
@@ -2542,7 +2542,7 @@ mod tests {
         );
     }
 
-    /// Ten stopped instances of one clustered app, the shape both respawn
+    /// Three stopped instances of one clustered app, the shape both respawn
     /// bugs needed and the shape `a_foldable_flock` cannot show: every sheep
     /// in it has a name of its own, so a selector naming a name and a
     /// selector naming a row pick the same set there.

--- a/crates/shep-cli/src/commands/lifecycle.rs
+++ b/crates/shep-cli/src/commands/lifecycle.rs
@@ -2542,7 +2542,8 @@ mod tests {
         );
     }
 
-    /// Three stopped instances of one clustered app, the shape both respawn
+    /// Three instances of one clustered app, stopped unless named in
+    /// `online`, the shape both respawn
     /// bugs needed and the shape `a_foldable_flock` cannot show: every sheep
     /// in it has a name of its own, so a selector naming a name and a
     /// selector naming a row pick the same set there.


### PR DESCRIPTION
CodeRabbit caught this on [#37](https://github.com/TurtIeSocks/shep/pull/37) after it had merged. The fixture's doc comment says ten stopped instances; the generator is `(0..3)`.

- Comment corrected to three, since nothing it goes on to say depends on the count
- Both callers pass either no online ids or `&[0]`, so neither wants more
- Comment only, no behaviour change

`cargo fmt --all --check` clean, 45 `commands::lifecycle` cases pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated clustered-app test documentation to accurately describe three stopped instances instead of ten.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->