### PR TITLE
Skip release PRs by label, since the title keyword did not hold

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -41,23 +41,34 @@ reviews:
     # that release-plz generated from commits already reviewed on their own
     # pull requests, and .github/workflows/release-plz-pr.yml auto-merges it
     # behind the `main` ruleset without a human in front of it. Eight of the
-    # last twenty pull requests here were releases, and CodeRabbit read every
-    # one; #38 got a 5.4 KB walkthrough and an approval nobody read.
+    # twenty pull requests before this rule went in were releases, and
+    # CodeRabbit read every one; #38 got a 5.4 KB walkthrough and an approval
+    # nobody read.
     #
-    # Matched on the title, not the author. `ignore_usernames` looks like the
-    # tidier answer and is the wrong one: release-plz posts under
-    # RELEASE_PLZ_TOKEN, which is the maintainer's PAT, so the release pull
-    # requests are authored by the same account as every other pull request
-    # in the repository. Ignoring that username would ignore all of them.
+    # Matched on a LABEL, which release-plz attaches itself through
+    # `pr_labels` in release-plz.toml. `!release` means "review everything
+    # except a pull request carrying this label".
     #
-    # The trailing `v` is load-bearing. Matching is a case-insensitive
-    # substring, so a bare "chore: release" would also swallow a real pull
-    # request titled "chore: release process cleanup". Every release-plz
-    # title here is "chore: release v0.1.9" and friends. If release-plz ever
-    # changes that format this stops matching and reviews come back, which is
-    # the failure worth having.
-    ignore_title_keywords:
-      - "chore: release v"
+    # ## Two mechanisms that look right and are not
+    #
+    # `ignore_usernames` is the tidier-looking answer and is wrong here:
+    # release-plz posts under RELEASE_PLZ_TOKEN, which is the maintainer's
+    # PAT, so its pull requests are authored by the same account as every
+    # other pull request in this repository. Ignoring that username would
+    # ignore all of them.
+    #
+    # `ignore_title_keywords: ["chore: release v"]` was tried first and did
+    # NOT hold, which is worth recording so nobody re-derives it. On #40 the
+    # configuration was present on the head commit, carried that exact
+    # keyword, and the title was "chore: release v0.1.10" -- and CodeRabbit
+    # reviewed it anyway, reporting a commit RANGE rather than a whole pull
+    # request. That is the tell: release-plz force-pushes its branch on every
+    # push to main, each force-push starts an incremental review, and the
+    # title gate does not appear to be re-evaluated on those. A label is
+    # checked per review instead of parsed once, so it survives the
+    # force-push that defeated the keyword.
+    labels:
+      - "!release"
 
   # Excluded because a comment on any of these cannot be acted on without
   # regenerating the file, which means the comment belongs on the generator

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -86,6 +86,13 @@ git_release_enable = true
 # force-pushes this branch on every push to main, and each force-push starts
 # an incremental review that the title gate did not stop. The label is
 # re-checked on every one of them.
+#
+# The label has to EXIST in the repository first. release-plz opens the pull
+# request and then calls GitHub's label endpoint, so a name nothing has
+# defined can leave the pull request opened and unlabelled with the job
+# failing around it. `release` was created for this on 2026-08-28. Renaming or
+# deleting it silently un-skips every release pull request, because
+# .coderabbit.yaml matches the name and nothing checks the two still agree.
 pr_labels = ["release"]
 
 # Generated from conventional commits through release-plz-changelog.toml.

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -77,6 +77,17 @@
 git_release_type = "auto"
 git_release_enable = true
 
+# Read by .coderabbit.yaml, whose `auto_review.labels: ["!release"]` skips a
+# pull request carrying this label. A release pull request has nothing to
+# review -- the commits in it were each reviewed on their own pull request,
+# and this one auto-merges without a human in front of it.
+#
+# A label rather than the title keyword that was there first: release-plz
+# force-pushes this branch on every push to main, and each force-push starts
+# an incremental review that the title gate did not stop. The label is
+# re-checked on every one of them.
+pr_labels = ["release"]
+
 # Generated from conventional commits through release-plz-changelog.toml.
 # See the header for what this used to be and what changed to make it safe.
 changelog_update = true


### PR DESCRIPTION
The `ignore_title_keywords` rule from [#39](https://github.com/TurtIeSocks/shep/pull/39) does not work. [#40](https://github.com/TurtIeSocks/shep/pull/40) got reviewed with the config on its head, the keyword in that copy, and `chore: release v0.1.10` as its title.

- Its run log reports a commit range, not a whole PR, so that was an incremental review
- release-plz force-pushes the branch on every push to main, and the title gate is not re-checked on those
- A label is checked per review, so it survives the force-push

- `pr_labels = ["release"]` in release-plz.toml makes the label
- `auto_review.labels: ["!release"]` consumes it
- Keyword removed rather than kept, since a dead rule next to a live one reads as redundancy that is not there

`ignore_usernames` is still wrong: release-plz posts under the maintainer's PAT.

YAML parses, `auto_review` keys validate against the published schema, `workspace.pr_labels` reads back as `["release"]`. The next release PR is the proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Improved release workflow automation by consistently labeling release pull requests.
  - Updated automated review settings to recognize release labels, including after updates to release changes.
  - Reduced unnecessary automated reviews for release-related changes.
  - Refined configuration guidance to make release management clearer and more predictable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->