### PR TITLE
Write the 0.1.10 changelog sections by hand

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -41,23 +41,34 @@ reviews:
     # that release-plz generated from commits already reviewed on their own
     # pull requests, and .github/workflows/release-plz-pr.yml auto-merges it
     # behind the `main` ruleset without a human in front of it. Eight of the
-    # last twenty pull requests here were releases, and CodeRabbit read every
-    # one; #38 got a 5.4 KB walkthrough and an approval nobody read.
+    # twenty pull requests before this rule went in were releases, and
+    # CodeRabbit read every one; #38 got a 5.4 KB walkthrough and an approval
+    # nobody read.
     #
-    # Matched on the title, not the author. `ignore_usernames` looks like the
-    # tidier answer and is the wrong one: release-plz posts under
-    # RELEASE_PLZ_TOKEN, which is the maintainer's PAT, so the release pull
-    # requests are authored by the same account as every other pull request
-    # in the repository. Ignoring that username would ignore all of them.
+    # Matched on a LABEL, which release-plz attaches itself through
+    # `pr_labels` in release-plz.toml. `!release` means "review everything
+    # except a pull request carrying this label".
     #
-    # The trailing `v` is load-bearing. Matching is a case-insensitive
-    # substring, so a bare "chore: release" would also swallow a real pull
-    # request titled "chore: release process cleanup". Every release-plz
-    # title here is "chore: release v0.1.9" and friends. If release-plz ever
-    # changes that format this stops matching and reviews come back, which is
-    # the failure worth having.
-    ignore_title_keywords:
-      - "chore: release v"
+    # ## Two mechanisms that look right and are not
+    #
+    # `ignore_usernames` is the tidier-looking answer and is wrong here:
+    # release-plz posts under RELEASE_PLZ_TOKEN, which is the maintainer's
+    # PAT, so its pull requests are authored by the same account as every
+    # other pull request in this repository. Ignoring that username would
+    # ignore all of them.
+    #
+    # `ignore_title_keywords: ["chore: release v"]` was tried first and did
+    # NOT hold, which is worth recording so nobody re-derives it. On #40 the
+    # configuration was present on the head commit, carried that exact
+    # keyword, and the title was "chore: release v0.1.10" -- and CodeRabbit
+    # reviewed it anyway, reporting a commit RANGE rather than a whole pull
+    # request. That is the tell: release-plz force-pushes its branch on every
+    # push to main, each force-push starts an incremental review, and the
+    # title gate does not appear to be re-evaluated on those. A label is
+    # checked per review instead of parsed once, so it survives the
+    # force-push that defeated the keyword.
+    labels:
+      - "!release"
 
   # Excluded because a comment on any of these cannot be acted on without
   # regenerating the file, which means the comment belongs on the generator

--- a/crates/shep-cli/CHANGELOG.md
+++ b/crates/shep-cli/CHANGELOG.md
@@ -13,6 +13,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.10] - 2026-08-28
+
+### Fixed
+
+- `shep start <selector>` acted on every sheep sharing a name instead of the
+  rows the selector named. It resolved the selector against the listing, then
+  collapsed the matched rows to their distinct NAMES before putting them on
+  the wire, and a name selector reaches every instance that name has. Two ways
+  that bit an operator running a clustered app: `shep start 0` against ten
+  stopped instances started all ten, and `shep start all` with one instance
+  online and nine stopped restarted the online one too, walking back over the
+  row `resume_all` had deliberately set aside. Respawns now go out one per
+  row, by id. Found on a ten-instance app.
+- A sheep that could not spawn no longer abandons the rows after it. `start`
+  returned on the first failure, so an app in a fold that could not start left
+  every app behind it in that fold down and unmentioned. It now attempts every
+  row and returns the first failing code, which is the rule the other
+  selector-taking verbs already state and follow.
+- The already-running notice quotes the target the operator typed. `shep start
+  0` against one live instance of a ten-instance app used to answer "zam is
+  already online; `shep restart zam` replaces it", suggesting a command that
+  acts on all ten. A path or Flockfile target still falls back to names, since
+  `shep restart ./rotom.sh` is not a command.
+- A failed `shep start` prints no flock table. Its output guards keyed on
+  whether any row had come up rather than on the outcome, which agreed with
+  itself only while a failure stopped the run. Once every row is attempted, a
+  fold whose second app fails and whose third succeeds ends both non-empty and
+  failed, and under `--format json` that put a data envelope beside an error
+  envelope: two answers to one question.
+
 ## [0.1.9] - 2026-08-28
 
 

--- a/crates/shep-client/CHANGELOG.md
+++ b/crates/shep-client/CHANGELOG.md
@@ -10,6 +10,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.10] - 2026-08-28
+
+### Added
+
+- `testing::fake_client_answering`, a fake daemon whose reply to each request
+  comes from a caller-supplied closure while every envelope is still forwarded
+  to the caller. The existing fakes each did one half: one shows the wire but
+  answers everything `Pong`, so a caller that reads its own reply and decides
+  what to send next stalls at the first request; the other answers a
+  `ListFlock` properly but keeps its envelopes to itself. A verb that lists,
+  decides from the listing, and then sends needs both at once. Available under
+  the `test-support` feature, like the rest of the module.
+
 ## [0.1.9] - 2026-08-28
 
 

--- a/crates/shep-core/CHANGELOG.md
+++ b/crates/shep-core/CHANGELOG.md
@@ -10,6 +10,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.10] - 2026-08-28
+
+### Added
+
+- A Flockfile app may carry a `dog` table, so a dog can configure the app it
+  manages. The key must BE a table: any other type is refused at parse time
+  rather than quietly ignored, which is the rule every other typed key in a
+  Flockfile already follows.
+
 ### Changed
 
 - `AppConfig::reuse_port` is accepted rather than refused, and now decides how

--- a/crates/shep-daemon/CHANGELOG.md
+++ b/crates/shep-daemon/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.10] - 2026-08-28
+
 ### Fixed
 
 - A reload's readiness probe could be answered by the instance the reload was

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -86,6 +86,13 @@ git_release_enable = true
 # force-pushes this branch on every push to main, and each force-push starts
 # an incremental review that the title gate did not stop. The label is
 # re-checked on every one of them.
+#
+# The label has to EXIST in the repository first. release-plz opens the pull
+# request and then calls GitHub's label endpoint, so a name nothing has
+# defined can leave the pull request opened and unlabelled with the job
+# failing around it. `release` was created for this on 2026-08-28. Renaming or
+# deleting it silently un-skips every release pull request, because
+# .coderabbit.yaml matches the name and nothing checks the two still agree.
 pr_labels = ["release"]
 
 # Generated from conventional commits through release-plz-changelog.toml.

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -77,6 +77,17 @@
 git_release_type = "auto"
 git_release_enable = true
 
+# Read by .coderabbit.yaml, whose `auto_review.labels: ["!release"]` skips a
+# pull request carrying this label. A release pull request has nothing to
+# review -- the commits in it were each reviewed on their own pull request,
+# and this one auto-merges without a human in front of it.
+#
+# A label rather than the title keyword that was there first: release-plz
+# force-pushes this branch on every push to main, and each force-push starts
+# an incremental review that the title gate did not stop. The label is
+# re-checked on every one of them.
+pr_labels = ["release"]
+
 # Generated from conventional commits through release-plz-changelog.toml.
 # See the header for what this used to be and what changed to make it safe.
 changelog_update = true


### PR DESCRIPTION
[#40](https://github.com/TurtIeSocks/shep/pull/40) bumped all four crates to 0.1.10 with `## [0.1.10] - 2026-08-28` and nothing under it. The no-op guard refused to auto-merge it on four runs, correctly.

Cause: I squash merged six PRs, and five of those subjects are PR titles with no `feat:`/`fix:` prefix, so git-cliff dropped them. The sixth was `ci:`, skipped by name. Merge commits from here, which is what the repo did before.

- shep-core: the `dog` table, plus the `reuse_port` block it was already carrying
- shep-daemon: its existing `[Unreleased]` block is this release
- shep: the four `shep start` fixes
- shep-client: `testing::fake_client_answering`

Entries recovered from the squash bodies, which still list each branch's conventional subjects. Test-only commits left out, matching the generator's own skip list.

`typos` passes on all four.

Merge this with a merge commit, not a squash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release automation to apply a `release` label to release pull requests.
  * Automatic review exclusions now use the `release` label instead of relying on release title text.
  * Added configuration guidance for the release labeling workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->