### PR TITLE
Canary: docs-only change against the scoped CI

### DIFF
--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -418,3 +418,5 @@ the crate it is building. They were never in danger of shipping.
 The largest archive is `shep-daemon` at 1.9 MiB uncompressed, 520 KiB
 compressed, which is `supervisor.rs` and `boot.rs` being large source files.
 That is well inside the 10 MiB registry limit.
+
+<!-- canary 2026-08-28: docs-only change against the scoped CI; PR closes unmerged -->


### PR DESCRIPTION
Proof run for #44, cut from main after it merged. Only docs/releasing.md changes, so every Rust job should skip. Closes unmerged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a canary note to the release documentation describing a documentation-only change and its CI context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->