### PR TITLE
Let the required matrix legs report even when the gate skips them

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -156,6 +156,15 @@ jobs:
       - uses: crate-ci/typos@v1
   test:
     needs: changes
+    # `!cancelled()` and nothing else. Without it, a FAILED `changes` job
+    # skips this job before matrix expansion, and the per-leg required checks
+    # go missing again through the one path the step gates cannot reach. With
+    # it, the legs always expand, and a failed filter makes every step's
+    # `result != 'success'` term true, so the full suite runs: fail closed,
+    # same as the job-level gates. The steps themselves deliberately do NOT
+    # carry `!cancelled()`; on a step it replaces the implicit `success()`,
+    # which would run `cargo test` after a failed toolchain install.
+    if: ${{ !cancelled() }}
     strategy:
       fail-fast: false
       matrix:
@@ -243,6 +252,15 @@ jobs:
       - run: cargo check --workspace --all-targets --all-features --locked --target x86_64-pc-windows-gnu
   features:
     needs: changes
+    # `!cancelled()` and nothing else. Without it, a FAILED `changes` job
+    # skips this job before matrix expansion, and the per-leg required checks
+    # go missing again through the one path the step gates cannot reach. With
+    # it, the legs always expand, and a failed filter makes every step's
+    # `result != 'success'` term true, so the full suite runs: fail closed,
+    # same as the job-level gates. The steps themselves deliberately do NOT
+    # carry `!cancelled()`; on a step it replaces the implicit `success()`,
+    # which would run `cargo test` after a failed toolchain install.
+    if: ${{ !cancelled() }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,6 +59,17 @@ jobs:
   # never reports at all, so every required check sits at "Expected" forever
   # and a docs pull request can never merge. Same feature, opposite outcomes.
   #
+  # EXCEPT for a matrix job, and the canary run for this gate is what proved
+  # it: a matrix job skipped at the job level never expands its matrix, so it
+  # reports one check run named `test`, and the ruleset's required contexts
+  # are the per-leg names, `test (ubuntu-latest, stable)` and friends. Those
+  # never get created and sit at "Expected" forever, which is the docs-PR
+  # deadlock again through a side door. So the two matrix jobs with required
+  # legs, `test` and `features`, gate every STEP instead of the job: each leg
+  # spins up, skips its steps in seconds, and reports SUCCESS under its own
+  # required name. Every non-matrix job keeps the job-level skip, which the
+  # same canary showed the ruleset accepting.
+  #
   # The fail-open corner is closed in the gate expression itself, not in the
   # ruleset. If this job errors its outputs are empty, and a naive gate would
   # skip every job while skipped-counts-as-success waves the pull request
@@ -145,7 +156,6 @@ jobs:
       - uses: crate-ci/typos@v1
   test:
     needs: changes
-    if: ${{ !cancelled() && (needs.changes.outputs.rust == 'true' || needs.changes.result != 'success' || github.event_name == 'workflow_dispatch') }}
     strategy:
       fail-fast: false
       matrix:
@@ -162,10 +172,14 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
+        if: ${{ needs.changes.outputs.rust == 'true' || needs.changes.result != 'success' || github.event_name == 'workflow_dispatch' }}
       - run: rustup toolchain install ${{ matrix.toolchain }} --profile minimal
+        if: ${{ needs.changes.outputs.rust == 'true' || needs.changes.result != 'success' || github.event_name == 'workflow_dispatch' }}
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
+        if: ${{ needs.changes.outputs.rust == 'true' || needs.changes.result != 'success' || github.event_name == 'workflow_dispatch' }}
       # `--all-features` mirrors the task gate, as in `lint` above.
       - run: 'cargo +${{ matrix.toolchain }} test --workspace --locked --all-features -- --skip ::slow:: --skip two_concurrent_boots --skip signal_ignored_then_kill_tree_reaps'
+        if: ${{ needs.changes.outputs.rust == 'true' || needs.changes.result != 'success' || github.event_name == 'workflow_dispatch' }}
   minimal-versions:
     needs: changes
     if: ${{ !cancelled() && (needs.changes.outputs.rust == 'true' || needs.changes.result != 'success' || github.event_name == 'workflow_dispatch') }}
@@ -229,7 +243,6 @@ jobs:
       - run: cargo check --workspace --all-targets --all-features --locked --target x86_64-pc-windows-gnu
   features:
     needs: changes
-    if: ${{ !cancelled() && (needs.changes.outputs.rust == 'true' || needs.changes.result != 'success' || github.event_name == 'workflow_dispatch') }}
     strategy:
       fail-fast: false
       matrix:
@@ -240,10 +253,15 @@ jobs:
     timeout-minutes: 25
     steps:
       - uses: actions/checkout@v4
+        if: ${{ needs.changes.outputs.rust == 'true' || needs.changes.result != 'success' || github.event_name == 'workflow_dispatch' }}
       - run: rustup toolchain install stable --profile minimal
+        if: ${{ needs.changes.outputs.rust == 'true' || needs.changes.result != 'success' || github.event_name == 'workflow_dispatch' }}
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
+        if: ${{ needs.changes.outputs.rust == 'true' || needs.changes.result != 'success' || github.event_name == 'workflow_dispatch' }}
       - run: 'cargo test -p shep-daemon --locked --no-default-features -- --skip ::slow:: --skip two_concurrent_boots --skip signal_ignored_then_kill_tree_reaps'
+        if: ${{ needs.changes.outputs.rust == 'true' || needs.changes.result != 'success' || github.event_name == 'workflow_dispatch' }}
       - run: 'cargo test --workspace --locked --all-features -- --skip ::slow:: --skip two_concurrent_boots --skip signal_ignored_then_kill_tree_reaps'
+        if: ${{ needs.changes.outputs.rust == 'true' || needs.changes.result != 'success' || github.event_name == 'workflow_dispatch' }}
   # Tests that need a quiet machine, run serially in a job of their own.
   #
   # Two groups belong here and neither is a flaky test in the usual sense:

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -418,3 +418,5 @@ the crate it is building. They were never in danger of shipping.
 The largest archive is `shep-daemon` at 1.9 MiB uncompressed, 520 KiB
 compressed, which is `supervisor.rs` and `boot.rs` being large source files.
 That is well inside the 10 MiB registry limit.
+
+<!-- canary 2026-08-28: docs-only change against the scoped CI; PR closes unmerged -->


### PR DESCRIPTION
The canary ([#46](https://github.com/TurtIeSocks/shep/pull/46)) caught a deadlock: a skipped matrix job never expands, so it reports one check named `test` while the ruleset requires the per-leg names. Those sit at Expected forever and no docs PR can merge.

- `test` and `features` now gate every step instead of the job, so each leg spins up, skips in seconds, and reports SUCCESS under its required name
- Non-matrix jobs keep the job-level skip, which #46 proved the ruleset accepts
- `slow` and `bench` stay job-gated: matrix jobs, but no required legs

Cost on a docs PR: ten runner spin-ups of a few seconds each. Canary re-runs against this after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CI status reporting across all test matrix configurations.
  * Ensured required checks remain visible while avoiding unnecessary test execution when appropriate.
  * Full test matrices now run if change detection cannot complete.

* **Documentation**
  * Added a release-workflow note documenting documentation-only changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->