### PR TITLE
Remove the canary line that landed by accident

### DIFF
--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -418,5 +418,3 @@ the crate it is building. They were never in danger of shipping.
 The largest archive is `shep-daemon` at 1.9 MiB uncompressed, 520 KiB
 compressed, which is `supervisor.rs` and `boot.rs` being large source files.
 That is well inside the 10 MiB registry limit.
-
-<!-- canary 2026-08-28: docs-only change against the scoped CI; PR closes unmerged -->


### PR DESCRIPTION
The #46 canary merged after all: #47's branch was cut from it by mistake, so its commit rode along. This removes the stray comment, and as a docs-only PR it is also the end-to-end proof of the gate: Rust legs skip, required names report, and this time the merge goes through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed the canary HTML comment from the release documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->