### PR TITLE
Buffer the log plane, and encode each bus event once

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -374,6 +374,39 @@ debug = "line-tables-only"
 [profile.dev.package."*"]
 debug = false
 
+# Cargo's default release profile optimizes each crate on its own, and the
+# daemon's hot paths cross crate boundaries on every log line: the pump is in
+# shep-daemon, the codec and `BusEvent` in shep-core, the channels and the
+# timer wheel in tokio.
+#
+# Measured 2026-08-28, clean `cargo build --release -p shep`, and the runtime
+# column against a sheep emitting 7,315 lines/s of 70 bytes with nothing
+# subscribed (two 30 s windows per binary, run round-robin so they share one
+# machine state):
+#
+#   default          28.8 s   18.60 MiB   1.62 us/line
+#   thin + cgu=1     68.3 s   14.23 MiB   1.57 us/line
+#   fat  + cgu=1     94.2 s   13.21 MiB   1.53 us/line
+#
+# The size column is the reason to set this at all: a quarter off the shipped
+# binary. The runtime column is nearly flat because this workload is bound by
+# syscalls and task wakeups rather than by inlinable code, and the gap between
+# thin and fat is inside the noise -- an earlier round had them equal. So
+# `lto = "thin"`, which leaves 26 s of build time on the table for 1.0 MiB
+# nobody has asked for.
+#
+# Not `panic = "abort"`, and that is a correctness limit rather than a
+# preference: `shep-client`'s `spawn.rs` calls `JoinError::is_panic` and
+# `resume_unwind` to re-raise a panicked task in its caller, which needs a
+# runtime that unwinds.
+#
+# Not `strip`: symbols are what let `sample(1)` name a frame, and the fix that
+# took 1.57 us/line down to 0.82 was found by profiling a binary built with
+# exactly this profile. 1.4 MiB is not worth giving that up.
+[profile.release]
+lto = "thin"
+codegen-units = 1
+
 [workspace.lints.rust]
 missing_docs = "deny"
 missing_debug_implementations = "deny"

--- a/crates/shep-daemon/src/boot.rs
+++ b/crates/shep-daemon/src/boot.rs
@@ -54,7 +54,7 @@ use shep_core::protocol::BusEvent;
 #[cfg(unix)]
 use shep_core::selector::ProcessSelector;
 
-use crate::bus::new_bus;
+use crate::bus::{SharedEvent, new_bus};
 use crate::cron::DEFAULT_MAX_CRON_SLEEP;
 use crate::dogs::{DogSpec, spawn_dog_watch};
 use crate::extras::{Extras, ExtrasReports, spawn_extras_reporter};
@@ -1174,7 +1174,7 @@ impl RunningDaemon {
         }
 
         // 3. Tell subscribers before their sockets close underneath them.
-        let _ = ctx.events.send(BusEvent::DaemonShutdown);
+        let _ = ctx.events.send(SharedEvent::new(BusEvent::DaemonShutdown));
 
         // 4. Kill ladder on every online sheep.
         ctx.supervisor.shutdown().await;
@@ -2824,7 +2824,7 @@ mod tests {
 
         let restarted = async {
             loop {
-                match events.recv().await {
+                match events.recv().await.map(|event| event.to_event()) {
                     Ok(BusEvent::Process {
                         event: ProcessEventKind::Restart,
                         info,

--- a/crates/shep-daemon/src/bus.rs
+++ b/crates/shep-daemon/src/bus.rs
@@ -6,7 +6,6 @@
 //! matching frames into that connection's write queue.
 
 use core::ops::Deref;
-#[cfg(test)]
 use core::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, OnceLock};
 
@@ -37,12 +36,140 @@ pub const MAX_TOPIC_PATTERNS: usize = 32;
 
 /// Creates the daemon's process-wide event bus.
 ///
-/// Every connection subscribes off the returned sender's `.subscribe()`;
-/// the sender itself is held by the daemon so the bus outlives every
-/// individual connection.
+/// Every connection subscribes off the returned [`Bus`]; the bus itself is
+/// held by the daemon so it outlives every individual connection.
 #[must_use]
-pub fn new_bus() -> broadcast::Sender<SharedEvent> {
-    broadcast::channel(BUS_CAPACITY).0
+pub fn new_bus() -> Bus {
+    Bus {
+        tx: broadcast::channel(BUS_CAPACITY).0,
+        log_subscribers: Arc::new(AtomicUsize::new(0)),
+    }
+}
+
+/// The daemon's event channel, plus the one question the channel cannot
+/// answer: whether anything is listening for log lines.
+///
+/// A `broadcast::Sender`'s `receiver_count` is the wrong question here and
+/// would always answer "yes". Two subscribers exist for the daemon's whole
+/// life and neither reads a log line: [`crate::dogs::spawn_dog_watch`] acts
+/// only on a dog's `Errored`, and the snapshot writer only on a lifecycle
+/// change. A sheep's stdout therefore woke both of them, once per line, to
+/// look at an event and drop it — measured at 39% of the daemon's per-line
+/// CPU on a sheep emitting 7,315 lines/s with nothing attached.
+///
+/// So the count kept here is of subscribers whose [`TopicFilter`] actually
+/// matches a log topic, which in practice means a `shep bleats`, a bark dog,
+/// or a `lookout`, and [`Self::publish_log`] skips the whole publish while it
+/// is zero.
+///
+/// # Debug (IR-41)
+///
+/// Derived, unredacted, and carrying nothing to redact: a channel handle and
+/// a counter.
+#[derive(Clone, Debug)]
+pub struct Bus {
+    tx: broadcast::Sender<SharedEvent>,
+    /// Subscribers whose filter matches `log.out` or `log.err`.
+    log_subscribers: Arc<AtomicUsize>,
+}
+
+impl Bus {
+    /// Publishes one log line, unless nothing is subscribed to log topics.
+    ///
+    /// # Why dropping it is not a lost event
+    ///
+    /// A `broadcast` receiver begins at the channel's CURRENT tail
+    /// (`tokio::sync::broadcast`'s `new_receiver` reads `tail.pos` into the
+    /// receiver's cursor), so a subscriber has never been shown an event
+    /// published before it attached. An event skipped while the count is zero
+    /// is therefore one no receiver could have read had it been published:
+    /// the ring would have carried it, every existing subscriber would have
+    /// filtered it out, and the next one to attach would have started past
+    /// it.
+    ///
+    /// What the gate does widen, by the time it takes one atomic store to
+    /// become visible to another core, is a window that is already there:
+    /// [`Self::subscribe_for`] registers a filter's interest BEFORE it takes
+    /// its receiver, so between an operator running `shep bleats` and its
+    /// first line there has always been an interval in which a line goes to
+    /// nobody. Nothing orders a client's `Subscribe` against a sheep's
+    /// stdout, and nothing could.
+    pub fn publish_log(&self, event: BusEvent) {
+        // Relaxed: nothing is published THROUGH this counter, and the only
+        // consequence of reading a stale zero is the race above.
+        if self.log_subscribers.load(Ordering::Relaxed) == 0 {
+            return;
+        }
+        let _ = self.tx.send(SharedEvent::new(event));
+    }
+
+    /// A receiver for one subscription, plus its registered log interest.
+    ///
+    /// Registered before the receiver exists, so the receiver can only ever
+    /// miss events from before it was created — see [`Self::publish_log`].
+    /// The guard restores the count when it is dropped, which for a
+    /// forwarder is when its task ends OR is aborted, since aborting a task
+    /// drops the future and everything it captured.
+    #[must_use]
+    fn subscribe_for(
+        &self,
+        filter: &TopicFilter,
+    ) -> (broadcast::Receiver<SharedEvent>, LogInterest) {
+        let interest = if filter.wants_logs() {
+            self.log_subscribers.fetch_add(1, Ordering::Relaxed);
+            LogInterest(Some(Arc::clone(&self.log_subscribers)))
+        } else {
+            LogInterest(None)
+        };
+        (self.tx.subscribe(), interest)
+    }
+
+    /// How many subscribers currently want log topics.
+    #[cfg(test)]
+    fn log_subscribers(&self) -> usize {
+        self.log_subscribers.load(Ordering::Relaxed)
+    }
+}
+
+impl Deref for Bus {
+    type Target = broadcast::Sender<SharedEvent>;
+
+    // IR-25: a field return, on the path every non-log publish takes.
+    #[inline]
+    fn deref(&self) -> &broadcast::Sender<SharedEvent> {
+        &self.tx
+    }
+}
+
+/// One subscriber's registered interest in log topics, released on drop.
+///
+/// `None` for a filter that never wanted logs, so a caller holds the same
+/// type either way and nothing branches on the way out.
+#[derive(Debug)]
+pub struct LogInterest(Option<Arc<AtomicUsize>>);
+
+impl Drop for LogInterest {
+    fn drop(&mut self) {
+        if let Some(count) = self.0.take() {
+            count.fetch_sub(1, Ordering::Relaxed);
+        }
+    }
+}
+
+/// A bus of the given ring capacity, plus one plain receiver.
+///
+/// The receiver is not registered for log topics, and cannot be: a bare
+/// `subscribe` has no [`TopicFilter`] for [`Bus::publish_log`] to ask about.
+/// A test that wants log lines takes them through [`spawn_forwarder`], the
+/// way a connection does.
+#[cfg(test)]
+pub(crate) fn test_bus(capacity: usize) -> (Bus, broadcast::Receiver<SharedEvent>) {
+    let (tx, rx) = broadcast::channel(capacity);
+    let bus = Bus {
+        tx,
+        log_subscribers: Arc::new(AtomicUsize::new(0)),
+    };
+    (bus, rx)
 }
 
 /// One published [`BusEvent`], plus the wire frame its subscribers share.
@@ -228,6 +355,20 @@ impl TopicFilter {
         self.set.is_match(event.topic())
     }
 
+    /// True when this filter would match either log topic.
+    ///
+    /// Asked once per subscription, never per event, and the answer is what
+    /// [`Bus::publish_log`] gates on. The two topic strings are duplicated
+    /// from [`BusEvent::topic`] because there is no event to ask — a
+    /// publisher decides whether to BUILD one. `wants_logs_agrees_with_the
+    /// _topics_log_events_carry` is what keeps the two in step.
+    #[must_use]
+    pub fn wants_logs(&self) -> bool {
+        ["log.out", "log.err"]
+            .iter()
+            .any(|topic| self.set.is_match(topic))
+    }
+
     /// The source patterns this filter was compiled from.
     // IR-25: trivial field return, no branch — inline across codegen units.
     // Not per-frame hot like `matches` above (a `GlobSet` call, not a
@@ -318,15 +459,15 @@ fn step(received: Result<SharedEvent, RecvError>, filter: &TopicFilter) -> Forwa
 // reports the exact count as `Lagged(n)`. That is spec §6's requirement
 // implemented by the runtime rather than by a hand-rolled `VecDeque`, and it
 // isolates one slow client from every other connection.
-pub fn spawn_forwarder(
-    mut rx: broadcast::Receiver<SharedEvent>,
-    filter: TopicFilter,
-    out: mpsc::Sender<Bytes>,
-) -> JoinHandle<()> {
+pub fn spawn_forwarder(bus: &Bus, filter: TopicFilter, out: mpsc::Sender<Bytes>) -> JoinHandle<()> {
+    let (mut rx, interest) = bus.subscribe_for(&filter);
     // Cancel-safety: `recv` and `send` are both cancel-safe and are awaited
     // sequentially (no select!), so an aborted forwarder can lose at most the
     // frame in flight — which the subscriber is no longer there to read.
     tokio::spawn(async move {
+        // Captured by the future rather than created inside it, so a
+        // forwarder aborted before its first poll still releases the count.
+        let _interest = interest;
         loop {
             match step(rx.recv().await, &filter) {
                 Forwarded::Frame(bytes) => {
@@ -432,7 +573,7 @@ mod tests {
     async fn lag_becomes_a_dropped_notice_that_bypasses_the_filter() {
         // The count is READ from the runtime, never hand-computed: whatever
         // tokio says was missed is exactly what the subscriber is told.
-        let (tx, mut rx) = tokio::sync::broadcast::channel(4);
+        let (tx, mut rx) = test_bus(4);
         for id in 0..10 {
             tx.send(process_event(id, ProcessEventKind::Start)).unwrap();
         }
@@ -454,9 +595,9 @@ mod tests {
 
     #[tokio::test(start_paused = true)]
     async fn forwarder_delivers_only_matching_frames_then_closes_with_the_bus() {
-        let (tx, rx) = tokio::sync::broadcast::channel(16);
+        let (tx, _rx) = test_bus(16);
         let (out_tx, mut out_rx) = tokio::sync::mpsc::channel(16);
-        let handle = spawn_forwarder(rx, filter(&["process.*"]), out_tx);
+        let handle = spawn_forwarder(&tx, filter(&["process.*"]), out_tx);
 
         tx.send(process_event(0, ProcessEventKind::Start)).unwrap();
         tx.send(
@@ -507,12 +648,12 @@ mod tests {
     /// and the rest of the subscribers cloned a refcount.
     #[tokio::test(start_paused = true)]
     async fn every_subscriber_gets_the_same_frame_from_one_encode() {
-        let (tx, _keep) = tokio::sync::broadcast::channel(16);
+        let (tx, _keep) = test_bus(16);
         let mut outs = Vec::new();
         let mut forwarders = Vec::new();
         for _ in 0..3 {
             let (out_tx, out_rx) = tokio::sync::mpsc::channel(16);
-            forwarders.push(spawn_forwarder(tx.subscribe(), filter(&["*"]), out_tx));
+            forwarders.push(spawn_forwarder(&tx, filter(&["*"]), out_tx));
             outs.push(out_rx);
         }
 
@@ -558,12 +699,12 @@ mod tests {
     #[tokio::test(start_paused = true)]
     async fn encode_frame_runs_once_per_event_however_many_subscribers() {
         const SUBSCRIBERS: usize = 5;
-        let (tx, _keep) = tokio::sync::broadcast::channel(16);
+        let (tx, _keep) = test_bus(16);
         let mut outs = Vec::new();
         let mut forwarders = Vec::new();
         for _ in 0..SUBSCRIBERS {
             let (out_tx, out_rx) = tokio::sync::mpsc::channel(16);
-            forwarders.push(spawn_forwarder(tx.subscribe(), filter(&["*"]), out_tx));
+            forwarders.push(spawn_forwarder(&tx, filter(&["*"]), out_tx));
             outs.push(out_rx);
         }
 
@@ -623,11 +764,99 @@ mod tests {
 
     #[tokio::test(start_paused = true)]
     async fn forwarder_stops_when_the_subscriber_hangs_up() {
-        let (tx, rx) = tokio::sync::broadcast::channel(16);
+        let (tx, _rx) = test_bus(16);
         let (out_tx, out_rx) = tokio::sync::mpsc::channel(1);
-        let handle = spawn_forwarder(rx, filter(&["*"]), out_tx);
+        let handle = spawn_forwarder(&tx, filter(&["*"]), out_tx);
         drop(out_rx);
         tx.send(BusEvent::DaemonShutdown.into()).unwrap();
         handle.await.unwrap(); // resolves rather than leaking a task
+    }
+
+    fn log_out(line: &str) -> BusEvent {
+        BusEvent::LogOut {
+            id: 1,
+            line: line.to_string(),
+        }
+    }
+
+    /// Fails if [`TopicFilter::wants_logs`]'s two hard-coded topics drift
+    /// from the ones [`BusEvent::topic`] actually returns.
+    ///
+    /// `wants_logs` is asked without an event in hand, so it cannot call
+    /// `topic()`; this is the join that keeps the duplication honest. A
+    /// rename of either topic string fails here rather than silently making
+    /// every `shep bleats` a subscriber to nothing.
+    #[test]
+    fn wants_logs_agrees_with_the_topics_log_events_carry() {
+        let out = log_out("x");
+        let err = BusEvent::LogErr {
+            id: 1,
+            line: "x".to_string(),
+        };
+        for patterns in [vec!["*"], vec!["log.*"], vec!["log.out", "log.err"]] {
+            let f = filter(&patterns);
+            assert!(f.wants_logs(), "{patterns:?} must register log interest");
+            assert!(f.matches(&out) && f.matches(&err), "{patterns:?}");
+        }
+        let f = filter(&["process.*", "channel.*", "daemon.*"]);
+        assert!(!f.wants_logs(), "no pattern here names a log topic");
+        assert!(!f.matches(&out) && !f.matches(&err));
+    }
+
+    /// Fails if a log line is published while nothing wants one.
+    ///
+    /// The count is the assertion rather than a clock, because the cost being
+    /// removed is a fact about how often a publish happens. `receiver_count`
+    /// cannot stand in: the daemon always has two subscribers that read every
+    /// event and act on no log line, and it is exactly their per-line wakeup
+    /// that the gate exists to stop.
+    #[tokio::test(start_paused = true)]
+    async fn a_log_line_is_not_published_while_no_filter_wants_one() {
+        let (bus, mut plain) = test_bus(16);
+        assert_eq!(bus.log_subscribers(), 0);
+
+        // A subscriber that reads everything and asked for nothing — the
+        // shape both of the daemon's own internal subscribers have.
+        bus.publish_log(log_out("dropped"));
+        assert!(
+            plain.try_recv().is_err(),
+            "a log line must not reach the ring while no filter wants one"
+        );
+
+        // A non-log publish still goes out: the gate is about log topics,
+        // not about publishing.
+        bus.send(BusEvent::DaemonShutdown.into()).unwrap();
+        assert_eq!(plain.try_recv().unwrap(), BusEvent::DaemonShutdown);
+    }
+
+    /// Fails if a subscriber that asked for log topics does not get them, or
+    /// if the interest outlives the forwarder that registered it.
+    #[tokio::test(start_paused = true)]
+    async fn a_log_subscriber_opens_the_gate_and_closes_it_again() {
+        let (bus, mut plain) = test_bus(16);
+        let (out_tx, mut out_rx) = mpsc::channel(16);
+        let forwarder = spawn_forwarder(&bus, filter(&["log.*"]), out_tx);
+        assert_eq!(bus.log_subscribers(), 1, "a log.* filter must register");
+
+        bus.publish_log(log_out("delivered"));
+        assert_eq!(
+            decode_frame::<BusEvent>(&next_frame(&mut out_rx).await).unwrap(),
+            log_out("delivered")
+        );
+        assert_eq!(
+            plain.try_recv().unwrap(),
+            log_out("delivered"),
+            "one open gate publishes to every subscriber, not only the asker"
+        );
+
+        forwarder.abort();
+        let _ = forwarder.await;
+        assert_eq!(
+            bus.log_subscribers(),
+            0,
+            "an aborted forwarder must release its interest, not strand it"
+        );
+        bus.publish_log(log_out("dropped again"));
+        assert!(plain.try_recv().is_err());
     }
 }

--- a/crates/shep-daemon/src/bus.rs
+++ b/crates/shep-daemon/src/bus.rs
@@ -57,7 +57,7 @@ pub fn new_bus() -> Bus {
 /// look at an event and drop it — measured at 39% of the daemon's per-line
 /// CPU on a sheep emitting 7,315 lines/s with nothing attached.
 ///
-/// So the count kept here is of subscribers whose [`TopicFilter`] actually
+/// So the count kept here is of subscribers whose `TopicFilter` actually
 /// matches a log topic, which in practice means a `shep bleats`, a bark dog,
 /// or a `lookout`, and [`Self::publish_log`] skips the whole publish while it
 /// is zero.
@@ -89,7 +89,7 @@ impl Bus {
     ///
     /// What the gate does widen, by the time it takes one atomic store to
     /// become visible to another core, is a window that is already there:
-    /// [`Self::subscribe_for`] registers a filter's interest BEFORE it takes
+    /// `Self::subscribe_for` registers a filter's interest BEFORE it takes
     /// its receiver, so between an operator running `shep bleats` and its
     /// first line there has always been an interval in which a line goes to
     /// nobody. Nothing orders a client's `Subscribe` against a sheep's

--- a/crates/shep-daemon/src/bus.rs
+++ b/crates/shep-daemon/src/bus.rs
@@ -58,8 +58,28 @@ pub fn new_bus() -> broadcast::Sender<SharedEvent> {
 ///
 /// The bytes are unchanged — this is how OFTEN [`encode_frame`] runs, never
 /// what it produces.
-#[derive(Clone, Debug)]
+///
+/// # Debug (IR-41)
+///
+/// Unredacted, and hand-written rather than derived. Nothing here is a
+/// secret that [`BusEvent`]'s own `Debug` is not already trusted with — the
+/// wrapper adds a cached frame, which is that same event encoded, and a
+/// test-only encode tally. Both are dropped from the output: the frame
+/// because printing a payload twice tells a reader nothing, and the tally
+/// because a `#[cfg(test)]` field in a derived format would make the string
+/// this type prints under `cargo test` a different one from the string it
+/// prints in a release daemon.
+#[derive(Clone)]
 pub struct SharedEvent(Arc<Shared>);
+
+impl core::fmt::Debug for SharedEvent {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SharedEvent")
+            .field("event", &self.0.event)
+            .field("encoded", &self.0.frame.get().is_some())
+            .finish()
+    }
+}
 
 /// [`SharedEvent`]'s payload — one allocation per published event.
 #[derive(Debug)]
@@ -567,6 +587,30 @@ mod tests {
         for frame in rest {
             assert_eq!(frame, first, "every subscriber must see identical bytes");
         }
+    }
+
+    /// Fails if [`SharedEvent`]'s `Debug` starts carrying the encoded frame,
+    /// the test-only encode tally, or a redaction nobody asked for (IR-41).
+    ///
+    /// An exact string rather than a `contains`: the claim is what a reader
+    /// of a `tracing` line or a panic message SEES, and every part of it —
+    /// the wrapper's name, the two fields, the event printed whole and
+    /// unredacted — is a decision this pins.
+    #[test]
+    fn shared_event_debug_prints_the_event_and_whether_it_is_encoded() {
+        let event = SharedEvent::new(BusEvent::LogOut {
+            id: 3,
+            line: "hello".to_string(),
+        });
+        assert_eq!(
+            format!("{event:?}"),
+            r#"SharedEvent { event: LogOut { id: 3, line: "hello" }, encoded: false }"#
+        );
+        event.frame().expect("a LogOut encodes");
+        assert_eq!(
+            format!("{event:?}"),
+            r#"SharedEvent { event: LogOut { id: 3, line: "hello" }, encoded: true }"#
+        );
     }
 
     #[tokio::test(start_paused = true)]

--- a/crates/shep-daemon/src/bus.rs
+++ b/crates/shep-daemon/src/bus.rs
@@ -347,6 +347,22 @@ mod tests {
     use shep_core::protocol::{BusEvent, ProcessEventKind, ProcessInfo, decode_frame};
     use shep_core::status::ProcStatus;
 
+    /// How long a test waits for a forwarder to produce a frame.
+    ///
+    /// Virtual, not wall clock: every caller runs `start_paused`, so a
+    /// forwarder that never sends leaves the runtime idle, time jumps
+    /// straight here, and the test fails with its own message instead of
+    /// hanging until CI's timeout (IR-33).
+    const FORWARD_DEADLINE: core::time::Duration = core::time::Duration::from_secs(1);
+
+    /// One frame from a forwarder, or a named failure if none arrives.
+    async fn next_frame(out: &mut mpsc::Receiver<Bytes>) -> Bytes {
+        tokio::time::timeout(FORWARD_DEADLINE, out.recv())
+            .await
+            .expect("a forwarder must produce a frame rather than stall")
+            .expect("every subscriber must receive the event")
+    }
+
     fn filter(patterns: &[&str]) -> TopicFilter {
         let owned: Vec<String> = patterns.iter().map(|p| (*p).to_string()).collect();
         TopicFilter::new(&owned).unwrap()
@@ -506,11 +522,7 @@ mod tests {
 
         let mut frames = Vec::new();
         for out in &mut outs {
-            frames.push(
-                out.recv()
-                    .await
-                    .expect("every subscriber must receive the event"),
-            );
+            frames.push(next_frame(out).await);
         }
         for forwarder in forwarders {
             forwarder.await.unwrap();
@@ -567,11 +579,7 @@ mod tests {
 
         let mut frames = Vec::new();
         for out in &mut outs {
-            frames.push(
-                out.recv()
-                    .await
-                    .expect("every subscriber must receive the event"),
-            );
+            frames.push(next_frame(out).await);
         }
         for forwarder in forwarders {
             forwarder.await.unwrap();

--- a/crates/shep-daemon/src/bus.rs
+++ b/crates/shep-daemon/src/bus.rs
@@ -1,9 +1,14 @@
 //! The daemon's process-wide event bus.
 //!
-//! One [`tokio::sync::broadcast`] channel carries every [`BusEvent`] to
+//! One [`tokio::sync::broadcast`] channel carries every [`SharedEvent`] to
 //! every subscriber; each connection compiles its `Subscribe` topic patterns
 //! into a [`TopicFilter`] and gets its own [`spawn_forwarder`] task pumping
 //! matching frames into that connection's write queue.
+
+use core::ops::Deref;
+#[cfg(test)]
+use core::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, OnceLock};
 
 use bytes::Bytes;
 use globset::{Glob, GlobSet, GlobSetBuilder};
@@ -36,8 +41,122 @@ pub const MAX_TOPIC_PATTERNS: usize = 32;
 /// the sender itself is held by the daemon so the bus outlives every
 /// individual connection.
 #[must_use]
-pub fn new_bus() -> broadcast::Sender<BusEvent> {
+pub fn new_bus() -> broadcast::Sender<SharedEvent> {
     broadcast::channel(BUS_CAPACITY).0
+}
+
+/// One published [`BusEvent`], plus the wire frame its subscribers share.
+///
+/// The bus carries this rather than the event itself because both of the
+/// costs it removes are LINEAR IN SUBSCRIBERS. A `broadcast` channel clones
+/// its item once per receiver, which for a `LogOut` is a fresh copy of the
+/// line; and every forwarder used to encode its own frame from that copy,
+/// so the same bytes were built once per attached client. Measured on a
+/// sheep logging 7,315 lines/s: one attached `shep bleats` took the daemon
+/// from 23.99% of a core to 37.50%, +18.6 us per line. Here a clone is a
+/// refcount bump and the frame is built by whichever forwarder asks first.
+///
+/// The bytes are unchanged — this is how OFTEN [`encode_frame`] runs, never
+/// what it produces.
+#[derive(Clone, Debug)]
+pub struct SharedEvent(Arc<Shared>);
+
+/// [`SharedEvent`]'s payload — one allocation per published event.
+#[derive(Debug)]
+struct Shared {
+    event: BusEvent,
+    /// The wire frame, filled by the first forwarder that needs it.
+    ///
+    /// `Some(None)` once encoding has been TRIED and failed, so an event
+    /// nothing can encode is reported once rather than once per subscriber.
+    frame: OnceLock<Option<Bytes>>,
+    /// How many times [`encode_frame`] has actually run for this event.
+    ///
+    /// Test-only. [`OnceLock`] already makes "at most once" a fact about the
+    /// type; what a test cannot otherwise see is that the encode ran AT ALL
+    /// through this path, and that no future edit reintroduces a
+    /// per-subscriber one beside it.
+    #[cfg(test)]
+    encodes: AtomicUsize,
+}
+
+impl SharedEvent {
+    /// Wraps one event for publication on the bus.
+    #[must_use]
+    pub fn new(event: BusEvent) -> Self {
+        Self(Arc::new(Shared {
+            event,
+            frame: OnceLock::new(),
+            #[cfg(test)]
+            encodes: AtomicUsize::new(0),
+        }))
+    }
+
+    /// How many times this event has been through [`encode_frame`].
+    #[cfg(test)]
+    fn encodes(&self) -> usize {
+        self.0.encodes.load(Ordering::Relaxed)
+    }
+
+    /// A clone of the event this carries, for a caller that needs to own one.
+    ///
+    /// Everything on the daemon's own hot paths reads through [`Deref`]
+    /// instead; this is for a caller that has to destructure a received
+    /// event by value.
+    #[must_use]
+    pub fn to_event(&self) -> BusEvent {
+        self.0.event.clone()
+    }
+
+    /// This event's wire frame, encoded on the first call and shared after.
+    ///
+    /// `None` when the event cannot be encoded at all, which is warned about
+    /// exactly once and leaves every subscriber skipping it alike.
+    fn frame(&self) -> Option<&Bytes> {
+        self.0
+            .frame
+            .get_or_init(|| {
+                #[cfg(test)]
+                self.0.encodes.fetch_add(1, Ordering::Relaxed);
+                match encode_frame(&self.0.event) {
+                    Ok(bytes) => Some(bytes),
+                    Err(err) => {
+                        tracing::warn!(
+                            %err,
+                            topic = self.0.event.topic(),
+                            "dropping an unencodable bus event"
+                        );
+                        None
+                    }
+                }
+            })
+            .as_ref()
+    }
+}
+
+impl Deref for SharedEvent {
+    type Target = BusEvent;
+
+    // IR-25: a field return through one pointer hop, on the path every
+    // subscriber takes for every event.
+    #[inline]
+    fn deref(&self) -> &BusEvent {
+        &self.0.event
+    }
+}
+
+impl From<BusEvent> for SharedEvent {
+    fn from(event: BusEvent) -> Self {
+        Self::new(event)
+    }
+}
+
+/// Compares a published event against the event it was published from, so a
+/// caller reading the bus asserts on what it sent rather than on the wrapper.
+impl PartialEq<BusEvent> for SharedEvent {
+    fn eq(&self, other: &BusEvent) -> bool {
+        self.0.event == *other
+    }
 }
 
 /// Compiled server-side topic filter for one subscription
@@ -151,22 +270,22 @@ enum Forwarded {
 
 // Pure: every forwarding decision lives here so the task itself has nothing
 // left to test but plumbing.
-fn step(received: Result<BusEvent, RecvError>, filter: &TopicFilter) -> Forwarded {
+fn step(received: Result<SharedEvent, RecvError>, filter: &TopicFilter) -> Forwarded {
     let event = match received {
         Ok(event) if filter.matches(&event) => event,
         Ok(_) => return Forwarded::Skip,
         // Drop notices BYPASS the filter on purpose: a subscriber to
         // `process.*` still has to learn it lost events, and `daemon.dropped`
         // would otherwise be filtered out exactly when it matters most.
-        Err(RecvError::Lagged(count)) => BusEvent::Dropped { count },
+        //
+        // Wrapped like any other event, but the count is this subscriber's
+        // own, so this is the one frame per lag nothing else can share.
+        Err(RecvError::Lagged(count)) => SharedEvent::new(BusEvent::Dropped { count }),
         Err(RecvError::Closed) => return Forwarded::Stop,
     };
-    match encode_frame(&event) {
-        Ok(bytes) => Forwarded::Frame(bytes),
-        Err(err) => {
-            tracing::warn!(%err, topic = event.topic(), "dropping an unencodable bus event");
-            Forwarded::Skip
-        }
+    match event.frame() {
+        Some(bytes) => Forwarded::Frame(bytes.clone()),
+        None => Forwarded::Skip,
     }
 }
 
@@ -180,7 +299,7 @@ fn step(received: Result<BusEvent, RecvError>, filter: &TopicFilter) -> Forwarde
 // implemented by the runtime rather than by a hand-rolled `VecDeque`, and it
 // isolates one slow client from every other connection.
 pub fn spawn_forwarder(
-    mut rx: broadcast::Receiver<BusEvent>,
+    mut rx: broadcast::Receiver<SharedEvent>,
     filter: TopicFilter,
     out: mpsc::Sender<Bytes>,
 ) -> JoinHandle<()> {
@@ -213,8 +332,8 @@ mod tests {
         TopicFilter::new(&owned).unwrap()
     }
 
-    fn process_event(id: u32, event: ProcessEventKind) -> BusEvent {
-        BusEvent::Process {
+    fn process_event(id: u32, event: ProcessEventKind) -> SharedEvent {
+        SharedEvent::new(BusEvent::Process {
             event,
             info: ProcessInfo::builder(id, format!("sheep-{id}"), ProcStatus::Online)
                 .pid(Some(1000 + id))
@@ -223,7 +342,7 @@ mod tests {
                 .build(),
             manually: false,
             at_ms: 0,
-        }
+        })
     }
 
     #[test]
@@ -304,10 +423,13 @@ mod tests {
         let handle = spawn_forwarder(rx, filter(&["process.*"]), out_tx);
 
         tx.send(process_event(0, ProcessEventKind::Start)).unwrap();
-        tx.send(BusEvent::LogOut {
-            id: 0,
-            line: "noise".to_string(),
-        })
+        tx.send(
+            BusEvent::LogOut {
+                id: 0,
+                line: "noise".to_string(),
+            }
+            .into(),
+        )
         .unwrap();
         tx.send(process_event(0, ProcessEventKind::Online)).unwrap();
         drop(tx);
@@ -337,13 +459,123 @@ mod tests {
         );
     }
 
+    /// Fails if every subscriber encodes its own copy of the same event.
+    ///
+    /// That cost is linear in attached clients, and it is the measured one:
+    /// a sheep logging 7,315 lines/s cost the daemon 23.99% of a core with
+    /// nobody watching and 37.50% with ONE `shep bleats` attached.
+    ///
+    /// Two assertions, and the second is the one that matters here. Byte
+    /// equality is the wire contract, which a per-subscriber encode would
+    /// also satisfy; SAME-BUFFER identity is what says the encode ran once
+    /// and the rest of the subscribers cloned a refcount.
+    #[tokio::test(start_paused = true)]
+    async fn every_subscriber_gets_the_same_frame_from_one_encode() {
+        let (tx, _keep) = tokio::sync::broadcast::channel(16);
+        let mut outs = Vec::new();
+        let mut forwarders = Vec::new();
+        for _ in 0..3 {
+            let (out_tx, out_rx) = tokio::sync::mpsc::channel(16);
+            forwarders.push(spawn_forwarder(tx.subscribe(), filter(&["*"]), out_tx));
+            outs.push(out_rx);
+        }
+
+        let published = process_event(7, ProcessEventKind::Online);
+        tx.send(published.clone()).unwrap();
+        drop(tx); // buffered events are delivered before the close is seen
+
+        let mut frames = Vec::new();
+        for out in &mut outs {
+            frames.push(
+                out.recv()
+                    .await
+                    .expect("every subscriber must receive the event"),
+            );
+        }
+        for forwarder in forwarders {
+            forwarder.await.unwrap();
+        }
+
+        let (first, rest) = frames
+            .split_first()
+            .expect("three subscribers, three frames");
+        assert_eq!(
+            decode_frame::<BusEvent>(first).unwrap(),
+            published.to_event(),
+            "sharing the frame must not change what is on the wire"
+        );
+        for frame in rest {
+            assert_eq!(frame, first, "every subscriber must see identical bytes");
+            assert_eq!(
+                frame.as_ptr(),
+                first.as_ptr(),
+                "identical bytes are not enough: they must be the SAME buffer, \
+                 or the daemon encoded this event once per subscriber"
+            );
+        }
+    }
+
+    /// Fails if [`encode_frame`] runs once per subscriber rather than once
+    /// per event.
+    ///
+    /// A count rather than a clock: the cost is linear in attached clients,
+    /// which is a fact about how many times a function ran and about nothing
+    /// else. Zero before anyone asks is half the claim — a `SharedEvent`
+    /// that eagerly encoded would charge every publisher for subscribers
+    /// that may not exist.
+    #[tokio::test(start_paused = true)]
+    async fn encode_frame_runs_once_per_event_however_many_subscribers() {
+        const SUBSCRIBERS: usize = 5;
+        let (tx, _keep) = tokio::sync::broadcast::channel(16);
+        let mut outs = Vec::new();
+        let mut forwarders = Vec::new();
+        for _ in 0..SUBSCRIBERS {
+            let (out_tx, out_rx) = tokio::sync::mpsc::channel(16);
+            forwarders.push(spawn_forwarder(tx.subscribe(), filter(&["*"]), out_tx));
+            outs.push(out_rx);
+        }
+
+        let published = process_event(11, ProcessEventKind::Start);
+        assert_eq!(
+            published.encodes(),
+            0,
+            "publishing must not encode before a subscriber needs the bytes"
+        );
+
+        tx.send(published.clone()).unwrap();
+        drop(tx);
+
+        let mut frames = Vec::new();
+        for out in &mut outs {
+            frames.push(
+                out.recv()
+                    .await
+                    .expect("every subscriber must receive the event"),
+            );
+        }
+        for forwarder in forwarders {
+            forwarder.await.unwrap();
+        }
+
+        assert_eq!(
+            published.encodes(),
+            1,
+            "{SUBSCRIBERS} subscribers, one encode"
+        );
+        assert_eq!(frames.len(), SUBSCRIBERS);
+        let (first, rest) = frames.split_first().expect("one frame per subscriber");
+        for frame in rest {
+            assert_eq!(frame, first, "every subscriber must see identical bytes");
+        }
+    }
+
     #[tokio::test(start_paused = true)]
     async fn forwarder_stops_when_the_subscriber_hangs_up() {
         let (tx, rx) = tokio::sync::broadcast::channel(16);
         let (out_tx, out_rx) = tokio::sync::mpsc::channel(1);
         let handle = spawn_forwarder(rx, filter(&["*"]), out_tx);
         drop(out_rx);
-        tx.send(BusEvent::DaemonShutdown).unwrap();
+        tx.send(BusEvent::DaemonShutdown.into()).unwrap();
         handle.await.unwrap(); // resolves rather than leaking a task
     }
 }

--- a/crates/shep-daemon/src/cron.rs
+++ b/crates/shep-daemon/src/cron.rs
@@ -305,7 +305,7 @@ mod tests {
         tempfile::TempDir,
     ) {
         let dir = tempfile::tempdir().unwrap();
-        let (events, rx) = broadcast::channel(64);
+        let (events, rx) = crate::bus::test_bus(64);
         let runner = ScriptedRunner::new(scripts);
         let handle = spawn_supervisor(runner, test_paths(&dir), events);
         (handle, rx, dir)

--- a/crates/shep-daemon/src/cron.rs
+++ b/crates/shep-daemon/src/cron.rs
@@ -258,6 +258,7 @@ mod tests {
     use tokio::sync::broadcast;
 
     use super::*;
+    use crate::bus::SharedEvent;
     use crate::fake::{ProcScript, ScriptedRunner};
     use crate::supervisor::spawn_supervisor;
     use crate::testing::{TestClock, test_paths};
@@ -287,7 +288,7 @@ mod tests {
     /// cron-triggered restarts in any single test below.
     fn spawn_test_fixture() -> (
         SupervisorHandle,
-        broadcast::Receiver<BusEvent>,
+        broadcast::Receiver<SharedEvent>,
         tempfile::TempDir,
     ) {
         spawn_test_fixture_with(vec![ProcScript::never_exits(); 8])
@@ -300,7 +301,7 @@ mod tests {
         scripts: Vec<ProcScript>,
     ) -> (
         SupervisorHandle,
-        broadcast::Receiver<BusEvent>,
+        broadcast::Receiver<SharedEvent>,
         tempfile::TempDir,
     ) {
         let dir = tempfile::tempdir().unwrap();
@@ -342,9 +343,12 @@ mod tests {
     /// Waits for the next `BusEvent::Process { event: Restart, .. }` for
     /// `name`, wrapped in a timeout so a worker that never restarts fails
     /// the test instead of hanging it (rule 4).
-    async fn expect_restart(rx: &mut broadcast::Receiver<BusEvent>, name: &str) -> ProcessInfo {
+    async fn expect_restart(rx: &mut broadcast::Receiver<SharedEvent>, name: &str) -> ProcessInfo {
         loop {
-            match tokio::time::timeout(EVENT_WAIT, rx.recv()).await {
+            match tokio::time::timeout(EVENT_WAIT, rx.recv())
+                .await
+                .map(|received| received.map(|event| event.to_event()))
+            {
                 Ok(Ok(BusEvent::Process {
                     event: ProcessEventKind::Restart,
                     info,
@@ -361,9 +365,9 @@ mod tests {
     /// Drains every already-queued event, panicking if any of them is a
     /// `Restart` for `name` — a claim that nothing happened, so it reads
     /// with `try_recv` rather than waiting on the (paused) clock to move.
-    fn assert_no_restart_pending(rx: &mut broadcast::Receiver<BusEvent>, name: &str) {
+    fn assert_no_restart_pending(rx: &mut broadcast::Receiver<SharedEvent>, name: &str) {
         loop {
-            match rx.try_recv() {
+            match rx.try_recv().map(|event| event.to_event()) {
                 Ok(BusEvent::Process {
                     event: ProcessEventKind::Restart,
                     info,
@@ -386,14 +390,17 @@ mod tests {
     /// swap for the `try_recv` form when the caller already forced that
     /// round trip to settle (e.g. a prior [`expect_restart`]).
     async fn assert_no_restart_within(
-        rx: &mut broadcast::Receiver<BusEvent>,
+        rx: &mut broadcast::Receiver<SharedEvent>,
         name: &str,
         window: Duration,
     ) {
         let deadline = tokio::time::Instant::now() + window;
         loop {
             let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
-            match tokio::time::timeout(remaining, rx.recv()).await {
+            match tokio::time::timeout(remaining, rx.recv())
+                .await
+                .map(|received| received.map(|event| event.to_event()))
+            {
                 Err(_) => return, // window elapsed with nothing matching — expected
                 Ok(Ok(BusEvent::Process {
                     event: ProcessEventKind::Restart,

--- a/crates/shep-daemon/src/dogs.rs
+++ b/crates/shep-daemon/src/dogs.rs
@@ -562,7 +562,7 @@ mod tests {
     async fn the_shepherd_records_a_dog_that_gave_up_and_leaves_the_sheep_to_bark() {
         let dir = tempfile::tempdir().unwrap();
         let barks_path = dir.path().join("barks.jsonl");
-        let (events, rx) = broadcast::channel(16);
+        let (events, rx) = crate::bus::test_bus(16);
         let watch = spawn_dog_watch(rx, barks_path.clone());
 
         events.send(errored_event("web", None)).unwrap();
@@ -589,7 +589,7 @@ mod tests {
     async fn a_dog_that_merely_exited_is_not_recorded() {
         let dir = tempfile::tempdir().unwrap();
         let barks_path = dir.path().join("barks.jsonl");
-        let (events, rx) = broadcast::channel(16);
+        let (events, rx) = crate::bus::test_bus(16);
         let watch = spawn_dog_watch(rx, barks_path.clone());
 
         events

--- a/crates/shep-daemon/src/dogs.rs
+++ b/crates/shep-daemon/src/dogs.rs
@@ -41,6 +41,7 @@ use shep_core::paths::ShepPaths;
 use shep_core::protocol::{BusEvent, DogSource, ProcessEventKind};
 use tokio::sync::broadcast::{self, error::RecvError};
 
+use crate::bus::SharedEvent;
 use crate::supervisor::SupervisorHandle;
 
 /// One dog the daemon knows about: its name, and where its binary comes from.
@@ -279,7 +280,7 @@ pub fn dog_section(path: &Path, name: &str) -> Result<String, DogError> {
 /// drops, and holding the handle is what makes the end deterministic rather
 /// than dependent on sender count.
 pub fn spawn_dog_watch(
-    mut events: broadcast::Receiver<BusEvent>,
+    mut events: broadcast::Receiver<SharedEvent>,
     barks: PathBuf,
 ) -> tokio::task::JoinHandle<()> {
     tokio::spawn(async move {
@@ -292,14 +293,17 @@ pub fn spawn_dog_watch(
                 // is excluded too: it fires on every restart a dog survives,
                 // and a `barks.jsonl` full of those is one an operator stops
                 // reading.
-                Ok(BusEvent::Process {
-                    event: ProcessEventKind::Errored,
-                    info,
-                    ..
-                }) if info.dog.is_some() => {
-                    record_dog_errored(&barks, &info.name, info.restarts);
+                Ok(event) => {
+                    if let BusEvent::Process {
+                        event: ProcessEventKind::Errored,
+                        info,
+                        ..
+                    } = &*event
+                        && info.dog.is_some()
+                    {
+                        record_dog_errored(&barks, &info.name, info.restarts);
+                    }
                 }
-                Ok(_) => {}
                 // The bus DROPS events for a lagging subscriber rather than
                 // queuing them (`tokio::sync::broadcast`'s own contract), so
                 // a dog's death notice may be among what this receiver just
@@ -515,8 +519,8 @@ mod tests {
 
     /// A minimal `Process` bus event, `name` carrying either a sheep's or a
     /// dog's entry depending on `dog`.
-    fn process_event(name: &str, kind: ProcessEventKind, dog: Option<DogSource>) -> BusEvent {
-        BusEvent::Process {
+    fn process_event(name: &str, kind: ProcessEventKind, dog: Option<DogSource>) -> SharedEvent {
+        SharedEvent::new(BusEvent::Process {
             event: kind,
             info: ProcessInfo::builder(1, name, ProcStatus::Errored)
                 .restarts(16)
@@ -524,10 +528,10 @@ mod tests {
                 .build(),
             manually: false,
             at_ms: 1_700_000_000_000,
-        }
+        })
     }
 
-    fn errored_event(name: &str, dog: Option<DogSource>) -> BusEvent {
+    fn errored_event(name: &str, dog: Option<DogSource>) -> SharedEvent {
         process_event(name, ProcessEventKind::Errored, dog)
     }
 

--- a/crates/shep-daemon/src/extras.rs
+++ b/crates/shep-daemon/src/extras.rs
@@ -745,7 +745,7 @@ mod tests {
         tempfile::TempDir,
     ) {
         let dir = tempfile::tempdir().unwrap();
-        let (events, rx) = broadcast::channel(64);
+        let (events, rx) = crate::bus::test_bus(64);
         let runner = ScriptedRunner::new(vec![ProcScript::never_exits(); 12]);
         let handle = spawn_supervisor(runner, test_paths(&dir), events);
         (handle, rx, dir)

--- a/crates/shep-daemon/src/extras.rs
+++ b/crates/shep-daemon/src/extras.rs
@@ -653,6 +653,7 @@ mod tests {
     use tokio::sync::broadcast;
 
     use super::*;
+    use crate::bus::SharedEvent;
     use crate::cron::DEFAULT_MAX_CRON_SLEEP;
     use crate::fake::{ProcScript, ScriptedRunner};
     use crate::limits::PollingEnforcer;
@@ -740,7 +741,7 @@ mod tests {
     /// the supervisor emit `Errored`, not `Restart`).
     fn spawn_test_fixture() -> (
         SupervisorHandle,
-        broadcast::Receiver<BusEvent>,
+        broadcast::Receiver<SharedEvent>,
         tempfile::TempDir,
     ) {
         let dir = tempfile::tempdir().unwrap();
@@ -779,7 +780,7 @@ mod tests {
     /// Waits up to `window` for a `Restart` naming `name`, panicking if none
     /// arrives.
     async fn expect_restart(
-        rx: &mut broadcast::Receiver<BusEvent>,
+        rx: &mut broadcast::Receiver<SharedEvent>,
         name: &str,
         window: Duration,
     ) -> ProcessInfo {
@@ -794,13 +795,13 @@ mod tests {
     /// because only the handful of cases below read the flag, and every other
     /// caller wants the snapshot alone.
     async fn expect_restart_event(
-        rx: &mut broadcast::Receiver<BusEvent>,
+        rx: &mut broadcast::Receiver<SharedEvent>,
         name: &str,
         window: Duration,
     ) -> (ProcessInfo, bool) {
         let restart = async {
             loop {
-                match rx.recv().await {
+                match rx.recv().await.map(|event| event.to_event()) {
                     Ok(BusEvent::Process {
                         event: ProcessEventKind::Restart,
                         info,
@@ -827,14 +828,17 @@ mod tests {
     /// the occurrence the abort was supposed to stop, so the same call both
     /// crosses it and makes the claim.
     async fn assert_no_restart_within(
-        rx: &mut broadcast::Receiver<BusEvent>,
+        rx: &mut broadcast::Receiver<SharedEvent>,
         name: &str,
         window: Duration,
     ) {
         let deadline = tokio::time::Instant::now() + window;
         loop {
             let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
-            match tokio::time::timeout(remaining, rx.recv()).await {
+            match tokio::time::timeout(remaining, rx.recv())
+                .await
+                .map(|received| received.map(|event| event.to_event()))
+            {
                 Err(_) => return, // window elapsed with nothing matching — expected
                 Ok(Ok(BusEvent::Process {
                     event: ProcessEventKind::Restart,
@@ -2014,14 +2018,14 @@ mod tests {
     /// swap puts two entries under ONE name, so a name alone cannot say which
     /// half of it an event is about.
     async fn expect_process_event(
-        rx: &mut broadcast::Receiver<BusEvent>,
+        rx: &mut broadcast::Receiver<SharedEvent>,
         id: u32,
         kind: ProcessEventKind,
         window: Duration,
     ) {
         let wanted = async {
             loop {
-                match rx.recv().await {
+                match rx.recv().await.map(|event| event.to_event()) {
                     Ok(BusEvent::Process { event, info, .. }) if event == kind && info.id == id => {
                         return;
                     }

--- a/crates/shep-daemon/src/lib.rs
+++ b/crates/shep-daemon/src/lib.rs
@@ -104,7 +104,7 @@
 //! let paths = ShepPaths::resolve(&|_| None, Path::new("/tmp/shep-example"));
 //!
 //! // Create the event bus every subscriber reads
-//! let events = shep_daemon::bus::new_bus();
+//! let events = shep_daemon::new_bus();
 //!
 //! // Spawn the supervisor actor
 //! let handle = spawn_supervisor(runner, paths, events);
@@ -220,6 +220,10 @@
 pub(crate) mod backoff;
 pub(crate) mod brain;
 pub(crate) mod bus;
+// The bus surface a caller of [`supervisor::spawn_supervisor`] needs, and no
+// more: the module stays crate-private so its internals (forwarders, topic
+// bookkeeping) never become API by accident.
+pub use bus::{Bus, SharedEvent, new_bus};
 pub(crate) mod cron;
 pub(crate) mod entry;
 pub(crate) mod extras;

--- a/crates/shep-daemon/src/lib.rs
+++ b/crates/shep-daemon/src/lib.rs
@@ -103,8 +103,8 @@
 //! // Set up temporary paths for this example
 //! let paths = ShepPaths::resolve(&|_| None, Path::new("/tmp/shep-example"));
 //!
-//! // Create a broadcast channel for events
-//! let (events, _rx) = tokio::sync::broadcast::channel(64);
+//! // Create the event bus every subscriber reads
+//! let events = shep_daemon::bus::new_bus();
 //!
 //! // Spawn the supervisor actor
 //! let handle = spawn_supervisor(runner, paths, events);

--- a/crates/shep-daemon/src/rpc.rs
+++ b/crates/shep-daemon/src/rpc.rs
@@ -22,7 +22,7 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use tokio::sync::{broadcast, watch};
+use tokio::sync::watch;
 
 use shep_core::config::normalize_all;
 use shep_core::paths::ShepPaths;
@@ -32,7 +32,7 @@ use shep_core::protocol::{
 use shep_core::selector::ProcessSelector;
 use shep_core::signals::OperatorSignal;
 
-use crate::bus::{SharedEvent, TopicFilter};
+use crate::bus::{Bus, TopicFilter};
 use crate::dogs::DogSpec;
 use crate::limits::stats::StatsState;
 use crate::snapshot::{FlockRegistry, SnapshotError, write_atomic};
@@ -60,7 +60,7 @@ pub struct RpcContext {
     /// The daemon-wide event bus; `Subscribe` compiles a [`TopicFilter`] the
     /// connection layer hands to [`crate::bus::spawn_forwarder`] alongside a
     /// receiver off this sender.
-    pub(crate) events: broadcast::Sender<SharedEvent>,
+    pub(crate) events: Bus,
     /// The muster roll's in-memory app registry — `Start` records into it.
     pub(crate) registry: FlockRegistry,
     /// Where [`Self::snapshot_now`] writes the muster roll.

--- a/crates/shep-daemon/src/rpc.rs
+++ b/crates/shep-daemon/src/rpc.rs
@@ -27,13 +27,12 @@ use tokio::sync::{broadcast, watch};
 use shep_core::config::normalize_all;
 use shep_core::paths::ShepPaths;
 use shep_core::protocol::{
-    BusEvent, Envelope, Lamb, ProcessInfo, Reply, Request, Response, RpcError, RpcErrorCode,
-    SelectorSpec,
+    Envelope, Lamb, ProcessInfo, Reply, Request, Response, RpcError, RpcErrorCode, SelectorSpec,
 };
 use shep_core::selector::ProcessSelector;
 use shep_core::signals::OperatorSignal;
 
-use crate::bus::TopicFilter;
+use crate::bus::{SharedEvent, TopicFilter};
 use crate::dogs::DogSpec;
 use crate::limits::stats::StatsState;
 use crate::snapshot::{FlockRegistry, SnapshotError, write_atomic};
@@ -61,7 +60,7 @@ pub struct RpcContext {
     /// The daemon-wide event bus; `Subscribe` compiles a [`TopicFilter`] the
     /// connection layer hands to [`crate::bus::spawn_forwarder`] alongside a
     /// receiver off this sender.
-    pub(crate) events: broadcast::Sender<BusEvent>,
+    pub(crate) events: broadcast::Sender<SharedEvent>,
     /// The muster roll's in-memory app registry — `Start` records into it.
     pub(crate) registry: FlockRegistry,
     /// Where [`Self::snapshot_now`] writes the muster roll.

--- a/crates/shep-daemon/src/runner.rs
+++ b/crates/shep-daemon/src/runner.rs
@@ -130,12 +130,12 @@ pub enum LogCtl {
         /// moment apart, and neither is a reopen that failed.
         done: oneshot::Sender<Result<(), ReopenError>>,
     },
-    /// Wait for every write already handed to the blocking pool to reach the
-    /// file, keeping the handle, then acknowledge. Sent as the first half of
+    /// Write out whatever the pump has buffered, wait for it to reach the
+    /// file, keep the handle, then acknowledge. Sent as the first half of
     /// `shep flush`, immediately before the recorded paths are truncated.
     Flush {
-        /// Fires once both handles have no write left in flight, carrying
-        /// what came of it.
+        /// Fires once both handles have nothing buffered and no write left
+        /// in flight, carrying what came of it.
         ///
         /// The acknowledgement is the barrier the truncate that follows is
         /// ordered against: `write_all` on a [`tokio::fs::File`] returns as

--- a/crates/shep-daemon/src/server.rs
+++ b/crates/shep-daemon/src/server.rs
@@ -516,6 +516,7 @@ mod tests {
     // clock the runtime auto-advances whenever it goes idle, which can expire
     // HANDSHAKE_TIMEOUT_MS before the peer's bytes are delivered.
     use super::*;
+    use crate::bus::SharedEvent;
     use crate::testing::harness;
     use futures_util::{SinkExt, StreamExt};
     use serde::Serialize;
@@ -676,23 +677,29 @@ mod tests {
         let frame: ServerFrame = client.recv().await;
         assert!(matches!(frame, ServerFrame::Reply(ref r) if r.result == Ok(Response::Subscribed)));
 
-        let event = |kind| BusEvent::Process {
-            event: kind,
-            info: ProcessInfo::builder(0, "web", shep_core::status::ProcStatus::Online)
-                .pid(Some(1000))
-                .out_file(Some("/logs/web-0-out.log".to_string()))
-                .err_file(Some("/logs/web-0-err.log".to_string()))
-                .build(),
-            manually: false,
-            at_ms: 0,
+        let event = |kind| -> SharedEvent {
+            BusEvent::Process {
+                event: kind,
+                info: ProcessInfo::builder(0, "web", shep_core::status::ProcStatus::Online)
+                    .pid(Some(1000))
+                    .out_file(Some("/logs/web-0-out.log".to_string()))
+                    .err_file(Some("/logs/web-0-err.log".to_string()))
+                    .build(),
+                manually: false,
+                at_ms: 0,
+            }
+            .into()
         };
         h.ctx.events.send(event(ProcessEventKind::Start)).unwrap();
         h.ctx
             .events
-            .send(BusEvent::LogOut {
-                id: 0,
-                line: "filtered".to_string(),
-            })
+            .send(
+                BusEvent::LogOut {
+                    id: 0,
+                    line: "filtered".to_string(),
+                }
+                .into(),
+            )
             .unwrap();
         h.ctx.events.send(event(ProcessEventKind::Online)).unwrap();
 
@@ -847,10 +854,13 @@ mod tests {
         for i in 0..flood {
             h.ctx
                 .events
-                .send(BusEvent::LogOut {
-                    id: 0,
-                    line: format!("line-{i}"),
-                })
+                .send(
+                    BusEvent::LogOut {
+                        id: 0,
+                        line: format!("line-{i}"),
+                    }
+                    .into(),
+                )
                 .unwrap();
         }
 

--- a/crates/shep-daemon/src/server.rs
+++ b/crates/shep-daemon/src/server.rs
@@ -447,7 +447,7 @@ async fn read_loop(
                 // A second Subscribe REPLACES the first: spec §6 gives a
                 // connection one topic list, not a growing union.
                 if let Some(old) =
-                    forwarder.replace(spawn_forwarder(ctx.events.subscribe(), filter, out.clone()))
+                    forwarder.replace(spawn_forwarder(&ctx.events, filter, out.clone()))
                 {
                     old.abort();
                 }

--- a/crates/shep-daemon/src/snapshot.rs
+++ b/crates/shep-daemon/src/snapshot.rs
@@ -852,7 +852,7 @@ mod tests {
         };
         write_atomic(&paths.snapshot, &roll).unwrap();
 
-        let (events, _rx) = tokio::sync::broadcast::channel(64);
+        let (events, _rx) = crate::bus::test_bus(64);
         let handle = spawn_supervisor(
             ScriptedRunner::new(vec![ProcScript::never_exits()]),
             paths.clone(),
@@ -921,7 +921,7 @@ mod tests {
         };
         write_atomic(&paths.snapshot, &roll).unwrap();
 
-        let (events, _rx) = tokio::sync::broadcast::channel(64);
+        let (events, _rx) = crate::bus::test_bus(64);
         let handle = spawn_supervisor(
             // Two scripts for the two that must come up. `b-bad` consumes
             // none, so a run that let it take one would starve `c-good` and
@@ -1005,7 +1005,7 @@ mod tests {
         };
         write_atomic(&paths.snapshot, &roll).unwrap();
 
-        let (events, _rx) = tokio::sync::broadcast::channel(64);
+        let (events, _rx) = crate::bus::test_bus(64);
         let handle = spawn_supervisor(
             ScriptedRunner::new(vec![ProcScript::never_exits()]).refusing(&["gone"]),
             paths.clone(),
@@ -1055,7 +1055,7 @@ mod tests {
         };
         write_atomic(&paths.snapshot, &roll).unwrap();
 
-        let (events, _rx) = tokio::sync::broadcast::channel(64);
+        let (events, _rx) = crate::bus::test_bus(64);
         let handle = spawn_supervisor(
             ScriptedRunner::new(vec![ProcScript::never_exits()]),
             paths.clone(),
@@ -1088,7 +1088,7 @@ mod tests {
         std::fs::create_dir_all(paths.snapshot.parent().unwrap()).unwrap();
         assert!(!paths.snapshot.exists());
 
-        let (events, _rx) = tokio::sync::broadcast::channel(64);
+        let (events, _rx) = crate::bus::test_bus(64);
         let handle = spawn_supervisor(
             ScriptedRunner::new(vec![ProcScript::never_exits()]),
             paths.clone(),
@@ -1109,7 +1109,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let paths = test_paths(&dir);
         std::fs::create_dir_all(&paths.home).unwrap();
-        let (events, _keep) = tokio::sync::broadcast::channel(64);
+        let (events, _keep) = crate::bus::test_bus(64);
         let supervisor = spawn_supervisor(
             ScriptedRunner::new(vec![ProcScript::never_exits()]),
             paths.clone(),
@@ -1158,7 +1158,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let paths = test_paths(&dir);
         std::fs::create_dir_all(&paths.home).unwrap();
-        let (events, _keep) = tokio::sync::broadcast::channel(64);
+        let (events, _keep) = crate::bus::test_bus(64);
         let supervisor = spawn_supervisor(
             ScriptedRunner::new(vec![ProcScript::never_exits()]),
             paths.clone(),

--- a/crates/shep-daemon/src/snapshot.rs
+++ b/crates/shep-daemon/src/snapshot.rs
@@ -44,6 +44,7 @@ use shep_core::config::{AppConfig, NormalizeError, ResolvedApp, normalize};
 use shep_core::protocol::{BusEvent, ProcessInfo};
 use shep_core::status::ProcStatus;
 
+use crate::bus::SharedEvent;
 use crate::supervisor::SupervisorHandle;
 
 /// Schema version of `flock.json`
@@ -517,7 +518,7 @@ pub(crate) fn spawn_snapshot_writer(
     path: PathBuf,
     supervisor: SupervisorHandle,
     registry: FlockRegistry,
-    events: broadcast::Receiver<BusEvent>,
+    events: broadcast::Receiver<SharedEvent>,
 ) -> SnapshotWriter {
     let writes = Arc::new(AtomicU64::new(0));
     let task_writes = Arc::clone(&writes);
@@ -532,7 +533,7 @@ async fn run_writer(
     path: PathBuf,
     supervisor: SupervisorHandle,
     registry: FlockRegistry,
-    mut events: broadcast::Receiver<BusEvent>,
+    mut events: broadcast::Receiver<SharedEvent>,
     writes: Arc<AtomicU64>,
 ) {
     let mut deadline: Option<Instant> = None;
@@ -1132,12 +1133,15 @@ mod tests {
             ProcessEventKind::Online,
         ] {
             events
-                .send(BusEvent::Process {
-                    event,
-                    info: info(0, "web", ProcStatus::Online),
-                    manually: false,
-                    at_ms: 0,
-                })
+                .send(
+                    BusEvent::Process {
+                        event,
+                        info: info(0, "web", ProcStatus::Online),
+                        manually: false,
+                        at_ms: 0,
+                    }
+                    .into(),
+                )
                 .unwrap();
         }
         tokio::time::sleep(Duration::from_millis(SNAPSHOT_DEBOUNCE_MS + 1)).await;
@@ -1168,10 +1172,13 @@ mod tests {
         );
         for id in 0..50 {
             events
-                .send(BusEvent::LogOut {
-                    id,
-                    line: "chatty".to_string(),
-                })
+                .send(
+                    BusEvent::LogOut {
+                        id,
+                        line: "chatty".to_string(),
+                    }
+                    .into(),
+                )
                 .unwrap();
         }
         tokio::time::sleep(Duration::from_millis(SNAPSHOT_DEBOUNCE_MS * 4)).await;

--- a/crates/shep-daemon/src/supervisor.rs
+++ b/crates/shep-daemon/src/supervisor.rs
@@ -42,7 +42,7 @@ use std::io;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-use tokio::sync::{broadcast, mpsc, oneshot};
+use tokio::sync::{mpsc, oneshot};
 
 use shep_core::config::{AppConfig, ResolvedApp, normalize};
 use shep_core::paths::ShepPaths;
@@ -56,7 +56,7 @@ use shep_core::status::ProcStatus;
 
 use crate::assemble::{assemble, instance_slots};
 use crate::brain::{Decision, decide_on_exit};
-use crate::bus::SharedEvent;
+use crate::bus::{Bus, SharedEvent};
 use crate::channel::{ChildMessage, ShepherdMessage};
 use crate::entry::{ProcessEntry, ReloadState, RestartBudget};
 use crate::extras::{Extras, ExtrasRegistry};
@@ -1436,7 +1436,7 @@ impl SupervisorHandle {
 pub(crate) struct SupervisorBuilder<R: ProcessRunner> {
     runner: R,
     paths: ShepPaths,
-    events: broadcast::Sender<SharedEvent>,
+    events: Bus,
     extras: Option<Extras>,
 }
 
@@ -1446,7 +1446,7 @@ impl<R: ProcessRunner> SupervisorBuilder<R> {
     ///
     /// `events` receives [`BusEvent::Process`] (+ `LogOut`/`LogErr` forwarded
     /// from each sheep's `ProcIo::logs`).
-    pub(crate) fn new(runner: R, paths: ShepPaths, events: broadcast::Sender<SharedEvent>) -> Self {
+    pub(crate) fn new(runner: R, paths: ShepPaths, events: Bus) -> Self {
         Self {
             runner,
             paths,
@@ -1496,7 +1496,7 @@ impl<R: ProcessRunner> SupervisorBuilder<R> {
 pub fn spawn_supervisor<R: ProcessRunner>(
     runner: R,
     paths: ShepPaths,
-    events: broadcast::Sender<SharedEvent>,
+    events: Bus,
 ) -> SupervisorHandle {
     SupervisorBuilder::new(runner, paths, events).spawn()
 }
@@ -2229,7 +2229,7 @@ struct Actor<R: ProcessRunner> {
     /// `$SHEP_HOME` layout, for assembling spawn specs.
     paths: ShepPaths,
     /// Bus: process lifecycle events + forwarded logs.
-    events: broadcast::Sender<SharedEvent>,
+    events: Bus,
     /// Clone handed to sheep tasks and restart timers so they can report
     /// back into this same actor's mailbox.
     tx: mpsc::Sender<Msg>,
@@ -7337,7 +7337,7 @@ fn spawn_sheep_task<P: RunningProcess>(
     proc: P,
     io: ProcIo,
     app: ResolvedApp,
-    events: broadcast::Sender<SharedEvent>,
+    events: Bus,
     actor_tx: mpsc::Sender<Msg>,
 ) -> SheepHandles {
     let (ctl_tx, ctl_rx) = mpsc::channel(SHEEP_CTL_CAPACITY);
@@ -7387,7 +7387,7 @@ async fn run_sheep<P: RunningProcess>(
     app: ResolvedApp,
     mut ctl_rx: mpsc::Receiver<SheepCtl>,
     mut signal_rx: mpsc::Receiver<SignalRequest>,
-    events: broadcast::Sender<SharedEvent>,
+    events: Bus,
     actor_tx: mpsc::Sender<Msg>,
 ) {
     // `io` is destructured here, in the task's own body, and that placement
@@ -7462,12 +7462,16 @@ async fn run_sheep<P: RunningProcess>(
             maybe_line = logs.recv(), if logs_open => {
                 match maybe_line {
                     Some(line) => {
-                        let event = if line.err {
+                        // Through the bus's own gate rather than `send`: with
+                        // nobody subscribed to a log topic this costs one
+                        // relaxed load, where a publish costs an allocation,
+                        // the ring's mutex, and a wakeup for each of the two
+                        // subscribers the daemon always has.
+                        events.publish_log(if line.err {
                             BusEvent::LogErr { id, line: line.line }
                         } else {
                             BusEvent::LogOut { id, line: line.line }
-                        };
-                        let _ = events.send(SharedEvent::new(event));
+                        });
                     }
                     None => logs_open = false,
                 }
@@ -7618,7 +7622,7 @@ mod tests {
     // on the shepherd channel's ready signal
     #[tokio::test(start_paused = true)]
     async fn wait_ready_app_stays_starting_until_the_channel_signals() {
-        let (events, mut rx) = tokio::sync::broadcast::channel(64);
+        let (events, mut rx) = crate::bus::test_bus(64);
         let runner = ScriptedRunner::new(vec![ProcScript::never_exits()]);
         let dir = tempfile::tempdir().unwrap();
         let handle = spawn_supervisor(runner, test_paths(&dir), events);
@@ -7670,7 +7674,7 @@ mod tests {
         let addr = reserved.local_addr().unwrap();
         drop(reserved);
 
-        let (events, mut rx) = tokio::sync::broadcast::channel(64);
+        let (events, mut rx) = crate::bus::test_bus(64);
         let runner = ScriptedRunner::new(vec![ProcScript::never_exits()]);
         let dir = tempfile::tempdir().unwrap();
         let handle = spawn_supervisor(runner, test_paths(&dir), events);
@@ -7724,7 +7728,7 @@ mod tests {
     #[cfg(unix)]
     #[tokio::test]
     async fn an_exec_readiness_probe_sees_the_assembled_env_not_the_apps_own() {
-        let (events, mut rx) = tokio::sync::broadcast::channel(64);
+        let (events, mut rx) = crate::bus::test_bus(64);
         let runner = ScriptedRunner::new(vec![ProcScript::never_exits()]);
         let dir = tempfile::tempdir().unwrap();
         // Instance 0 is the only slot a single-instance app gets, so this is
@@ -7775,7 +7779,7 @@ mod tests {
     // through the readiness wait.
     #[tokio::test(start_paused = true)]
     async fn a_gated_apps_online_carries_the_same_manually_flag_an_ungated_one_does() {
-        let (events, mut rx) = tokio::sync::broadcast::channel(64);
+        let (events, mut rx) = crate::bus::test_bus(64);
         let runner = ScriptedRunner::new(vec![
             ProcScript::never_exits(), // id 0: gated
             ProcScript::never_exits(), // id 1: ungated
@@ -7848,7 +7852,7 @@ mod tests {
     // stops reading the origin at all and reports every restart as automatic.
     #[tokio::test(start_paused = true)]
     async fn an_operators_restart_is_reported_as_a_user_action() {
-        let (events, mut rx) = tokio::sync::broadcast::channel(64);
+        let (events, mut rx) = crate::bus::test_bus(64);
         // Two: the sheep, and the respawn the restart performs. One would
         // leave that respawn `SpawnFailed("script exhausted")`, which emits
         // `Errored` instead of `Restart` — and `await_event` would then wait
@@ -7881,7 +7885,7 @@ mod tests {
     // restart loop, exactly what max_restarts exists to contain
     #[tokio::test(start_paused = true)]
     async fn a_gated_app_whose_deadline_elapses_goes_online_anyway() {
-        let (events, mut rx) = tokio::sync::broadcast::channel(64);
+        let (events, mut rx) = crate::bus::test_bus(64);
         let runner = ScriptedRunner::new(vec![ProcScript::never_exits()]);
         let dir = tempfile::tempdir().unwrap();
         let handle = spawn_supervisor(runner, test_paths(&dir), events);
@@ -7910,7 +7914,7 @@ mod tests {
     // respawn path.
     #[tokio::test(start_paused = true)]
     async fn a_gated_app_that_exits_while_starting_never_reaches_online_from_the_old_wait() {
-        let (events, mut rx) = tokio::sync::broadcast::channel(64);
+        let (events, mut rx) = crate::bus::test_bus(64);
         let runner = ScriptedRunner::new(vec![
             ProcScript::stable_then_exit(500, 1), // unstable exit while Starting
             ProcScript::never_exits(),            // the automatic respawn
@@ -7973,7 +7977,7 @@ mod tests {
     // specifically (the epoch check alone would let this one through).
     #[tokio::test(start_paused = true)]
     async fn a_gated_app_stopped_while_starting_ignores_the_old_wait() {
-        let (events, mut rx) = tokio::sync::broadcast::channel(64);
+        let (events, mut rx) = crate::bus::test_bus(64);
         let runner = ScriptedRunner::new(vec![ProcScript::stable_then_exit(500, 1)]);
         let dir = tempfile::tempdir().unwrap();
         let handle = spawn_supervisor(runner, test_paths(&dir), events);
@@ -8004,7 +8008,7 @@ mod tests {
     // RESPAWNED process online instead of being dropped by the epoch guard
     #[tokio::test(start_paused = true)]
     async fn a_gated_app_restarted_while_starting_ignores_the_old_wait() {
-        let (events, mut rx) = tokio::sync::broadcast::channel(64);
+        let (events, mut rx) = crate::bus::test_bus(64);
         let runner =
             ScriptedRunner::new(vec![ProcScript::never_exits(), ProcScript::never_exits()]);
         let dir = tempfile::tempdir().unwrap();
@@ -8056,7 +8060,7 @@ mod tests {
 
     #[tokio::test(start_paused = true)]
     async fn start_lists_online_instances() {
-        let (events, _rx) = tokio::sync::broadcast::channel(64);
+        let (events, _rx) = crate::bus::test_bus(64);
         let runner =
             ScriptedRunner::new(vec![ProcScript::never_exits(), ProcScript::never_exits()]);
         let dir = tempfile::tempdir().unwrap();
@@ -8073,7 +8077,7 @@ mod tests {
 
     #[tokio::test(start_paused = true)]
     async fn listed_log_paths_are_the_derived_defaults() {
-        let (events, _rx) = tokio::sync::broadcast::channel(64);
+        let (events, _rx) = crate::bus::test_bus(64);
         let runner = ScriptedRunner::new(vec![ProcScript::never_exits()]);
         let dir = tempfile::tempdir().unwrap();
         let paths = test_paths(&dir);
@@ -8104,7 +8108,7 @@ mod tests {
         // the same app on purpose — the two resolve independently, and
         // pinning both here proves reporting one explicitly does not drag
         // the other off its default.
-        let (events, _rx) = tokio::sync::broadcast::channel(64);
+        let (events, _rx) = crate::bus::test_bus(64);
         let runner = ScriptedRunner::new(vec![ProcScript::never_exits()]);
         let dir = tempfile::tempdir().unwrap();
         let paths = test_paths(&dir);
@@ -8125,7 +8129,7 @@ mod tests {
 
     #[tokio::test(start_paused = true)]
     async fn crash_loop_erroreds_after_budget_with_pinned_delays() {
-        let (events, mut rx) = tokio::sync::broadcast::channel(1024);
+        let (events, mut rx) = crate::bus::test_bus(1024);
         // 16 spawns: initial + 15 restarts; every exit instant (unstable).
         let runner = ScriptedRunner::new((0..16).map(|_| ProcScript::const_exit(1)).collect());
         let dir = tempfile::tempdir().unwrap();
@@ -8168,7 +8172,7 @@ mod tests {
         // a still-buggy `>` check would consume a 17th spawn and report
         // restarts==16 instead. Real shipped default max_restarts (16, no
         // override) throughout.
-        let (events, mut rx) = tokio::sync::broadcast::channel(1024);
+        let (events, mut rx) = crate::bus::test_bus(1024);
         let runner = ScriptedRunner::new((0..20).map(|_| ProcScript::const_exit(1)).collect());
         let dir = tempfile::tempdir().unwrap();
         let handle = spawn_supervisor(runner, test_paths(&dir), events);
@@ -8185,7 +8189,7 @@ mod tests {
 
     #[tokio::test(start_paused = true)]
     async fn stable_run_resets_budget() {
-        let (events, mut rx) = tokio::sync::broadcast::channel(256);
+        let (events, mut rx) = crate::bus::test_bus(256);
         let mut script = vec![
             ProcScript::const_exit(1),
             ProcScript::const_exit(1),
@@ -8209,7 +8213,7 @@ mod tests {
 
     #[tokio::test(start_paused = true)]
     async fn manual_stop_prevents_restart() {
-        let (events, _rx) = tokio::sync::broadcast::channel(64);
+        let (events, _rx) = crate::bus::test_bus(64);
         let runner = ScriptedRunner::new(vec![ProcScript {
             delay_ms: u64::MAX,
             outcome: ExitOutcome {
@@ -8238,7 +8242,7 @@ mod tests {
 
     #[tokio::test(start_paused = true)]
     async fn stop_exit_codes_mean_clean_stop() {
-        let (events, mut rx) = tokio::sync::broadcast::channel(64);
+        let (events, mut rx) = crate::bus::test_bus(64);
         let runner = ScriptedRunner::new(vec![ProcScript::const_exit(0)]);
         let dir = tempfile::tempdir().unwrap();
         let handle = spawn_supervisor(runner, test_paths(&dir), events);
@@ -8251,7 +8255,7 @@ mod tests {
 
     #[tokio::test(start_paused = true)]
     async fn spawn_failure_surfaces_and_erroreds() {
-        let (events, _rx) = tokio::sync::broadcast::channel(64);
+        let (events, _rx) = crate::bus::test_bus(64);
         let runner = ScriptedRunner::new(vec![]); // exhausted immediately
         let dir = tempfile::tempdir().unwrap();
         let handle = spawn_supervisor(runner, test_paths(&dir), events);
@@ -8267,7 +8271,7 @@ mod tests {
     #[tokio::test(start_paused = true)]
     async fn an_unresolvable_user_fails_the_start() {
         let dir = tempfile::tempdir().unwrap();
-        let (events, _rx) = tokio::sync::broadcast::channel(64);
+        let (events, _rx) = crate::bus::test_bus(64);
         let handle = spawn_supervisor(
             ScriptedRunner::new(vec![ProcScript::never_exits()]),
             test_paths(&dir),
@@ -8298,7 +8302,7 @@ mod tests {
     #[tokio::test(start_paused = true)]
     async fn a_refusal_is_counted_once_per_app_not_once_per_failed_check() {
         let dir = tempfile::tempdir().unwrap();
-        let (events, _rx) = tokio::sync::broadcast::channel(64);
+        let (events, _rx) = crate::bus::test_bus(64);
         let handle = spawn_supervisor(
             // `refusing` is what makes this test able to fail. Without it
             // the fake answers `Preflight::Unknown` for everything, only the
@@ -8331,7 +8335,7 @@ mod tests {
 
     #[tokio::test(start_paused = true)]
     async fn delete_and_selectors_route() {
-        let (events, _rx) = tokio::sync::broadcast::channel(64);
+        let (events, _rx) = crate::bus::test_bus(64);
         let runner =
             ScriptedRunner::new(vec![ProcScript::never_exits(), ProcScript::never_exits()]);
         let dir = tempfile::tempdir().unwrap();
@@ -8388,7 +8392,7 @@ mod tests {
     // three restarts instead of carrying it to a fourth.
     #[tokio::test(start_paused = true)]
     async fn manual_restart_resets_budget_and_respawns() {
-        let (events, _rx) = tokio::sync::broadcast::channel(64);
+        let (events, _rx) = crate::bus::test_bus(64);
         // Five procs, sized against the mutation rather than against a correct
         // run: two unstable crashes, the long-lived proc they land on, the
         // respawn the manual restart performs (unstable again, to spend the
@@ -8478,7 +8482,7 @@ mod tests {
     // restarting it.
     #[tokio::test(start_paused = true)]
     async fn an_automatic_restart_resets_the_budget_like_an_operators_does() {
-        let (events, _rx) = tokio::sync::broadcast::channel(64);
+        let (events, _rx) = crate::bus::test_bus(64);
         // Five procs, which is the most this test can demand: two unstable
         // crashes, the long-lived proc they land on, the respawn the
         // automatic restart performs (unstable again, to spend the budget the
@@ -8566,7 +8570,7 @@ mod tests {
     // fourth.
     #[tokio::test(start_paused = true)]
     async fn restarting_a_stopped_sheep_resets_the_budget() {
-        let (events, _rx) = tokio::sync::broadcast::channel(64);
+        let (events, _rx) = crate::bus::test_bus(64);
         // Five procs, sized against the mutation rather than against a correct
         // run: two unstable crashes, the long-lived proc they land on and the
         // stop below ends, the respawn the restart performs (unstable again,
@@ -8661,7 +8665,7 @@ mod tests {
 
     #[tokio::test(start_paused = true)]
     async fn shutdown_kills_all_and_stops_the_engine() {
-        let (events, _rx) = tokio::sync::broadcast::channel(64);
+        let (events, _rx) = crate::bus::test_bus(64);
         let runner =
             ScriptedRunner::new(vec![ProcScript::never_exits(), ProcScript::never_exits()]);
         let dir = tempfile::tempdir().unwrap();
@@ -8700,7 +8704,7 @@ mod tests {
     // never be killed.
     #[tokio::test(start_paused = true)]
     async fn shutdown_ignores_a_pending_restart_timer() {
-        let (events, mut rx) = tokio::sync::broadcast::channel(1024);
+        let (events, mut rx) = crate::bus::test_bus(1024);
         let runner = ScriptedRunner::new(vec![
             ProcScript::const_exit(1),     // crash: instant exit -> waiting-restart
             ProcScript::ignores_signals(), // web: full 1600ms kill ladder
@@ -8760,7 +8764,7 @@ mod tests {
     // fails if `handle_ready_result` stops guarding on `shutting_down`.
     #[tokio::test(start_paused = true)]
     async fn shutdown_ignores_a_pending_readiness_wait() {
-        let (events, mut rx) = tokio::sync::broadcast::channel(1024);
+        let (events, mut rx) = crate::bus::test_bus(1024);
         let runner = ScriptedRunner::new(vec![ProcScript::ignores_signals()]);
         let dir = tempfile::tempdir().unwrap();
         let handle = spawn_supervisor(runner, test_paths(&dir), events);
@@ -8794,7 +8798,7 @@ mod tests {
     // `online` snapshot, computed afterward, catches it).
     #[tokio::test(start_paused = true)]
     async fn late_start_racing_shutdown_never_orphans() {
-        let (events, mut rx) = tokio::sync::broadcast::channel(1024);
+        let (events, mut rx) = crate::bus::test_bus(1024);
         let runner = ScriptedRunner::new(vec![
             ProcScript::ignores_signals(), // web: 1600ms ladder
             ProcScript::never_exits(),     // the late Start, if it lands before Shutdown
@@ -8833,7 +8837,7 @@ mod tests {
     // schedules.
     #[tokio::test(start_paused = true)]
     async fn stale_restart_timer_never_short_circuits_a_newer_backoff() {
-        let (events, mut rx) = tokio::sync::broadcast::channel(1024);
+        let (events, mut rx) = crate::bus::test_bus(1024);
         let runner = ScriptedRunner::new(vec![
             ProcScript::const_exit(1),             // t=0 exit -> T1 @ 2000
             ProcScript::stable_then_exit(1500, 1), // manual respawn, dies @1500 -> T2 @ 3500
@@ -8886,7 +8890,7 @@ mod tests {
     // the sheep, and hand the `stop()` caller an `Online` snapshot again.
     #[tokio::test(start_paused = true)]
     async fn overlapping_stop_and_restart_agree_on_one_outcome() {
-        let (events, _rx) = tokio::sync::broadcast::channel(1024);
+        let (events, _rx) = crate::bus::test_bus(1024);
         let runner = ScriptedRunner::new(vec![
             ProcScript::ignores_signals(), // 1600ms ladder: a wide race window
             ProcScript::never_exits(),
@@ -8923,7 +8927,7 @@ mod tests {
     // not delay processing an unrelated sheep's own, unrelated exit.
     #[tokio::test(start_paused = true)]
     async fn actor_never_blocks_behind_a_busy_kill_ladder() {
-        let (events, mut rx) = tokio::sync::broadcast::channel(1024);
+        let (events, mut rx) = crate::bus::test_bus(1024);
         let runner = ScriptedRunner::new(vec![
             ProcScript::ignores_signals(),        // sheep a: 1600ms ladder
             ProcScript::stable_then_exit(800, 0), // sheep b: exits at t=800
@@ -8964,7 +8968,7 @@ mod tests {
     // (mailbox full) used to mean neither could ever make progress again.
     #[tokio::test(start_paused = true)]
     async fn mailbox_flood_during_a_kill_never_deadlocks() {
-        let (events, mut rx) = tokio::sync::broadcast::channel(4096);
+        let (events, mut rx) = crate::bus::test_bus(4096);
         let runner = ScriptedRunner::new(vec![ProcScript::ignores_signals()]);
         let dir = tempfile::tempdir().unwrap();
         let handle = spawn_supervisor(runner, test_paths(&dir), events);
@@ -9027,7 +9031,7 @@ mod tests {
     // hit `EngineStopped`, whether or not the fix was applied.
     #[tokio::test(start_paused = true)]
     async fn delete_racing_shutdown_still_deregisters_the_sheep() {
-        let (events, _rx) = tokio::sync::broadcast::channel(1024);
+        let (events, _rx) = crate::bus::test_bus(1024);
         let runner = ScriptedRunner::new(vec![
             ProcScript::ignores_signals(), // target: default 1600ms kill_timeout ladder
             ProcScript::ignores_signals(), // decoy: kept alive far longer, see comment above
@@ -9085,7 +9089,7 @@ mod tests {
     // LIVE PROCESS while still telling the `Delete` caller it succeeded.
     #[tokio::test(start_paused = true)]
     async fn delete_racing_restart_still_deregisters_the_sheep() {
-        let (events, _rx) = tokio::sync::broadcast::channel(1024);
+        let (events, _rx) = crate::bus::test_bus(1024);
         let runner = ScriptedRunner::new(vec![
             ProcScript::ignores_signals(), // wide kill-ladder window
             // A second script so the pre-fix bug's illegitimate respawn
@@ -9145,7 +9149,7 @@ mod tests {
     // snapshot of a sheep that is genuinely back up with `restarts: 1`.
     #[tokio::test(start_paused = true)]
     async fn an_operators_stop_beats_an_automatic_restart_mid_ladder() {
-        let (events, _rx) = tokio::sync::broadcast::channel(1024);
+        let (events, _rx) = crate::bus::test_bus(1024);
         // Two scripts is the most this test can demand: the sheep itself, plus
         // the one respawn a broken implementation performs. Sized for that
         // second spawn on purpose -- a pool of one would answer it
@@ -9196,7 +9200,7 @@ mod tests {
     // the `delete()` caller is told it was deleted.
     #[tokio::test(start_paused = true)]
     async fn an_operators_delete_beats_an_automatic_restart_mid_ladder() {
-        let (events, _rx) = tokio::sync::broadcast::channel(1024);
+        let (events, _rx) = crate::bus::test_bus(1024);
         // Two, for the same reason as above: the sheep, plus the respawn a
         // broken implementation performs behind the delete's back.
         let runner = ScriptedRunner::new(vec![
@@ -9233,7 +9237,7 @@ mod tests {
     /// pins is 15, the same constant `ExitOutcome`'s own doc names.
     #[tokio::test(start_paused = true)]
     async fn an_operators_stop_still_shows_its_signal_as_the_last_exit() {
-        let (events, _rx) = tokio::sync::broadcast::channel(64);
+        let (events, _rx) = crate::bus::test_bus(64);
         let runner = ScriptedRunner::new(vec![ProcScript::never_exits()]);
         let dir = tempfile::tempdir().unwrap();
         let handle = spawn_supervisor(runner, test_paths(&dir), events);
@@ -9265,7 +9269,7 @@ mod tests {
     /// a real exit that records a code, then a respawn that fails to spawn.
     #[tokio::test(start_paused = true)]
     async fn a_respawn_that_fails_to_spawn_clears_the_previous_exit_code() {
-        let (events, _rx) = tokio::sync::broadcast::channel(64);
+        let (events, _rx) = crate::bus::test_bus(64);
         let runner = ScriptedRunner::new(vec![ProcScript::const_exit(1)]);
         let dir = tempfile::tempdir().unwrap();
         let handle = spawn_supervisor(runner, test_paths(&dir), events);
@@ -9334,7 +9338,7 @@ mod tests {
         };
         let mut sheep = HashMap::new();
         sheep.insert(0, slot);
-        let (events, _events_rx) = broadcast::channel(16);
+        let (events, _events_rx) = crate::bus::test_bus(16);
         let (tx, _rx) = mpsc::channel(16);
         let actor = Actor {
             runner: ScriptedRunner::new(vec![]),
@@ -9997,7 +10001,7 @@ mod tests {
         Arc<ScriptedRunner>,
         tokio::sync::broadcast::Receiver<SharedEvent>,
     ) {
-        let (events, rx) = tokio::sync::broadcast::channel(256);
+        let (events, rx) = crate::bus::test_bus(256);
         let runner = Arc::new(ScriptedRunner::new(scripts));
         let handle = spawn_supervisor(SharedRunner(Arc::clone(&runner)), test_paths(dir), events);
         handle.start(vec![normalize(app).unwrap()]).await.unwrap();
@@ -10045,7 +10049,7 @@ mod tests {
                 ready_failed: false,
             },
         );
-        let (events, _events_rx) = broadcast::channel(64);
+        let (events, _events_rx) = crate::bus::test_bus(64);
         let (tx, rx) = mpsc::channel(MAILBOX_CAPACITY);
         let actor = Actor {
             runner: ScriptedRunner::new(scripts),
@@ -10108,7 +10112,7 @@ mod tests {
                 },
             );
         }
-        let (events, _events_rx) = broadcast::channel(64);
+        let (events, _events_rx) = crate::bus::test_bus(64);
         let (tx, rx) = mpsc::channel(MAILBOX_CAPACITY);
         let actor = Actor {
             runner: ScriptedRunner::new(Vec::new()),
@@ -10304,7 +10308,7 @@ mod tests {
                 },
             );
         }
-        let (events, _events_rx) = broadcast::channel(64);
+        let (events, _events_rx) = crate::bus::test_bus(64);
         let (tx, _rx) = mpsc::channel(MAILBOX_CAPACITY);
         Actor {
             runner: ScriptedRunner::new(scripts),
@@ -10737,7 +10741,7 @@ mod tests {
     #[tokio::test(start_paused = true)]
     async fn a_dog_that_restarts_is_still_a_dog() {
         let dir = tempfile::tempdir().unwrap();
-        let (events, mut rx) = broadcast::channel(64);
+        let (events, mut rx) = crate::bus::test_bus(64);
         let runner =
             ScriptedRunner::new(vec![ProcScript::const_exit(1), ProcScript::never_exits()]);
         let handle = spawn_supervisor(runner, test_paths(&dir), events);
@@ -10773,7 +10777,7 @@ mod tests {
     #[tokio::test(start_paused = true)]
     async fn a_dog_that_cannot_be_spawned_is_still_a_dog() {
         let dir = tempfile::tempdir().unwrap();
-        let (events, _rx) = broadcast::channel(64);
+        let (events, _rx) = crate::bus::test_bus(64);
         let handle = spawn_supervisor(ScriptedRunner::new(Vec::new()), test_paths(&dir), events);
 
         let failed = handle
@@ -10912,7 +10916,7 @@ mod tests {
     #[tokio::test(start_paused = true)]
     async fn an_all_or_nothing_start_stops_at_the_first_failed_spawn() {
         let dir = tempfile::tempdir().unwrap();
-        let (events, _rx) = broadcast::channel(64);
+        let (events, _rx) = crate::bus::test_bus(64);
         let handle = spawn_supervisor(
             // A script for the second app, which must NOT get as far as
             // using it: an exhausted pool would fail it for a reason of its
@@ -10969,7 +10973,7 @@ mod tests {
     #[tokio::test(start_paused = true)]
     async fn a_dog_that_cannot_spawn_is_registered_errored_rather_than_refused() {
         let dir = tempfile::tempdir().unwrap();
-        let (events, _rx) = broadcast::channel(64);
+        let (events, _rx) = crate::bus::test_bus(64);
         // Empty scripts, so the spawn this now reaches fails on its own too:
         // the point is that it is REACHED, and that the wreck is registered.
         let runner = ScriptedRunner::new(Vec::new()).refusing(&["bark"]);
@@ -11011,7 +11015,7 @@ mod tests {
     #[tokio::test(start_paused = true)]
     async fn a_reloaded_dog_is_still_a_dog() {
         let dir = tempfile::tempdir().unwrap();
-        let (events, mut rx) = broadcast::channel(256);
+        let (events, mut rx) = crate::bus::test_bus(256);
         let runner = ScriptedRunner::new(vec![ProcScript::never_exits(); 3]);
         let handle = spawn_supervisor(runner, test_paths(&dir), events);
 
@@ -11083,7 +11087,7 @@ mod tests {
     #[tokio::test(start_paused = true)]
     async fn enabling_a_dog_twice_starts_one_process() {
         let dir = tempfile::tempdir().unwrap();
-        let (events, _rx) = broadcast::channel(64);
+        let (events, _rx) = crate::bus::test_bus(64);
         let runner = ScriptedRunner::new(vec![ProcScript::never_exits(); 2]);
         let handle = spawn_supervisor(runner, test_paths(&dir), events);
 
@@ -11543,7 +11547,7 @@ mod tests {
             refuse: 2,
             attempts: Arc::clone(&attempts),
         };
-        let (events, mut rx) = tokio::sync::broadcast::channel(256);
+        let (events, mut rx) = crate::bus::test_bus(256);
         let handle = spawn_supervisor(runner, test_paths(&dir), events);
         handle.start(vec![normalize(app).unwrap()]).await.unwrap();
 
@@ -11840,7 +11844,7 @@ mod tests {
         // that respawn `Errored` rather than the live process the bug really
         // produces, and `Errored` is a state this case could mistake for the
         // failure it is looking for.
-        let (events, mut rx) = tokio::sync::broadcast::channel(256);
+        let (events, mut rx) = crate::bus::test_bus(256);
         let runner = Arc::new(ScriptedRunner::new(vec![ProcScript::never_exits(); 4]));
         // Capacity past anything this case raises: one liveness failure per
         // armed instance, and no breaches at all.
@@ -12784,7 +12788,7 @@ mod tests {
         let (proc, io) = runner.spawn(&log_ctl_spec()).unwrap();
         assert!(runner.log_ctl_live(0), "sanity: the fake starts it live");
 
-        let (events, _rx) = tokio::sync::broadcast::channel(64);
+        let (events, _rx) = crate::bus::test_bus(64);
         let (_ctl_tx, ctl_rx) = mpsc::channel(8);
         let (_signal_tx, signal_rx) = mpsc::channel(8);
         let (actor_tx, _actor_rx) = mpsc::channel(8);
@@ -12824,7 +12828,7 @@ mod tests {
     /// second copy of "is the pump still there".
     #[tokio::test(start_paused = true)]
     async fn a_pump_is_reaped_when_its_sheep_ends_even_with_a_lamb_on_the_pipe() {
-        let (events, mut rx) = tokio::sync::broadcast::channel(64);
+        let (events, mut rx) = crate::bus::test_bus(64);
         // One script for one spawn: `autorestart = false` below means the
         // supervisor never asks for a second.
         let runner = Arc::new(ScriptedRunner::new(vec![
@@ -14198,7 +14202,7 @@ mod tests {
     /// exactly that mutation.
     #[tokio::test(start_paused = true)]
     async fn the_actor_keeps_answering_while_a_reopen_waits_on_a_silent_pump() {
-        let (events, _rx) = tokio::sync::broadcast::channel(64);
+        let (events, _rx) = crate::bus::test_bus(64);
         let (runner, mut requests) = SilentPumpRunner::new(vec![ProcScript::never_exits()]);
         let dir = tempfile::tempdir().unwrap();
         let handle = spawn_supervisor(runner, test_paths(&dir), events);
@@ -14239,7 +14243,7 @@ mod tests {
     /// smallest shape that catches both halves — too narrow and too wide.
     #[tokio::test(start_paused = true)]
     async fn a_reopen_reaches_every_matched_sheep_and_no_others() {
-        let (events, _rx) = tokio::sync::broadcast::channel(64);
+        let (events, _rx) = crate::bus::test_bus(64);
         // Three scripts for three instances, counted: a fourth spawn would
         // answer `SpawnFailed("script exhausted")` and land that sheep in
         // `Errored` with no pump at all — a state this case could not tell
@@ -14300,7 +14304,7 @@ mod tests {
     /// reads exactly like the pump that was never reached.
     #[tokio::test(start_paused = true)]
     async fn a_reopen_after_a_restart_reaches_the_pump_the_restart_spawned() {
-        let (events, _rx) = tokio::sync::broadcast::channel(64);
+        let (events, _rx) = crate::bus::test_bus(64);
         let runner = Arc::new(ScriptedRunner::new(vec![
             ProcScript::never_exits(),
             ProcScript::never_exits(),
@@ -14351,7 +14355,7 @@ mod tests {
     /// and silence would look exactly like a rotation that worked.
     #[tokio::test(start_paused = true)]
     async fn a_reopen_matching_nothing_is_not_found() {
-        let (events, _rx) = tokio::sync::broadcast::channel(64);
+        let (events, _rx) = crate::bus::test_bus(64);
         let runner = ScriptedRunner::new(vec![]);
         let dir = tempfile::tempdir().unwrap();
         let handle = spawn_supervisor(runner, test_paths(&dir), events);
@@ -14372,7 +14376,7 @@ mod tests {
     /// is issued rather than merely notionally so.
     #[tokio::test(start_paused = true)]
     async fn a_stopped_sheep_is_a_no_op_success() {
-        let (events, _rx) = tokio::sync::broadcast::channel(64);
+        let (events, _rx) = crate::bus::test_bus(64);
         // One script, one spawn: `autorestart = false` below means the
         // supervisor never asks for a second.
         let runner = ScriptedRunner::new(vec![ProcScript::never_exits()]);
@@ -14553,7 +14557,7 @@ mod tests {
     /// nothing here would say so — except that count.
     #[tokio::test(start_paused = true)]
     async fn a_pump_that_could_not_reopen_fails_the_request_and_names_its_sheep() {
-        let (events, _rx) = tokio::sync::broadcast::channel(64);
+        let (events, _rx) = crate::bus::test_bus(64);
         // Two scripts for two instances, counted: a third spawn would answer
         // `SpawnFailed("script exhausted")` and land that sheep in `Errored`
         // with no pump at all.
@@ -14911,7 +14915,7 @@ mod tests {
     /// that catches both halves.
     #[tokio::test(start_paused = true)]
     async fn a_flush_reaches_every_matched_sheep_and_no_others() {
-        let (events, _rx) = tokio::sync::broadcast::channel(64);
+        let (events, _rx) = crate::bus::test_bus(64);
         // Three scripts for three instances, counted, for the reason the
         // reopen case gives: a fourth spawn would fail and land that sheep
         // pumpless, which reads the same as the skip being looked for.
@@ -14968,7 +14972,7 @@ mod tests {
     /// measurement behind that.
     #[tokio::test(start_paused = true)]
     async fn the_actor_keeps_answering_while_a_flush_waits_on_a_silent_pump() {
-        let (events, _rx) = tokio::sync::broadcast::channel(64);
+        let (events, _rx) = crate::bus::test_bus(64);
         let (runner, mut requests) = SilentPumpRunner::new(vec![ProcScript::never_exits()]);
         let dir = tempfile::tempdir().unwrap();
         let handle = spawn_supervisor(runner, test_paths(&dir), events);
@@ -15108,7 +15112,7 @@ mod tests {
     /// second.
     #[tokio::test(start_paused = true)]
     async fn a_flush_truncates_only_after_its_pump_has_answered() {
-        let (events, _rx) = tokio::sync::broadcast::channel(64);
+        let (events, _rx) = crate::bus::test_bus(64);
         let dir = tempfile::tempdir().unwrap();
         let handle = spawn_supervisor(
             LateWritingPumpRunner::new(ScriptedRunner::new(vec![ProcScript::never_exits()])),
@@ -15159,7 +15163,7 @@ mod tests {
     /// so, and the truncate is reached through the no-pump leg.
     #[tokio::test(start_paused = true)]
     async fn a_stopped_sheeps_log_file_is_truncated_too() {
-        let (events, _rx) = tokio::sync::broadcast::channel(64);
+        let (events, _rx) = crate::bus::test_bus(64);
         // One script, one spawn: `autorestart = false` means no second.
         let runner = ScriptedRunner::new(vec![ProcScript::never_exits()]);
         let dir = tempfile::tempdir().unwrap();
@@ -15209,7 +15213,7 @@ mod tests {
     /// this case testing two ordinary sheep and proving nothing.
     #[tokio::test(start_paused = true)]
     async fn instances_sharing_one_log_path_answer_one_row_each() {
-        let (events, _rx) = tokio::sync::broadcast::channel(64);
+        let (events, _rx) = crate::bus::test_bus(64);
         let runner =
             ScriptedRunner::new(vec![ProcScript::never_exits(), ProcScript::never_exits()]);
         let dir = tempfile::tempdir().unwrap();
@@ -15260,7 +15264,7 @@ mod tests {
     /// acknowledgement.
     #[tokio::test(start_paused = true)]
     async fn a_sibling_sharing_a_path_is_flushed_even_when_the_selector_skips_it() {
-        let (events, _rx) = tokio::sync::broadcast::channel(64);
+        let (events, _rx) = crate::bus::test_bus(64);
         // Two scripts for two apps of one instance each, counted: a third
         // spawn would answer `SpawnFailed("script exhausted")` and land that
         // sheep pumpless, which reads exactly like the skipped pump this case
@@ -15336,7 +15340,7 @@ mod tests {
     /// that count.
     #[tokio::test(start_paused = true)]
     async fn a_pump_that_could_not_flush_fails_the_request() {
-        let (events, _rx) = tokio::sync::broadcast::channel(64);
+        let (events, _rx) = crate::bus::test_bus(64);
         // Two scripts for two instances, counted: a third spawn would answer
         // `SpawnFailed("script exhausted")` and land that sheep pumpless.
         let scripted = Arc::new(ScriptedRunner::new(vec![
@@ -15383,7 +15387,7 @@ mod tests {
     /// touched at all.
     #[tokio::test(start_paused = true)]
     async fn a_flush_matching_nothing_is_not_found() {
-        let (events, _rx) = tokio::sync::broadcast::channel(64);
+        let (events, _rx) = crate::bus::test_bus(64);
         let dir = tempfile::tempdir().unwrap();
         let handle = spawn_supervisor(ScriptedRunner::new(vec![]), test_paths(&dir), events);
 
@@ -15696,7 +15700,7 @@ mod tests {
         dir: &tempfile::TempDir,
         scripts: Vec<ProcScript>,
     ) -> Actor<ScriptedRunner> {
-        let (events, _events_rx) = broadcast::channel(64);
+        let (events, _events_rx) = crate::bus::test_bus(64);
         let (tx, _rx) = mpsc::channel(MAILBOX_CAPACITY);
         Actor {
             runner: ScriptedRunner::new(scripts),
@@ -16339,7 +16343,7 @@ mod tests {
                 // Capacity above `EVENT_BUDGET`: the drain below treats a
                 // `Lagged` as a failure rather than skipping past it, since a
                 // hole in the stream is a hole in every claim read off it.
-                let (events, mut rx) = tokio::sync::broadcast::channel(8192);
+                let (events, mut rx) = crate::bus::test_bus(8192);
                 let handle = spawn_supervisor(
                     ScriptedRunner::new(scripts),
                     test_paths(&dir),

--- a/crates/shep-daemon/src/supervisor.rs
+++ b/crates/shep-daemon/src/supervisor.rs
@@ -56,6 +56,7 @@ use shep_core::status::ProcStatus;
 
 use crate::assemble::{assemble, instance_slots};
 use crate::brain::{Decision, decide_on_exit};
+use crate::bus::SharedEvent;
 use crate::channel::{ChildMessage, ShepherdMessage};
 use crate::entry::{ProcessEntry, ReloadState, RestartBudget};
 use crate::extras::{Extras, ExtrasRegistry};
@@ -1435,7 +1436,7 @@ impl SupervisorHandle {
 pub(crate) struct SupervisorBuilder<R: ProcessRunner> {
     runner: R,
     paths: ShepPaths,
-    events: broadcast::Sender<BusEvent>,
+    events: broadcast::Sender<SharedEvent>,
     extras: Option<Extras>,
 }
 
@@ -1445,7 +1446,7 @@ impl<R: ProcessRunner> SupervisorBuilder<R> {
     ///
     /// `events` receives [`BusEvent::Process`] (+ `LogOut`/`LogErr` forwarded
     /// from each sheep's `ProcIo::logs`).
-    pub(crate) fn new(runner: R, paths: ShepPaths, events: broadcast::Sender<BusEvent>) -> Self {
+    pub(crate) fn new(runner: R, paths: ShepPaths, events: broadcast::Sender<SharedEvent>) -> Self {
         Self {
             runner,
             paths,
@@ -1495,7 +1496,7 @@ impl<R: ProcessRunner> SupervisorBuilder<R> {
 pub fn spawn_supervisor<R: ProcessRunner>(
     runner: R,
     paths: ShepPaths,
-    events: broadcast::Sender<BusEvent>,
+    events: broadcast::Sender<SharedEvent>,
 ) -> SupervisorHandle {
     SupervisorBuilder::new(runner, paths, events).spawn()
 }
@@ -2228,7 +2229,7 @@ struct Actor<R: ProcessRunner> {
     /// `$SHEP_HOME` layout, for assembling spawn specs.
     paths: ShepPaths,
     /// Bus: process lifecycle events + forwarded logs.
-    events: broadcast::Sender<BusEvent>,
+    events: broadcast::Sender<SharedEvent>,
     /// Clone handed to sheep tasks and restart timers so they can report
     /// back into this same actor's mailbox.
     tx: mpsc::Sender<Msg>,
@@ -6688,12 +6689,12 @@ impl<R: ProcessRunner> Actor<R> {
     /// Broadcasts one lifecycle transition. Send failures (no receivers)
     /// are not an error — the bus is fire-and-forget from the actor's side.
     fn emit(&self, event: ProcessEventKind, info: ProcessInfo, manually: bool) {
-        let _ = self.events.send(BusEvent::Process {
+        let _ = self.events.send(SharedEvent::new(BusEvent::Process {
             event,
             info,
             manually,
             at_ms: crate::now_ms(),
-        });
+        }));
     }
 }
 
@@ -7336,7 +7337,7 @@ fn spawn_sheep_task<P: RunningProcess>(
     proc: P,
     io: ProcIo,
     app: ResolvedApp,
-    events: broadcast::Sender<BusEvent>,
+    events: broadcast::Sender<SharedEvent>,
     actor_tx: mpsc::Sender<Msg>,
 ) -> SheepHandles {
     let (ctl_tx, ctl_rx) = mpsc::channel(SHEEP_CTL_CAPACITY);
@@ -7386,7 +7387,7 @@ async fn run_sheep<P: RunningProcess>(
     app: ResolvedApp,
     mut ctl_rx: mpsc::Receiver<SheepCtl>,
     mut signal_rx: mpsc::Receiver<SignalRequest>,
-    events: broadcast::Sender<BusEvent>,
+    events: broadcast::Sender<SharedEvent>,
     actor_tx: mpsc::Sender<Msg>,
 ) {
     // `io` is destructured here, in the task's own body, and that placement
@@ -7466,7 +7467,7 @@ async fn run_sheep<P: RunningProcess>(
                         } else {
                             BusEvent::LogOut { id, line: line.line }
                         };
-                        let _ = events.send(event);
+                        let _ = events.send(SharedEvent::new(event));
                     }
                     None => logs_open = false,
                 }
@@ -7481,10 +7482,10 @@ async fn run_sheep<P: RunningProcess>(
                         // is dropped a few lines below, and `deferred.md`
                         // names exactly that message as the traffic the bus
                         // exists to stop losing.
-                        let _ = events.send(BusEvent::Channel {
+                        let _ = events.send(SharedEvent::new(BusEvent::Channel {
                             id,
                             message: message.clone(),
-                        });
+                        }));
                         match message {
                             ChildMessage::Ready => {
                                 let _ = actor_tx.send(Msg::Ready { id }).await;
@@ -7561,22 +7562,23 @@ mod tests {
     /// it not" a question a list can answer where [`await_event`]'s search
     /// cannot.
     fn drained_process_kinds(
-        rx: &mut tokio::sync::broadcast::Receiver<BusEvent>,
+        rx: &mut tokio::sync::broadcast::Receiver<SharedEvent>,
     ) -> Vec<ProcessEventKind> {
         let mut kinds = Vec::new();
-        while let Ok(BusEvent::Process { event, .. }) = rx.try_recv() {
+        while let Ok(BusEvent::Process { event, .. }) = rx.try_recv().map(|event| event.to_event())
+        {
             kinds.push(event);
         }
         kinds
     }
 
     async fn await_event(
-        rx: &mut tokio::sync::broadcast::Receiver<BusEvent>,
+        rx: &mut tokio::sync::broadcast::Receiver<SharedEvent>,
         id: u32,
         kind: ProcessEventKind,
     ) -> bool {
         loop {
-            match rx.recv().await {
+            match rx.recv().await.map(|event| event.to_event()) {
                 Ok(BusEvent::Process {
                     event,
                     info,
@@ -7599,7 +7601,7 @@ mod tests {
     /// queue yet, so a bare `try_recv` would read empty regardless of
     /// whether the code under test is correct.
     async fn assert_no_event_within(
-        rx: &mut tokio::sync::broadcast::Receiver<BusEvent>,
+        rx: &mut tokio::sync::broadcast::Receiver<SharedEvent>,
         id: u32,
         kind: ProcessEventKind,
         window: Duration,
@@ -8681,10 +8683,10 @@ mod tests {
     // ---------------------------------------------------------------
 
     async fn drain_kinds(
-        rx: &mut tokio::sync::broadcast::Receiver<BusEvent>,
+        rx: &mut tokio::sync::broadcast::Receiver<SharedEvent>,
     ) -> Vec<(u32, ProcessEventKind)> {
         let mut out = Vec::new();
-        while let Ok(ev) = rx.try_recv() {
+        while let Ok(ev) = rx.try_recv().map(|event| event.to_event()) {
             if let BusEvent::Process { event, info, .. } = ev {
                 out.push((info.id, event));
             }
@@ -9967,7 +9969,7 @@ mod tests {
     /// Drives virtual time until `kind` arrives for `id`, failing rather than
     /// hanging if it never does.
     async fn expect_event(
-        rx: &mut tokio::sync::broadcast::Receiver<BusEvent>,
+        rx: &mut tokio::sync::broadcast::Receiver<SharedEvent>,
         id: u32,
         kind: ProcessEventKind,
     ) {
@@ -9993,7 +9995,7 @@ mod tests {
     ) -> (
         SupervisorHandle,
         Arc<ScriptedRunner>,
-        tokio::sync::broadcast::Receiver<BusEvent>,
+        tokio::sync::broadcast::Receiver<SharedEvent>,
     ) {
         let (events, rx) = tokio::sync::broadcast::channel(256);
         let runner = Arc::new(ScriptedRunner::new(scripts));
@@ -12325,14 +12327,14 @@ mod tests {
     /// than skipped: a hole in the stream is a hole in every claim read off
     /// it.
     async fn events_through(
-        rx: &mut tokio::sync::broadcast::Receiver<BusEvent>,
+        rx: &mut tokio::sync::broadcast::Receiver<SharedEvent>,
         id: u32,
         kind: ProcessEventKind,
     ) -> Vec<Seen> {
         let collect = async {
             let mut seen = Vec::new();
             loop {
-                match rx.recv().await {
+                match rx.recv().await.map(|event| event.to_event()) {
                     Ok(BusEvent::Process {
                         event,
                         info,
@@ -13286,7 +13288,7 @@ mod tests {
         // than fail it, and there is no other failure mode to give it.
         let seen = tokio::time::timeout(ACTION_WINDOW, async {
             loop {
-                if let BusEvent::Channel { id, message } = events.recv().await.unwrap() {
+                if let BusEvent::Channel { id, message } = events.recv().await.unwrap().to_event() {
                     break (id, message);
                 }
             }
@@ -13324,7 +13326,7 @@ mod tests {
 
         let seen = tokio::time::timeout(ACTION_WINDOW, async {
             loop {
-                if let BusEvent::Channel { id, message } = events.recv().await.unwrap() {
+                if let BusEvent::Channel { id, message } = events.recv().await.unwrap().to_event() {
                     break (id, message);
                 }
             }
@@ -13369,7 +13371,7 @@ mod tests {
 
         let seen = tokio::time::timeout(ACTION_WINDOW, async {
             loop {
-                if let BusEvent::Channel { message, .. } = events.recv().await.unwrap() {
+                if let BusEvent::Channel { message, .. } = events.recv().await.unwrap().to_event() {
                     break message;
                 }
             }
@@ -15988,7 +15990,7 @@ mod tests {
         );
 
         let mut errored = 0;
-        while let Ok(event) = events.try_recv() {
+        while let Ok(event) = events.try_recv().map(|event| event.to_event()) {
             if let BusEvent::Process {
                 event: ProcessEventKind::Errored,
                 info,
@@ -16444,7 +16446,7 @@ mod tests {
                 loop {
                     match tokio::time::timeout(QUIET_WINDOW, rx.recv()).await {
                         Ok(Ok(event)) => {
-                            observed.push(event);
+                            observed.push(event.to_event());
                             proptest::prop_assert!(
                                 observed.len() <= EVENT_BUDGET,
                                 "the flock never reached steady state: {} transitions after \

--- a/crates/shep-daemon/src/testing.rs
+++ b/crates/shep-daemon/src/testing.rs
@@ -19,6 +19,7 @@ use tokio::net::TcpListener;
 use tokio::sync::{broadcast, mpsc, watch};
 
 use crate::assemble::assemble;
+use crate::bus::SharedEvent;
 use crate::cron::{Clock, DEFAULT_MAX_CRON_SLEEP};
 use crate::entry::{ProcessEntry, ReloadState, RestartBudget};
 use crate::extras::{Extras, ExtrasReports};
@@ -331,7 +332,7 @@ pub(crate) struct Harness {
     _dir: tempfile::TempDir,
     // Kept alive only: dropping the sender's last receiver would turn
     // every future `events.send()` into a silent no-op.
-    _events_rx: broadcast::Receiver<shep_core::protocol::BusEvent>,
+    _events_rx: broadcast::Receiver<SharedEvent>,
     pub(crate) shutdown_rx: watch::Receiver<bool>,
     /// Breach reports the supervisor's extras produce, for tests that assert
     /// a memory limit fired.

--- a/crates/shep-daemon/src/testing.rs
+++ b/crates/shep-daemon/src/testing.rs
@@ -487,7 +487,7 @@ pub(crate) fn harness_with_extras(
 ) -> Harness {
     let dir = tempfile::tempdir().unwrap();
     let paths = test_paths(&dir);
-    let (events, events_rx) = broadcast::channel(256);
+    let (events, events_rx) = crate::bus::test_bus(256);
     let (breach_tx, breaches) = mpsc::channel(HARNESS_REPORT_CAPACITY);
     let (live_tx, liveness) = mpsc::channel(HARNESS_REPORT_CAPACITY);
     let extras = build_extras(ExtrasReports {

--- a/crates/shep-daemon/src/tokio_runner.rs
+++ b/crates/shep-daemon/src/tokio_runner.rs
@@ -12,8 +12,9 @@
 //! `shep` can ask of a live log file without restarting the sheep:
 //! [`Reopen`](crate::runner::LogCtl::Reopen) drops both handles and opens the
 //! paths again, which is how an externally rotated file gets picked up, and
-//! [`Flush`](crate::runner::LogCtl::Flush) waits for the writes already in
-//! flight to land, which is the barrier `shep flush` truncates behind.
+//! [`Flush`](crate::runner::LogCtl::Flush) writes out what a stream has
+//! buffered and waits for it to land, which is the barrier `shep flush`
+//! truncates behind.
 //!
 //! # Shepherd-channel fd lifecycle
 //!
@@ -27,6 +28,7 @@
 //! side of the channel sees a clean EOF once the child closes or exits
 //! rather than being kept artificially open by our own leftover reference.
 
+use core::time::Duration;
 use std::fs;
 use std::io;
 #[cfg(unix)]
@@ -44,12 +46,13 @@ use nix::sys::signal::{self, Signal};
 use nix::unistd::Pid;
 use shep_core::signals::OperatorSignal;
 use tokio::io::{
-    AsyncBufReadExt as _, AsyncRead, AsyncWrite, AsyncWriteExt as _, BufReader, Lines,
+    AsyncBufReadExt as _, AsyncRead, AsyncWrite, AsyncWriteExt as _, BufReader, BufWriter, Lines,
 };
 #[cfg(unix)]
 use tokio::net::UnixStream;
 use tokio::process::{Child, Command};
 use tokio::sync::mpsc;
+use tokio::time::{Instant, sleep_until};
 
 #[cfg(unix)]
 use crate::boot::DIR_MODE;
@@ -64,6 +67,25 @@ use crate::runner::{
 /// bursty child doesn't back-pressure against a sheep task that's merely
 /// slow to poll, without buffering unboundedly.
 const CHANNEL_CAPACITY: usize = 32;
+
+/// Bytes a log file buffers before the pump writes them through.
+///
+/// `tokio::fs::File` hands every `write` to the blocking pool, and that
+/// dispatch — not the `write(2)` under it — is what a log line costs the
+/// daemon: measured at 32.8 us of daemon CPU per line against 0.99 us for the
+/// same line written unbuffered from a plain loop. Batching amortises one
+/// dispatch over a whole buffer instead of paying it per line.
+const LOG_BUFFER: usize = 8 * 1024;
+
+/// How long a line may sit in that buffer before the pump writes it out
+/// anyway.
+///
+/// Measured from the FIRST unflushed line rather than the most recent, so a
+/// steady trickle cannot push the deadline out indefinitely; a busy stream
+/// fills [`LOG_BUFFER`] and flushes long before this fires. Without it a
+/// sheep that logged one line and went quiet would leave that line in the
+/// buffer until its next one, which for some sheep is never.
+const IDLE_FLUSH: Duration = Duration::from_millis(50);
 
 /// Real [`crate::runner::ProcessRunner`] over actual OS processes.
 #[derive(Debug, Default)]
@@ -885,15 +907,27 @@ impl ProcessRunner for TokioRunner {
     }
 }
 
-/// One stream's log file: the path the spec named, plus the handle currently
-/// open on it — `None` when the open failed (see [`open_append`]).
+/// One stream's log file: the path the spec named, plus the buffered handle
+/// currently open on it — `None` when the open failed (see [`open_append`]).
+///
+/// Generic over the sink only so a test can count the writes that reach it —
+/// how OFTEN the buffer spills is the whole point of [`LOG_BUFFER`], and it
+/// is observable in neither the bytes on disk nor the wall clock. Production
+/// only ever builds the default.
 #[derive(Debug)]
-struct LogFile {
+struct LogFile<W = tokio::fs::File> {
     path: PathBuf,
-    handle: Option<tokio::fs::File>,
+    handle: Option<BufWriter<W>>,
+    /// When the oldest line the pump has not tried to flush yet was
+    /// appended; the pump reads it as an [`IDLE_FLUSH`] deadline.
+    ///
+    /// Cleared by every flush ATTEMPT, successful or not: a file that cannot
+    /// be written must not turn the idle flush into a twenty-per-second
+    /// retry loop, and the next appended line re-arms it either way.
+    buffered_since: Option<Instant>,
 }
 
-impl LogFile {
+impl LogFile<tokio::fs::File> {
     /// Opens `path` for appending, keeping the path for later reopens.
     ///
     /// A failed open is not fatal here — it is already logged, and the pump
@@ -901,61 +935,27 @@ impl LogFile {
     /// them anywhere. [`LogFile::reopen`] is the one that reports, because
     /// there a caller is waiting to hear.
     async fn open(path: PathBuf) -> Self {
-        let handle = open_append(&path).await.ok();
-        Self { path, handle }
-    }
-
-    /// Appends one line and its newline, logging (never propagating) a write
-    /// failure — a log we cannot write to must not stop the pump draining
-    /// the child's pipes.
-    async fn append(&mut self, line: &str) {
-        let Some(handle) = self.handle.as_mut() else {
-            return;
-        };
-        let mut buf = String::with_capacity(line.len() + 1);
-        buf.push_str(line);
-        buf.push('\n');
-        if let Err(error) = handle.write_all(buf.as_bytes()).await {
-            tracing::error!(path = ?self.path, %error, "log file append failed");
+        let handle = open_append(&path)
+            .await
+            .ok()
+            .map(|file| BufWriter::with_capacity(LOG_BUFFER, file));
+        Self {
+            path,
+            handle,
+            buffered_since: None,
         }
-    }
-
-    /// Waits for every write already handed to the blocking pool to reach
-    /// the file, keeping the handle open.
-    ///
-    /// The whole of [`LogCtl::Flush`], and the reason `shep flush` has two
-    /// halves: `write_all` returns once the real `write(2)` is queued, so
-    /// truncating the path without waiting here can empty the file a moment
-    /// before a line that was already in flight lands at offset 0 of it.
-    ///
-    /// A stream whose open failed has no handle and nothing queued, so it
-    /// has nothing to wait for and answers `Ok`.
-    ///
-    /// # Errors
-    ///
-    /// A write already dispatched failed — a full disk, an unlinked
-    /// filesystem, an IO error the queued `write(2)` hit. Unlike
-    /// [`Self::reopen`]'s own flush this is reported rather than logged:
-    /// there no caller depends on the result (the handle is being replaced
-    /// by a working one), while here the caller is about to truncate this
-    /// exact path and the un-landed bytes are what it is racing.
-    async fn flush(&mut self) -> Result<(), FlushError> {
-        let Some(handle) = self.handle.as_mut() else {
-            return Ok(());
-        };
-        handle.flush().await.map_err(|error| FlushError {
-            message: format!("{}: {error}", self.path.display()),
-        })
     }
 
     /// Flushes and closes the current handle, then opens the path again.
     ///
     /// Flushing first is what makes [`LogCtl::Reopen`]'s acknowledgement
-    /// worth having: `write_all` returning only means the write was queued
-    /// onto the blocking pool, while `flush` waits for the operation in
-    /// flight — so every line read before the reopen has reached the OLD
-    /// file (the renamed one, in the rotation this exists for) by the time
-    /// the caller hears back.
+    /// worth having: an [`Self::append`] only reaches the buffer and a write
+    /// through it only means the `write(2)` was queued, while `flush` empties
+    /// the buffer and waits for the operation in flight — so every line read
+    /// before the reopen has reached the OLD file (the renamed one, in the
+    /// rotation this exists for) by the time the caller hears back. The
+    /// buffer travels with the handle that is being dropped, so a reopen that
+    /// skipped it would DISCARD those lines rather than merely delay them.
     ///
     /// Reopening goes through [`open_append`] rather than opening the path
     /// here, so the new handle is an appending one exactly like the original
@@ -971,6 +971,7 @@ impl LogFile {
     /// error: it is logged, and the handle it belongs to is being replaced
     /// by a working one, so the sheep keeps logging.
     async fn reopen(&mut self) -> Result<(), ReopenError> {
+        self.buffered_since = None;
         if let Some(handle) = self.handle.as_mut()
             && let Err(error) = handle.flush().await
         {
@@ -981,13 +982,67 @@ impl LogFile {
         drop(self.handle.take());
         match open_append(&self.path).await {
             Ok(handle) => {
-                self.handle = Some(handle);
+                self.handle = Some(BufWriter::with_capacity(LOG_BUFFER, handle));
                 Ok(())
             }
             Err(error) => Err(ReopenError {
                 message: format!("{}: {error}", self.path.display()),
             }),
         }
+    }
+}
+
+impl<W: AsyncWrite + Unpin> LogFile<W> {
+    /// Appends one line and its newline to the buffer, logging (never
+    /// propagating) a write failure — a log we cannot write to must not stop
+    /// the pump draining the child's pipes.
+    ///
+    /// The newline is a second write into that same buffer rather than a
+    /// joined copy of the line: the file sees one contiguous run of bytes
+    /// either way, so the copy bought nothing but an allocation per line.
+    async fn append(&mut self, line: &str) {
+        let Some(handle) = self.handle.as_mut() else {
+            return;
+        };
+        let written = async {
+            handle.write_all(line.as_bytes()).await?;
+            handle.write_all(b"\n").await
+        }
+        .await;
+        self.buffered_since.get_or_insert_with(Instant::now);
+        if let Err(error) = written {
+            tracing::error!(path = ?self.path, %error, "log file append failed");
+        }
+    }
+
+    /// Writes out whatever the buffer holds and waits for it to reach the
+    /// file, keeping the handle open.
+    ///
+    /// The whole of [`LogCtl::Flush`], and the reason `shep flush` has two
+    /// halves: an [`Self::append`] only reaches the buffer, and a write
+    /// through the buffer returns once the real `write(2)` is queued — so
+    /// truncating the path without waiting here can empty the file a moment
+    /// before lines it already accepted land at offset 0 of it.
+    ///
+    /// A stream whose open failed has no handle and nothing buffered, so it
+    /// has nothing to wait for and answers `Ok`.
+    ///
+    /// # Errors
+    ///
+    /// A buffered or already-dispatched write failed — a full disk, an
+    /// unlinked filesystem, an IO error the queued `write(2)` hit. Unlike
+    /// [`Self::reopen`]'s own flush this is reported rather than logged:
+    /// there no caller depends on the result (the handle is being replaced
+    /// by a working one), while here the caller is about to truncate this
+    /// exact path and the un-landed bytes are what it is racing.
+    async fn flush(&mut self) -> Result<(), FlushError> {
+        self.buffered_since = None;
+        let Some(handle) = self.handle.as_mut() else {
+            return Ok(());
+        };
+        handle.flush().await.map_err(|error| FlushError {
+            message: format!("{}: {error}", self.path.display()),
+        })
     }
 }
 
@@ -1003,6 +1058,33 @@ impl LogFiles {
     /// The file a line from this stream is appended to (`err` picks stderr).
     fn stream(&mut self, err: bool) -> &mut LogFile {
         if err { &mut self.err } else { &mut self.out }
+    }
+
+    /// When the pump owes the older of the two buffers a flush, or `None`
+    /// when neither holds anything.
+    ///
+    /// Derived rather than stored, so an explicit [`LogCtl::Flush`] or
+    /// [`LogCtl::Reopen`] retires the deadline by the same act that empties
+    /// the buffer; nothing here can be left armed for a buffer that is
+    /// already on disk.
+    fn flush_deadline(&self) -> Option<Instant> {
+        let oldest = match (self.out.buffered_since, self.err.buffered_since) {
+            (Some(out), Some(err)) => out.min(err),
+            (Some(only), None) | (None, Some(only)) => only,
+            (None, None) => return None,
+        };
+        Some(oldest + IDLE_FLUSH)
+    }
+
+    /// Flushes both buffers, logging rather than reporting a failure — no
+    /// caller is waiting on an idle flush, and the pump must go on draining
+    /// the child's pipes whether or not its logs can be written.
+    async fn flush_idle(&mut self) {
+        for file in [&mut self.out, &mut self.err] {
+            if let Err(error) = file.flush().await {
+                tracing::error!(%error, "log file idle flush failed");
+            }
+        }
     }
 
     /// Carries out one control request and then answers it.
@@ -1112,9 +1194,16 @@ async fn deliver_line(
     }
 }
 
-/// Waits for room on `logs_tx`, serving control requests while it waits.
+/// Waits for room on `logs_tx`, serving control requests and idle flushes
+/// while it waits.
 ///
 /// Returns `None` once the `logs` receiver is gone.
+///
+/// The idle flush is here for the same reason the control branch is: a pump
+/// parked on a full `logs` channel is parked for as long as the sheep task
+/// takes, which is unbounded. Without a branch of its own the line just
+/// appended would sit in the buffer for exactly that long, and
+/// [`IDLE_FLUSH`] would bound nothing.
 ///
 /// # Why not a bare `send().await`
 ///
@@ -1133,9 +1222,14 @@ async fn reserve_slot<'tx>(
     ctl_rx: &mut mpsc::Receiver<LogCtl>,
 ) -> Option<mpsc::Permit<'tx, LogLine>> {
     loop {
-        // Both branches are documented cancel-safe, as `select!` requires: a
-        // `reserve` that loses the race has taken no slot, and a `recv` that
-        // loses it has taken no message.
+        // Recomputed every iteration from the STORED mark, so losing the
+        // race never extends the window (`snapshot::run_writer`'s debounce
+        // is the same shape).
+        let flush_at = files.flush_deadline();
+        // Every branch is documented cancel-safe, as `select!` requires: a
+        // `reserve` that loses the race has taken no slot, a `recv` that
+        // loses it has taken no message, and a `sleep_until` that loses it
+        // is rebuilt against the same absolute deadline.
         tokio::select! {
             slot = logs_tx.reserve() => return slot.ok(),
             ctl = ctl_rx.recv() => match ctl {
@@ -1147,6 +1241,9 @@ async fn reserve_slot<'tx>(
                 // loop then sees the same closed channel and ends.
                 None => return logs_tx.reserve().await.ok(),
             },
+            () = sleep_until(flush_at.unwrap_or_else(Instant::now)), if flush_at.is_some() => {
+                files.flush_idle().await;
+            }
         }
     }
 }
@@ -1218,12 +1315,14 @@ where
 ///
 /// # Ordering
 ///
-/// The file write is ISSUED before the line is forwarded, but
-/// `tokio::fs::File::write_all` returning means the write was queued onto
-/// the blocking pool, not that it reached the file. A receiver that observes
-/// a line on `logs_tx` therefore cannot conclude the file already holds it.
-/// The barrier that can be relied on is [`LogCtl::Reopen`]'s
-/// acknowledgement, which flushes before swapping handles.
+/// The file write is ISSUED before the line is forwarded, but it lands in a
+/// [`BufWriter`] rather than in the file, and a write through that buffer
+/// only means the real `write(2)` was queued onto the blocking pool. A
+/// receiver that observes a line on `logs_tx` therefore cannot conclude the
+/// file already holds it. The barriers that can be relied on are
+/// [`LogCtl::Reopen`]'s and [`LogCtl::Flush`]'s acknowledgements, which both
+/// drain the buffer and wait; absent either, [`IDLE_FLUSH`] bounds how long
+/// a line stays buffered.
 ///
 /// # When a pump ends
 ///
@@ -1257,6 +1356,10 @@ fn spawn_log_pump<O, E>(
         let mut err_lines = stderr.map(|reader| BufReader::new(reader).lines());
 
         while out_lines.is_some() || err_lines.is_some() {
+            // Recomputed every iteration from the STORED mark; see
+            // `reserve_slot`, which carries the same branch for the window
+            // this loop cannot see.
+            let flush_at = files.flush_deadline();
             tokio::select! {
                 result = next_line(&mut out_lines) => {
                     match deliver_line(result, false, &mut files, &logs_tx, &mut ctl_rx).await {
@@ -1290,8 +1393,19 @@ fn spawn_log_pump<O, E>(
                 // closed channel stays closed, so losing the race loses
                 // nothing.
                 () = logs_tx.closed() => break,
+
+                // Cancel-safe: rebuilt against the same absolute deadline
+                // every iteration, so losing the race costs nothing.
+                () = sleep_until(flush_at.unwrap_or_else(Instant::now)), if flush_at.is_some() => {
+                    files.flush_idle().await;
+                }
             }
         }
+        // A `BufWriter` cannot flush itself as it drops, and every way out of
+        // the loop above drops both of them: without this, whatever a child
+        // wrote since the last flush would be lost at its exit — the lines an
+        // operator reaches for first.
+        files.flush_idle().await;
     });
 }
 
@@ -1521,10 +1635,14 @@ fn spawn_channel_pumps<S>(
 
 #[cfg(test)]
 mod tests {
+    use core::pin::Pin;
+    use core::sync::atomic::{AtomicUsize, Ordering};
+    use core::task::{Context, Poll};
     use std::collections::BTreeMap;
     use std::fs;
     #[cfg(unix)]
     use std::os::unix::fs::PermissionsExt as _;
+    use std::sync::Arc;
     use std::time::Duration;
 
     use tokio::io::DuplexStream;
@@ -1669,9 +1787,10 @@ mod tests {
 
     /// Waits for `path` to hold exactly `expected`.
     ///
-    /// A line observed on `logs` has had its file write ISSUED, not
-    /// necessarily completed (see [`spawn_log_pump`]'s ordering note), so
-    /// this polls for the write to land instead of asserting it already has.
+    /// A line observed on `logs` has reached the stream's BUFFER, not
+    /// necessarily the file (see [`spawn_log_pump`]'s ordering note), so this
+    /// polls for [`IDLE_FLUSH`] to write it through instead of asserting it
+    /// already has.
     /// The barrier that would make polling unnecessary — a reopen
     /// acknowledgement — is not usable where the point is what the CURRENT
     /// handle does, since a reopen replaces it.
@@ -1687,6 +1806,211 @@ mod tests {
             "{}: expected {expected:?}, found {:?}",
             path.display(),
             fs::read_to_string(path)
+        );
+    }
+
+    /// A sink standing in for the [`tokio::fs::File`] a real [`LogFile`]
+    /// holds, counting the writes that reach it.
+    ///
+    /// The count is the only place the buffering is visible. Bytes on disk
+    /// come out the same either way, and the timing difference is exactly
+    /// what a contended runner cannot be asked about — so a counter is what
+    /// pins [`LOG_BUFFER`] against a future append that writes straight
+    /// through.
+    #[derive(Clone, Debug, Default)]
+    struct WriteCounter {
+        writes: Arc<AtomicUsize>,
+        bytes: Arc<AtomicUsize>,
+    }
+
+    impl WriteCounter {
+        fn writes(&self) -> usize {
+            self.writes.load(Ordering::Relaxed)
+        }
+
+        fn bytes(&self) -> usize {
+            self.bytes.load(Ordering::Relaxed)
+        }
+    }
+
+    impl AsyncWrite for WriteCounter {
+        fn poll_write(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+            buf: &[u8],
+        ) -> Poll<io::Result<usize>> {
+            self.writes.fetch_add(1, Ordering::Relaxed);
+            self.bytes.fetch_add(buf.len(), Ordering::Relaxed);
+            Poll::Ready(Ok(buf.len()))
+        }
+
+        fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+            Poll::Ready(Ok(()))
+        }
+
+        fn poll_shutdown(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+            Poll::Ready(Ok(()))
+        }
+    }
+
+    /// Fails if an appended line still costs one write to the file.
+    ///
+    /// That write is the whole cost this change exists to remove:
+    /// `tokio::fs::File` hands each one to the blocking pool, measured at
+    /// 32.8 us of daemon CPU per line against 0.99 us for the `write(2)`
+    /// underneath it. A buffer turns N of them into one per bufferful, and
+    /// the count is the only observable that says so.
+    ///
+    /// Paused clock (IR-33), and that is load-bearing rather than
+    /// conventional: no time passes, so [`IDLE_FLUSH`] never fires and every
+    /// write counted below is the buffer spilling or the explicit flush at
+    /// the end. Nothing here can be made flaky by a contended runner.
+    #[tokio::test(start_paused = true)]
+    async fn a_run_of_lines_costs_one_write_per_bufferful_not_one_per_line() {
+        // 69 characters, so `append`'s newline makes the 70-byte line the
+        // measurement behind `LOG_BUFFER` used.
+        const LINE: &str = "012345678901234567890123456789012345678901234567890123456789012345678";
+        const LINE_BYTES: usize = LINE.len() + 1;
+        let lines = 3 * LOG_BUFFER / LINE_BYTES;
+
+        let sink = WriteCounter::default();
+        let mut log = LogFile {
+            path: PathBuf::from("counted.log"),
+            handle: Some(BufWriter::with_capacity(LOG_BUFFER, sink.clone())),
+            buffered_since: None,
+        };
+        for _ in 0..lines {
+            log.append(LINE).await;
+        }
+        log.flush().await.unwrap();
+
+        let total = lines * LINE_BYTES;
+        let ceiling = total.div_ceil(LOG_BUFFER) + 1; // + the closing flush's partial buffer
+        assert_eq!(
+            sink.bytes(),
+            total,
+            "buffering must not lose or repeat a byte"
+        );
+        assert!(
+            sink.writes() <= ceiling,
+            "{lines} lines cost {} writes; one per bufferful plus the closing flush is {ceiling}",
+            sink.writes()
+        );
+        assert!(
+            sink.writes() < lines,
+            "a write per line is the regression this exists to catch: \
+             {lines} lines, {} writes",
+            sink.writes()
+        );
+    }
+
+    /// Fails if a line only reaches the file when the buffer fills or when
+    /// something asks — that is, if the pump has no idle flush at all.
+    ///
+    /// A sheep that logs once and goes quiet is the whole case: nothing here
+    /// sends a `Flush`, nothing reopens, and no second line arrives to push
+    /// the first one out. `assert_file_settles` is the entire assertion, and
+    /// its own deadline is what fails if nothing ever writes the line
+    /// through. Real clock like every other case in this module (IR-33): the
+    /// wait is on file I/O the blocking pool has to actually do. The window's
+    /// arithmetic is pinned on the paused clock instead, by
+    /// [`the_idle_flush_window_is_measured_from_the_oldest_buffered_line`].
+    #[tokio::test]
+    async fn a_line_from_a_sheep_that_then_goes_quiet_still_reaches_its_file() {
+        let mut pump = PumpHarness::start();
+        pump.feed(false, "the-only-line").await;
+        assert_file_settles(&pump.out_path, "the-only-line\n").await;
+    }
+
+    /// Fails if the idle-flush window is measured from the NEWEST buffered
+    /// line rather than the oldest: a stream logging just inside the window
+    /// would then keep pushing the deadline out, and "buffered but not on
+    /// disk" would have no bound at all.
+    ///
+    /// Paused clock (IR-33): the question is arithmetic over `Instant`s, and
+    /// an append that fits in the buffer touches no file to wait on.
+    #[tokio::test(start_paused = true)]
+    async fn the_idle_flush_window_is_measured_from_the_oldest_buffered_line() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut files = LogFiles {
+            out: LogFile::open(dir.path().join("out.log")).await,
+            err: LogFile::open(dir.path().join("err.log")).await,
+        };
+        assert_eq!(
+            files.flush_deadline(),
+            None,
+            "an untouched pair owes no flush"
+        );
+
+        let oldest = Instant::now();
+        files.stream(false).append("out-first").await;
+        assert_eq!(files.flush_deadline(), Some(oldest + IDLE_FLUSH));
+
+        // Both streams, so the deadline is answering for the pair rather
+        // than for whichever one happened to be written last.
+        tokio::time::advance(IDLE_FLUSH / 2).await;
+        files.stream(false).append("out-second").await;
+        files.stream(true).append("err-first").await;
+        assert_eq!(
+            files.flush_deadline(),
+            Some(oldest + IDLE_FLUSH),
+            "a later line must not push the window out"
+        );
+
+        files.flush_idle().await;
+        assert_eq!(
+            files.flush_deadline(),
+            None,
+            "a flush must retire the deadline it satisfied"
+        );
+    }
+
+    /// Fails if a rotation loses or duplicates what the buffers were
+    /// holding.
+    ///
+    /// Every line below fits in [`LOG_BUFFER`], so at the rename the file may
+    /// hold none of them: a reopen that dropped its handle without flushing
+    /// would lose the lot, and one that flushed after swapping handles would
+    /// write them into the FRESH file — an operator reading the archive finds
+    /// a gap, and reading the live log finds lines from before the rotation.
+    /// Exact equality on both paths is what tells those two apart from a
+    /// reopen that got it right.
+    #[tokio::test]
+    async fn a_rotation_lands_every_buffered_line_exactly_once() {
+        let mut pump = PumpHarness::start();
+        let mut before = String::new();
+        for n in 0..40 {
+            let line = format!("before-{n}");
+            pump.feed(false, &line).await;
+            before.push_str(&line);
+            before.push('\n');
+        }
+        assert!(
+            before.len() < LOG_BUFFER,
+            "the case needs lines small enough that the buffer may still hold them"
+        );
+
+        let rotated = pump.dir.path().join("out.log.1");
+        fs::rename(&pump.out_path, &rotated).unwrap();
+        pump.reopen().await;
+
+        assert_eq!(fs::read_to_string(&rotated).unwrap(), before);
+        assert_eq!(fs::read_to_string(&pump.out_path).unwrap(), "");
+
+        let mut after = String::new();
+        for n in 0..40 {
+            let line = format!("after-{n}");
+            pump.feed(false, &line).await;
+            after.push_str(&line);
+            after.push('\n');
+        }
+        pump.flush().await;
+
+        assert_eq!(fs::read_to_string(&pump.out_path).unwrap(), after);
+        assert_eq!(
+            fs::read_to_string(&rotated).unwrap(),
+            before,
+            "the archive must have stopped growing at the swap"
         );
     }
 
@@ -2069,14 +2393,15 @@ mod tests {
     /// Fails if [`LogFile::flush`] stops asking the file anything — an early
     /// `return Ok(())`, or a `map_err` traded for `.ok()`.
     ///
-    /// A `tokio::fs::File` reports a failed write on the NEXT operation
-    /// rather than the one that failed: `write_all` returns as soon as the
-    /// real `write(2)` is queued on the blocking pool, so that write's error
-    /// is owed to whoever asks next. `flush` is who asks. This is the whole
-    /// reason the flush half of `shep flush` reports where
-    /// [`LogFile::reopen`]'s own flush logs — and a flush that answered
-    /// without asking would swallow the only signal there is that a sheep's
-    /// log went unwritten.
+    /// An append reaches the buffer and nothing else, and even once the
+    /// buffer is written through, a `tokio::fs::File` reports a failed write
+    /// on the NEXT operation rather than the one that failed: `write_all`
+    /// returns as soon as the real `write(2)` is queued on the blocking pool,
+    /// so that write's error is owed to whoever asks next. `flush` is who
+    /// asks, for both layers. This is the whole reason the flush half of
+    /// `shep flush` reports where [`LogFile::reopen`]'s own flush logs — and
+    /// a flush that answered without asking would swallow the only signal
+    /// there is that a sheep's log went unwritten.
     ///
     /// Driven against a [`LogFile`] rather than through [`PumpHarness`]
     /// because the pump opens its own handles: a read-only one is the
@@ -2090,7 +2415,11 @@ mod tests {
         fs::write(&path, "").unwrap();
         let mut log = LogFile {
             path: path.clone(),
-            handle: Some(tokio::fs::File::open(&path).await.unwrap()),
+            handle: Some(BufWriter::with_capacity(
+                LOG_BUFFER,
+                tokio::fs::File::open(&path).await.unwrap(),
+            )),
+            buffered_since: None,
         };
 
         // Swallowed by design — the pump must keep draining a child whose

--- a/crates/shep-daemon/src/tokio_runner.rs
+++ b/crates/shep-daemon/src/tokio_runner.rs
@@ -1904,22 +1904,52 @@ mod tests {
         );
     }
 
-    /// Fails if a line only reaches the file when the buffer fills or when
-    /// something asks — that is, if the pump has no idle flush at all.
+    /// Fails if a line only leaves the buffer when the buffer fills or when
+    /// something asks — that is, if [`IDLE_FLUSH`] bounds nothing.
     ///
-    /// A sheep that logs once and goes quiet is the whole case: nothing here
-    /// sends a `Flush`, nothing reopens, and no second line arrives to push
-    /// the first one out. `assert_file_settles` is the entire assertion, and
-    /// its own deadline is what fails if nothing ever writes the line
-    /// through. Real clock like every other case in this module (IR-33): the
-    /// wait is on file I/O the blocking pool has to actually do. The window's
-    /// arithmetic is pinned on the paused clock instead, by
-    /// [`the_idle_flush_window_is_measured_from_the_oldest_buffered_line`].
-    #[tokio::test]
+    /// A sheep that logs once and goes quiet is the whole case: no `Flush`,
+    /// no reopen, and no second line to push the first one out. One line of
+    /// 70 bytes is nowhere near [`LOG_BUFFER`], so the idle flush is the only
+    /// thing that can write it through.
+    ///
+    /// Paused clock and a counting sink (IR-33), for two different reasons.
+    /// The clock, because the wait is on [`IDLE_FLUSH`] rather than on any
+    /// real work, and a real 50 ms is a claim about the machine. The sink,
+    /// because "the bytes left the buffer" is what is being asserted, and a
+    /// file would answer that only once the blocking pool caught up — which
+    /// is the wall clock again, through the filesystem.
+    #[tokio::test(start_paused = true)]
     async fn a_line_from_a_sheep_that_then_goes_quiet_still_reaches_its_file() {
-        let mut pump = PumpHarness::start();
-        pump.feed(false, "the-only-line").await;
-        assert_file_settles(&pump.out_path, "the-only-line\n").await;
+        const LINE: &str = "the-only-line";
+        let sink = WriteCounter::default();
+        let mut log = LogFile {
+            path: PathBuf::from("quiet.log"),
+            handle: Some(BufWriter::with_capacity(LOG_BUFFER, sink.clone())),
+            buffered_since: None,
+        };
+
+        log.append(LINE).await;
+        assert_eq!(
+            sink.bytes(),
+            0,
+            "one short line must sit in the buffer, or there is nothing for the idle flush to do"
+        );
+
+        let armed = log
+            .buffered_since
+            .expect("an appended line must arm the flush deadline");
+        tokio::time::sleep_until(armed + IDLE_FLUSH).await;
+        log.flush().await.unwrap();
+
+        assert_eq!(
+            sink.bytes(),
+            LINE.len() + 1,
+            "the line and its newline must reach the file once the window closes"
+        );
+        assert_eq!(
+            log.buffered_since, None,
+            "a flush must retire the deadline, or the pump re-arms it every window"
+        );
     }
 
     /// Fails if the idle-flush window is measured from the NEWEST buffered

--- a/crates/shep-daemon/src/watch/mod.rs
+++ b/crates/shep-daemon/src/watch/mod.rs
@@ -734,7 +734,7 @@ mod tests {
         tempfile::TempDir,
     ) {
         let dir = tempfile::tempdir().unwrap();
-        let (events, rx) = broadcast::channel(64);
+        let (events, rx) = crate::bus::test_bus(64);
         let runner = ScriptedRunner::new(scripts);
         let handle = spawn_supervisor(runner, test_paths(&dir), events);
         (handle, rx, dir)
@@ -1481,7 +1481,7 @@ mod tests {
             let dir = tempfile::tempdir().unwrap();
             runtime.block_on(async move {
                 let kill_timeout = Duration::from_millis(kill_timeout_ms);
-                let (events, mut rx) = broadcast::channel(1024);
+                let (events, mut rx) = crate::bus::test_bus(1024);
                 let runner =
                     ScriptedRunner::new(vec![ProcScript::ignores_signals(); SINGLE_FLIGHT_SCRIPTS]);
                 let handle = spawn_supervisor(runner, test_paths(&dir), events);

--- a/crates/shep-daemon/src/watch/mod.rs
+++ b/crates/shep-daemon/src/watch/mod.rs
@@ -523,6 +523,7 @@ mod tests {
     use tokio::sync::broadcast;
 
     use super::*;
+    use crate::bus::SharedEvent;
     use crate::fake::{ProcScript, ScriptedRunner};
     use crate::supervisor::spawn_supervisor;
     use crate::testing::test_paths;
@@ -729,7 +730,7 @@ mod tests {
         scripts: Vec<ProcScript>,
     ) -> (
         SupervisorHandle,
-        broadcast::Receiver<BusEvent>,
+        broadcast::Receiver<SharedEvent>,
         tempfile::TempDir,
     ) {
         let dir = tempfile::tempdir().unwrap();
@@ -752,12 +753,15 @@ mod tests {
     /// restarts fails the test instead of hanging it (Global Constraints
     /// rule 11).
     async fn expect_restart(
-        rx: &mut broadcast::Receiver<BusEvent>,
+        rx: &mut broadcast::Receiver<SharedEvent>,
         name: &str,
         deadline: Duration,
     ) -> ProcessInfo {
         loop {
-            match tokio::time::timeout(deadline, rx.recv()).await {
+            match tokio::time::timeout(deadline, rx.recv())
+                .await
+                .map(|received| received.map(|event| event.to_event()))
+            {
                 Ok(Ok(BusEvent::Process {
                     event: ProcessEventKind::Restart,
                     info,
@@ -777,14 +781,17 @@ mod tests {
     /// sheep-task round trip needs the scheduling rounds a bounded `recv`
     /// gives it, which a `try_recv` negative cannot.
     async fn assert_no_restart_within(
-        rx: &mut broadcast::Receiver<BusEvent>,
+        rx: &mut broadcast::Receiver<SharedEvent>,
         name: &str,
         window: Duration,
     ) {
         let deadline = tokio::time::Instant::now() + window;
         loop {
             let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
-            match tokio::time::timeout(remaining, rx.recv()).await {
+            match tokio::time::timeout(remaining, rx.recv())
+                .await
+                .map(|received| received.map(|event| event.to_event()))
+            {
                 Err(_) => return, // window elapsed with nothing matching — expected
                 Ok(Ok(BusEvent::Process {
                     event: ProcessEventKind::Restart,
@@ -1509,7 +1516,7 @@ mod tests {
                 let collector = tokio::spawn(async move {
                     let mut observed = Vec::new();
                     loop {
-                        match tokio::time::timeout(EVENT_WAIT, rx.recv()).await {
+                        match tokio::time::timeout(EVENT_WAIT, rx.recv()).await.map(|received| received.map(|event| event.to_event())) {
                             Ok(Ok(BusEvent::Process {
                                 event: ProcessEventKind::Restart,
                                 info,


### PR DESCRIPTION
The audit's CPU measurement found the daemon idles at 0.15% but pays 32.8µs of CPU per log line, one blocking-pool round trip each, plus 18.6µs per line per attached bus subscriber. Two measured passes.

First pass:

- `LogFile` writes through an 8KiB `BufWriter` with a 50ms idle flush, measured from the oldest unflushed line
- `flush` and reopen drain the buffer first, so rotation and `shep flush` still mean what they say
- The bus publishes `Arc<BusEvent>` and encodes the frame once via `OnceLock<Bytes>`; subscribers clone the buffer

Second pass, profile-driven:

- The publish path was ~29% of what remained. `receiver_count == 0` could never gate it: the dog watcher and snapshot writer subscribe for the daemon's whole life and discard every log line. The gate counts subscribers whose filter matches log topics instead: another -45% per line with nothing attached
- `[profile.release]` gains thin LTO and one codegen unit: 18.6 to 14.2 MiB, `fat` and `strip` measured and declined, `panic="abort"` ruled out by shep-client's `is_panic` use
- Late subscribers were never replayed old events; verified against tokio's broadcast source, not assumed

Numbers, same box, same 7.3k lines/s sheep:

| | before | after both passes |
|---|---|---|
| daemon CPU | 27.98% | ~1% class |
| µs per line, no subscriber | 32.8 | 0.79 |
| throughput ceiling | 92k lines/s | 329k+ lines/s |

Counter tests pin every mechanism with no wall-clock assertions; each new test was mutation-checked. Absolute µs varies with the laptop's power state, so the paired ratios are the claim; both held in both states.

The trade: a SIGKILLed daemon can lose up to 8KiB or 50ms of a sheep's log. Every orderly path drains first. Close this PR if that window is not acceptable.

`SharedEvent` adds public API to shep-daemon, so this is a minor bump, not a patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved event delivery efficiency by sharing encoded event data across subscribers.
  * Added buffered log writing with periodic idle flushing for smoother output handling.
  * Reduced unnecessary log publication when no subscribers are interested.
  * Improved release-build performance through additional optimization.

* **Bug Fixes**
  * Prevented repeated event encoding and duplicate error logging.
  * Improved reliability during log rotation, backpressure, and shutdown.

* **Documentation**
  * Clarified log flush behavior and completion guarantees.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->