### PR TITLE
Hold the test pipe with a second node, not Git Bash's sleep

### DIFF
--- a/crates/shep-cli/src/commands/lifecycle.rs
+++ b/crates/shep-cli/src/commands/lifecycle.rs
@@ -3338,8 +3338,13 @@ mod tests {
             let path = dir.path().join("flock.js");
             std::fs::write(
                 &path,
+                // The pipe-holder is a second node, not `sleep`: node exists
+                // wherever this test runs (it gated on node_available above),
+                // while `sleep` on a Windows runner is Git Bash's, and twice
+                // on CI the parent node sat out the whole 5s budget with it.
                 "require('child_process')\
-                 .spawn('sleep', ['30'], { detached: true, stdio: 'inherit' })\
+                 .spawn(process.execPath, ['-e', 'setTimeout(()=>{},30000)'], \
+                 { detached: true, stdio: 'inherit' })\
                  .unref(); \
                  module.exports = { app: [] };",
             )


### PR DESCRIPTION
The `.js` Flockfile slow test failed three times today on `slow (windows-latest)`, on two diffs that never touched it. Its detached pipe-holder was `sleep 30`, which on a Windows runner is Git Bash's MSYS binary.

- The holder is now a second node via `process.execPath`, present wherever the test runs
- Assertion unchanged: node exits, the child holds the pipe, the message says so
- Local run passes in 5.02s. The Windows slow leg on this PR is the real proof

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of a lifecycle test across platforms.
  * Ensured the test correctly distinguishes held-open output streams from timeout or process termination errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->