### PR TITLE
Commit the pm2 benchmark, and put its numbers on the docs page

### DIFF
--- a/benches/versus-pm2/README.md
+++ b/benches/versus-pm2/README.md
@@ -1,0 +1,71 @@
+# shep versus pm2
+
+A head-to-head measurement of the two process managers on one machine, run by
+hand at a release and never in CI: it installs a third-party npm package and
+times a wall clock, and a shared runner can hold neither still.
+
+```sh
+./benches/versus-pm2/versus-pm2.sh
+```
+
+`VERSUS_SCRATCH` picks where builds, the pm2 install and the raw samples go
+(default `/tmp/shep-versus-pm2`); `SHEP_BIN` points at an already-built
+release binary if you have one.
+
+## What it measures, and why each is fair
+
+Both tools run the *same two shell scripts* the harness writes, under the same
+`/bin/sh`, with logs going to each tool's own default file capture.
+
+| Metric | Workload |
+| --- | --- |
+| Idle daemon CPU and RSS | ten `while true; do sleep 5; done` apps |
+| Log-plane CPU per line | one unthrottled `echo` loop, 62-byte lines |
+| Start latency | ten apps, cold daemon and warm |
+| Footprint | shep's binary against the pm2 install tree |
+
+The daemon is what is sampled, never the children.
+
+## The order is A/B/A on purpose
+
+shep, then pm2, then shep again. A laptop that changes power state mid-run
+shows up as disagreement between the two shep rounds instead of hiding inside
+a ratio. The first run caught exactly that: the battery flipped from
+discharging to charging, and the two shep rounds still agreed within 2.6%, so
+the numbers stood.
+
+Read the ratios, not the absolute figures. The box is not required to be idle,
+and the run that produced the committed results had a load average near five
+from unrelated work.
+
+## Clean room
+
+This benchmark drives the **published npm package** as a black box:
+`npm install pm2`, then its own binary and its own `pm2 ecosystem simple`
+generator for the config format. Observing what a shipped program does is not
+porting it. Nothing here reads pm2's source, and neither should you.
+
+## Results, 2026-08-29
+
+shep 0.1.12 (`d113586`) against pm2 7.0.4 on node v26.5.0, macOS.
+
+| Metric | shep | pm2 | Ratio |
+| --- | --- | --- | --- |
+| Idle daemon RSS, ten apps | 13.90 MiB | 71.16 MiB | 5.1x |
+| Log-plane CPU per line | 2.10 us | 4.03 us | 1.9x |
+| Start ten apps, cold | 0.158 s | 0.374 s | 2.4x |
+| Start ten apps, warm | 0.056 s | 0.197 s | 3.5x |
+| Install footprint | 14.23 MiB | 23.10 MiB | 1.6x |
+| Idle daemon CPU | 0.045% | 0.020% | a tie at the noise floor |
+
+Idle CPU is reported as the instrument read it. Both figures are hundredths
+of one percent of one core; the difference is not a result.
+
+The log-plane figure is worth its own sentence. shep cost 32.8 us per line
+before the 2026-08-28 audit, so pm2 was ahead by 8x on this measure until the
+day before these numbers were taken.
+
+Verified while measuring, rather than assumed: neither tool prefixed or
+timestamped a line, and the two out logs are byte-identical to the script's
+own echo; each daemon grew exactly one file during the window; pm2 ran at its
+defaults with only name, script and interpreter set.

--- a/benches/versus-pm2/README.md
+++ b/benches/versus-pm2/README.md
@@ -24,7 +24,8 @@ Both tools run the *same two shell scripts* the harness writes, under the same
 | Start latency | ten apps, cold daemon and warm |
 | Footprint | shep's binary against the pm2 install tree |
 
-The daemon is what is sampled, never the children.
+The shepherd is what is sampled, never the children. On the pm2 side that
+means its God Daemon.
 
 ## The order is A/B/A on purpose
 

--- a/benches/versus-pm2/versus-pm2.sh
+++ b/benches/versus-pm2/versus-pm2.sh
@@ -29,6 +29,8 @@ SETTLE_IDLE=10
 SAMPLE_IDLE=60
 SETTLE_LOG=5
 SAMPLE_LOG=30
+START_TIMEOUT=60
+POLL_INTERVAL=0.01
 LINE_BYTES=62   # verified at runtime by check_line_bytes
 
 mkdir -p "$RAW" "$APPS"
@@ -170,6 +172,20 @@ pm2_dpid()  { cat "$PM2_HOME/pm2.pid" 2>/dev/null; }
 
 # --------------------------------------------------- metric 1+2: idle CPU --
 
+# The two workloads every metric runs. Written here rather than assumed on
+# disk: the generated configs name these paths, and a missing script makes a
+# tool report zero online forever.
+write_workloads() {
+  mkdir -p "$APPS"
+  printf '#!/bin/sh\nwhile true; do sleep 5; done\n' > "$APPS/quiet.sh"
+  # 62 bytes per line, fixed, so a byte delta divides into an exact line count.
+  printf '#!/bin/sh\nwhile true; do echo "%s"; done\n' \
+    "shep versus pm2 benchmark line, fixed width payload xxxxx" > "$APPS/loud.sh"
+  chmod +x "$APPS/quiet.sh" "$APPS/loud.sh"
+  [ -x "$APPS/quiet.sh" ] && [ -x "$APPS/loud.sh" ] || {
+    echo "workload scripts missing under $APPS" >&2; return 1; }
+}
+
 m_idle() { # tool tag
   local tool="$1" tag="$2" cfg dpid n kids hrss
   echo "[idle] $tool $tag"
@@ -186,6 +202,14 @@ m_idle() { # tool tag
   fi
   echo "  online=$n dpid=$dpid"
   sleep "$SETTLE_IDLE"
+
+  # Both start commands return before the children are all up, so the counts
+  # taken above are pre-settle. Re-read them here or a late child is counted
+  # as helper RSS and the reported online count is stale.
+  if [ "$tool" = shep ]; then n=$(shep_online); kids=$(shep_pids)
+  else n=$(pm2_online); kids=$(pm2_pids); fi
+  [ "${n:-0}" -eq "$N_APPS" ] || {
+    echo "  only $n/$N_APPS online after settle, refusing to report" >&2; return 1; }
 
   local rss; rss=$(rss_kb "$dpid")
   hrss=$(helper_rss_kb "$dpid" $kids)
@@ -274,6 +298,11 @@ print(json.dumps({k: e.get(k) for k in keys}, indent=1))' \
   local s; s=$(stats_csv "$RAW/log-$tool-$tag.csv")
   local mean max cnt; read -r mean max cnt <<< "$s"
 
+  # A log that stopped growing, or a zero line width, would divide by zero
+  # below and leave the metric record silently absent.
+  [ "${lb:-0}" -gt 0 ] || { echo "  line width is 0, refusing to derive" >&2; return 1; }
+  [ "$b1" -gt "$b0" ] || { echo "  log did not grow during the window" >&2; return 1; }
+
   local res
   res=$(python3 -c "
 b0,b1,c0,c1,t0,t1,lb = $b0,$b1,$c0,$c1,$t0,$t1,$lb
@@ -296,14 +325,26 @@ print(f'{lines:.0f} {lines/el:.1f} {cpu/lines*1e6:.4f} {cpu/el*100:.3f} {el:.2f}
 timed_start() { # tool cfg
   local tool="$1" cfg="$2" t0 t1 n
   t0=$(now)
+  # Deadline and interval both matter. Unbounded, a failed start spins the
+  # list command forever and its own CPU lands in the measurement it is
+  # supposed to be timing.
+  local deadline; deadline=$(python3 -c "print($t0 + $START_TIMEOUT)")
   if [ "$tool" = shep ]; then
-    shepc start "$cfg" >/dev/null 2>&1
+    shepc start "$cfg" >/dev/null 2>&1 || { echo "  shep start failed" >&2; return 1; }
     n=$(shep_online)
-    while [ "${n:-0}" -lt "$N_APPS" ]; do n=$(shep_online); done
+    while [ "${n:-0}" -lt "$N_APPS" ]; do
+      python3 -c "import sys; sys.exit(0 if $(now) < $deadline else 1)" \
+        || { echo "  timed out at $n/$N_APPS" >&2; return 1; }
+      sleep "$POLL_INTERVAL"; n=$(shep_online)
+    done
   else
-    pm2c start "$cfg" >/dev/null 2>&1
+    pm2c start "$cfg" >/dev/null 2>&1 || { echo "  pm2 start failed" >&2; return 1; }
     n=$(pm2_online)
-    while [ "${n:-0}" -lt "$N_APPS" ]; do n=$(pm2_online); done
+    while [ "${n:-0}" -lt "$N_APPS" ]; do
+      python3 -c "import sys; sys.exit(0 if $(now) < $deadline else 1)" \
+        || { echo "  timed out at $n/$N_APPS" >&2; return 1; }
+      sleep "$POLL_INTERVAL"; n=$(pm2_online)
+    done
   fi
   t1=$(now)
   echo "$(python3 -c "print(f'{$t1-$t0:.4f}')") $n"
@@ -369,7 +410,11 @@ m_versions() {
   echo "  shep $sha | pm2 $pv | node $nv"
 }
 
+# Idempotent: the trap and the normal path both call this.
+_cleaned=0
 cleanup_all() {
+  [ "$_cleaned" = 1 ] && return 0
+  _cleaned=1
   echo "[cleanup]"
   shepc delete all >/dev/null 2>&1
   shepc kill       >/dev/null 2>&1
@@ -392,6 +437,10 @@ round() { # tag
   local tag="$1"
   m_idle  shep "$tag"; m_log  shep "$tag"; m_start shep "$tag"
 }
+
+# Installed here, below cleanup_all's definition: a trap set before the
+# function exists fires into an unbound name on an early interrupt.
+trap cleanup_all EXIT INT TERM
 
 main() {
   : > "$METRICS"

--- a/benches/versus-pm2/versus-pm2.sh
+++ b/benches/versus-pm2/versus-pm2.sh
@@ -347,6 +347,10 @@ timed_start() { # tool cfg
     done
   fi
   t1=$(now)
+  # Exactly the configured count. A surplus means a stale process survived a
+  # previous round, and the time it took to see it is not this run's number.
+  [ "${n:-0}" -eq "$N_APPS" ] || {
+    echo "  saw $n online, expected exactly $N_APPS" >&2; return 1; }
   echo "$(python3 -c "print(f'{$t1-$t0:.4f}')") $n"
 }
 
@@ -440,7 +444,13 @@ round() { # tag
 
 # Installed here, below cleanup_all's definition: a trap set before the
 # function exists fires into an unbound name on an early interrupt.
-trap cleanup_all EXIT INT TERM
+#
+# INT and TERM get their own handler because EXIT alone would clean up and
+# then let the next round restart everything the operator just interrupted.
+# 128+signal is the shell's own convention for a signal death.
+trap cleanup_all EXIT
+trap 'cleanup_all; exit 130' INT
+trap 'cleanup_all; exit 143' TERM
 
 main() {
   : > "$METRICS"

--- a/benches/versus-pm2/versus-pm2.sh
+++ b/benches/versus-pm2/versus-pm2.sh
@@ -1,0 +1,418 @@
+#!/bin/bash
+# versus-pm2.sh - head-to-head benchmark of shep against pm2.
+#
+# Order is A/B/A (shep, pm2, shep) so a machine state shift shows itself as
+# disagreement between the two shep rounds rather than hiding in the ratio.
+#
+# Every metric is a function; run the whole thing or source it and call one.
+#
+# WHY $ROOT IS NOT UNDER $SCRATCH: an AF_UNIX sun_path is 104 bytes. The
+# scratch dir alone is 155 chars, so both daemons fail to bind a socket under
+# it - pm2 wedges a God Daemon at 100% CPU, shep refuses outright. pm2 also
+# realpath()s PM2_HOME, so a short symlink does not help. Both tools therefore
+# get an equally short REAL root. Harness + raw samples still live in scratch.
+
+set -uo pipefail
+
+# Where builds, the pm2 install and raw samples go. Override to run elsewhere.
+SCRATCH="${VERSUS_SCRATCH:-/tmp/shep-versus-pm2}"
+ROOT="/private/tmp/shbvs"
+RAW="$SCRATCH/versus-pm2-raw"
+SHEP_BIN="${SHEP_BIN:-$SCRATCH/wt-bench/target/release/shep}"
+PM2_BIN="$SCRATCH/pm2-install/node_modules/.bin/pm2"
+SHEP_HOME_DIR="$ROOT/shep-bench-home"
+APPS="$ROOT/apps"
+export PM2_HOME="$ROOT/pm2-home"
+
+N_APPS=10
+SETTLE_IDLE=10
+SAMPLE_IDLE=60
+SETTLE_LOG=5
+SAMPLE_LOG=30
+LINE_BYTES=62   # verified at runtime by check_line_bytes
+
+mkdir -p "$RAW" "$APPS"
+METRICS="$RAW/metrics.jsonl"
+
+# ---------------------------------------------------------------- helpers --
+
+shepc() { "$SHEP_BIN" --home "$SHEP_HOME_DIR" --style bare "$@"; }
+pm2c()  { "$PM2_BIN" "$@"; }
+
+now() { perl -MTime::HiRes -e 'printf "%.6f", Time::HiRes::time()'; }
+
+# ps cputime "MM:SS.ss" / "H:MM:SS.ss" -> seconds
+cputime_s() {
+  ps -o cputime= -p "$1" 2>/dev/null \
+    | tr -d ' ' \
+    | awk -F: '{s=0; for(i=1;i<=NF;i++) s=s*60+$i; printf "%.2f", s}'
+}
+rss_kb() { ps -o rss= -p "$1" 2>/dev/null | tr -d ' '; }
+
+emit() { echo "$1" >> "$METRICS"; }
+
+# Sum RSS of processes parented by the daemon that are NOT managed apps.
+helper_rss_kb() {
+  local dpid="$1"; shift
+  ps ax -o pid=,ppid=,rss= | awk -v d="$dpid" -v k="$*" '
+    BEGIN { n=split(k,a," "); for(i=1;i<=n;i++) ex[a[i]]=1 }
+    $2==d && !($1 in ex) { s+=$3 }
+    END { printf "%d", s+0 }'
+}
+
+# ps %cpu + rss + cputime once per second, into a CSV.
+sample_daemon() {
+  local pid="$1" secs="$2" out="$3"
+  echo "wall,pcpu,rss_kb,cputime_s" > "$out"
+  local i
+  for ((i=0; i<secs; i++)); do
+    local line
+    line=$(ps -o %cpu=,rss=,cputime= -p "$pid" 2>/dev/null \
+      | awk '{t=$3; n=split(t,p,":"); s=0; for(j=1;j<=n;j++) s=s*60+p[j];
+              printf "%s,%s,%.2f", $1, $2, s}')
+    [ -z "$line" ] && line="NA,NA,NA"
+    echo "$(now),$line" >> "$out"
+    sleep 1
+  done
+}
+
+# mean/max of the pcpu column
+stats_csv() {
+  python3 - "$1" <<'PY'
+import sys, csv
+rows = list(csv.DictReader(open(sys.argv[1])))
+v = [float(r["pcpu"]) for r in rows if r["pcpu"] not in ("NA", "")]
+print(f'{sum(v)/len(v):.3f} {max(v):.3f} {len(v)}' if v else '0 0 0')
+PY
+}
+
+# ------------------------------------------------------------ config gen --
+
+gen_flockfile() { # kind outfile
+  local kind="$1" out="$2" i
+  : > "$out"
+  if [ "$kind" = quiet ]; then
+    for ((i=0; i<N_APPS; i++)); do
+      printf '[[app]]\nname = "q%d"\nscript = "%s/quiet.sh"\n\n' "$i" "$APPS" >> "$out"
+    done
+  else
+    printf '[[app]]\nname = "loud"\nscript = "%s/loud.sh"\n' "$APPS" >> "$out"
+  fi
+}
+
+# pm2 ecosystem format, per pm2's own `pm2 ecosystem simple` generator.
+# interpreter is pinned to /bin/sh so both tools execute the identical script
+# under the identical shell (pm2 otherwise picks /bin/bash, a different binary).
+gen_ecosystem() { # kind outfile
+  local kind="$1" out="$2" i
+  {
+    echo "module.exports = {"
+    echo "  apps : ["
+    if [ "$kind" = quiet ]; then
+      for ((i=0; i<N_APPS; i++)); do
+        printf '    { name: "q%d", script: "%s/quiet.sh", interpreter: "/bin/sh" },\n' "$i" "$APPS"
+      done
+    else
+      printf '    { name: "loud", script: "%s/loud.sh", interpreter: "/bin/sh" }\n' "$APPS"
+    fi
+    echo "  ]"
+    echo "}"
+  } > "$out"
+}
+
+# --------------------------------------------------------------- lifecycle --
+
+reset_shep() {
+  shepc delete all  >/dev/null 2>&1
+  shepc kill        >/dev/null 2>&1
+  sleep 2
+  rm -f "$SHEP_HOME_DIR"/logs/*.log
+}
+
+reset_pm2() {
+  pm2c delete all >/dev/null 2>&1
+  pm2c kill       >/dev/null 2>&1
+  sleep 2
+  rm -f "$PM2_HOME"/logs/*.log
+}
+
+shep_online() {
+  shepc --format json flock 2>/dev/null | python3 -c '
+import sys, json
+try: d = json.load(sys.stdin)
+except Exception: print(0); sys.exit()
+print(sum(1 for a in d.get("data", []) if a.get("status") == "online"))'
+}
+
+pm2_online() {
+  pm2c jlist 2>/dev/null | python3 -c '
+import sys, json
+try: d = json.load(sys.stdin)
+except Exception: print(0); sys.exit()
+print(sum(1 for a in d if a.get("pm2_env", {}).get("status") == "online"))'
+}
+
+shep_pids() {
+  shepc --format json flock 2>/dev/null | python3 -c '
+import sys, json
+d = json.load(sys.stdin)
+print(" ".join(str(a["pid"]) for a in d.get("data", []) if a.get("pid")))' 2>/dev/null
+}
+
+pm2_pids() {
+  pm2c jlist 2>/dev/null | python3 -c '
+import sys, json
+print(" ".join(str(a["pid"]) for a in json.load(sys.stdin) if a.get("pid")))' 2>/dev/null
+}
+
+shep_dpid() { cat "$SHEP_HOME_DIR/pids/shepd.pid" 2>/dev/null; }
+pm2_dpid()  { cat "$PM2_HOME/pm2.pid" 2>/dev/null; }
+
+# --------------------------------------------------- metric 1+2: idle CPU --
+
+m_idle() { # tool tag
+  local tool="$1" tag="$2" cfg dpid n kids hrss
+  echo "[idle] $tool $tag"
+  if [ "$tool" = shep ]; then
+    reset_shep
+    cfg="$ROOT/Flockfile.quiet.toml"; gen_flockfile quiet "$cfg"
+    shepc start "$cfg" >/dev/null 2>&1
+    n=$(shep_online); dpid=$(shep_dpid); kids=$(shep_pids)
+  else
+    reset_pm2
+    cfg="$ROOT/ecosystem.quiet.config.js"; gen_ecosystem quiet "$cfg"
+    pm2c start "$cfg" >/dev/null 2>&1
+    n=$(pm2_online); dpid=$(pm2_dpid); kids=$(pm2_pids)
+  fi
+  echo "  online=$n dpid=$dpid"
+  sleep "$SETTLE_IDLE"
+
+  local rss; rss=$(rss_kb "$dpid")
+  hrss=$(helper_rss_kb "$dpid" $kids)
+
+  local c0 t0 c1 t1
+  c0=$(cputime_s "$dpid"); t0=$(now)
+  sample_daemon "$dpid" "$SAMPLE_IDLE" "$RAW/idle-$tool-$tag.csv"
+  c1=$(cputime_s "$dpid"); t1=$(now)
+
+  local s; s=$(stats_csv "$RAW/idle-$tool-$tag.csv")
+  local mean max cnt; read -r mean max cnt <<< "$s"
+  local derived
+  derived=$(python3 -c "print(f'{($c1-$c0)/($t1-$t0)*100:.3f}')")
+
+  emit "{\"metric\":\"idle\",\"tool\":\"$tool\",\"tag\":\"$tag\",\"online\":$n,\
+\"pcpu_mean\":$mean,\"pcpu_max\":$max,\"samples\":$cnt,\
+\"cputime_derived_pct\":$derived,\"rss_kb\":${rss:-0},\"helper_rss_kb\":${hrss:-0}}"
+  echo "  mean=$mean max=$max derived=$derived rss_kb=$rss helper_rss_kb=$hrss"
+}
+
+# ------------------------------------------------- metric 3: log-plane CPU --
+
+check_line_bytes() { # file -> bytes per line, from the first 100 lines
+  head -n 100 "$1" | wc -c | awk '{printf "%d", $1/100}'
+}
+
+m_log() { # tool tag
+  local tool="$1" tag="$2" cfg dpid logf
+  echo "[log] $tool $tag"
+  if [ "$tool" = shep ]; then
+    reset_shep
+    cfg="$ROOT/Flockfile.loud.toml"; gen_flockfile loud "$cfg"
+    shepc start "$cfg" >/dev/null 2>&1
+    dpid=$(shep_dpid)
+    logf=$(shepc --format json flock 2>/dev/null | python3 -c '
+import sys, json; print(json.load(sys.stdin)["data"][0]["out_file"])')
+  else
+    reset_pm2
+    cfg="$ROOT/ecosystem.loud.config.js"; gen_ecosystem loud "$cfg"
+    pm2c start "$cfg" >/dev/null 2>&1
+    dpid=$(pm2_dpid)
+    logf=$(pm2c jlist 2>/dev/null | python3 -c '
+import sys, json; print(json.load(sys.stdin)[0]["pm2_env"]["pm_out_log_path"])')
+  fi
+  echo "  dpid=$dpid log=$logf"
+  sleep "$SETTLE_LOG"
+
+  # Verify the file is actually growing on disk before sampling anything.
+  local g0 g1 growing
+  g0=$(stat -f %z "$logf" 2>/dev/null || echo 0)
+  sleep 1
+  g1=$(stat -f %z "$logf" 2>/dev/null || echo 0)
+  growing=$(( g1 > g0 ? 1 : 0 ))
+  echo "  growing=$growing ($g0 -> $g1 bytes)"
+
+  local lb; lb=$(check_line_bytes "$logf")
+
+  # What does the daemon write per line, beyond the app's own out log? Snapshot
+  # every file in the log dir before and after; anything that grew is per-line
+  # work. Observed, not assumed.
+  local logdir; logdir=$(dirname "$logf")
+  ls -l "$logdir" > "$RAW/logdir-$tool-$tag.before.txt" 2>&1
+
+  # Byte deltas, not `wc -l`: stat is instantaneous, while wc -l on a
+  # multi-hundred-MB file takes long enough to smear the window boundary.
+  local b0 c0 t0 b1 c1 t1
+  b0=$(stat -f %z "$logf"); c0=$(cputime_s "$dpid"); t0=$(now)
+  sample_daemon "$dpid" "$SAMPLE_LOG" "$RAW/log-$tool-$tag.csv"
+  b1=$(stat -f %z "$logf"); c1=$(cputime_s "$dpid"); t1=$(now)
+  ls -l "$logdir" > "$RAW/logdir-$tool-$tag.after.txt" 2>&1
+
+  # Record the effective per-app log settings, to show they are defaults.
+  if [ "$tool" = pm2 ]; then
+    pm2c jlist 2>/dev/null | python3 -c '
+import sys, json
+e = json.load(sys.stdin)[0]["pm2_env"]
+keys = ["pm_out_log_path","pm_err_log_path","log_date_format","merge_logs",
+        "log_type","out_file","error_file","disable_logs","vizion","autorestart",
+        "exec_mode","instances","pmx","automation","treekill","windowsHide"]
+print(json.dumps({k: e.get(k) for k in keys}, indent=1))' \
+      > "$RAW/pm2-logsettings-$tag.json" 2>&1
+  fi
+  # First 3 lines exactly as written, to show prefix/timestamp bytes (or none).
+  head -n 3 "$logf" | cat -v > "$RAW/logsample-$tool-$tag.txt" 2>&1
+
+  local s; s=$(stats_csv "$RAW/log-$tool-$tag.csv")
+  local mean max cnt; read -r mean max cnt <<< "$s"
+
+  local res
+  res=$(python3 -c "
+b0,b1,c0,c1,t0,t1,lb = $b0,$b1,$c0,$c1,$t0,$t1,$lb
+el = t1-t0; lines = (b1-b0)/lb; cpu = c1-c0
+print(f'{lines:.0f} {lines/el:.1f} {cpu/lines*1e6:.4f} {cpu/el*100:.3f} {el:.2f} {cpu:.2f}')")
+  local lines lps uspl dpct el cpu
+  read -r lines lps uspl dpct el cpu <<< "$res"
+
+  emit "{\"metric\":\"log\",\"tool\":\"$tool\",\"tag\":\"$tag\",\"growing\":$growing,\
+\"line_bytes\":$lb,\"pcpu_mean\":$mean,\"pcpu_max\":$max,\
+\"cputime_derived_pct\":$dpct,\"lines\":$lines,\"lines_per_s\":$lps,\
+\"us_per_line\":$uspl,\"elapsed_s\":$el,\"daemon_cpu_s\":$cpu,\"log\":\"$logf\"}"
+  echo "  mean=$mean derived=$dpct lines/s=$lps us/line=$uspl"
+}
+
+# ------------------------------------------------- metric 4: start latency --
+
+# One timed start: invoke the start command, then poll the tool's own list
+# command until all N report online. Returns "seconds online".
+timed_start() { # tool cfg
+  local tool="$1" cfg="$2" t0 t1 n
+  t0=$(now)
+  if [ "$tool" = shep ]; then
+    shepc start "$cfg" >/dev/null 2>&1
+    n=$(shep_online)
+    while [ "${n:-0}" -lt "$N_APPS" ]; do n=$(shep_online); done
+  else
+    pm2c start "$cfg" >/dev/null 2>&1
+    n=$(pm2_online)
+    while [ "${n:-0}" -lt "$N_APPS" ]; do n=$(pm2_online); done
+  fi
+  t1=$(now)
+  echo "$(python3 -c "print(f'{$t1-$t0:.4f}')") $n"
+}
+
+# Measured twice, because neither reading alone is the whole story:
+#   cold - daemon down, so `start` also pays daemon boot. What a user feels on
+#          a fresh box, and symmetric: `shep ping`/`shep set` do NOT boot shep's
+#          daemon, so only `start` can, while `pm2 ping` DOES boot God. Warming
+#          via ping would have handed pm2 a warm daemon and shep a cold one.
+#   warm - daemon already up with zero apps. Isolates the spawn-10-apps path.
+m_start() { # tool tag
+  local tool="$1" tag="$2" cfg
+  echo "[start] $tool $tag"
+  if [ "$tool" = shep ]; then
+    reset_shep   # kills the daemon
+    cfg="$ROOT/Flockfile.quiet.toml"; gen_flockfile quiet "$cfg"
+  else
+    reset_pm2
+    cfg="$ROOT/ecosystem.quiet.config.js"; gen_ecosystem quiet "$cfg"
+  fi
+
+  local cold n_cold; read -r cold n_cold <<< "$(timed_start "$tool" "$cfg")"
+
+  # Delete the apps but leave the daemon up -> warm.
+  if [ "$tool" = shep ]; then shepc delete all >/dev/null 2>&1
+  else pm2c delete all >/dev/null 2>&1; fi
+  sleep 2
+  local warm n_warm; read -r warm n_warm <<< "$(timed_start "$tool" "$cfg")"
+
+  # Cost of ONE list round trip, so poll overhead can be separated out:
+  # pm2's list is a fresh node process, shep's is a small static binary.
+  local l0 l1 listcost
+  l0=$(now)
+  if [ "$tool" = shep ]; then shepc --format json flock >/dev/null 2>&1
+  else pm2c jlist >/dev/null 2>&1; fi
+  l1=$(now)
+  listcost=$(python3 -c "print(f'{$l1-$l0:.4f}')")
+
+  emit "{\"metric\":\"start\",\"tool\":\"$tool\",\"tag\":\"$tag\",\
+\"cold_s\":$cold,\"cold_online\":$n_cold,\"warm_s\":$warm,\"warm_online\":$n_warm,\
+\"list_roundtrip_s\":$listcost}"
+  echo "  cold=${cold}s warm=${warm}s online=$n_cold/$n_warm list_roundtrip=${listcost}s"
+}
+
+# ------------------------------------------------------ metric 5: footprint --
+
+m_footprint() {
+  echo "[footprint]"
+  local sb pm
+  sb=$(stat -f %z "$SHEP_BIN")
+  pm=$(du -sk "$SCRATCH/pm2-install" | awk '{print $1}')
+  emit "{\"metric\":\"footprint\",\"shep_binary_bytes\":$sb,\"pm2_install_kb\":$pm}"
+  python3 -c "print(f'  shep binary {$sb/1048576:.2f} MiB   pm2 install {$pm/1024:.2f} MiB')"
+}
+
+m_versions() {
+  local sha pv nv
+  sha=$(cd "$SCRATCH/wt-bench" && git rev-parse HEAD)
+  pv=$(node -e "console.log(require('$SCRATCH/pm2-install/node_modules/pm2/package.json').version)")
+  nv=$(node --version)
+  emit "{\"metric\":\"versions\",\"shep_sha\":\"$sha\",\"shep_version\":\"$("$SHEP_BIN" --version | awk '{print $2}')\",\"pm2\":\"$pv\",\"node\":\"$nv\"}"
+  echo "  shep $sha | pm2 $pv | node $nv"
+}
+
+cleanup_all() {
+  echo "[cleanup]"
+  shepc delete all >/dev/null 2>&1
+  shepc kill       >/dev/null 2>&1
+  pm2c delete all  >/dev/null 2>&1
+  pm2c kill        >/dev/null 2>&1
+  sleep 2
+  echo "  shepd pid file:"; cat "$SHEP_HOME_DIR/pids/shepd.pid" 2>/dev/null || echo "   (gone)"
+  echo "  pm2 god daemons:"; ps ax -o pid=,command= | grep "[P]M2 v" || echo "   none"
+  echo "  workload children:"; ps ax -o pid=,command= | grep -E "[q]uiet\.sh|[l]oud\.sh" || echo "   none"
+  echo "  daemons rooted at $ROOT:"; ps ax -o pid=,command= | grep "[s]hbvs" | grep -v grep || echo "   none"
+  # The loud workload leaves ~GB of log behind; reclaim it.
+  du -sh "$PM2_HOME/logs" "$SHEP_HOME_DIR/logs" 2>/dev/null
+  rm -f "$PM2_HOME"/logs/*.log "$SHEP_HOME_DIR"/logs/*.log
+  echo "  logs reclaimed"
+}
+
+# ------------------------------------------------------------------- main --
+
+round() { # tag
+  local tag="$1"
+  m_idle  shep "$tag"; m_log  shep "$tag"; m_start shep "$tag"
+}
+
+main() {
+  : > "$METRICS"
+  echo "=== versus-pm2 :: $(date) ==="
+  m_versions
+  echo "--- machine ---"
+  echo "$(sysctl -n machdep.cpu.brand_string) / $(sysctl -n hw.ncpu) cpus"
+  pmset -g batt | head -2
+  uptime
+
+  # A / B / A
+  echo; echo "########## ROUND A1 (shep) ##########"
+  m_idle shep A1; m_log shep A1; m_start shep A1
+  echo; echo "########## ROUND B  (pm2)  ##########"
+  m_idle pm2  B;  m_log pm2  B;  m_start pm2  B
+  echo; echo "########## ROUND A2 (shep) ##########"
+  m_idle shep A2; m_log shep A2; m_start shep A2
+
+  m_footprint
+  cleanup_all
+  echo; echo "=== metrics.jsonl ==="; cat "$METRICS"
+}
+
+[ "${1:-}" = "--source-only" ] || main "$@"

--- a/web/src/pages/docs/from-pm2.astro
+++ b/web/src/pages/docs/from-pm2.astro
@@ -608,9 +608,14 @@ cwd = "/srv/migrate"`}</CodeBlock>
     line-height: 1.5;
   }
 
+  .bench-table .row {
+    grid-template-columns: 1.6fr 1fr 1fr 0.6fr;
+  }
+
   @media (max-width: 640px) {
     .field-table .row,
-    .verb-table .row {
+    .verb-table .row,
+    .bench-table .row {
       grid-template-columns: 1fr;
       gap: 4px;
     }
@@ -658,7 +663,4 @@ cwd = "/srv/migrate"`}</CodeBlock>
     color: var(--ink-2);
   }
 
-  .bench-table .row {
-    grid-template-columns: 1.6fr 1fr 1fr 0.6fr;
-  }
 </style>

--- a/web/src/pages/docs/from-pm2.astro
+++ b/web/src/pages/docs/from-pm2.astro
@@ -28,6 +28,15 @@ const meta = {
     "shep import reads a real dump.pm2 and writes a Flockfile. It starts nothing, and names on stderr everything that could not survive the trip unchanged.",
 };
 
+const benchTable: { metric: string; shep: string; pm2: string; ratio: string }[] = [
+  { metric: "Idle daemon RSS, ten apps", shep: "13.90 MiB", pm2: "71.16 MiB", ratio: "5.1x" },
+  { metric: "Log-plane CPU per line", shep: "2.10 us", pm2: "4.03 us", ratio: "1.9x" },
+  { metric: "Start ten apps, cold daemon", shep: "0.158 s", pm2: "0.374 s", ratio: "2.4x" },
+  { metric: "Start ten apps, warm daemon", shep: "0.056 s", pm2: "0.197 s", ratio: "3.5x" },
+  { metric: "Install footprint", shep: "14.23 MiB", pm2: "23.10 MiB", ratio: "1.6x" },
+  { metric: "Idle daemon CPU", shep: "0.045%", pm2: "0.020%", ratio: "a tie" },
+];
+
 const verbTable: { pm2: string; shep: string; note?: string }[] = [
   { pm2: "pm2 start <script>", shep: "shep start <script>" },
   {
@@ -300,6 +309,55 @@ cwd = "/srv/migrate"`}</CodeBlock>
       an interpreter under <code>~/.bun/bin</code> or <code>~/.cargo/bin</code>
       is still findable after a reboot with no login shell behind the daemon
       at all.
+    </p>
+
+    <h2>What it costs to run</h2>
+    <p>
+      Measured on one machine on 2026-08-29: shep 0.1.12 against pm2 7.0.4 on
+      node v26.5.0. Both tools ran the same two shell scripts under the same
+      <code>/bin/sh</code>, with logs going to each tool's own default file
+      capture, and the daemon is what was sampled rather than the children.
+    </p>
+    <div class="verb-table bench-table">
+      <div class="row header">
+        <span>metric</span>
+        <span>shep</span>
+        <span>pm2</span>
+        <span>ratio</span>
+      </div>
+      {
+        benchTable.map((row) => (
+          <div class="row">
+            <span class="note-cell">{row.metric}</span>
+            <span class="shep-cell"><code>{row.shep}</code></span>
+            <span class="pm2-cell"><code>{row.pm2}</code></span>
+            <span class="note-cell">{row.ratio}</span>
+          </div>
+        ))
+      }
+    </div>
+    <Callout variant="careful">
+      Read the ratios, not the absolute figures. The box was not idle, and it
+      changed power state partway through the run. The order is shep, pm2,
+      shep, so a shift like that shows up as disagreement between the two
+      shep rounds: they agreed within 2.6%, which is why these numbers stand.
+      Idle CPU is printed as the instrument read it, and both figures are
+      hundredths of one percent of one core, so the difference there is not a
+      result.
+    </Callout>
+    <p>
+      The log-plane figure has only just gone this way. shep cost 32.8 us per
+      line until an audit on 2026-08-28 buffered the writes and stopped
+      encoding one bus event once per subscriber, so pm2 was ahead by 8x on
+      that measure the day before this was taken.
+    </p>
+    <p>
+      The RSS gap is structural rather than clever: pm2's daemon is a node
+      process and pays that runtime's floor whatever it does. Everything here
+      is reproducible from
+      <code>benches/versus-pm2/versus-pm2.sh</code> in the repository, which
+      drives the published npm package as a black box and keeps its raw
+      samples.
     </p>
 
     <h2>The verb-by-verb table</h2>
@@ -598,5 +656,9 @@ cwd = "/srv/migrate"`}</CodeBlock>
     font-size: 14px;
     line-height: 1.5;
     color: var(--ink-2);
+  }
+
+  .bench-table .row {
+    grid-template-columns: 1.6fr 1fr 1fr 0.6fr;
   }
 </style>


### PR DESCRIPTION
The comparison was a scratch script, so every number in it died with the directory. It is in the tree now, and the results are on the page that invites the comparison.

- `benches/versus-pm2/` holds the harness and a README with the conditions
- Not in CI: it installs an npm package and times a wall clock
- `from-pm2` gains six measured rows, a callout saying to read ratios not absolutes, and a pointer at the harness

Measured 2026-08-29, shep 0.1.12 against pm2 7.0.4 on node v26.5.0:

| | shep | pm2 | ratio |
|---|---|---|---|
| Idle RSS, ten apps | 13.90 MiB | 71.16 MiB | 5.1x |
| Log-plane CPU per line | 2.10 us | 4.03 us | 1.9x |
| Start ten apps, warm | 0.056 s | 0.197 s | 3.5x |
| Idle daemon CPU | 0.045% | 0.020% | a tie |

Two things both the README and the page say out loud: idle CPU is a tie at the noise floor, printed as measured, and pm2 led the log-plane number by 8x until the audit landed the day before.

Clean room intact. The harness drives the published npm package as a black box and takes its config format from `pm2 ecosystem simple`.

`astro check` 0 errors, `astro build` 21 pages, `typos` clean, `shellcheck -S error` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a guide for manually comparing runtime performance with PM2.
  * Documented benchmark setup, workloads, fairness controls, validation steps, and reproducibility guidance.
  * Published benchmark results covering memory usage, CPU consumption, startup time, logging performance, throughput, and installation footprint.
  * Added responsive tables, measurement methodology, caveats, and historical context to help readers interpret the results.
  * Added a benchmark tool for generating repeatable comparisons and recording raw performance measurements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->