### PR TITLE
fix(ci): build aarch64-musl natively, so a release ships its binaries again

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -16,7 +16,10 @@ name: Release artifacts
 #     Add a fourth binary there and this file does not notice.
 #   * `test.yml`'s matrix is what proves these targets build at all. Six of
 #     the seven legs below appear there; `aarch64-unknown-linux-musl` is the
-#     exception and is built natively, so it needs no cross toolchain.
+#     exception. It IS built natively, but only because its matrix entry says
+#     `build_tool: cargo`. This comment asserted it as a fact for weeks while
+#     the action was quietly using `cross`, which is how shep-v0.1.13 shipped
+#     with no binaries at all.
 #
 # ## Why `release: published` works here
 #
@@ -142,6 +145,19 @@ jobs:
           - target: aarch64-unknown-linux-musl
             os: ubuntu-24.04-arm
             packages: musl-tools
+            # The one leg that names its build tool, because it is the one
+            # where the action's own choice is wrong. Left to itself it sees
+            # target != host (musl against the runner's gnu) and reaches for
+            # `cross`, and cross 0.2.5 opens by installing
+            # `stable-x86_64-unknown-linux-gnu`, which an arm64 runner refuses:
+            # "toolchain may not be able to run on this system". That is what
+            # failed on shep-v0.1.13 and took the whole downstream packaging
+            # chain with it.
+            #
+            # The arch already matches, so there is nothing to cross-compile.
+            # `musl-tools` above supplies the C toolchain `ring`'s build script
+            # needs, the same as the x86_64 musl leg.
+            build_tool: cargo
           # msvc, deliberately, not gnu. `x86_64-pc-windows-gnu` in this
           # repository is `cargo check` only, cross-compiled from ubuntu by
           # test.yml, and has never executed a shep binary anywhere. msvc is
@@ -190,6 +206,9 @@ jobs:
           # be renamed later without breaking published URLs.
           archive: shep-$target
           target: ${{ matrix.target }}
+          # Empty for every leg that does not set it, which the action reads as
+          # "choose for me" -- its default, and right everywhere else.
+          build-tool: ${{ matrix.build_tool }}
           # `tar` defaults to `unix` and `zip` to `windows`, which is exactly
           # the split wanted here, so neither is set.
           #


### PR DESCRIPTION
shep 0.1.13 published to crates.io with no binaries. `aarch64-unknown-linux-musl` failed and took the whole downstream chain with it.

`taiki-e/upload-rust-binary-action` picks its build tool by comparing target to host. Those differ for that leg (musl against the runner's gnu) even though the architecture matches, so it chose `cross`. cross 0.2.5 opens by installing `stable-x86_64-unknown-linux-gnu`, which `ubuntu-24.04-arm` refuses:

```
error: toolchain 'stable-x86_64-unknown-linux-gnu' may not be able to run on this system
```

- `build_tool: cargo` on that one matrix entry, so the native build it was always meant to do actually happens
- every other leg leaves the key unset, which reaches the action as an empty string meaning "choose for me"
- the x86_64 musl leg takes the same `cross` path and passes, because there cross's assumption about the host is true. That is why the two legs looked symmetric

The workflow header has said since it was written that this leg "is built natively, so it needs no cross toolchain". That was the author's intent and nothing in the file enforced it, so the action was free to decide otherwise. Header now says the leg is native because the matrix entry says so.

Verified with a dry run against `shep-v0.1.13` from this branch, uploading nothing: all eight legs green, including the one that failed. Run [33269896783](https://github.com/TurtIeSocks/shep/actions/runs/33269896783).

The package-manager jobs still show skipped, which is correct twice over. They gate on `github.event_name == 'release'`, and this was a dispatch. They also gate on repository variables, and `actions/variables` returns 0, which is what `docs/distribution.md` describes as deliberate. So the next real release uploads the eight archives and SHA256SUMS, and Homebrew, Scoop, Chocolatey, deb and WinGet stay switched off until you set their variables.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that the ARM 64-bit musl release artifact is built with Cargo.

* **Release Process**
  * Improved release artifact configuration to apply the correct build tool for the ARM musl target.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->