### PR TITLE
docs(dogs): list shep-deploy in the community registry

### DIFF
--- a/web/public/dogs.json
+++ b/web/public/dogs.json
@@ -13,6 +13,18 @@
       "source": {
         "kind": "cargo"
       }
+    },
+    {
+      "name": "Scout",
+      "package": "shep-deploy",
+      "adopt_as": "deploy",
+      "description": "Watches a git branch, builds a release in an isolated directory, swaps to it, and rolls back on its own if the new release does not come up.",
+      "repo": "https://github.com/TurtIeSocks/shep-deploy",
+      "license": "MIT OR Apache-2.0",
+      "category": "deploy",
+      "source": {
+        "kind": "cargo"
+      }
     }
   ]
 }

--- a/web/public/dogs.json
+++ b/web/public/dogs.json
@@ -15,7 +15,7 @@
       }
     },
     {
-      "name": "Scout",
+      "name": "Moon",
       "package": "shep-deploy",
       "adopt_as": "deploy",
       "description": "Watches a git branch, builds a release in an isolated directory, swaps to it, and rolls back on its own if the new release does not come up.",


### PR DESCRIPTION
`shep-deploy` has been on crates.io for a while and the site never listed it, so `/docs/community-dogs` showed only `shep-log-rotate`.

- adds the registry entry to `web/public/dogs.json`
- `deploy` was already a category with no entries, so it rendered as nothing. It is a real section now

Fields read from the source rather than assumed:

- licence is `MIT OR Apache-2.0` from the crate's `Cargo.toml`. GitHub's API reports `Apache-2.0`, which is its reading of the LICENSE files rather than the manifest, and would have understated the dual licence
- description is the repo's own sentence, minus the `A deploy dog for shep:` prefix the page already supplies
- checked the crate is published and unyanked before adding a line telling people to `cargo install shep-deploy`

Verified against the built HTML, not by eye. The page emits a Deploy heading and generates `cargo install shep-deploy` and `shep adopt ~/.cargo/bin/shep-deploy --name deploy`.

One field had no source to read: the dog's name. Moon follows Bella's register and suits a dog that goes out ahead, checks the ground, and comes back when it is bad.

`astro build` and `astro check` both exit 0.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Moon to the available dog entries for the `shep-deploy` package, including deployment details, licensing, category, repository, and source information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->