### PR TITLE
docs(web): pages for the verbs that had none, and pm2 talk back to the migration guide

### DIFF
--- a/web/src/components/docs/ReferencePills.astro
+++ b/web/src/components/docs/ReferencePills.astro
@@ -7,11 +7,10 @@
  * a Source pill — that field has no `?`, so leaving it off is a type error,
  * not a silent gap.
  *
- * Source and Spec both point into the (currently private) GitHub repo; API
- * points at docs.rs, which has nothing until shep-core's first publish.
- * Both targets are real, final URLs today — a private repo and an
- * unpublished crate, not wrong paths — so nothing about the link itself
- * needs to change later. `pillTargetsLive` in docsNav.ts is the single
+ * Source and Spec both point into the GitHub repo, which went public on
+ * 2026-08-16; API points at docs.rs, which has nothing until shep-core's
+ * first publish. Both targets are real, final URLs today, so nothing about
+ * the link itself needs to change later. `pillTargetsLive` in docsNav.ts is the single
  * switch: while a kind is `false` the pill renders dimmed, non-interactive,
  * and marked `aria-disabled`, with a tooltip saying why, instead of either
  * a confident-looking link that 404s or hiding the sourcing until launch
@@ -35,14 +34,16 @@ if (!item) {
 const REPO = "https://github.com/TurtIeSocks/shep";
 const SPEC_FILE = "docs/specs/shep-v1.md";
 
+const sources = Array.isArray(item.source) ? item.source : [item.source];
+
 const pills = [
-  {
+  ...sources.map((path) => ({
     kind: "Source" as const,
-    label: item.source,
-    href: `${REPO}/blob/main/${item.source}`,
+    label: path,
+    href: `${REPO}/blob/main/${path}`,
     live: pillTargetsLive.github,
     disabledReason: "Not public yet. The repo is private until launch.",
-  },
+  })),
   item.spec && {
     kind: "Spec" as const,
     label: item.spec.label,

--- a/web/src/data/cli-reference.generated.txt
+++ b/web/src/data/cli-reference.generated.txt
@@ -1,5 +1,5 @@
 @@VERSION@@
-shep 0.1.12
+shep 0.1.15
 @@TOPLEVEL@@
 A process manager for your flock
 

--- a/web/src/data/docsNav.ts
+++ b/web/src/data/docsNav.ts
@@ -117,7 +117,11 @@ export const docsNav: DocsNavGroup[] = [
         slug: "talking-to-a-sheep",
         label: "Talking to a sheep",
         built: true,
-        source: "crates/shep-core/src/signals.rs",
+        source: [
+          "crates/shep-core/src/signals.rs",
+          "crates/shep-cli/src/commands/signal.rs",
+          "crates/shep-cli/src/commands/whisper.rs",
+        ],
         spec: { anchor: "9-cli-surface-sheep-native", label: "§9 CLI surface" },
         api: {
           path: "signals/enum.OperatorSignal.html",

--- a/web/src/data/docsNav.ts
+++ b/web/src/data/docsNav.ts
@@ -36,8 +36,15 @@ export interface DocsNavItem {
   /** Route is always `/docs/${slug}`. */
   label: string;
   built: boolean;
-  /** Repo-relative path this page's material is drawn from — the Source pill. */
-  source: string;
+  /**
+   * Repo-relative path this page's material is drawn from — the Source pill.
+   *
+   * An array where a page's verbs genuinely span more than one module, which
+   * renders one Source pill per file. The Logs page is the case that forced
+   * it: `bleats` lives in `commands/bleats.rs` and `reopen`/`flush` in
+   * `commands/logs.rs`, so either path alone under-represents the page.
+   */
+  source: string | string[];
   spec?: SpecRef;
   api?: ApiRef;
 }
@@ -219,7 +226,10 @@ export const docsNav: DocsNavGroup[] = [
         slug: "logs",
         label: "Logs",
         built: true,
-        source: "crates/shep-cli/src/commands/logs.rs",
+        source: [
+          "crates/shep-cli/src/commands/bleats.rs",
+          "crates/shep-cli/src/commands/logs.rs",
+        ],
         spec: { anchor: "9-cli-surface-sheep-native", label: "§9 CLI surface" },
       },
       {

--- a/web/src/data/docsNav.ts
+++ b/web/src/data/docsNav.ts
@@ -125,6 +125,17 @@ export const docsNav: DocsNavGroup[] = [
         },
       },
       {
+        slug: "lifecycle",
+        label: "Stopping and replacing a sheep",
+        built: true,
+        source: [
+          "crates/shep-daemon/src/kill.rs",
+          "crates/shep-daemon/src/supervisor.rs",
+          "crates/shep-daemon/src/snapshot.rs",
+        ],
+        spec: { anchor: "9-cli-surface-sheep-native", label: "§9 CLI surface" },
+      },
+      {
         slug: "dogs",
         label: "Dogs",
         built: true,

--- a/web/src/data/docsNav.ts
+++ b/web/src/data/docsNav.ts
@@ -107,6 +107,17 @@ export const docsNav: DocsNavGroup[] = [
         },
       },
       {
+        slug: "talking-to-a-sheep",
+        label: "Talking to a sheep",
+        built: true,
+        source: "crates/shep-core/src/signals.rs",
+        spec: { anchor: "9-cli-surface-sheep-native", label: "§9 CLI surface" },
+        api: {
+          path: "signals/enum.OperatorSignal.html",
+          label: "shep_core::signals::OperatorSignal",
+        },
+      },
+      {
         slug: "dogs",
         label: "Dogs",
         built: true,

--- a/web/src/data/docsNav.ts
+++ b/web/src/data/docsNav.ts
@@ -216,6 +216,13 @@ export const docsNav: DocsNavGroup[] = [
         },
       },
       {
+        slug: "logs",
+        label: "Logs",
+        built: true,
+        source: "crates/shep-cli/src/commands/logs.rs",
+        spec: { anchor: "9-cli-surface-sheep-native", label: "§9 CLI surface" },
+      },
+      {
         slug: "not-built",
         label: "What's not built",
         built: true,

--- a/web/src/pages/docs/dogs.astro
+++ b/web/src/pages/docs/dogs.astro
@@ -70,8 +70,8 @@ WHEN                 RULE    SUBJECT  MESSAGE                                   
         shepherd is listening. Run it with nothing listening and it still
         exits 0: the config says the dog belongs, and the next shepherd
         that boots brings it up. Nothing here autostarts a shepherd on your
-        behalf; <code>shep muster</code> is the one verb in this CLI that
-        does that.
+        behalf. Two verbs do, and neither is a dog verb:{" "}
+        <code>shep start</code> and <code>shep muster</code>.
       </p>
     </VerbSignature>
     <VerbSignature verb="disable" usage="shep disable <name>">

--- a/web/src/pages/docs/dogs.astro
+++ b/web/src/pages/docs/dogs.astro
@@ -10,6 +10,10 @@ import ReferencePills from "../../components/docs/ReferencePills.astro";
 import Callout from "../../components/docs/Callout.astro";
 import CodeBlock from "../../components/docs/CodeBlock.astro";
 import VerbSignature from "../../components/docs/VerbSignature.astro";
+
+const barksDemo = `$ shep barks
+WHEN                 RULE    SUBJECT  MESSAGE                                                                     SINKS
+2026-08-29 21:06:35  daemon  flaky    dog flaky exhausted its restart budget: 15 restarts against a budget of 16  -`;
 ---
 
 <DocsLayout
@@ -235,6 +239,37 @@ sinks = ["oncall"]`}</CodeBlock>
       an advisory file lock, never truncated in place, because two different
       processes append to it: the bark dog when a rule fires, and the
       shepherd itself when an enabled dog exhausts its own restart budget.
+    </p>
+
+    <h2>Reading the alert history</h2>
+    <VerbSignature verb="barks" usage="shep barks [--tail N]">
+      <p>
+        Prints that file, newest last, with <code>--tail</code> to see only
+        the last few. It reads <code>barks.jsonl</code> straight off disk and
+        never connects to the shepherd, which is the whole point: the history
+        is on disk precisely so it outlives the shepherd, and the moment this
+        verb exists for is an operator reading it after a crash. Same
+        precedent as <code>shep flush --daemon</code>, which also works on
+        files rather than through the socket.
+      </p>
+    </VerbSignature>
+    <CodeBlock>{barksDemo}</CodeBlock>
+    <p>
+      <code>SINKS</code> names each sink the alert was delivered to, with{" "}
+      <code>(failed)</code> appended to any that refused it, so a delivery
+      failure is visible in the table you are already reading rather than
+      only in <code>--format json</code>. It never carries the sink's own
+      error text, which can quote a webhook's HTTP response and would widen
+      an already-tight column for something the JSON already has in full. A{" "}
+      <code>-</code> means the shepherd wrote the record itself, with no
+      sinks and no webhook code behind it, which is the case above.
+    </p>
+    <p class="fine">
+      A line that won't parse costs you that one record, not the history. A
+      writer that died mid-append, or a record from a newer shep, is skipped
+      and the rest still prints. This file is read during an incident, and
+      refusing the whole ring over one bad line would be the wrong failure
+      mode.
     </p>
 
     <h2>Writing your own</h2>

--- a/web/src/pages/docs/examples.astro
+++ b/web/src/pages/docs/examples.astro
@@ -58,7 +58,7 @@ const rustRows: ExampleRow[] = [
 const polyglotRows: ExampleRow[] = [
   {
     program: "node-http / node-http-cluster",
-    demonstrates: "The pm2 audience's default case, plus instances above 1.",
+    demonstrates: "A plain Node HTTP server, plus instances above 1.",
     watch: "curl 127.0.0.1:19090/, then 19091 through 19094 for each clustered instance.",
   },
   {
@@ -308,22 +308,18 @@ py = "python3"`}</CodeBlock>
       <code>node-http-cluster</code> is the same script again,
       <code>instances = 4</code>. Each instance gets its own
       <code>SHEP_INSTANCE</code> env var (0 through 3), and the script adds
-      that to its base port — four separate listeners on 19091 through
-      19094, not one port shared four ways. That is a genuinely different
-      shape from pm2's own cluster mode, which does not use
-      <code>SO_REUSEPORT</code> at all: pm2 runs Node's built-in
-      <code>cluster</code> module, where a single primary process holds the
-      one listening socket and hands each accepted connection to a worker
-      round robin. shep's own <code>reuse_port</code> field is the more
-      interesting half of this contrast, because it decides how a reload
-      runs: an app that sets it is asserting it calls
-      <code>SO_REUSEPORT</code> itself, and gets its two instances
-      overlapped during a reload. An app that does not, and that has a
-      <code>readiness_probe</code>, is reloaded serially instead: the old
-      instance drains before the new one starts, because a probe against a
-      shared address cannot tell you which of two instances answered it.
+      that to its base port: four separate listeners on 19091 through
+      19094, not one port shared four ways. shep's own <code>reuse_port</code>
+      field is what decides how a reload runs: an app that sets it is
+      asserting it calls <code>SO_REUSEPORT</code> itself, and gets its two
+      instances overlapped during a reload. An app that does not, and that
+      has a <code>readiness_probe</code>, is reloaded serially instead: the
+      old instance drains before the new one starts, because a probe against
+      a shared address cannot tell you which of two instances answered it.
       This example offsets the port rather than sharing it, so the question
-      never arises: four listeners, four ports, nothing to share.
+      never arises: four listeners, four ports, nothing to share. See
+      <a href="/docs/from-pm2">Coming from pm2</a> for how this compares to
+      pm2's own cluster mode.
     </p>
 
     <h3>A venv's own python</h3>

--- a/web/src/pages/docs/examples.astro
+++ b/web/src/pages/docs/examples.astro
@@ -309,13 +309,19 @@ py = "python3"`}</CodeBlock>
       <code>instances = 4</code>. Each instance gets its own
       <code>SHEP_INSTANCE</code> env var (0 through 3), and the script adds
       that to its base port: four separate listeners on 19091 through
-      19094, not one port shared four ways. shep's own <code>reuse_port</code>
-      field is what decides how a reload runs: an app that sets it is
-      asserting it calls <code>SO_REUSEPORT</code> itself, and gets its two
-      instances overlapped during a reload. An app that does not, and that
-      has a <code>readiness_probe</code>, is reloaded serially instead: the
-      old instance drains before the new one starts, because a probe against
-      a shared address cannot tell you which of two instances answered it.
+      19094, not one port shared four ways. A <code>readiness_probe</code> is what
+      makes the reload ordering a question at all. Without one, and with{" "}
+      <code>wait_ready</code>, a reload overlaps whatever{" "}
+      <code>reuse_port</code> says. A probed app that does not set{" "}
+      <code>reuse_port</code> is reloaded serially instead: the old instance
+      drains before the new one starts, because a probe against a shared
+      address cannot tell you which of two instances answered it. Setting{" "}
+      <code>reuse_port</code> is the app's own claim that it calls{" "}
+      <code>SO_REUSEPORT</code> before its <code>bind()</code>. shep never
+      binds a listening socket on an app's behalf and cannot check that
+      claim, so the field buys an overlap attempt rather than a working
+      overlap: an app that claims it wrongly gets a replacement that takes{" "}
+      <code>EADDRINUSE</code>.
       This example offsets the port rather than sharing it, so the question
       never arises: four listeners, four ports, nothing to share. See
       <a href="/docs/from-pm2">Coming from pm2</a> for how this compares to

--- a/web/src/pages/docs/first-flockfile.astro
+++ b/web/src/pages/docs/first-flockfile.astro
@@ -73,7 +73,7 @@ const fieldGroups: FieldGroup[] = [
       { name: "cwd", type: "string?", default: "the Flockfile's own directory", does: "Working directory at spawn. Unset, an app in a Flockfile runs where that Flockfile lives, so a relative script resolves the way you would read it." },
       { name: "interpreter", type: "string?", default: "none", does: "Interpreter override; \"none\" runs the script directly." },
       { name: "env", type: "map<string,string>", default: "{}", does: "Merged over the daemon's filtered environment; values support {{instance}} and {{name}}. SHEP_INSTANCE and SHEP_NAME are always set and may not be set here." },
-      { name: "instances", type: "integer", default: "1", does: "How many separate copies of this app to run (pm2's fork mode, not its cluster mode: no shared socket). SHEP_INSTANCE and SHEP_NAME are always set on every instance; other env values, args, out_file and err_file may use {{instance}} and {{name}} templates." },
+      { name: "instances", type: "integer", default: "1", does: "How many separate copies of this app to run, each its own process; shep does not share a socket between them (see reuse_port if the app does that itself). SHEP_INSTANCE and SHEP_NAME are always set on every instance; other env values, args, out_file and err_file may use {{instance}} and {{name}} templates." },
       { name: "increment_var", type: "string?", default: "removed", does: "Refused at normalize with the replacement named: set env.YOUR_VAR = \"{{instance}}\" instead." },
     ],
   },

--- a/web/src/pages/docs/first-flockfile.astro
+++ b/web/src/pages/docs/first-flockfile.astro
@@ -26,6 +26,28 @@ const initScaffold = `# Manage your app in a Flockfile
 # Where the process runs. Without it, the daemon's own directory
 #cwd = "/srv/app"`;
 
+const stockDemo = `$ shep stock web 4
+ID  NAME    STATUS  PID    RESTARTS  EXIT  CPU  MEM     UPTIME  FOLD  SMIT
+0   web:0   online  62888  0         -     -    3.0M    0s      -     -
+1   web:1   online  62889  0         -     -    3.0M    0s      -     -
+3   web:2   online  62936  0         -     -    176.0K  0s      -     -
+4   web:3   online  62937  0         -     -    144.0K  0s      -     -
+2   worker  online  62890  0         -     -    3.0M    0s      -     -
+
+$ shep stock web 2
+ID  NAME    STATUS  PID    RESTARTS  EXIT  CPU  MEM   UPTIME  FOLD  SMIT
+0   web:0   online  62888  0         -     -    3.0M  1s      -     -
+1   web:1   online  62889  0         -     -    3.0M  1s      -     -
+3   web:2   online  62936  0         -     -    0B    1s      -     -
+4   web:3   online  62937  0         -     -    0B    1s      -     -
+2   worker  online  62890  0         -     -    3.0M  1s      -     -
+
+$ shep flock
+ID  NAME    STATUS  PID    RESTARTS  EXIT  CPU  MEM   UPTIME  FOLD  SMIT
+0   web:0   online  62888  0         -     -    3.0M  2s      -     -
+1   web:1   online  62889  0         -     -    3.0M  2s      -     -
+2   worker  online  62890  0         -     -    3.0M  2s      -     -`;
+
 const initJsonRefusal = `$ shep init deploy.json --all
 error[usage]: JSON has no comment syntax, so a full scaffold would pin every default instead of explaining it; write a .json5 Flockfile for the same syntax with comments, or drop --all`;
 
@@ -384,6 +406,33 @@ Z_DEVICE_ID = "z-{{instance}}d"`}</CodeBlock>
       refused rather than silently overwritten:
     </p>
     <CodeBlock label="env sets a reserved variable">{`error[invalid_config]: the daemon reported InvalidConfig: sheep \`z-worker\` sets \`SHEP_INSTANCE\` in env, but shep injects it: use a different name, or \`{{instance}}\` in your own variable`}</CodeBlock>
+
+    <h2>Changing the count without editing the file</h2>
+    <VerbSignature verb="stock" aliases={["scale"]} usage="shep stock <name> <n>">
+      <p>
+        An absolute count, not a change: <code>shep stock web 4</code> means
+        web has four instances afterwards, whatever it had before. There is
+        no <code>+N</code> or <code>-N</code> form, so running it twice
+        leaves the same flock as running it once.
+      </p>
+    </VerbSignature>
+    <CodeBlock>{stockDemo}</CodeBlock>
+    <p>
+      Stocking up fills the lowest free slots, and stocking down releases the
+      highest, so stocking out and back gives you the same slot numbers, the
+      same <code>SHEP_INSTANCE</code> values and the same log files you
+      started with. Slots are not ids: <code>web:2</code> above arrived with
+      id 3, because an id is handed out once per sheep and a slot describes
+      its place in the app.
+    </p>
+    <p>
+      The second command printed four instances because it answers the
+      moment the shepherd accepts, and the two on their way out were still
+      running their stop ladders at that point. They report themselves on
+      the bus under <code>process.delete</code>, and a listing a moment later
+      shows the flock settled. The new count goes into the muster roll, so{" "}
+      <a href="/docs/startup">a reboot</a> keeps it.
+    </p>
 
     <h2>The full field reference</h2>
     <p>

--- a/web/src/pages/docs/first-flockfile.astro
+++ b/web/src/pages/docs/first-flockfile.astro
@@ -11,6 +11,23 @@ import DocsLayout from "../../layouts/DocsLayout.astro";
 import ReferencePills from "../../components/docs/ReferencePills.astro";
 import Callout from "../../components/docs/Callout.astro";
 import CodeBlock from "../../components/docs/CodeBlock.astro";
+import VerbSignature from "../../components/docs/VerbSignature.astro";
+
+const initScaffold = `# Manage your app in a Flockfile
+# Add as many apps as you would like using TOML syntax
+
+#[[app]]
+# A convenient and unique name for shep to display
+#name = "my-first-sheep"
+# The script that shep should use to launch your app
+#script = "./index.js"
+# Restarts the process automatically when it exits unexpectedly
+#autorestart = true
+# Where the process runs. Without it, the daemon's own directory
+#cwd = "/srv/app"`;
+
+const initJsonRefusal = `$ shep init deploy.json --all
+error[usage]: JSON has no comment syntax, so a full scaffold would pin every default instead of explaining it; write a .json5 Flockfile for the same syntax with comments, or drop --all`;
 
 interface Field {
   name: string;
@@ -136,6 +153,53 @@ const fieldGroups: FieldGroup[] = [
     <CodeBlock label="Flockfile.toml">{`[[app]]
 name   = "web"
 script = "./server"`}</CodeBlock>
+
+    <h2>Or start from a generated one</h2>
+    <VerbSignature verb="init" usage="shep init [path] [--all] [--force]">
+      <p>
+        Writes a commented Flockfile to fill in. With no path that's{" "}
+        <code>Flockfile.toml</code> in the current directory; give it one and
+        the extension picks the language, out of <code>.toml</code>,{" "}
+        <code>.yaml</code>, <code>.yml</code>, <code>.json</code> and{" "}
+        <code>.json5</code>.
+      </p>
+    </VerbSignature>
+    <CodeBlock label="Flockfile.toml">{initScaffold}</CodeBlock>
+    <p>
+      Almost every line is commented out, and uncommenting the ones you want
+      is the whole workflow. The generator builds a real document first and
+      comments it in a single pass afterwards, which is why the same
+      scaffold exists in four languages instead of one: the comment marker
+      never touches the structure. A test uncomments each format
+      mechanically and parses the result, so this is a Flockfile that works
+      rather than prose shaped like one.
+    </p>
+    <p>
+      <code>--all</code> writes every field the grammar has instead of the
+      handful worth meeting on day one, which is 82 lines of TOML against
+      the 12 above. <code>--force</code> replaces a Flockfile that is
+      already there, keeping <em>that</em> file's format rather than the
+      default one, so forcing over a <code>.yaml</code> writes YAML instead
+      of dropping TOML into it. Without <code>--force</code>, an existing
+      Flockfile is a refusal and nothing is written.
+    </p>
+    <Callout variant="note">
+      JSON has no comment syntax, so the thing this verb makes cannot be
+      made in it. A <code>.json</code> scaffold is a live minimal document
+      with real values and no guidance, and <code>--all</code> is refused
+      there outright rather than fudged, because a JSON document naming
+      every field would pin every default explicitly. That is a Flockfile
+      you would tell somebody not to commit.
+    </Callout>
+    <CodeBlock>{initJsonRefusal}</CodeBlock>
+    <p class="fine">
+      Writing a second Flockfile beside an existing one is legal and said out
+      loud rather than refused, since somebody naming a path explicitly may
+      well be migrating. Discovery walks the fixed order below and stops at
+      the first hit, so the new file can be one shep never reads;{" "}
+      <code>shep init</code> prints an <code>init_shadowed</code> notice
+      naming both files when it spots that.
+    </p>
 
     <h2>Formats and discovery</h2>
     <p>

--- a/web/src/pages/docs/getting-started.astro
+++ b/web/src/pages/docs/getting-started.astro
@@ -51,6 +51,17 @@ import CodeBlock from "../../components/docs/CodeBlock.astro";
       <code>target/release/shep</code> on your PATH, or keep typing the full
       path. Everything below works either way.
     </p>
+    <p class="fine">
+      Two more things that belong to this step.
+      <code>shep completions &lt;shell&gt;</code> prints a completion script
+      for bash, elvish, fish, powershell or zsh, to redirect wherever your
+      shell reads them from. It completes verbs and flags and stops there:
+      sheep names, fold names and anything else the shepherd knows are never
+      completed, because the script never talks to one. And
+      <code>shep welcome</code> reprints the greeting a fresh
+      <code>$SHEP_HOME</code> shows once on its own: the sheep, the home it
+      set up, and the five commands worth knowing.
+    </p>
 
     <h2>2. Write a Flockfile</h2>
     <p>

--- a/web/src/pages/docs/kv.astro
+++ b/web/src/pages/docs/kv.astro
@@ -94,10 +94,10 @@ KEY  VALUE`;
       A key is <code>[A-Za-z0-9._-]</code>, one to 128 bytes, and can't start
       with a dot. <strong>A dot is part of a name, not a path</strong>:
       <code>bark.cooldown</code> is one flat key, not a nested object, and
-      <code>shep get bark</code> won't find it. This is a deliberate
-      departure from pm2's own dotted/colon store: a nesting grammar here
-      would be a second config language, with its own quoting rules, for a
-      store that's explicitly not the primary one. The narrow alphabet is
+      <code>shep get bark</code> won't find it. This is deliberate: a
+      nesting grammar here would be a second config language, with its own
+      quoting rules, for a store that's explicitly not the primary one. The
+      narrow alphabet is
       also why <code>shep get $key</code> never needs quoting in a script. A
       value is a string, capped at 4&nbsp;KiB: the store is read whole on
       every access, and the cap is what keeps <code>kv.json</code> from

--- a/web/src/pages/docs/lifecycle.astro
+++ b/web/src/pages/docs/lifecycle.astro
@@ -1,0 +1,603 @@
+---
+/*
+ * Stopping and replacing a sheep (`shep stop/restart/reload/delete --help`,
+ * crates/shep-daemon/src/kill.rs, crates/shep-daemon/src/supervisor.rs's
+ * ReloadMode and apply_immediate, crates/shep-daemon/src/brain.rs's
+ * decide_on_exit, crates/shep-daemon/src/snapshot.rs's restorable). Terminal
+ * output below was run for real against target/release/shep on 2026-08-29 -
+ * see this page's PR for the transcript.
+ *
+ * These four verbs are the ones an operator types most and had no page of
+ * their own: the material was smeared across startup.astro, examples.astro,
+ * from-pm2.astro, first-flockfile.astro, output.astro, folds.astro,
+ * shepherd-channel.astro, not-built.astro, talking-to-a-sheep.astro and
+ * whistle.astro, each covering a fragment for its own reason. This page
+ * collects the one thing none of them state directly: what each verb
+ * leaves behind, and in particular what shep stop leaves in the muster
+ * roll that shep delete removes for good.
+ */
+import DocsLayout from "../../layouts/DocsLayout.astro";
+import ReferencePills from "../../components/docs/ReferencePills.astro";
+import Callout from "../../components/docs/Callout.astro";
+import CodeBlock from "../../components/docs/CodeBlock.astro";
+import VerbSignature from "../../components/docs/VerbSignature.astro";
+
+const stopSurvivesDemo = `$ shep stop parked
+ID  NAME    STATUS   PID    RESTARTS  EXIT     CPU  MEM   UPTIME  FOLD  SMIT
+0   keeper  online   79454  0         -        -    1.4M  6s      -     -
+1   parked  stopped  -      0         SIGTERM  -    -     0s      -     -
+4   probed  online   79458  0         -        -    1.5M  6s      -     -
+2   web     online   79456  0         -        -    1.4M  6s      -     -
+3   worker  online   79457  0         -        -    1.4M  6s      -     -
+
+$ shep save
+FILE                                     APPS
+/tmp/shepdocs-lifecycle/home/flock.json  5
+
+$ shep kill
+PID    SOCKET_REMOVED
+79433  true
+
+$ shep muster
+ID  NAME    STATUS    PID    RESTARTS  EXIT  CPU  MEM  UPTIME  FOLD  SMIT
+1   keeper  online    79631  0         -     -    -    0s      -     -
+0   parked  stopped   -      0         -     -    -    0s      -     -
+2   probed  starting  79632  0         -     -    -    0s      -     -
+3   web     online    79633  0         -     -    -    0s      -     -
+4   worker  online    79634  0         -     -    -    0s      -     -`;
+
+const deleteRemovesDemo = `$ shep delete parked
+notice[delete]: deleted 1 sheep, id 0
+ID  NAME    STATUS  PID    RESTARTS  EXIT  CPU  MEM   UPTIME  FOLD  SMIT
+1   keeper  online  79631  0         -     -    1.4M  5s      -     -
+2   probed  online  79632  0         -     -    1.5M  5s      -     -
+3   web     online  79633  0         -     -    1.4M  5s      -     -
+4   worker  online  79634  0         -     -    1.4M  5s      -     -
+
+$ shep save
+FILE                                     APPS
+/tmp/shepdocs-lifecycle/home/flock.json  4
+
+$ shep kill
+PID    SOCKET_REMOVED
+79610  true
+
+$ shep muster
+ID  NAME    STATUS    PID    RESTARTS  EXIT  CPU  MEM  UPTIME  FOLD  SMIT
+0   keeper  online    79791  0         -     -    -    0s      -     -
+1   probed  starting  79792  0         -     -    -    0s      -     -
+2   web     online    79793  0         -     -    -    0s      -     -
+3   worker  online    79794  0         -     -    -    0s      -     -`;
+
+const restartDemo = `$ shep restart keeper
+ID  NAME    STATUS  PID    RESTARTS  EXIT  CPU  MEM     UPTIME  FOLD  SMIT
+0   keeper  online  79867  1         -     -    640.0K  0s      -     -
+1   probed  online  79792  0         -     -    1.5M    5s      -     -
+2   web     online  79793  0         -     -    1.4M    5s      -     -
+3   worker  online  79794  0         -     -    1.4M    5s      -     -`;
+
+const overlapDemo = `$ shep reload worker
+ID  NAME      STATUS    PID    RESTARTS  EXIT  CPU  MEM   UPTIME  FOLD  SMIT
+0   keeper    online    79867  1         -     -    1.4M  2s      -     -
+1   probed    online    79792  0         -     -    1.5M  7s      -     -
+2   web       online    79793  0         -     -    1.4M  7s      -     -
+3   worker:0  stopping  79794  0         -     -    1.4M  7s      -     -
+4   worker:0  starting  79907  0         -     -    -     0s      -     -
+
+$ shep flock
+ID  NAME    STATUS  PID    RESTARTS  EXIT  CPU  MEM   UPTIME  FOLD  SMIT
+0   keeper  online  79867  1         -     -    1.4M  4s      -     -
+1   probed  online  79792  0         -     -    1.5M  10s     -     -
+2   web     online  79793  0         -     -    1.4M  10s     -     -
+4   worker  online  79907  0         -     -    1.4M  2s      -     -`;
+
+const brokenOverlapDemo = `$ shep reload web
+ID  NAME    STATUS    PID    RESTARTS  EXIT  CPU   MEM   UPTIME  FOLD  SMIT
+0   keeper  online    79867  1         -     0.0%  1.4M  10s     -     -
+1   probed  online    79792  0         -     0.0%  1.5M  15s     -     -
+2   web:0   stopping  79793  0         -     0.0%  1.4M  15s     -     -
+5   web:0   starting  80029  0         -     -     -     0s      -     -
+4   worker  online    79907  0         -     0.0%  1.4M  7s      -     -
+
+$ shep bleats web --no-follow --lines 4
+web | http_server pid=79456 listening on 127.0.0.1:19293
+web | http_server pid=79633 listening on 127.0.0.1:19293
+web | http_server pid=79793 listening on 127.0.0.1:19293
+web |
+web | thread 'main' (54715137) panicked at examples/src/bin/http_server.rs:31:33:
+web | could not bind 127.0.0.1:19293: Address already in use (os error 48)
+web | note: run with \`RUST_BACKTRACE=1\` environment variable to display a backtrace
+
+$ shep flock
+ID  NAME    STATUS  PID    RESTARTS  EXIT  CPU   MEM   UPTIME  FOLD  SMIT
+0   keeper  online  79867  1         -     0.0%  1.4M  12s     -     -
+1   probed  online  79792  0         -     0.0%  1.5M  17s     -     -
+2   web     online  79793  0         -     0.0%  1.4M  17s     -     -
+4   worker  online  79907  0         -     0.0%  1.4M  10s     -     -`;
+
+const serialGapDemo = `$ shep reload probed
+ID  NAME    STATUS    PID    RESTARTS  EXIT  CPU   MEM   UPTIME  FOLD  SMIT
+0   keeper  online    79867  1         -     0.0%  1.4M  3m 42s  -     -
+7   probed  stopping  80436  0         -     0.0%  0B    2m 56s  -     -
+2   web     online    79793  0         -     0.0%  1.4M  3m 48s  -     -
+4   worker  online    79907  0         -     0.0%  1.4M  3m 40s  -     -
+
+$ while sleep 0.3; do curl -m 0.5 -s -o /dev/null -w "%{http_code}\\n" http://127.0.0.1:19294/; done
+000
+000
+000
+000
+000
+000
+000
+000
+000
+200
+200
+200
+
+$ shep flock
+ID  NAME    STATUS    PID    RESTARTS  EXIT  CPU   MEM   UPTIME  FOLD  SMIT
+0   keeper  online    79867  1         -     0.0%  1.4M  3m 46s  -     -
+8   probed  starting  82373  0         -     -     -     3s      -     -
+2   web     online    79793  0         -     0.0%  1.4M  3m 51s  -     -
+4   worker  online    79907  0         -     0.0%  1.4M  3m 44s  -     -`;
+---
+
+<DocsLayout
+  title="Stopping and replacing a sheep"
+  description="What shep stop, restart, reload and delete each do to a running sheep and to the muster roll: one kill ladder shared by three of them, two different orders a reload can run, and the one difference between stop and delete that decides what comes back after a restart."
+  crumb="Concepts / Stopping and replacing a sheep"
+  activeSlug="lifecycle"
+>
+  <article>
+    <h1>Stopping and replacing a sheep</h1>
+    <ReferencePills slug="lifecycle" />
+    <p class="lede">
+      Four verbs end a sheep's current process: <code>stop</code>,{" "}
+      <code>restart</code>, <code>reload</code> and <code>delete</code>. All
+      four take the same selector grammar as everything else (a name, an id,{" "}
+      <code>fold:&lt;name&gt;</code>, <code>all</code>, and the rest are on{" "}
+      <a href="/docs/folds">the folds page</a>),
+      and three of them run through the exact same kill ladder underneath.
+      What they don't share is what they leave behind: a stopped sheep is
+      still in the flock, a deleted one is gone, and a reload can end either
+      as a clean handover or as a crash you get to watch happen. That is what
+      this page is for.
+    </p>
+
+    <div class="verb-table">
+      <div class="row header">
+        <span>verb</span> <span>the current process</span> <span>the muster roll</span>
+      </div>
+      <div class="row">
+        <span><code>stop</code></span>
+        <span>killed, through the ladder below</span>
+        <span>stays, entry marked stopped</span>
+      </div>
+      <div class="row">
+        <span><code>restart</code></span>
+        <span>killed, then a fresh one at once</span>
+        <span>stays, marked online again</span>
+      </div>
+      <div class="row">
+        <span><code>reload</code></span>
+        <span>one instance replaced, old or new order below</span>
+        <span>unchanged, still the same app</span>
+      </div>
+      <div class="row">
+        <span><code>delete</code></span>
+        <span>killed if running, through the same ladder</span>
+        <span>removed, for good</span>
+      </div>
+    </div>
+    <p class="fine">
+      <code>shep thatlldo</code> is a hidden, working alias for{" "}
+      <code>stop</code>, "graceful stop" in{" "}
+      <a href="/docs/getting-started">Getting started</a>'s own alias grid.
+      It isn't in <code>--help</code>, but it runs the same code as the row
+      above.
+    </p>
+
+    <h2>One ladder, two grace periods</h2>
+    <p>
+      <code>stop</code>, <code>restart</code> and <code>delete</code> all
+      end a live process the same way. First, either the app's configured{" "}
+      <code>kill_signal</code> goes to the sheep's whole process group
+      (lambs included), or, if the app set{" "}
+      <code>shutdown_with_message</code>, a{" "}
+      <code>{`{"kind":"shutdown"}`}</code> message goes over the{" "}
+      <a href="/docs/shepherd-channel">shepherd channel</a> instead, no
+      signal at all. Then shep waits. If the process is still alive when the
+      grace period runs out, the whole process tree gets{" "}
+      <code>SIGKILL</code>, a signal nothing can trap, and that's the end of
+      it either way.
+    </p>
+    <p>
+      The grace period is where the two verbs that also drive a reload
+      diverge from the two that don't. <code>stop</code>, <code>restart</code>{" "}
+      and <code>delete</code> wait <code>kill_timeout</code>, 1.6 seconds by
+      default. A <code>reload</code>'s drain of the OLD instance waits{" "}
+      <code>graceful_timeout</code> instead, 8 seconds by default and
+      configured separately, because a reload's whole premise is that the
+      instance being replaced might be mid-request and deserves more time to
+      finish than an ordinary stop does. See{" "}
+      <a href="/docs/first-flockfile">the field table</a> for both,
+      and <a href="/docs/examples">
+        Examples
+      </a> for a live run watching a sheep that ignores its stop signal get
+      escalated to <code>SIGKILL</code>.
+    </p>
+    <Callout variant="note">
+      A signal <code>stop</code> sends is never mistaken for something else
+      afterward. Whatever the app's own <code>autorestart</code> says, an
+      exit that ends a manual <code>stop</code> is always recorded as a clean
+      stop, never as something worth restarting for. That's also why an
+      operator's command always wins a race against the daemon's own: a
+      cron occurrence or a watched file landing on a sheep mid-kill-ladder
+      gets dropped rather than reviving it out from under you.
+    </Callout>
+    <p class="fine">
+      On Windows there is nothing SIGTERM-shaped to send, so{" "}
+      <code>stop</code> waits out the whole of <code>kill_timeout</code> with
+      no signal delivered and then terminates the process directly, unless
+      the app opted into <code>shutdown_with_message</code>. See{" "}
+      <a href="/docs/not-built">
+        What's not built yet
+      </a>.
+    </p>
+
+    <h2>What stays, what goes: the muster roll</h2>
+    <p>
+      shep keeps a file at <code>$SHEP_HOME/flock.json</code>, the muster
+      roll, recording every registered app's config and whether it was
+      running the last time the roll was written. A shepherd that starts
+      back up reads it and restores what was up.{" "}
+      <a href="/docs/startup">Surviving reboots</a> is the
+      full account of <code>save</code> and <code>muster</code>; this
+      section is only the one thing that page doesn't say: what{" "}
+      <code>stop</code> leaves in that file, and what <code>delete</code>{" "}
+      takes out of it.
+    </p>
+    <VerbSignature verb="stop" usage="shep stop <selector>...">
+      <p>
+        Runs the kill ladder against every matched sheep and marks it{" "}
+        <code>stopped</code>. The sheep is not removed: it stays a member of
+        the flock, still shows up in <code>shep flock</code>, and is still
+        there for the next <code>restart</code> or <code>delete</code> to
+        find.
+      </p>
+    </VerbSignature>
+    <CodeBlock>{stopSurvivesDemo}</CodeBlock>
+    <p>
+      <code>parked</code> was stopped, then the roll was saved, then the
+      whole shepherd went down and came back through <code>muster</code>.
+      It's back, registered, still called <code>parked</code>, still{" "}
+      <code>stopped</code>. Nothing restarted it, because it wasn't running
+      when the roll was written and <code>muster</code>'s rule is "was it up
+      when we saved," not "does it exist."
+    </p>
+    <VerbSignature verb="delete" usage="shep delete <selector>...">
+      <p>
+        Runs the same kill ladder if the sheep is running, then removes the
+        registration entirely. In table format the listing that follows is
+        the whole remaining flock, the same as every other lifecycle verb;
+        the ids it removed are named on stderr because their own rows are
+        gone by the time anything could print them.
+      </p>
+    </VerbSignature>
+    <CodeBlock>{deleteRemovesDemo}</CodeBlock>
+    <p>
+      Same sheep, same save-kill-muster sequence, different verb. This time{" "}
+      <code>parked</code> is not in the restored flock at all, not even as a{" "}
+      <code>stopped</code> row. Deleting it took it out of the registry
+      immediately, so it was never a candidate for the roll <code>save</code>{" "}
+      wrote afterward, and <code>muster</code> can only restore what the
+      roll remembers. There's no undelete: the config is gone unless you
+      kept the Flockfile that produced it.
+    </p>
+    <p class="fine">
+      whistle's four control tools mirror three of these verbs (
+      <code>start_sheep</code>, <code>stop_sheep</code>,{" "}
+      <code>restart_sheep</code>, <code>reload_sheep</code>), deliberately
+      with no <code>delete_sheep</code>. See{" "}
+      <a href="/docs/whistle">whistle</a>.
+    </p>
+
+    <h2>restart: back immediately</h2>
+    <VerbSignature verb="restart" usage="shep restart <selector>...">
+      <p>
+        Runs the kill ladder, then spawns a fresh process in the same slot
+        at once, whatever <code>autorestart</code> or{" "}
+        <code>stop_exit_codes</code> would otherwise decide. The restart
+        budget is reset the same way a spec-mandated manual action always
+        resets it, and the daemon records that a person asked for this one,
+        which is what lets <code>shep describe</code> and the bus tell an
+        operator's restart apart from one the daemon raised on its own.
+      </p>
+    </VerbSignature>
+    <CodeBlock>{restartDemo}</CodeBlock>
+    <p class="fine">
+      <code>keeper</code>'s pid changed and its <code>RESTARTS</code> column
+      went from 0 to 1. Everything else in the flock is untouched: a
+      lifecycle verb's listing always shows the whole flock, not only what it
+      touched, which is why the other three rows are here too. See{" "}
+      <a href="/docs/output#after-a-lifecycle-command">
+        Terminal output
+      </a>.
+    </p>
+
+    <h2>reload: one instance at a time, in one of two orders</h2>
+    <p>
+      A reload overlaps the old instance and the new one by default: the
+      replacement is spawned and confirmed before the old one drains, so the
+      app is never short an instance. Whether that overlap is actually
+      seamless is a property of the app, not of shep. shep never binds an
+      app's listening socket and never sets <code>SO_REUSEPORT</code> on
+      one; if the app hasn't set that option on its own listener, the second
+      instance has nowhere to go but <code>EADDRINUSE</code>, the moment it
+      tries to bind the port the first one is still holding.
+    </p>
+    <VerbSignature verb="reload" usage="shep reload <selector>...">
+      <p>
+        Replaces each matched sheep's instances one at a time with a fresh
+        process, so a clustered app is never short more than one instance
+        mid-swap. Answers as soon as the shepherd accepts the reload,
+        printing the flock as it stands at that moment; the swaps themselves
+        land afterward and are reported on the bus.
+      </p>
+    </VerbSignature>
+    <p>
+      Before anything is killed, shep has to decide the order, and it picks
+      from the app's own config: an app with a <code>readiness_probe</code>{" "}
+      and no <code>reuse_port</code> is reloaded serially, old instance
+      fully gone before the new one starts. Every other app overlaps, new
+      instance spawned and confirmed before the old one drains: that's an
+      app with no probe at all, one using <code>wait_ready</code> (its
+      channel belongs to one instance, so an outgoing instance has no way to
+      answer on the replacement's behalf, and <code>wait_ready</code> wins
+      over a configured probe if an app sets both), or a probed app that
+      also sets <code>reuse_port</code>.
+    </p>
+    <p>
+      The reason is what a <code>readiness_probe</code> is actually asking.
+      It polls an address, and an address can't say which of two processes
+      answered it. Overlap two instances of a probed app and the outgoing
+      one is still bound when the probe lands, so it answers for the
+      incoming one and shep calls a release ready that may never have come
+      up at all. Serializing removes the ambiguity by removing the
+      overlap: there's only ever one instance to ask.
+    </p>
+
+    <h3>Overlap, done right</h3>
+    <p>
+      <code>worker</code> below has no probe, so it always overlaps. It
+      writes to its own log file and binds nothing, so there's nothing for
+      two instances to fight over:
+    </p>
+    <CodeBlock>{overlapDemo}</CodeBlock>
+    <p>
+      <code>reload</code>'s own printed table is the proof: it shows two
+      rows for <code>worker</code> at once, id 3 <code>stopping</code> on
+      the old pid and id 4 <code>starting</code> on the new one. Both are
+      real, live processes for that moment, which is the entire point of
+      overlapping. A moment later the drainee is gone and the replacement
+      has taken the name back.
+    </p>
+
+    <h3>Overlap, when the app doesn't cooperate</h3>
+    <p>
+      <code>web</code> also has no probe, so it also overlaps, but it
+      binds a port and does nothing to share it. shep never sets{" "}
+      <code>SO_REUSEPORT</code> on an app's behalf; that has to happen
+      inside the child, on a socket shep never sees. Without it, two
+      instances cannot hold the same port at once:
+    </p>
+    <CodeBlock>{brokenOverlapDemo}</CodeBlock>
+    <p>
+      The replacement spawns, tries to bind the port the drainee is still
+      holding, and panics with <code>Address already in use</code>. The
+      reload is abandoned right there: the drainee was never told to
+      drain, so it's still the one answering requests, still on its
+      original pid, and <code>RESTARTS</code> never moves, because the
+      failure belongs to a replacement that was never registered as{" "}
+      <em>the</em> sheep. This exits 0. The daemon accepted the reload and
+      the acceptance is what the exit code answers for; the failed swap is
+      reported only on the bus, under{" "}
+      <code>process.reload_abandoned</code>.
+    </p>
+    <Callout variant="careful">
+      <code>reuse_port = true</code> doesn't make an app share its socket.
+      It tells shep the app already does, on its own, so shep will pick the
+      overlap order for it. Setting the field without the app actually
+      calling the option doesn't fail at config time; it fails exactly like
+      the run above, at reload time, with the same panic. Getting this
+      right is entirely on the app.
+    </Callout>
+
+    <h3>Serial: the gap you can see</h3>
+    <p>
+      <code>probed</code> has a <code>readiness_probe</code> and no{" "}
+      <code>reuse_port</code>, so it reloads serially. Watch the flock table
+      right after the command, and watch the address itself while the swap
+      runs:
+    </p>
+    <CodeBlock>{serialGapDemo}</CodeBlock>
+    <p>
+      <code>reload</code>'s own table shows only one row for{" "}
+      <code>probed</code>, <code>stopping</code>, no replacement id yet: a
+      serial reload doesn't spawn one until the old instance is fully gone.{" "}
+      <code>curl</code>'s <code>000</code> is what it prints when there's
+      nobody to connect to at all, not a real status code, and nine of them
+      at roughly 300ms apiece is about the 2.7 seconds the drain and the
+      new instance's own startup delay together take here, before the
+      probe passes and the address answers again. An overlapping reload
+      never produces that gap, because the old instance is still bound the
+      entire time. A serial one always will, on any app whose replacement
+      takes real time to become ready.
+    </p>
+    <p class="fine">
+      <code>SIGKILL</code>ing a sheep's own process never reaches every
+      lamb it forked; see{" "}
+      <a href="/docs/folds">Folds</a> for what a stop
+      actually kills versus what a sheep's process tree contains.
+    </p>
+
+    <h2>Where to go next</h2>
+
+    <div class="next-grid">
+      <a href="/docs/startup" class="next-card">
+        <div class="next-title">Surviving reboots →</div>
+        <div class="next-body">
+          <code>shep save</code> and <code>shep muster</code> in full, plus
+          the reboot runbook this page's roll demos borrow from.
+        </div>
+      </a>
+      <a href="/docs/from-pm2" class="next-card">
+        <div class="next-title">Coming from pm2 →</div>
+        <div class="next-body">
+          What <code>instances</code> does and doesn't do, and both real
+          ways to put N instances behind one address.
+        </div>
+      </a>
+      <a href="/docs/examples" class="next-card">
+        <div class="next-title">Examples →</div>
+        <div class="next-body">
+          A sheep that blocks its stop signal, watched live all the way to
+          the <code>SIGKILL</code> that ends it.
+        </div>
+      </a>
+      <a href="/docs/talking-to-a-sheep" class="next-card">
+        <div class="next-title">Talking to a sheep →</div>
+        <div class="next-body">
+          The three verbs that reach a running sheep without replacing it:
+          a signal, a line on stdin, a named action over the channel.
+        </div>
+      </a>
+    </div>
+  </article>
+</DocsLayout>
+
+<style>
+  h1 {
+    font-size: clamp(36px, 4.6vw, 56px);
+    line-height: 1;
+    letter-spacing: -0.04em;
+    margin: 0 0 18px;
+  }
+
+  h2 {
+    font-size: 29px;
+    letter-spacing: -0.03em;
+    margin: 40px 0 8px;
+  }
+
+  h2:first-of-type {
+    margin-top: 0;
+  }
+
+  h3 {
+    font-size: 20px;
+    letter-spacing: -0.02em;
+    margin: 28px 0 8px;
+  }
+
+  .lede {
+    font-size: 19px;
+    line-height: 1.6;
+    color: var(--ink-2);
+    margin: 0 0 24px;
+    text-wrap: pretty;
+  }
+
+  p {
+    font-size: 16.5px;
+    line-height: 1.65;
+    color: var(--ink-2);
+    margin: 0 0 18px;
+  }
+
+  .fine {
+    font-size: 15px;
+    line-height: 1.6;
+    color: var(--ink-3);
+    margin: -8px 0 30px;
+  }
+
+  .verb-table {
+    border: 3px solid var(--line);
+    border-radius: 16px;
+    overflow-x: auto;
+    margin: 0 0 8px;
+  }
+
+  .verb-table .row {
+    display: grid;
+    grid-template-columns: minmax(90px, 0.7fr) minmax(180px, 1.4fr) minmax(160px, 1.2fr);
+    gap: 14px;
+    padding: 12px 20px;
+    font-size: 14.5px;
+    align-items: start;
+  }
+
+  .verb-table .row:not(:last-child) {
+    border-bottom: 2px solid var(--hair);
+  }
+
+  .verb-table .row.header {
+    background: var(--paper-2);
+    font-family: "Space Mono", monospace;
+    font-size: 11px;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--ink-3);
+    font-weight: 700;
+  }
+
+  .verb-table .row:not(.header) span:first-child {
+    font-family: "Space Mono", monospace;
+    font-weight: 700;
+  }
+
+  .verb-table .row:not(.header) span:not(:first-child) {
+    color: var(--ink-2);
+  }
+
+  .next-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    gap: 16px;
+    margin-top: 8px;
+  }
+
+  .next-card {
+    text-align: left;
+    background: var(--paper-2);
+    border: 3px solid var(--line);
+    border-radius: 18px;
+    box-shadow: 5px 5px 0 var(--shadow);
+    padding: 20px;
+    color: var(--ink);
+    text-decoration: none;
+    display: block;
+  }
+
+  .next-card:hover {
+    transform: translate(2px, 2px);
+    box-shadow: 3px 3px 0 var(--shadow);
+    color: var(--ink);
+  }
+
+  .next-title {
+    font-family: "Bricolage Grotesque", sans-serif;
+    font-weight: 800;
+    font-size: 17px;
+    margin-bottom: 7px;
+  }
+
+  .next-body {
+    font-size: 14px;
+    line-height: 1.5;
+    color: var(--ink-2);
+  }
+</style>

--- a/web/src/pages/docs/lifecycle.astro
+++ b/web/src/pages/docs/lifecycle.astro
@@ -209,7 +209,7 @@ ID  NAME    STATUS    PID    RESTARTS  EXIT  CPU   MEM   UPTIME  FOLD  SMIT
       <code>{`{"kind":"shutdown"}`}</code> message goes over the{" "}
       <a href="/docs/shepherd-channel">shepherd channel</a> instead, no
       signal at all. Then shep waits. If the process is still alive when the
-      grace period runs out, the whole process tree gets{" "}
+      grace period runs out, that same process group gets{" "}
       <code>SIGKILL</code>, a signal nothing can trap, and that's the end of
       it either way.
     </p>

--- a/web/src/pages/docs/logs.astro
+++ b/web/src/pages/docs/logs.astro
@@ -36,14 +36,14 @@ ID  NAME   STATUS  PID    RESTARTS  EXIT  CPU  MEM  UPTIME  FOLD  SMIT
 0   web:0  online  54244  0         -     -    -    43s     -     -
 1   web:1  online  54338  1         -     -    -    37s     -     -`;
 
-const logrotate = `~/.shep/logs/*.log {
+const logrotate = `/home/shepherd/.shep/logs/*.log {
     daily
     rotate 7
     missingok
     notifempty
     sharedscripts
     postrotate
-        shep reopen
+        su shepherd -c 'shep reopen'
     endscript
 }`;
 
@@ -188,6 +188,22 @@ stderr  /tmp/shepdocs/home/logs/shepd.err.log  emptied`;
       there would be the silent failure this verb exists to end.
     </p>
     <CodeBlock label="/etc/logrotate.d/shep">{logrotate}</CodeBlock>
+    <p>
+      Both halves of that stanza are more literal than they look. logrotate
+      globs the pattern with <code>glob(3)</code> and never asks for tilde
+      expansion, so <code>~/.shep/logs/*.log</code> looks for a directory
+      actually named <code>~</code> and matches nothing even when the real one
+      is sitting there. With <code>missingok</code> set, that failure is
+      silent. Write the shepherd account's absolute log directory, and
+      substitute a custom <code>SHEP_HOME</code> if the account sets one.
+    </p>
+    <p>
+      <code>postrotate</code> then runs as whoever runs logrotate, usually
+      root, and <code>shep reopen</code> finds its shepherd through that
+      user's <code>$SHEP_HOME</code>. A root job would look under{" "}
+      <code>/root/.shep</code> and report no shepherd running, so it has to
+      become the account that owns the flock first.
+    </p>
 
     <h2>Emptying them</h2>
     <VerbSignature verb="flush" usage="shep flush <selector> | shep flush --daemon">

--- a/web/src/pages/docs/logs.astro
+++ b/web/src/pages/docs/logs.astro
@@ -83,7 +83,8 @@ stderr  /tmp/shepdocs/home/logs/shepd.err.log  emptied`;
     <p>
       Two files per sheep, under <code>$SHEP_HOME/logs/</code>, named{" "}
       <code>&lt;name&gt;-&lt;instance&gt;-out.log</code> and{" "}
-      <code>-err.log</code>. An app can point either somewhere else with{" "}
+      <code>&lt;name&gt;-&lt;instance&gt;-err.log</code>. An app can point either
+      somewhere else with{" "}
       <code>out_file</code> and <code>err_file</code>, or fold both streams
       into one file with <code>merge_logs</code>. A clustered app gets one
       pair per instance unless it says otherwise, which is why an explicit{" "}

--- a/web/src/pages/docs/logs.astro
+++ b/web/src/pages/docs/logs.astro
@@ -1,0 +1,352 @@
+---
+/*
+ * Logs (`shep bleats/reopen/flush --help`,
+ * crates/shep-cli/src/commands/logs.rs and bleats.rs, shep-daemon's
+ * LogFile::reopen and open_append). Terminal output below was run for real
+ * against target/release/shep on 2026-08-29 - see this page's PR for the
+ * transcript.
+ *
+ * `reopen` had no mention anywhere on this site before this page, and
+ * `flush` had one row in the pm2 comparison table plus one warning aimed at
+ * dog authors on the dogs page. `bleats` was used in examples on four
+ * pages and explained on none of them.
+ */
+import DocsLayout from "../../layouts/DocsLayout.astro";
+import ReferencePills from "../../components/docs/ReferencePills.astro";
+import Callout from "../../components/docs/Callout.astro";
+import CodeBlock from "../../components/docs/CodeBlock.astro";
+import VerbSignature from "../../components/docs/VerbSignature.astro";
+
+const bleatsDemo = `$ shep bleats noisy --no-follow
+noisy | to stdout
+noisy | to stderr
+
+$ shep bleats noisy --no-follow --err
+noisy | to stderr
+
+$ shep bleats --no-follow --lines 1
+echoer | got: reload
+noisy | to stdout
+noisy | to stderr`;
+
+const reopenDemo = `$ mv /tmp/shepdocs/home/logs/web-0-out.log /tmp/shepdocs/home/logs/web-0-out.log.1
+$ mv /tmp/shepdocs/home/logs/web-1-out.log /tmp/shepdocs/home/logs/web-1-out.log.1
+$ shep reopen web
+ID  NAME   STATUS  PID    RESTARTS  EXIT  CPU  MEM  UPTIME  FOLD  SMIT
+0   web:0  online  54244  0         -     -    -    43s     -     -
+1   web:1  online  54338  1         -     -    -    37s     -     -`;
+
+const logrotate = `~/.shep/logs/*.log {
+    daily
+    rotate 7
+    missingok
+    notifempty
+    sharedscripts
+    postrotate
+        shep reopen
+    endscript
+}`;
+
+const flushDemo = `$ shep flush worker
+ID  NAME    OUT_FILE                                  ERR_FILE
+2   worker  /tmp/shepdocs/home/logs/worker-0-out.log  /tmp/shepdocs/home/logs/worker-0-err.log
+
+$ shep flush
+error: the following required arguments were not provided:
+  <SELECTOR>
+
+$ shep flush --daemon
+STREAM  FILE                                   RESULT
+stdout  /tmp/shepdocs/home/logs/shepd.out.log  emptied
+stderr  /tmp/shepdocs/home/logs/shepd.err.log  emptied`;
+---
+
+<DocsLayout
+  title="Logs"
+  description="Where a sheep's output lands, how to read it, and the two verbs that act on the files themselves: reopen for an external rotator, flush to empty them."
+  crumb="Reference / Logs"
+  activeSlug="logs"
+>
+  <article>
+    <h1>Logs</h1>
+    <ReferencePills slug="logs" />
+    <p class="lede">
+      A sheep never sees its own log file. It is spawned with its stdout and
+      stderr on pipes, and the shepherd does the file writing on the far side
+      of them. That one fact is why every verb on this page is cheap: swapping
+      the shepherd's handle, or emptying the file under it, is invisible
+      across the process boundary. No signal to the app, no fd surgery, no
+      restart, and no gap in the pipe.
+    </p>
+
+    <h2>Where the lines land</h2>
+    <p>
+      Two files per sheep, under <code>$SHEP_HOME/logs/</code>, named{" "}
+      <code>&lt;name&gt;-&lt;instance&gt;-out.log</code> and{" "}
+      <code>-err.log</code>. An app can point either somewhere else with{" "}
+      <code>out_file</code> and <code>err_file</code>, or fold both streams
+      into one file with <code>merge_logs</code>. A clustered app gets one
+      pair per instance unless it says otherwise, which is why an explicit{" "}
+      <code>out_file</code> on a multi-instance app is refused unless it
+      carries <code>{"{{instance}}"}</code> or the app sets{" "}
+      <code>merge_logs</code>: without one of those, every instance would be
+      appending to the same path by accident rather than on purpose.
+    </p>
+    <p class="fine">
+      Every handle is opened append-only, and a symlink sitting at the path
+      is refused rather than written through. Append matters more than it
+      looks: a handle that tracked its own offset would seek back to where it
+      had got to and write past the end of a file a rotator had just
+      replaced, leaving a sparse hole the size of everything rotated away,
+      after every rotation.
+    </p>
+
+    <h2>Reading them</h2>
+    <VerbSignature
+      verb="bleats"
+      aliases={["logs"]}
+      usage="shep bleats [selector] [--no-follow] [--lines N] [--out | --err]"
+    >
+      <p>
+        Prints the tail of each matched sheep's log files and then follows
+        what arrives next. The selector defaults to <code>all</code>, since
+        reading destroys nothing. <code>--no-follow</code> stops after the
+        tail, <code>--lines</code> sets how much history comes first (15 by
+        default, counted <em>per stream</em>, so the default is up to 15
+        lines of stdout and up to 15 of stderr for each matched sheep), and{" "}
+        <code>--out</code> or <code>--err</code> narrows a sheep to one of
+        its two files.
+      </p>
+    </VerbSignature>
+    <p>
+      Following prints that history first and then subscribes, rather than
+      showing only new lines. A sheep that already crashed has said
+      everything it is going to say, and a follow that skipped the tail
+      showed an empty screen while the reason sat in the file, which is
+      exactly how a boot-looping sheep came to look like it had logged
+      nothing at all. <code>--lines 0</code> is how you ask for the old
+      behaviour.
+    </p>
+    <CodeBlock>{bleatsDemo}</CodeBlock>
+    <p>
+      A sheep's own output always goes to stdout, both streams of it, because
+      both are the data you asked for. Only shep's own diagnostics, the
+      dropped-event count and the shutdown notice, go to stderr, so{" "}
+      <code>shep bleats &gt; file</code> captures everything the flock said
+      and nothing shep said about it. Interleaving a sheep's stderr into
+      shep's would silently lose half the output of that redirect and make{" "}
+      <code>--err</code> produce an empty file.
+    </p>
+    <Callout variant="note">
+      <code>--no-follow</code> reads files and <code>--follow</code> reads
+      the bus, and the difference shows up twice. A stopped sheep still has
+      files, so <code>--no-follow</code> can show its last output while a
+      follow has nothing left to hear. And within one file lines print in
+      append order, but across a sheep's two files there is no merge:{" "}
+      <code>out_file</code> prints in full, then <code>err_file</code>{" "}
+      starts. A log line carries no timestamp, so there is no key to
+      interleave them on, and seeing all of stdout before any of stderr must
+      not be read as everything on stdout having happened first. Following
+      has no such seam, because the bus delivers in arrival order.
+    </Callout>
+    <p class="fine">
+      The tail is bounded twice: <code>--lines</code> lines, found within the
+      last 256 KiB of the file, read one file at a time. Peak memory for that
+      path is one window regardless of how large the flock or the log is.
+    </p>
+
+    <h2>Handing them to a rotator</h2>
+    <VerbSignature verb="reopen" usage="shep reopen [selector]">
+      <p>
+        Closes each matched sheep's log handle and opens the recorded path
+        again, creating the file if the rotator did not. For an external
+        rotator that has renamed the file out from under a running shepherd:
+        rename first, then reopen. The selector defaults to{" "}
+        <code>all</code>, which is the useful default for a{" "}
+        <code>postrotate</code> stanza and is safe because this destroys
+        nothing.
+      </p>
+    </VerbSignature>
+    <CodeBlock>{reopenDemo}</CodeBlock>
+    <p>
+      A zero exit is a promise worth relying on: every matched sheep's log
+      pump holds a handle on the recreated path, so a <code>postrotate</code>{" "}
+      that waits for this command knows no live pump is still filling the
+      archive it just renamed. That holds because the shepherd reaches every
+      writer to a path it is rotating, not only the sheep the selector named.
+      Several instances can share one file, and one of them left unasked
+      would go on filling the archive.
+    </p>
+    <p>
+      A matched sheep that is not running has no pump and nothing to reopen,
+      and is reported alongside the rest rather than as a failure. A pump
+      that could <em>not</em> open its path again fails the command instead,
+      naming the sheep and the path on stderr. The rename is still safe to
+      act on, because the old handle was closed either way, but that sheep is
+      writing its stream nowhere until the path can be opened, and exiting 0
+      there would be the silent failure this verb exists to end.
+    </p>
+    <CodeBlock label="/etc/logrotate.d/shep">{logrotate}</CodeBlock>
+
+    <h2>Emptying them</h2>
+    <VerbSignature verb="flush" usage="shep flush <selector> | shep flush --daemon">
+      <p>
+        Flushes what every pump still owes the file, then truncates it. What
+        gets emptied is exactly the paths the Flockfile named,{" "}
+        <code>out_file</code> and <code>err_file</code> as the shepherd
+        resolved them, for every registered sheep the selector matches,
+        whether or not it has ever run.
+      </p>
+    </VerbSignature>
+    <CodeBlock>{flushDemo}</CodeBlock>
+    <p>
+      The selector is required here and defaulted everywhere else on this
+      page. <code>bleats</code> and <code>reopen</code> default to{" "}
+      <code>all</code> because neither destroys anything; this one follows{" "}
+      <code>stop</code>, <code>restart</code> and <code>delete</code> in
+      demanding a target, because it is the one command on this page whose
+      slip of the finger cannot be undone. <code>shep flush all</code> is a
+      short thing to type when it is meant.
+    </p>
+    <p>
+      The table is one row per sheep carrying both of its paths, rather than
+      the lifecycle columns every other flock-shaped verb answers with. Those
+      keep <code>out_file</code> and <code>err_file</code> out for being too
+      wide, and here they are the answer: a verb that empties files an
+      operator may have mistyped, and then reports uptime and restart counts
+      it did not touch, has said nothing about what it destroyed.
+    </p>
+    <p class="fine">
+      A stopped sheep is emptied like any other, since the shepherd truncates
+      recorded paths rather than open handles, and a stopped sheep's logs are
+      still readable with <code>shep bleats --no-follow</code>. Several sheep
+      can share one path, and each distinct path is truncated once, so the
+      same path can appear in two rows. A sharing sheep the selector skipped
+      has that file emptied under it all the same, with its pump flushed
+      first so none of its pending lines lands in the file afterwards. It is
+      not a row here because it is not a sheep you named, and that is the one
+      thing this table cannot show you.
+    </p>
+    <Callout variant="careful">
+      Those paths are ordinary config values, taken verbatim and never
+      checked against the log directory. An app whose <code>out_file</code>{" "}
+      points at something that is not a log file has that file emptied too,
+      with the shepherd's privileges.
+    </Callout>
+    <p>
+      <code>--daemon</code> empties the shepherd's own two files instead, and
+      takes no selector because no selector can reach them. Those files
+      belong to the CLI: the launcher creates them before the shepherd
+      exists and hands them over as plain fds 1 and 2, so the shepherd never
+      learns their paths and holds no handle it could be asked about. The
+      useful consequence is that <code>shep flush --daemon</code> needs no
+      running shepherd at all.
+    </p>
+    <Callout variant="careful">
+      Never reach for <code>flush</code> as part of rotating anything. Its
+      name reads like settling a buffer and it does the opposite of what a
+      rotator wants: it flushes what is pending and then{" "}
+      <strong>truncates</strong>. Called before a rename, it deletes the
+      lines you were about to rotate. Rename, then <code>reopen</code>.
+    </Callout>
+
+    <h2>Where to go next</h2>
+
+    <div class="next-grid">
+      <a href="/docs/output" class="next-card">
+        <div class="next-title">Terminal output →</div>
+        <div class="next-body">
+          What the tables above are doing: colour, the sheep in the STATUS
+          column, and the <code>full</code>/<code>plain</code>/<code>bare</code>{" "}
+          dial that turns it off.
+        </div>
+      </a>
+      <a href="/docs/dogs" class="next-card">
+        <div class="next-title">Dogs →</div>
+        <div class="next-body">
+          <code>shep barks</code> and the alert history, which is a different
+          file with a different lifetime from anything on this page.
+        </div>
+      </a>
+    </div>
+  </article>
+</DocsLayout>
+
+<style>
+  h1 {
+    font-size: clamp(36px, 4.6vw, 56px);
+    line-height: 1;
+    letter-spacing: -0.04em;
+    margin: 0 0 18px;
+  }
+
+  h2 {
+    font-size: 29px;
+    letter-spacing: -0.03em;
+    margin: 40px 0 8px;
+  }
+
+  h2:first-of-type {
+    margin-top: 0;
+  }
+
+  .lede {
+    font-size: 19px;
+    line-height: 1.6;
+    color: var(--ink-2);
+    margin: 0 0 30px;
+    text-wrap: pretty;
+  }
+
+  p {
+    font-size: 16.5px;
+    line-height: 1.65;
+    color: var(--ink-2);
+    margin: 0 0 18px;
+  }
+
+  .fine {
+    font-size: 15px;
+    line-height: 1.6;
+    color: var(--ink-3);
+    margin: -8px 0 30px;
+  }
+
+  .next-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    gap: 16px;
+    margin-top: 8px;
+  }
+
+  .next-card {
+    text-align: left;
+    background: var(--paper-2);
+    border: 3px solid var(--line);
+    border-radius: 18px;
+    box-shadow: 5px 5px 0 var(--shadow);
+    padding: 20px;
+    color: var(--ink);
+    text-decoration: none;
+    display: block;
+  }
+
+  .next-card:hover {
+    transform: translate(2px, 2px);
+    box-shadow: 3px 3px 0 var(--shadow);
+    color: var(--ink);
+  }
+
+  .next-title {
+    font-family: "Bricolage Grotesque", sans-serif;
+    font-weight: 800;
+    font-size: 17px;
+    margin-bottom: 7px;
+  }
+
+  .next-body {
+    font-size: 14px;
+    line-height: 1.5;
+    color: var(--ink-2);
+  }
+</style>

--- a/web/src/pages/docs/serve.astro
+++ b/web/src/pages/docs/serve.astro
@@ -102,8 +102,8 @@ $ curl -o /dev/null -w '%{http_code}\\n' http://127.0.0.1:8080/link.html
     </p>
     <p class="fine">
       What isn't here: range requests, conditional requests, ETags,
-      compression, keep-alive, TLS, HTTP/2, or any <code>PM2_SERVE_*</code>
-      compatibility <NotBuilt note="range/conditional requests are v1.1 candidates" />.
+      compression, keep-alive, TLS, or HTTP/2
+      <NotBuilt note="range/conditional requests are v1.1 candidates" />.
       <code>shep serve</code> takes no configuration from the environment:
       pass <code>--port</code>, <code>--bind</code>, <code>--spa</code>,
       <code>--auth</code> and the flags above on the command line instead.
@@ -111,16 +111,6 @@ $ curl -o /dev/null -w '%{http_code}\\n' http://127.0.0.1:8080/link.html
       request.
     </p>
 
-    <h2>Coming from pm2</h2>
-    <p>
-      Three defaults are flipped from pm2's own <code>serve</code>, and each
-      is a regression before it's a fix if you weren't expecting it: listing
-      and dotfiles are pm2's <em>on</em>, shep's <em>off</em>; following an
-      in-docroot symlink is pm2's <em>on</em>, shep's <em>off</em>. All three
-      are one flag away (<code>--listing</code>, <code>--hidden</code>,
-      <code>--follow-symlinks</code>) once you've decided the trade is worth
-      it for your layout.
-    </p>
     <h2>Where to go next</h2>
 
     <div class="next-grid">

--- a/web/src/pages/docs/startup.astro
+++ b/web/src/pages/docs/startup.astro
@@ -214,10 +214,14 @@ const runbook = `1.  shep import --dry-run           # read the Flockfile before
     <CodeBlock>{pingDemo}</CodeBlock>
     <p>
       A reply is not treated as success. <code>shep kill</code> waits for the
-      socket file to actually disappear before reporting one, which is what
+      control address to stop answering before reporting one, which is what
       makes <code>shep kill &amp;&amp; shep start</code> safe: without the
-      wait, the new shepherd could bind before the old one had finished
-      unlinking the path out from under it.
+      wait, the new shepherd could claim the address before the old one had
+      released it. On unix that means watching the socket file disappear,
+      since the daemon unlinks it last. On Windows the address is a named
+      pipe with no directory entry to watch, so <code>shep kill</code> probes
+      it instead, and a connect that fails because the name is gone is the
+      same proof.
     </p>
 
     <h2>Honestly: openrc and the BSDs are untested</h2>

--- a/web/src/pages/docs/startup.astro
+++ b/web/src/pages/docs/startup.astro
@@ -10,6 +10,35 @@ import DocsLayout from "../../layouts/DocsLayout.astro";
 import ReferencePills from "../../components/docs/ReferencePills.astro";
 import Callout from "../../components/docs/Callout.astro";
 import CodeBlock from "../../components/docs/CodeBlock.astro";
+import VerbSignature from "../../components/docs/VerbSignature.astro";
+
+const rollDemo = `$ shep save
+FILE                           APPS
+/tmp/shepdocs/home/flock.json  2
+
+$ shep muster
+ID  NAME    STATUS  PID    RESTARTS  EXIT  CPU  MEM  UPTIME  FOLD  SMIT
+0   web:0   online  61835  0         -     -    -    0s      -     -
+1   web:1   online  61836  0         -     -    -    0s      -     -
+2   worker  online  61837  0         -     -    -    0s      -     -`;
+
+const pingDemo = `$ shep ping
+shepherd  online
+version   0.1.15
+pid       61682
+home      /tmp/shepdocs/home
+socket    /tmp/shepdocs/home/run/shep.sock
+
+$ shep kill
+PID    SOCKET_REMOVED
+61682  true
+
+$ shep ping
+shepherd  offline
+home      /tmp/shepdocs/home
+socket    /tmp/shepdocs/home/run/shep.sock
+$ echo $?
+5`;
 
 const realOutput = `$ shep startup
 error[failure]: installing the unit needs root; run: sudo /opt/shep/target/release/shep startup --user deploy --home /tmp/shep_startup_demo
@@ -91,6 +120,63 @@ const runbook = `1.  shep import --dry-run           # read the Flockfile before
       <code>startup</code> refuses to overwrite the unit it just wrote).
     </Callout>
 
+    <h2>The muster roll</h2>
+    <p>
+      The unit brings the shepherd back. What brings the <em>flock</em> back
+      is a file: <code>$SHEP_HOME/flock.json</code>, the muster roll, holding
+      every registered app's config and how many of its instances were
+      running when it was written.
+    </p>
+    <VerbSignature verb="save" usage="shep save">
+      <p>
+        Writes the roll now and reports where it landed and how many apps it
+        recorded. Not the only thing that writes it: the shepherd keeps the
+        roll current on its own, folding a burst of lifecycle events into one
+        write so a restart storm costs one rewrite rather than one per event.
+        This verb exists so you can see the roll is on disk before a reboot
+        instead of trusting that it is, which is why a failed save is loud
+        rather than a quiet no-op. It refuses when no shepherd is running
+        rather than starting one, since a shepherd started to answer a{" "}
+        <code>save</code> has an empty flock, and writing <em>that</em> would
+        replace a good roll with a blank one.
+      </p>
+    </VerbSignature>
+    <VerbSignature verb="muster" usage="shep muster">
+      <p>
+        Assembles the flock from that roll, starting a shepherd first if none
+        is running. Only two verbs in the CLI will do that, this one and{" "}
+        <code>shep start</code>, and this is the one the init unit calls at
+        boot: the restore that runs unattended after a reboot is the same
+        code path you can drive by hand.
+      </p>
+    </VerbSignature>
+    <CodeBlock>{rollDemo}</CodeBlock>
+    <p class="fine">
+      Those pids are new because that <code>muster</code> ran with no
+      shepherd at all: it started one, the boot restore brought the flock up,
+      and the request that followed reported what came back.
+    </p>
+    <p>
+      An app restores if it was running when the roll was saved{" "}
+      <em>and</em> its <code>autostart</code> is still true. Being up when
+      the roll was written is the contract, and{" "}
+      <code>autostart = false</code> is the explicit opt-out of being brought
+      back. An app the flock already has is left exactly where it stands and
+      still reported as restored, which is what makes the verb safe to run
+      twice: an init system that calls it a second time gets the same honest
+      answer rather than a duplicate flock. A roll that restored nothing says
+      so on stderr rather than exiting 0 in silence.
+    </p>
+    <Callout variant="careful">
+      The roll is the one place shep writes secrets to disk. It stores each
+      app's <code>env</code> verbatim, because a restore has to reproduce it,
+      while every other surface redacts them. On unix the file is written
+      owner-only, through a temp file and a rename so a reader never sees a
+      half-written roll. It is plain JSON and editable by hand, and every
+      entry is re-validated on the way back in, with failures collected and
+      reported rather than aborting the whole muster.
+    </Callout>
+
     <h2>The runbook</h2>
     <p>
       This is the full sequence a migration from pm2 walks through (import,
@@ -104,6 +190,34 @@ const runbook = `1.  shep import --dry-run           # read the Flockfile before
       only once the muster restore from step 6's roll has finished, not the
       moment the process execs. A green status at step 8 is already evidence
       the restore path works, before the reboot ever happens.
+    </p>
+
+    <h2>Is it up, and stopping it on purpose</h2>
+    <VerbSignature verb="ping" usage="shep ping">
+      <p>
+        Asks whether a shepherd is answering, and says which one: its
+        version, its pid, the home it is serving and the socket it is
+        listening on. Offline it still names the home and the socket, since
+        the usual reason for a surprise is that <code>--home</code> or{" "}
+        <code>$SHEP_HOME</code> is pointing somewhere other than where you
+        thought, and exits 5 so a script can branch on it. It never starts a
+        shepherd.
+      </p>
+    </VerbSignature>
+    <VerbSignature verb="kill" usage="shep kill">
+      <p>
+        Shuts the shepherd down, and the flock with it. Every online sheep
+        goes through the full stop ladder first, so this is an orderly
+        shutdown rather than a rug pull, and the socket is unlinked last.
+      </p>
+    </VerbSignature>
+    <CodeBlock>{pingDemo}</CodeBlock>
+    <p>
+      A reply is not treated as success. <code>shep kill</code> waits for the
+      socket file to actually disappear before reporting one, which is what
+      makes <code>shep kill &amp;&amp; shep start</code> safe: without the
+      wait, the new shepherd could bind before the old one had finished
+      unlinking the path out from under it.
     </p>
 
     <h2>Honestly: openrc and the BSDs are untested</h2>

--- a/web/src/pages/docs/startup.astro
+++ b/web/src/pages/docs/startup.astro
@@ -47,17 +47,6 @@ $ shep unstartup
 ACTION   TARGET                                                          RESULT
 removed  /Library/LaunchDaemons/io.github.turtiesocks.shep.deploy.plist  absent`;
 
-const runbook = `1.  shep import --dry-run           # read the Flockfile before it's written
-2.  shep import                     # writes ./Flockfile.toml; starts nothing
-3.  pm2 delete all && pm2 kill      # the one destructive step, and it's pm2's
-4.  shep start ./Flockfile.toml     # the flock comes up under shep
-5.  shep flock                      # every app online, CPU and MEM populated
-6.  shep save                       # names the roll it wrote and the app count
-7.  sudo shep startup --user <you>  # writes and enables the unit
-8.  systemctl status shep-<you>     # active (running), and green
-9.  reboot
-10. systemctl status shep-<you>     # active (running) WITHOUT anyone logging in
-11. shep flock                      # the same apps, new pids, uptime near zero`;
 ---
 
 <DocsLayout
@@ -177,21 +166,6 @@ const runbook = `1.  shep import --dry-run           # read the Flockfile before
       reported rather than aborting the whole muster.
     </Callout>
 
-    <h2>The runbook</h2>
-    <p>
-      This is the full sequence a migration from pm2 walks through (import,
-      start, save, install, reboot, verify), end to end on a Linux box:
-    </p>
-    <CodeBlock>{runbook}</CodeBlock>
-    <p>
-      Step 8's <code>active (running)</code> means something specific: the
-      generated unit is <code>Type=notify</code>, so systemd doesn't consider
-      it started until the daemon itself says so: it sends that signal
-      only once the muster restore from step 6's roll has finished, not the
-      moment the process execs. A green status at step 8 is already evidence
-      the restore path works, before the reboot ever happens.
-    </p>
-
     <h2>Is it up, and stopping it on purpose</h2>
     <VerbSignature verb="ping" usage="shep ping">
       <p>
@@ -254,8 +228,9 @@ const runbook = `1.  shep import --dry-run           # read the Flockfile before
       <a href="/docs/from-pm2" class="next-card">
         <div class="next-title">Coming from pm2 →</div>
         <div class="next-body">
-          The runbook above is the tail end of this guide: start there for
-          the import step and the env rule that precedes it.
+          The full runbook, from <code>shep import</code> through the
+          reboot check, lives there: this page covers the save and muster
+          half in more depth.
         </div>
       </a>
       <a href="/docs/containers" class="next-card">

--- a/web/src/pages/docs/talking-to-a-sheep.astro
+++ b/web/src/pages/docs/talking-to-a-sheep.astro
@@ -74,7 +74,7 @@ ID  NAME    OUTCOME   DETAIL
 
 <DocsLayout
   title="Talking to a sheep"
-  description="Reaching an app that is already running: a unix signal, a line on its stdin, or a named action over the shepherd channel. None of the three replaces the process."
+  description="Reaching an app that is already running: a unix signal, a line on its stdin, or a named action over the shepherd channel. None of the three restarts it, though a signal it does not handle can still kill it."
   crumb="Concepts / Talking to a sheep"
   activeSlug="talking-to-a-sheep"
 >

--- a/web/src/pages/docs/talking-to-a-sheep.astro
+++ b/web/src/pages/docs/talking-to-a-sheep.astro
@@ -1,0 +1,424 @@
+---
+/*
+ * Talking to a sheep (`shep signal --help`, `shep whisper --help`,
+ * crates/shep-core/src/signals.rs, crates/shep-cli/src/commands/signal.rs,
+ * shep-daemon's `begin_signal`). Terminal output below was run for real
+ * against target/release/shep on 2026-08-29 - see this page's PR for the
+ * transcript.
+ *
+ * The three verbs the binary's own `--help` groups under "Talk to a sheep":
+ * signal, whisper, trigger. `trigger` has a page of its own (the shepherd
+ * channel) and is a pointer here; the other two had nothing anywhere on
+ * this site before this page.
+ */
+import DocsLayout from "../../layouts/DocsLayout.astro";
+import ReferencePills from "../../components/docs/ReferencePills.astro";
+import Callout from "../../components/docs/Callout.astro";
+import CodeBlock from "../../components/docs/CodeBlock.astro";
+import VerbSignature from "../../components/docs/VerbSignature.astro";
+
+const hupDemo = `$ shep signal web HUP
+ID  NAME  OUTCOME    DETAIL
+0   web   delivered
+1   web   delivered
+
+$ shep bleats web --no-follow --lines 3
+web:0 | reloaded config`;
+
+const refusals = `$ shep signal web SIGSTOP
+error[usage]: \`SIGSTOP\` is not a signal shep will send; accepted: SIGHUP, SIGINT, SIGQUIT, SIGTERM, SIGUSR1, SIGUSR2, SIGWINCH, SIGCONT, SIGKILL
+$ echo $?
+2
+
+$ shep signal nope HUP
+error[not_found]: the daemon reported NotFound: selector matched no registered sheep
+$ echo $?
+3`;
+
+const untrapped = `$ shep signal batch USR1
+ID  NAME   OUTCOME    DETAIL
+3   batch  delivered
+
+$ shep flock
+ID  NAME    STATUS   PID    RESTARTS  EXIT     CPU   MEM   UPTIME  FOLD  SMIT
+3   batch   stopped  -      0         SIGUSR1  -     -     0s      -     -
+0   web:0   online   54244  0         -        0.1%  3.0M  33s     -     -
+1   web:1   online   54338  1         -        0.1%  3.0M  26s     -     -
+2   worker  online   54639  2         -        0.1%  3.0M  10s     -     -`;
+
+const selectors = `$ shep signal web:1 usr1
+ID  NAME  OUTCOME    DETAIL
+1   web   delivered
+
+$ shep signal all WINCH
+ID  NAME    OUTCOME    DETAIL
+0   web     delivered
+1   web     delivered
+2   worker  delivered
+
+$ shep signal worker HUP
+ID  NAME    OUTCOME      DETAIL
+2   worker  not_running  no live process to signal`;
+
+const whisperDemo = `$ shep whisper echoer "reload"
+ID  NAME    OUTCOME  DETAIL
+4   echoer  sent
+
+$ shep bleats echoer --no-follow --lines 5
+echoer | got: reload
+
+$ shep whisper worker "hello"
+ID  NAME    OUTCOME   DETAIL
+2   worker  no_stdin  no stdin pipe — set stdin = true`;
+---
+
+<DocsLayout
+  title="Talking to a sheep"
+  description="Reaching an app that is already running: a unix signal, a line on its stdin, or a named action over the shepherd channel. None of the three replaces the process."
+  crumb="Concepts / Talking to a sheep"
+  activeSlug="talking-to-a-sheep"
+>
+  <article>
+    <h1>Talking to a sheep</h1>
+    <ReferencePills slug="talking-to-a-sheep" />
+    <p class="lede">
+      An app that re-reads its configuration on <code>SIGHUP</code> can be
+      reconfigured with <code>shep signal &lt;name&gt; HUP</code> without
+      being restarted, so it keeps every warm cache, open pool and in-flight
+      request it was holding. That is a pattern shep can reach and cannot
+      offer on its own: <code>restart</code> and <code>reload</code> both
+      replace the process. This page is the three verbs that don't.
+    </p>
+
+    <h2>Signals</h2>
+    <VerbSignature verb="signal" usage="shep signal <selector> <signal>">
+      <p>
+        Delivers one signal to each matched sheep's <strong>own</strong>{" "}
+        process, never to its process group. The lambs it forked are not
+        signalled. That is the difference between this verb and the stop
+        ladder: <code>shep stop</code> signals the whole group and then
+        escalates, and this one is a nudge to a single process with nothing
+        behind it.
+      </p>
+    </VerbSignature>
+
+    <h2>A config change is not a binary upgrade</h2>
+    <p>
+      shep prices those two identically, and your app almost certainly does
+      not. Replacing a process throws away everything it had built up in
+      memory, which is the right price for new code and a steep one for a
+      changed setting. For a process holding state that is expensive to
+      rebuild, the gap between the two is the whole reason this verb is worth
+      knowing about:
+    </p>
+    <ul>
+      <li>
+        <code>shep restart api</code> replaces the process. The new one reads
+        the new config, and also starts from nothing: caches cold, pools
+        empty, whatever was in flight gone.
+      </li>
+      <li>
+        <code>shep signal api HUP</code> leaves the process where it is. If
+        the app re-reads its config on <code>SIGHUP</code>, it picks up the
+        change and keeps everything else.
+      </li>
+    </ul>
+    <p>
+      Only the application can make the second one true. shep delivers the
+      signal and reports that it was delivered; what <code>SIGHUP</code>{" "}
+      means is the app's convention, though a widely kept one. Server
+      software has treated it as "re-read your configuration" for decades,
+      and plenty of application frameworks and long-running daemons do the
+      same. Here is a sheep that traps it, saying so in its own output:
+    </p>
+    <CodeBlock>{hupDemo}</CodeBlock>
+
+    <h2>The nine names</h2>
+    <p>
+      <code>SIGHUP</code>, <code>SIGINT</code>, <code>SIGQUIT</code>,{" "}
+      <code>SIGTERM</code>, <code>SIGUSR1</code>, <code>SIGUSR2</code>,{" "}
+      <code>SIGWINCH</code>, <code>SIGCONT</code> and <code>SIGKILL</code>.
+      The <code>SIG</code> prefix and the case are both optional, so{" "}
+      <code>hup</code>, <code>Hup</code> and <code>SIGHUP</code> are the same
+      request, and the wire carries the canonical spelling whichever you
+      typed. Anything outside the nine is refused locally, before the command
+      opens a connection at all.
+    </p>
+    <p>
+      A raw number is refused with them, deliberately. Signal numbers are not
+      portable: <code>SIGUSR1</code> is 10 on Linux and 30 on macOS, so a
+      command that took one would mean two different things on two hosts and
+      shep will not guess which you meant.
+    </p>
+    <p>
+      <code>SIGSTOP</code> is the one real, spellable, deliverable signal
+      that is missing on purpose. A stopped process still reads{" "}
+      <code>online</code> in <code>shep flock</code>, in{" "}
+      <code>describe</code>, on the bus and to every dog, because the
+      shepherd owns no mechanism that could tell the difference. Refusing it
+      keeps shep out of a flock state it cannot describe.{" "}
+      <code>SIGCONT</code> is accepted, so an operator who stopped a sheep by
+      some other route has a way back.
+    </p>
+    <CodeBlock>{refusals}</CodeBlock>
+
+    <Callout variant="careful">
+      <code>delivered</code> means the kernel took it, not that the app did
+      anything with it. A signal the app blocks or ignores reads exactly like
+      one it acts on, because there is nothing on this path that could tell
+      them apart and a supervisor inventing a distinction would be guessing.
+    </Callout>
+
+    <p>
+      That cuts the other way too, and this is the one to be careful with: a
+      signal the app does not handle still has a kernel default, and for most
+      of the nine that default is to terminate the process. A sheep that
+      never installed a <code>SIGUSR1</code> handler is killed by one, the
+      row still says <code>delivered</code>, and the exit shows up in the
+      <code>EXIT</code> column like any other:
+    </p>
+    <CodeBlock>{untrapped}</CodeBlock>
+    <p class="fine">
+      <code>batch</code> above sets <code>autorestart = false</code>, which
+      is why it stayed down. With the default <code>autorestart</code> it
+      would have come straight back with its restart counter one higher, and
+      a <code>shep signal all USR2</code> across a flock you have not checked
+      is a restart of everything in it that does not handle{" "}
+      <code>SIGUSR2</code>.
+    </p>
+
+    <h2>Which sheep the selector reaches</h2>
+    <p>
+      The same grammar every other verb takes: a name, a numeric id,{" "}
+      <code>name:slot</code> for one instance of a clustered app, a glob, a{" "}
+      <code>/regex/</code>, <code>fold:&lt;name&gt;</code>, or{" "}
+      <code>all</code>. A bare name reaches <em>every</em> instance of that
+      app, so <code>shep signal web HUP</code> against three instances is
+      three deliveries and three rows.
+    </p>
+    <p>
+      The <code>NAME</code> column carries the app's name, not the{" "}
+      <code>web:0</code> spelling <code>shep flock</code> uses, so{" "}
+      <code>ID</code> is what tells two instances apart in a reply. Dogs are
+      reached only by a selector that named one exactly:{" "}
+      <code>shep signal all HUP</code> passes every dog by, and{" "}
+      <code>shep signal metrics HUP</code> does not.
+    </p>
+    <CodeBlock>{selectors}</CodeBlock>
+    <p class="fine">
+      A sheep being drained by a reload is signalled like any other. It is a
+      live process the selector matched, and holding it back would be a
+      silent refusal with nowhere to explain itself.
+    </p>
+
+    <h2>What the rows say, and what the exit code says</h2>
+    <p>
+      Three outcomes per matched sheep. <code>delivered</code>: the kernel
+      accepted the signal for that pid. <code>not_running</code>: the sheep
+      is registered but has no live process, so it is stopped, errored, or
+      waiting out a restart backoff. <code>failed</code>: the kernel refused
+      the delivery, and <code>DETAIL</code> carries its reason, such as{" "}
+      <code>ESRCH</code> for a process reaped between the lookup and the
+      syscall or <code>EPERM</code> for one this shepherd may not signal.
+    </p>
+    <p>
+      None of the three fails the command. A selector like{" "}
+      <code>fold:backend</code> makes a mixed flock the normal case, so the
+      per-sheep answer lives in the row and the exit code answers a different
+      question: whether the <em>request</em> worked. Exit 2 for a malformed
+      selector or a signal name outside the nine, both caught locally before
+      anything reaches the shepherd. Exit 3 when the selector matched no
+      registered sheep at all.
+    </p>
+
+    <h2>What it is not</h2>
+    <p>
+      <code>shep signal &lt;name&gt; TERM</code> is not{" "}
+      <code>shep stop</code>. A stop runs the ladder: the configured{" "}
+      <code>kill_signal</code> to the whole process group, then{" "}
+      <code>kill_timeout</code>, then <code>SIGKILL</code>, and the sheep
+      ends up marked stopped. Sending <code>SIGTERM</code> here does none of
+      that. There is no ladder, no timeout, no escalation and no stopped
+      marking, so whatever the app's restart policy says happens next is what
+      happens.
+    </p>
+    <p>
+      <code>shep signal &lt;name&gt; KILL</code> is a real{" "}
+      <code>SIGKILL</code> to one process, and the restart policy reads the
+      exit as any other unexpected one: an app with <code>autorestart</code>{" "}
+      on comes back. And swapping instances is <code>shep reload</code>, not
+      a signal an app happens to interpret that way.
+    </p>
+    <Callout variant="note">
+      On Windows only <code>SIGKILL</code> is delivered, and the other eight
+      names are refused one at a time rather than the whole verb failing.
+      Seven of them have no delivery mechanism to a foreign Windows process
+      at all. <code>SIGINT</code> is the judgement call: the console control
+      event exists, but Ctrl+C is disabled by default in a process group
+      created the way shep creates every sheep's, so it would arrive nowhere
+      while reading as success.
+    </Callout>
+
+    <h2>A line on its stdin</h2>
+    <VerbSignature
+      verb="whisper"
+      aliases={["sendline"]}
+      usage="shep whisper <selector> <line>"
+    >
+      <p>
+        Writes one line to each matched sheep's stdin. Only reaches an app
+        whose Flockfile sets <code>stdin = true</code>, and nothing else
+        implies it: unlike the shepherd channel, which{" "}
+        <code>wait_ready</code> and <code>shutdown_with_message</code> both
+        turn on, nothing inside shep needs a sheep's stdin except this verb.
+        One line, and the terminator is shep's to add, so a line containing a
+        newline or a carriage return is a usage error rather than two
+        commands.
+      </p>
+    </VerbSignature>
+    <CodeBlock>{whisperDemo}</CodeBlock>
+    <p>
+      <code>sent</code> means the bytes were written and flushed to the pipe,
+      not that the app read them. A pipe holds 64 KiB before it blocks, so a
+      short line to an app that never reads its stdin is still{" "}
+      <code>sent</code>. <code>no_stdin</code> is one outcome for two causes,
+      the field being unset and the sheep not running, because the row is
+      read to answer "why did my line not arrive" and both answers are "there
+      is no pipe here".
+    </p>
+    <p>
+      <code>not_written</code> carries which of three things happened: the
+      far end went away, the line arrived to find that sheep's queue already
+      full, or the write did not finish inside the shepherd's own bound.
+    </p>
+    <Callout variant="careful">
+      That last one does not promise the line was never written. A write that
+      timed out is a write the shepherd stopped <em>waiting</em> for: the
+      bytes may be sitting part-written in a pipe the app is not draining,
+      and they land in full the moment it drains. Lines still queued behind
+      it are dropped once their caller gives up, so a retry cannot pile
+      duplicates up and deliver them together later, but treat the retry as a
+      second command rather than a repeat of the first.
+    </Callout>
+
+    <h2>A named action</h2>
+    <p>
+      The third way in is <code>shep trigger</code>, which sends an action
+      name and optional parameters over the sheep's shepherd channel and
+      reports what the app answered. It is the only one of the three where
+      the app talks back, and it needs the channel open:{" "}
+      <code>channel = true</code>, or either of the two fields that imply it.
+      It has a page to itself.
+    </p>
+
+    <h2>Where to go next</h2>
+
+    <div class="next-grid">
+      <a href="/docs/shepherd-channel" class="next-card">
+        <div class="next-title">The shepherd channel →</div>
+        <div class="next-body">
+          <code>shep trigger</code>, the fd-3 pipe it speaks over, and what
+          an app has to answer for a reply to come back.
+        </div>
+      </a>
+      <a href="/docs/cli" class="next-card">
+        <div class="next-title">CLI reference →</div>
+        <div class="next-body">
+          Every flag on <code>signal</code>, <code>whisper</code> and{" "}
+          <code>trigger</code>, generated from the binary's own help.
+        </div>
+      </a>
+    </div>
+  </article>
+</DocsLayout>
+
+<style>
+  h1 {
+    font-size: clamp(36px, 4.6vw, 56px);
+    line-height: 1;
+    letter-spacing: -0.04em;
+    margin: 0 0 18px;
+  }
+
+  h2 {
+    font-size: 29px;
+    letter-spacing: -0.03em;
+    margin: 40px 0 8px;
+  }
+
+  h2:first-of-type {
+    margin-top: 0;
+  }
+
+  .lede {
+    font-size: 19px;
+    line-height: 1.6;
+    color: var(--ink-2);
+    margin: 0 0 30px;
+    text-wrap: pretty;
+  }
+
+  p {
+    font-size: 16.5px;
+    line-height: 1.65;
+    color: var(--ink-2);
+    margin: 0 0 18px;
+  }
+
+  ul {
+    font-size: 16.5px;
+    line-height: 1.65;
+    color: var(--ink-2);
+    margin: 0 0 18px;
+    padding-left: 22px;
+  }
+
+  li {
+    margin-bottom: 8px;
+  }
+
+  .fine {
+    font-size: 15px;
+    line-height: 1.6;
+    color: var(--ink-3);
+    margin: -8px 0 30px;
+  }
+
+  .next-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    gap: 16px;
+    margin-top: 8px;
+  }
+
+  .next-card {
+    text-align: left;
+    background: var(--paper-2);
+    border: 3px solid var(--line);
+    border-radius: 18px;
+    box-shadow: 5px 5px 0 var(--shadow);
+    padding: 20px;
+    color: var(--ink);
+    text-decoration: none;
+    display: block;
+  }
+
+  .next-card:hover {
+    transform: translate(2px, 2px);
+    box-shadow: 3px 3px 0 var(--shadow);
+    color: var(--ink);
+  }
+
+  .next-title {
+    font-family: "Bricolage Grotesque", sans-serif;
+    font-weight: 800;
+    font-size: 17px;
+    margin-bottom: 7px;
+  }
+
+  .next-body {
+    font-size: 14px;
+    line-height: 1.5;
+    color: var(--ink-2);
+  }
+</style>


### PR DESCRIPTION
Several verbs shipped with no documentation, and a page that names a verb in a comparison table is not a page that explains it.

Three new pages:

- `talking-to-a-sheep` covers `signal` and `whisper`. The lede is the thing that was invisible: an app that re-reads its config on SIGHUP can be reconfigured without losing what it holds, and shep prices a config change and a binary replacement identically today, since `restart` and `reload` both replace the process
- `logs` covers `bleats`, `reopen` and `flush`, plus a logrotate stanza, which is what `reopen` exists for and there was nowhere to find one
- `lifecycle` covers `stop`, `restart`, `reload` and `delete`. This one was not in the original scope and should have been. The material existed, smeared across five or six pages that are each about something else, and `shep delete` had three mentions with no page about deleting

Existing pages gained the rest: `barks` on the dogs page, `init` and `stock` on the Flockfile page, the muster roll and shepherd liveness on the startup page, `completions` and `welcome` in the install step.

The lifecycle page's one genuinely new contribution is putting what `stop` leaves behind next to what `delete` removes. `snapshot.rs`'s own `restorable()` doc states that distinction almost verbatim while nothing operator-facing did.

Second half of the PR moves every direct pm2 comparison back to the migration guide. shep does not need to be defined by its relationship to another tool on every page, and three of the seven sites turned out to be pure duplication: the serve defaults, the `PM2_SERVE_*` note and the whole startup runbook were already word for word in `from-pm2.astro`. Net 39 lines lighter. What stays is links to that page, and `dump.pm2` as a filename `shep import` genuinely reads.

Five fixes found along the way, each its own commit:

- the logrotate stanza globbed `~/.shep/logs/*.log`. logrotate passes the pattern to `glob(3)` without `GLOB_TILDE`, so the tilde is literal. Measured with a real `~/.shep/logs` present: `GLOB_NOMATCH`, zero matches. Not fragile, dead, and `missingok` kept it quiet
- `shep kill` was documented as waiting for the socket file to disappear. That is the unix arm only; on Windows the control address is a named pipe with no directory entry and `admin.rs` probes it instead
- the `talking-to-a-sheep` description said none of the three verbs replaces the process, which the page's own transcript disproves
- two Source pills named one module for a page whose verbs span two or three
- `dogs.astro` said `shep muster` was the one verb that starts a shepherd. There are two

Every transcript on all three new pages is a real run against a release binary, not composed. `astro check` and `astro build` both exit 0, 24 pages.

Two things that came out of writing the lifecycle page and are worth a look on their own, neither changed here. `ReloadMode::Overlap`'s doc comment says a `reuse_port`-less app crash-loops on an overlapping reload; the reproduction gave exactly one panic per `shep reload` with `RESTARTS` at 0. And `brain.rs`'s manual-stop-wins rule means a `shep stop` always resolves as a clean stop whatever the app's `autorestart` says, which was documented nowhere.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guides for lifecycle management, logs, and communicating with running processes.
  * Expanded startup, initialization, scaling, shell completion, greetings, and signal-command documentation.
  * Added examples for `barks`, log handling, reload behavior, and cluster applications.
  * Clarified command behavior, persistence, validation, platform support, HTTP/2, and configuration key rules.
  * Improved documentation navigation and source references, including support for multiple source links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->