### PR TITLE
feat(cli): refuse a version-skewed shepherd, and ship the reload that fixes it

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,7 @@ is one class of test.
 cargo test -p shep-daemon --lib --all-features -- --skip ::slow::
 ```
 
-**~1.3s, 488 of 506 lib tests as of 2026-08-19** — the exact counts drift
+**~1.7s, 548 of 566 lib tests as of 2026-08-29** — the exact counts drift
 every time a task adds one, so treat them as a shape, not a checksum. Three
 briefs have now shipped a stale figure, and this file carried "437 of 454"
 for long enough to be wrong by fifty. The 18 tests this skips live in a nested `mod slow`

--- a/crates/shep-cli/src/cli.rs
+++ b/crates/shep-cli/src/cli.rs
@@ -1116,6 +1116,14 @@ pub struct StyleArgs {
 /// `shep daemon --foreground --log-level info` without a config file.
 #[derive(Debug, clap::Args)]
 pub struct DaemonArgs {
+    /// What to do to the shepherd. Omit to BE the shepherd.
+    ///
+    /// `None` is the boot path and the reason this is optional at all: the
+    /// binary daemonizes by re-execing itself with `daemon` and nothing
+    /// else (`crate::launch::launch_daemon`), so a required subcommand here
+    /// would break daemonization itself rather than merely a verb.
+    #[command(subcommand)]
+    pub cmd: Option<DaemonCmd>,
     /// Boot without restoring the saved muster roll
     #[arg(long)]
     pub no_restore: bool,
@@ -1142,6 +1150,22 @@ pub struct DaemonArgs {
     /// Longest a cron worker sleeps before re-deriving its next occurrence
     #[arg(long, value_name = "DURATION", value_parser = duration_flag)]
     pub max_cron_sleep: Option<shep_core::values::UpDuration>,
+}
+
+/// The one thing `shep daemon` can be asked to do rather than be.
+///
+/// A separate enum rather than a flag on [`DaemonArgs`] because it is a
+/// different verb: `shep daemon` runs a shepherd in this process, and
+/// `shep daemon reload` replaces the one already running with this
+/// binary's own code.
+#[derive(Debug, clap::Subcommand)]
+pub enum DaemonCmd {
+    /// Replace the running shepherd with this binary, and bring the flock back
+    ///
+    /// `cargo install shep` replaces the binary and leaves the shepherd
+    /// running the old code. This is what restarts it, and it is the
+    /// command a version-skew refusal names.
+    Reload,
 }
 
 /// Arguments to `shep init`.
@@ -1490,6 +1514,82 @@ mod tests {
                 other => panic!("expected Daemon, got {other:?}"),
             }
         }
+    }
+
+    /// `shep daemon` with no subcommand is how this binary daemonizes:
+    /// `launch::launch_daemon` re-execs it with exactly that one argument.
+    /// An optional subcommand must not turn a bare invocation into a
+    /// missing-subcommand error, or daemonization itself stops working and
+    /// nothing in shep starts.
+    #[test]
+    fn a_bare_shep_daemon_still_boots_and_is_not_a_subcommand_error() {
+        use clap::Parser;
+        let parsed =
+            Cli::try_parse_from(["shep", "daemon"]).expect("`shep daemon` must still parse");
+        let Commands::Daemon(args) = parsed.command else {
+            panic!("`shep daemon` must still parse as the daemon verb");
+        };
+        assert!(
+            args.cmd.is_none(),
+            "bare `shep daemon` must remain the boot path"
+        );
+    }
+
+    /// fails if the subcommand changes what any existing `daemon` flag
+    /// means. clap can behave surprisingly when a subcommand and a struct's
+    /// own flags share one `Args` type, and every one of these flags is an
+    /// init unit's `ExecStart` line somewhere.
+    #[test]
+    fn the_daemon_flags_still_parse_alongside_the_subcommand() {
+        use clap::Parser;
+        let argv = [
+            "shep",
+            "daemon",
+            "--foreground",
+            "--no-restore",
+            "--log-json=false",
+            "--log-level",
+            "info",
+            "--socket",
+            "run/shep.sock",
+            "--max-cron-sleep",
+            "30s",
+        ];
+        let parsed = Cli::try_parse_from(argv).unwrap_or_else(|e| panic!("{argv:?} failed: {e}"));
+        let Commands::Daemon(args) = parsed.command else {
+            panic!("expected the daemon verb")
+        };
+        assert!(args.foreground);
+        assert!(args.no_restore);
+        assert_eq!(args.log_json, Some(false));
+        assert_eq!(args.log_level, Some(shep_core::config::LogLevel::Info));
+        assert_eq!(args.socket.as_deref(), Some(Path::new("run/shep.sock")));
+        assert_eq!(
+            args.max_cron_sleep
+                .map(shep_core::values::UpDuration::as_duration),
+            Some(std::time::Duration::from_secs(30))
+        );
+        assert!(
+            args.cmd.is_none(),
+            "flags alone must not select a subcommand"
+        );
+    }
+
+    /// The verb the version-skew refusal names. It has to parse, or that
+    /// refusal points an operator at a command that does not exist.
+    #[test]
+    fn daemon_reload_parses_as_the_reload_subcommand() {
+        use clap::Parser;
+        let parsed = Cli::try_parse_from(["shep", "daemon", "reload"])
+            .expect("`shep daemon reload` must parse");
+        let Commands::Daemon(args) = parsed.command else {
+            panic!("expected the daemon verb")
+        };
+        assert!(
+            matches!(args.cmd, Some(DaemonCmd::Reload)),
+            "got {:?}",
+            args.cmd
+        );
     }
 
     /// fails if the flag grammar widens past the env grammar — the exact

--- a/crates/shep-cli/src/cli.rs
+++ b/crates/shep-cli/src/cli.rs
@@ -82,6 +82,7 @@ Coming from pm2  import
 Help             welcome init help completions style
 
 Aliases          flock: list, ls   bleats: logs   lookout: dash   stock: scale   whisper: sendline
+Upgrading        cargo install shep replaces the binary, not the running shepherd: shep daemon reload
 
 {options}{after-help}";
 
@@ -1396,6 +1397,23 @@ mod tests {
                 );
             }
         }
+    }
+
+    /// `daemon reload` is hidden along with `daemon`, since `daemon` itself
+    /// is `#[command(hide = true)]` -- it is the internal re-exec path, not
+    /// a verb an operator picks off a menu. The version-skew refusal (Task
+    /// 5) names `shep daemon reload` as the fix, so `--help` must name it
+    /// too or an operator who goes looking for it finds nothing.
+    #[test]
+    fn the_help_template_names_the_upgrade_path() {
+        let line = HELP_TEMPLATE
+            .lines()
+            .find(|l| l.starts_with("Upgrading"))
+            .expect("HELP_TEMPLATE has an Upgrading line");
+        assert_eq!(
+            line,
+            "Upgrading        cargo install shep replaces the binary, not the running shepherd: shep daemon reload"
+        );
     }
 
     /// `HELP_TEMPLATE` is a literal and `HELP_GROUPS` is structured data, so

--- a/crates/shep-cli/src/commands/admin.rs
+++ b/crates/shep-cli/src/commands/admin.rs
@@ -361,6 +361,7 @@ mod tests {
         let refusal = Err(shep_core::protocol::RpcError {
             code: shep_core::protocol::RpcErrorCode::ProtocolMismatch,
             message: "daemon speaks protocol 1, client sent 2".to_string(),
+            daemon_version: None,
         });
         let _daemon = shep_client::testing::fake_daemon(&paths.socket, refusal).await;
 

--- a/crates/shep-cli/src/commands/admin.rs
+++ b/crates/shep-cli/src/commands/admin.rs
@@ -5,12 +5,22 @@
 //! finishes tearing itself down. A reply alone is not success: [`kill`]
 //! polls for the socket file to actually disappear before reporting one, so
 //! `shep kill && shep start` cannot race the old daemon's own unlink.
+//!
+//! **And a second path, for when the socket is itself the problem.** That
+//! request rides over a connection the client only has after a handshake, so
+//! a daemon that refuses the handshake — on protocol skew, say — could not
+//! be stopped by this verb, and no other verb in shep could stop it either:
+//! a live daemon, a live flock, and no way forward. So a connect failure of
+//! any kind falls through to [`kill_socket_free`], which proves the recorded
+//! pid through the pidfile lock and signals it directly.
 
 use std::path::Path;
 use std::time::{Duration, Instant};
 
 use shep_client::Client;
+use shep_core::paths::ShepPaths;
 use shep_core::protocol::{Request, Response};
+use shep_daemon::boot::{self, Shepherd};
 
 use crate::exit::ExitCode;
 use crate::output::{KillRow, Streams, emit, write_outcome};
@@ -35,12 +45,129 @@ const KILL_TEARDOWN_WAIT: Duration = Duration::from_secs(10);
 /// Global Constraints' bounded-receive line, one tier down.
 const KILL_POLL_INTERVAL: Duration = Duration::from_millis(20);
 
-/// Shuts the shepherd down.
+/// Shuts the shepherd down, over the socket if it can and without it if it
+/// cannot.
 ///
-/// Delegates to [`kill_with_wait`] with [`KILL_TEARDOWN_WAIT`]. Production's
-/// only call site; see that function's own doc for the full contract.
-pub async fn kill(client: Client, streams: &mut Streams<'_>) -> ExitCode {
-    kill_with_wait(client, streams, KILL_TEARDOWN_WAIT).await
+/// Connects here rather than being handed a [`Client`], unlike every other
+/// verb: a failure to connect is not a reason for THIS verb to give up. The
+/// socket-free path below is the whole point of the verb in the state that
+/// motivated it — a daemon that answers and then refuses the handshake — and
+/// it reports its own diagnosis, including when there is genuinely nothing
+/// running.
+///
+/// See [`kill_with_wait`] for the socket path's contract and
+/// [`kill_socket_free`] for the other one.
+pub async fn kill(paths: &ShepPaths, streams: &mut Streams<'_>) -> ExitCode {
+    match Client::connect(&paths.socket).await {
+        Ok(client) => kill_with_wait(client, streams, KILL_TEARDOWN_WAIT).await,
+        // Every connect failure lands here, deliberately: a refused
+        // handshake, a socket nothing is listening on, and a home with no
+        // socket at all are one question from this verb's point of view —
+        // does a live shepherd own this home — and the lock answers it
+        // better than the connect error does.
+        Err(_) => kill_socket_free(paths, streams).await,
+    }
+}
+
+/// Stops a shepherd without the socket, for when the socket is the problem.
+///
+/// Proves the pid through [`boot::daemon_liveness`] before signalling. A
+/// stale pidfile still names a pid, and that pid may since have been reused
+/// by something unrelated, so the file alone is never evidence: a live
+/// shepherd HOLDS the pidfile lock and the kernel drops it on process death,
+/// which is the one claim a leftover file cannot make.
+///
+/// `SIGTERM`, never `SIGKILL`. The daemon's own handler drives the graceful
+/// teardown that runs the kill ladder over every online sheep before
+/// stopping, so the flock stops cleanly instead of being orphaned.
+///
+/// Reports, and exits non-zero, when no live shepherd owns this home, when
+/// one is still starting and has no pid to signal yet, and on Windows, which
+/// has no signal to send.
+pub async fn kill_socket_free(paths: &ShepPaths, streams: &mut Streams<'_>) -> ExitCode {
+    kill_socket_free_with_wait(paths, streams, KILL_TEARDOWN_WAIT).await
+}
+
+/// As [`kill_socket_free`], but with a caller-chosen teardown wait — the
+/// same injectable-timing shape [`kill_with_wait`] carries, and for the same
+/// reason.
+async fn kill_socket_free_with_wait(
+    paths: &ShepPaths,
+    streams: &mut Streams<'_>,
+    wait: Duration,
+) -> ExitCode {
+    let pid = match boot::daemon_liveness(paths) {
+        Ok(Shepherd::Running(pid)) => pid,
+        // Alive and owns the home, but between taking the lock and
+        // recording its pid there is nothing to signal. Not an absence, and
+        // not a pid to guess at: the honest answer is to say so and let the
+        // operator ask again in a moment.
+        Ok(Shepherd::Booting) => {
+            let message = "a shepherd is starting up and has not recorded its pid yet; try again";
+            return streams.fail(ExitCode::DaemonUnreachable, message);
+        }
+        Ok(Shepherd::Absent) => {
+            let message = format!(
+                "no shepherd is running (nothing holds the lock on `{}`)",
+                boot::pidfile(paths).display()
+            );
+            return streams.fail(ExitCode::DaemonUnreachable, &message);
+        }
+        Err(err) => return streams.fail(ExitCode::Failure, &err.to_string()),
+    };
+
+    // Two arms for the same reason `control_address_answers` has two: the
+    // platforms do not offer the same thing. Unix has a signal whose handler
+    // the daemon already installs; Windows has no way to deliver an
+    // arbitrary console control event to another process, so there is
+    // nothing here to write and guessing at one would stop the shepherd
+    // without walking the ladder.
+    #[cfg(unix)]
+    {
+        use nix::sys::signal::{self, Signal};
+        use nix::unistd::Pid;
+
+        let Ok(target) = i32::try_from(pid) else {
+            let message = format!("the recorded pid {pid} is not one this platform can signal");
+            return streams.fail(ExitCode::Internal, &message);
+        };
+        // SIGTERM, not SIGKILL: the daemon's own handler runs the kill
+        // ladder over every online sheep before it exits, so the flock stops
+        // cleanly rather than being orphaned with broken pipes.
+        if let Err(errno) = signal::kill(Pid::from_raw(target), Signal::SIGTERM) {
+            let message = format!("could not signal the shepherd at pid {pid}: {errno}");
+            return streams.fail(ExitCode::Failure, &message);
+        }
+        // The same completion check the socket path uses, so a socket-free
+        // stop is no more willing to claim success before teardown finishes
+        // than a socket one is.
+        if wait_for_socket_to_disappear(&paths.socket, wait).await {
+            write_outcome(emit(
+                &mut *streams.out,
+                streams.fmt,
+                "kill",
+                KillRow {
+                    pid,
+                    socket_removed: true,
+                },
+                streams.style,
+            ))
+        } else {
+            let message = "the shepherd was signalled, but teardown is still in progress";
+            streams.fail(ExitCode::DeadlineExceeded, message)
+        }
+    }
+    #[cfg(windows)]
+    {
+        let _ = wait;
+        let message = format!(
+            "stopping the shepherd without the control pipe is not available on Windows: \
+             there is no signal to send it. The shepherd (pid {pid}) does handle the console \
+             control events, so press Ctrl-C in the window it is running in, or close that \
+             window, and it will stop its flock on the way out"
+        );
+        streams.fail(ExitCode::Failure, &message)
+    }
 }
 
 /// As [`kill`], but with a caller-chosen teardown wait — the same
@@ -170,6 +297,170 @@ mod tests {
     use crate::exit::ExitCode;
     use crate::output::Streams;
 
+    /// A [`ShepPaths`] rooted at `dir`, with the two directories the
+    /// socket-free path reads under it: `pids/` for the pidfile and `run/`
+    /// for the control socket. `shep_daemon::boot::init_dirs` is
+    /// `pub(crate)` over there, so this creates them rather than calling it.
+    ///
+    /// One tempdir per test, never shared (IR-33/34).
+    fn test_paths(dir: &tempfile::TempDir) -> ShepPaths {
+        let paths = ShepPaths::resolve(
+            &|key| (key == "SHEP_HOME").then(|| dir.path().to_string_lossy().into_owned()),
+            Path::new("/nonexistent"),
+        );
+        std::fs::create_dir_all(&paths.pids).unwrap();
+        std::fs::create_dir_all(&paths.run).unwrap();
+        paths
+    }
+
+    /// Holds `paths`'s pidfile lock the way a live shepherd does — an
+    /// `flock` on the pidfile itself — and records `pid` in it, or leaves
+    /// the file empty to stand in for a shepherd that has not reached its
+    /// own `record` yet.
+    ///
+    /// `flock` conflicts between open file DESCRIPTIONS rather than between
+    /// processes, so the lock this returns contends with `daemon_liveness`'s
+    /// own acquire even though both run inside this one test binary.
+    #[cfg(unix)]
+    fn hold_pidfile_lock(paths: &ShepPaths, pid: Option<u32>) -> nix::fcntl::Flock<std::fs::File> {
+        use std::io::Write as _;
+
+        let file = std::fs::OpenOptions::new()
+            .create(true)
+            .write(true)
+            .truncate(true)
+            .open(boot::pidfile(paths))
+            .unwrap();
+        let mut lock =
+            nix::fcntl::Flock::lock(file, nix::fcntl::FlockArg::LockExclusiveNonblock).unwrap();
+        if let Some(pid) = pid {
+            write!(&mut *lock, "{pid}").unwrap();
+            lock.flush().unwrap();
+        }
+        lock
+    }
+
+    /// The incident case: a daemon that answers the socket and then refuses
+    /// at the handshake. Every verb reaches the shepherd through that
+    /// handshake, `kill` included, so before this fallback a version-skewed
+    /// daemon could not be stopped by anything in shep.
+    ///
+    /// `cfg(unix)` for the FAKE's mechanism, not the feature's — the same
+    /// distinction the note on
+    /// `a_teardown_that_never_finishes_reports_in_progress_not_success`
+    /// draws. The stand-in shepherd is a real child process holding a real
+    /// pid, and the proof it was stopped gracefully is the signal number in
+    /// its exit status.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn kill_falls_back_to_the_pidfile_when_the_handshake_refuses() {
+        use std::os::unix::process::ExitStatusExt as _;
+
+        let dir = tempfile::tempdir().unwrap();
+        let paths = test_paths(&dir);
+        let refusal = Err(shep_core::protocol::RpcError {
+            code: shep_core::protocol::RpcErrorCode::ProtocolMismatch,
+            message: "daemon speaks protocol 1, client sent 2".to_string(),
+        });
+        let _daemon = shep_client::testing::fake_daemon(&paths.socket, refusal).await;
+
+        let child = std::process::Command::new("sleep")
+            .arg("30")
+            .spawn()
+            .unwrap();
+        let _lock = hold_pidfile_lock(&paths, Some(child.id()));
+
+        // Stands in for the daemon's own last teardown step: a real
+        // shepherd unlinks the socket as it exits, and that unlink is what
+        // `wait_for_socket_to_disappear` waits for. On its own thread
+        // because `Child::wait` blocks, and the poll loop it has to make
+        // progress against is a task on this test's single-threaded runtime.
+        let socket = paths.socket.clone();
+        let reaper = std::thread::spawn(move || {
+            let mut child = child;
+            let status = child.wait().unwrap();
+            let _ = std::fs::remove_file(&socket);
+            status
+        });
+
+        let mut out = Vec::new();
+        let mut err = Vec::new();
+        let code = {
+            let mut streams = Streams {
+                out: &mut out,
+                err: &mut err,
+                style: crate::style::Presentation::BARE,
+                fmt: Format::Table,
+            };
+            kill(&paths, &mut streams).await
+        };
+        assert_eq!(code, ExitCode::Success, "{}", String::from_utf8_lossy(&err));
+        let status = reaper.join().unwrap();
+        assert_eq!(
+            status.signal(),
+            Some(nix::sys::signal::Signal::SIGTERM as i32),
+            "the flock stops cleanly only if the daemon got its own handler's signal"
+        );
+    }
+
+    #[tokio::test]
+    async fn kill_refuses_a_pid_the_lock_does_not_prove_is_sheps() {
+        let dir = tempfile::tempdir().unwrap();
+        let paths = test_paths(&dir);
+        std::fs::write(boot::pidfile(&paths), "999999").unwrap();
+
+        // Stale file, nothing holds the lock. Signalling 999999 could hit an
+        // unrelated process that has since been given that pid, so this must
+        // refuse rather than guess.
+        let mut out = Vec::new();
+        let mut err = Vec::new();
+        let code = {
+            let mut streams = Streams {
+                out: &mut out,
+                err: &mut err,
+                style: crate::style::Presentation::BARE,
+                fmt: Format::Table,
+            };
+            kill(&paths, &mut streams).await
+        };
+        assert_ne!(code, ExitCode::Success);
+        let err = String::from_utf8(err).unwrap();
+        assert!(err.contains("no shepherd"), "{err}");
+    }
+
+    /// A shepherd between `PidfileLock::acquire` and its own `record` holds
+    /// the lock with nothing written in the file. It is alive and owns the
+    /// home, so reporting it as an absence would send an operator on to
+    /// start a second daemon that then dies unable to take the lock.
+    ///
+    /// `cfg(unix)` for the lock helper's mechanism, as above.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn kill_reports_a_booting_shepherd_rather_than_an_absence() {
+        let dir = tempfile::tempdir().unwrap();
+        let paths = test_paths(&dir);
+        let _lock = hold_pidfile_lock(&paths, None);
+
+        let mut out = Vec::new();
+        let mut err = Vec::new();
+        let code = {
+            let mut streams = Streams {
+                out: &mut out,
+                err: &mut err,
+                style: crate::style::Presentation::BARE,
+                fmt: Format::Table,
+            };
+            kill(&paths, &mut streams).await
+        };
+        assert_ne!(code, ExitCode::Success);
+        let err = String::from_utf8(err).unwrap();
+        assert!(err.contains("starting up"), "{err}");
+        assert!(
+            !err.contains("no shepherd"),
+            "a shepherd that is starting is not an absent one: {err}"
+        );
+    }
+
     #[tokio::test]
     async fn kill_waits_for_the_socket_to_disappear_before_reporting_success() {
         let dir = tempfile::tempdir().unwrap();
@@ -188,7 +479,7 @@ mod tests {
                 style: crate::style::Presentation::BARE,
                 fmt: Format::Table,
             };
-            kill(client, &mut streams).await
+            kill_with_wait(client, &mut streams, KILL_TEARDOWN_WAIT).await
         };
         assert_eq!(code, ExitCode::Success);
         assert!(

--- a/crates/shep-cli/src/commands/admin.rs
+++ b/crates/shep-cli/src/commands/admin.rs
@@ -30,7 +30,11 @@ use crate::output::{KillRow, Streams, emit, write_outcome};
 /// (`boot.rs:727`), behind the full kill ladder over every online sheep
 /// (`:722`) — this has to cover that ladder's whole budget, not just a
 /// round trip (IR-26: named, not a prose "a few seconds").
-const KILL_TEARDOWN_WAIT: Duration = Duration::from_secs(10);
+///
+/// `pub(crate)`: `commands::daemon`'s reload waits out the same teardown,
+/// because a shepherd's ladder does not get shorter for having been asked
+/// to stop by a reload rather than by a kill.
+pub(crate) const KILL_TEARDOWN_WAIT: Duration = Duration::from_secs(10);
 
 /// Gap between socket-existence checks while waiting out teardown. Fixed, not
 /// a backoff: the wait is already bounded and short, and a backoff would only
@@ -116,28 +120,11 @@ async fn kill_socket_free_with_wait(
         Err(err) => return streams.fail(ExitCode::Failure, &err.to_string()),
     };
 
-    // Two arms for the same reason `control_address_answers` has two: the
-    // platforms do not offer the same thing. Unix has a signal whose handler
-    // the daemon already installs; Windows has no way to deliver an
-    // arbitrary console control event to another process, so there is
-    // nothing here to write and guessing at one would stop the shepherd
-    // without walking the ladder.
+    if let Err((code, message)) = signal_graceful_stop(pid) {
+        return streams.fail(code, &message);
+    }
     #[cfg(unix)]
     {
-        use nix::sys::signal::{self, Signal};
-        use nix::unistd::Pid;
-
-        let Ok(target) = i32::try_from(pid) else {
-            let message = format!("the recorded pid {pid} is not one this platform can signal");
-            return streams.fail(ExitCode::Internal, &message);
-        };
-        // SIGTERM, not SIGKILL: the daemon's own handler runs the kill
-        // ladder over every online sheep before it exits, so the flock stops
-        // cleanly rather than being orphaned with broken pipes.
-        if let Err(errno) = signal::kill(Pid::from_raw(target), Signal::SIGTERM) {
-            let message = format!("could not signal the shepherd at pid {pid}: {errno}");
-            return streams.fail(ExitCode::Failure, &message);
-        }
         // The same completion check the socket path uses, so a socket-free
         // stop is no more willing to claim success before teardown finishes
         // than a socket one is.
@@ -157,16 +144,62 @@ async fn kill_socket_free_with_wait(
             streams.fail(ExitCode::DeadlineExceeded, message)
         }
     }
+    // Unreachable: `signal_graceful_stop` has already returned above on this
+    // platform. Written as a `cfg` rather than an `unreachable!` so nothing
+    // here can panic if that ever stops being true.
     #[cfg(windows)]
     {
         let _ = wait;
+        ExitCode::Failure
+    }
+}
+
+/// Asks the shepherd at `pid` to stop the way its own handler does.
+///
+/// The one place in the CLI that knows what stopping a shepherd without its
+/// control socket means per platform, so `kill`'s fallback and
+/// `commands::daemon`'s reload share it rather than each growing their own
+/// arm of it.
+///
+/// `SIGTERM`, never `SIGKILL`. The daemon's own handler drives the graceful
+/// teardown that runs the kill ladder over every online sheep before
+/// stopping, so the flock stops cleanly instead of being orphaned.
+///
+/// Two arms for the same reason `control_address_answers` has two: the
+/// platforms do not offer the same thing. Unix has a signal whose handler
+/// the daemon already installs; Windows has no way to deliver an arbitrary
+/// console control event to another process, so there is nothing to send
+/// and guessing at one would stop the shepherd without walking the ladder.
+///
+/// # Errors
+/// The exit code and the sentence to report, when the pid is not one this
+/// platform can name, when the signal itself failed, or on Windows, which
+/// has no signal to send at all. The caller prints it; this function writes
+/// nothing.
+pub(crate) fn signal_graceful_stop(pid: u32) -> Result<(), (ExitCode, String)> {
+    #[cfg(unix)]
+    {
+        use nix::sys::signal::{self, Signal};
+        use nix::unistd::Pid;
+
+        let Ok(target) = i32::try_from(pid) else {
+            let message = format!("the recorded pid {pid} is not one this platform can signal");
+            return Err((ExitCode::Internal, message));
+        };
+        signal::kill(Pid::from_raw(target), Signal::SIGTERM).map_err(|errno| {
+            let message = format!("could not signal the shepherd at pid {pid}: {errno}");
+            (ExitCode::Failure, message)
+        })
+    }
+    #[cfg(windows)]
+    {
         let message = format!(
             "stopping the shepherd without the control pipe is not available on Windows: \
              there is no signal to send it. The shepherd (pid {pid}) does handle the console \
              control events, so press Ctrl-C in the window it is running in, or close that \
              window, and it will stop its flock on the way out"
         );
-        streams.fail(ExitCode::Failure, &message)
+        Err((ExitCode::Failure, message))
     }
 }
 
@@ -248,7 +281,11 @@ pub async fn kill_with_wait(client: Client, streams: &mut Streams<'_>, wait: Dur
 /// socket file gives on unix. `ERROR_PIPE_BUSY` is deliberately treated as
 /// STILL ALIVE rather than gone: it means the pipe is there and every
 /// instance is in use, which is a daemon that has not finished.
-async fn wait_for_socket_to_disappear(socket: &Path, wait: Duration) -> bool {
+///
+/// `pub(crate)`: `commands::daemon`'s reload waits out the same teardown
+/// before it starts a successor, and a second waiter would be a second
+/// answer to the platform question above.
+pub(crate) async fn wait_for_socket_to_disappear(socket: &Path, wait: Duration) -> bool {
     let start = Instant::now();
     loop {
         if !control_address_answers(socket) {

--- a/crates/shep-cli/src/commands/daemon.rs
+++ b/crates/shep-cli/src/commands/daemon.rs
@@ -29,11 +29,12 @@
 use std::ffi::OsStr;
 use std::io::IsTerminal;
 
+use shep_client::{Client, ConnectError};
 use shep_core::config::{DaemonConfig, DaemonConfigError, DaemonOverrides};
 use shep_core::paths::ShepPaths;
 use shep_core::protocol::DogSource;
 use shep_core::values::UpDuration;
-use shep_daemon::boot::{BootError, BootOptions, RunningDaemon, boot};
+use shep_daemon::boot::{self, BootError, BootOptions, RunningDaemon, Shepherd, boot};
 use shep_daemon::dogs::DogSpec;
 #[cfg(unix)]
 use shep_daemon::notify::NOTIFY_SOCKET_ENV;
@@ -41,7 +42,9 @@ use shep_daemon::tokio_runner::TokioRunner;
 use tracing_subscriber::EnvFilter;
 
 use crate::cli::DaemonArgs;
+use crate::commands::{admin, muster};
 use crate::exit::ExitCode;
+use crate::output::Streams;
 
 /// Everything [`run_daemon`] can fail with. Per-module, per IR-18, and the
 /// same shape shep-daemon itself uses (`BootError`, `SnapshotError`,
@@ -414,10 +417,188 @@ pub fn daemon_exit_code(err: &DaemonRunError) -> ExitCode {
     }
 }
 
+/// Which mechanism a reload uses to give the flock a shepherd running this
+/// binary's code.
+///
+/// [`Self::StopAndStart`] is not scaffolding to be deleted when the
+/// handover lands. It is the permanent answer to three cases the handover
+/// cannot serve (spec H5): Windows, which has no `exec`; any shepherd
+/// predating the handover, which cannot be taught it after the fact; and a
+/// handover that fails to rehydrate, where the operator needs a reload that
+/// works rather than a wedged one.
+#[derive(Debug, PartialEq, Eq)]
+enum Arm {
+    /// Phase 2's `execve` handover: the shepherd replaces its own image and
+    /// the flock never stops.
+    ///
+    /// Nothing returns this yet, deliberately. A stub that pretended to
+    /// hand over and quietly stopped the flock instead would be worse than
+    /// a variant that is honestly unreachable, because the whole value of
+    /// the handover is the promise that a sheep keeps its pid.
+    #[expect(
+        dead_code,
+        reason = "phase 2 constructs this; phase 1 ships no handover for any version to support"
+    )]
+    Handover,
+    /// Stop the shepherd the way `kill` does, wait out its teardown, start a
+    /// successor, and muster the roll back.
+    StopAndStart,
+}
+
+impl Arm {
+    /// The arm that reloads a shepherd reporting `daemon_version`, or `None`
+    /// where the CLI could not learn it.
+    ///
+    /// Always [`Self::StopAndStart`] in phase 1, and the parameter is unused
+    /// rather than removed because it is the whole of phase 2's decision.
+    /// The handover has to exist in the OLD shepherd (spec H6), so no
+    /// version a running shepherd can report today supports it.
+    ///
+    /// **Unknown always means the safe arm, never the fast one.** `None`
+    /// arrives from a shepherd whose refusal named no version — one built
+    /// before the refusal carried the field, which no upgrade can reach
+    /// backwards to fix — and from a home where nothing answered at all.
+    /// Guessing at either would hand a flock to a mechanism the shepherd
+    /// holding it does not have.
+    fn for_daemon(_daemon_version: Option<&str>) -> Self {
+        Self::StopAndStart
+    }
+}
+
+/// The running shepherd's own crate version, as far as a failed connect can
+/// report it.
+///
+/// Only a protocol refusal names one: every other connect failure happened
+/// before the shepherd said who it is. `None` therefore means unknown, which
+/// is not the same as absent and is treated identically by
+/// [`Arm::for_daemon`].
+fn version_from_refusal(err: &ConnectError) -> Option<&str> {
+    match err {
+        ConnectError::ProtocolMismatch { daemon_version, .. } => daemon_version.as_deref(),
+        _ => None,
+    }
+}
+
+/// Replaces the running shepherd with one running this binary's code, and
+/// brings the flock back.
+///
+/// The verb a version-skew refusal names, and one of the three recovery
+/// verbs the guard exempts — so it must work against a shepherd that
+/// refuses the handshake, which is why it never needs the socket to succeed.
+///
+/// `guard` is threaded from `crate::run` rather than named here, so the
+/// exemption stays decided in one place.
+pub async fn reload(
+    streams: &mut Streams<'_>,
+    paths: &ShepPaths,
+    guard: crate::VersionGuard,
+) -> ExitCode {
+    reload_with_wait(streams, paths, guard, admin::KILL_TEARDOWN_WAIT).await
+}
+
+/// As [`reload`], but with a caller-chosen teardown wait — the same
+/// injectable-timing shape `commands::admin`'s `kill_with_wait` carries, and
+/// for the same reason.
+async fn reload_with_wait(
+    streams: &mut Streams<'_>,
+    paths: &ShepPaths,
+    guard: crate::VersionGuard,
+    wait: std::time::Duration,
+) -> ExitCode {
+    // Connected only to ask who is there, and dropped before anything is
+    // signalled: this connection is to the process about to be stopped.
+    let running_version = match Client::connect(&paths.socket).await {
+        Ok(client) => Some(client.daemon().daemon_version.clone()),
+        Err(err) => version_from_refusal(&err).map(str::to_owned),
+    };
+    match Arm::for_daemon(running_version.as_deref()) {
+        // Unreachable by construction: `Arm::for_daemon` never returns it in
+        // phase 1. Left as a panic rather than a silent fall-through to the
+        // stop arm, because a handover that quietly stopped the flock would
+        // be a lie about the one thing it promises.
+        Arm::Handover => unreachable!("the handover arm lands in phase 2"),
+        Arm::StopAndStart => stop_and_start(streams, paths, guard, wait).await,
+    }
+}
+
+/// Stops the shepherd, waits it out, starts a successor, and musters.
+///
+/// Four steps, no new mechanism in any of them: the pidfile lock proves the
+/// pid ([`boot::daemon_liveness`]), `commands::admin` owns the
+/// signal and the teardown wait, and `crate::connect_or_spawn_client` is the
+/// same autostart `shep start` and `shep muster` already use.
+async fn stop_and_start(
+    streams: &mut Streams<'_>,
+    paths: &ShepPaths,
+    guard: crate::VersionGuard,
+    wait: std::time::Duration,
+) -> ExitCode {
+    let pid = match boot::daemon_liveness(paths) {
+        Ok(Shepherd::Running(pid)) => pid,
+        // Alive and owns the home, but has not recorded a pid yet. Not an
+        // absence, and not a pid to guess at.
+        Ok(Shepherd::Booting) => {
+            let message = "a shepherd is starting up and has not recorded its pid yet; try again";
+            return streams.fail(ExitCode::DaemonUnreachable, message);
+        }
+        // Nothing to replace. Says what starts one instead, rather than
+        // starting it unasked: `reload` is how an operator makes a RUNNING
+        // system match the binary, and a home with no shepherd has no
+        // running system to make match.
+        Ok(Shepherd::Absent) => {
+            let message = format!(
+                "no shepherd is running, so there is nothing to reload (nothing holds the lock \
+                 on `{}`). `shep muster` brings the flock up from the roll",
+                boot::pidfile(paths).display()
+            );
+            return streams.fail(ExitCode::DaemonUnreachable, &message);
+        }
+        Err(err) => return streams.fail(ExitCode::Failure, &err.to_string()),
+    };
+    if let Err((code, message)) = admin::signal_graceful_stop(pid) {
+        return streams.fail(code, &message);
+    }
+    if !admin::wait_for_socket_to_disappear(&paths.socket, wait).await {
+        let message = "the shepherd was signalled, but teardown is still in progress; \
+                       nothing has been started in its place";
+        return streams.fail(ExitCode::DeadlineExceeded, message);
+    }
+    let client = match crate::connect_or_spawn_client(streams, paths, guard).await {
+        Ok(client) => client,
+        Err(code) => return code,
+    };
+    report_reload(&client, streams).await
+}
+
+/// Reports the shepherd now serving, then what happened to each sheep.
+///
+/// The per-sheep table is the whole report on purpose (spec H4): the
+/// handover arm does not stop the flock, so nothing here may announce that
+/// it did, and nothing may assume a reload gives a sheep a new pid. The one
+/// line above the table names the SHEPHERD's version and pid, which is true
+/// under both arms and is the fact the operator ran this verb for.
+///
+/// `Request::Muster` rather than a plain list: under the stop arm the
+/// successor has already restored the roll by the time this runs, so the
+/// muster spawns nothing new and reports the flock that restore produced —
+/// see `commands::muster::muster`'s own doc on why that is idempotent.
+async fn report_reload(client: &Client, streams: &mut Streams<'_>) -> ExitCode {
+    let shepherd = client.daemon();
+    let message = format!(
+        "the shepherd is now {} (pid {})",
+        shepherd.daemon_version, shepherd.pid
+    );
+    streams.aside("reload", &message);
+    muster::muster(client, streams).await
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::VersionGuard;
+    use crate::cli::Format;
     use shep_core::config::LogLevel;
+    use shep_core::protocol::Response;
 
     /// fails if `run_daemon` builds its overrides from the wrong fields, or
     /// drops one. Drives the config assembly, not the boot — booting a real
@@ -427,6 +608,7 @@ mod tests {
     #[test]
     fn every_daemon_flag_reaches_the_config() {
         let args = DaemonArgs {
+            cmd: None,
             no_restore: false,
             foreground: false,
             log_json: Some(true),
@@ -483,6 +665,7 @@ mod tests {
         let opts = boot_options(
             &config,
             &DaemonArgs {
+                cmd: None,
                 no_restore: false,
                 foreground: false,
                 log_json: None,
@@ -521,6 +704,7 @@ otel = "/usr/local/bin/shep-otel"
         let opts = boot_options(
             &config,
             &DaemonArgs {
+                cmd: None,
                 no_restore: false,
                 foreground: false,
                 log_json: None,
@@ -560,6 +744,7 @@ otel = "/usr/local/bin/shep-otel"
             boot_options(
                 &configured,
                 &DaemonArgs {
+                    cmd: None,
                     no_restore: false,
                     foreground: false,
                     log_json: None,
@@ -578,6 +763,7 @@ otel = "/usr/local/bin/shep-otel"
             boot_options(
                 &unset,
                 &DaemonArgs {
+                    cmd: None,
                     no_restore: false,
                     foreground: false,
                     log_json: None,
@@ -603,6 +789,7 @@ otel = "/usr/local/bin/shep-otel"
         let opts = boot_options(
             &config,
             &DaemonArgs {
+                cmd: None,
                 no_restore: true,
                 foreground: false,
                 log_json: None,
@@ -624,6 +811,7 @@ otel = "/usr/local/bin/shep-otel"
         let bare = boot_options(
             &config,
             &DaemonArgs {
+                cmd: None,
                 no_restore: false,
                 foreground: false,
                 log_json: None,
@@ -641,6 +829,7 @@ otel = "/usr/local/bin/shep-otel"
         let supervised = boot_options(
             &config,
             &DaemonArgs {
+                cmd: None,
                 no_restore: false,
                 foreground: true,
                 log_json: None,
@@ -661,6 +850,7 @@ otel = "/usr/local/bin/shep-otel"
         let unflagged = boot_options(
             &config,
             &DaemonArgs {
+                cmd: None,
                 no_restore: false,
                 foreground: true,
                 log_json: None,
@@ -675,6 +865,7 @@ otel = "/usr/local/bin/shep-otel"
         let inherited = boot_options(
             &config,
             &DaemonArgs {
+                cmd: None,
                 no_restore: false,
                 foreground: false,
                 log_json: None,
@@ -698,6 +889,7 @@ otel = "/usr/local/bin/shep-otel"
         let opts = boot_options(
             &config,
             &DaemonArgs {
+                cmd: None,
                 no_restore: false,
                 foreground: true,
                 log_json: None,
@@ -781,5 +973,126 @@ otel = "/usr/local/bin/shep-otel"
             "a run-phase failure must not still claim to be a boot failure: {run_msg:?}"
         );
         assert!(run_msg.starts_with("the daemon failed while running"));
+    }
+
+    /// A shepherd that answers cleanly and names an older version still
+    /// takes the stop arm in phase 1: the handover has to exist in the
+    /// shepherd being replaced (spec H6), and no released shep carries it.
+    #[test]
+    fn reload_picks_the_stop_arm_against_a_daemon_too_old_to_hand_over() {
+        assert_eq!(Arm::for_daemon(Some("0.1.8")), Arm::StopAndStart);
+    }
+
+    /// Not even this binary's own version selects the handover, which is
+    /// what makes the arm honest rather than a stub: phase 1 ships no
+    /// handover for any version to support.
+    #[test]
+    fn reload_picks_the_stop_arm_against_a_daemon_of_this_very_version() {
+        assert_eq!(
+            Arm::for_daemon(Some(env!("CARGO_PKG_VERSION"))),
+            Arm::StopAndStart
+        );
+    }
+
+    /// A shepherd predating Task 4's field sends no `daemon_version` at
+    /// all, and no upgrade can reach backwards to change that. Unknown must
+    /// mean the safe arm, never the fast one.
+    #[test]
+    fn reload_picks_the_stop_arm_when_the_handshake_is_refused_without_a_version() {
+        let refusal = ConnectError::ProtocolMismatch {
+            client: shep_core::protocol::PROTOCOL_VERSION,
+            daemon_version: None,
+            message: "this daemon speaks protocol 1".to_string(),
+        };
+        assert_eq!(version_from_refusal(&refusal), None);
+        assert_eq!(
+            Arm::for_daemon(version_from_refusal(&refusal)),
+            Arm::StopAndStart
+        );
+    }
+
+    /// The other half: a refusal that DOES name a version must hand it on.
+    /// This is the seam Task 4 added the field for, and dropping it here
+    /// would leave phase 2 unable to ever pick the handover after a
+    /// protocol bump -- the one case it matters most.
+    #[test]
+    fn a_refusal_that_names_a_version_yields_it_for_the_arm_choice() {
+        let refusal = ConnectError::ProtocolMismatch {
+            client: shep_core::protocol::PROTOCOL_VERSION,
+            daemon_version: Some("0.1.8".to_string()),
+            message: "this daemon speaks protocol 1".to_string(),
+        };
+        assert_eq!(version_from_refusal(&refusal), Some("0.1.8"));
+    }
+
+    /// Nothing else in a connect failure names a version: the handshake
+    /// never got far enough for the shepherd to say who it is.
+    #[test]
+    fn a_connect_failure_that_is_not_a_refusal_names_no_version() {
+        let err = ConnectError::HandshakeClosed;
+        assert_eq!(version_from_refusal(&err), None);
+    }
+
+    /// Spec H4: the report is per-sheep, because phase 2's handover does
+    /// not stop the flock and the same output shape has to be true under
+    /// both arms. Sheep DO stop under phase 1's stop arm -- this pins the
+    /// SHAPE, not the mechanism.
+    #[tokio::test]
+    async fn reload_reports_each_sheep_rather_than_announcing_the_flock_stopped() {
+        let dir = tempfile::tempdir().unwrap();
+        let addr = shep_client::testing::control_address(dir.path());
+        let (client, _envelopes) = shep_client::testing::fake_client_answering(&addr, |_req| {
+            Response::Mustered(vec![shep_client::testing::sample_info()])
+        })
+        .await;
+
+        let mut out = Vec::new();
+        let mut err = Vec::new();
+        let code = {
+            let mut streams = Streams {
+                out: &mut out,
+                err: &mut err,
+                style: crate::style::Presentation::BARE,
+                fmt: Format::Table,
+            };
+            report_reload(&client, &mut streams).await
+        };
+
+        assert_eq!(code, ExitCode::Success);
+        let text = format!(
+            "{}{}",
+            String::from_utf8(out).unwrap(),
+            String::from_utf8(err).unwrap()
+        );
+        assert!(text.contains("web"), "{text}");
+        assert!(!text.to_lowercase().contains("flock stopped"), "{text}");
+    }
+
+    /// A home no shepherd owns has nothing to reload, and the pidfile lock
+    /// is what proves that -- not the socket, which is exactly what a
+    /// skewed shepherd refuses over. Drives `reload` end to end, so the
+    /// connect, the arm choice and the liveness proof are all in the path.
+    #[tokio::test]
+    async fn reload_refuses_a_home_no_shepherd_owns() {
+        let dir = tempfile::tempdir().unwrap();
+        let paths = ShepPaths::resolve(&|_| None, dir.path());
+        std::fs::create_dir_all(&paths.run).unwrap();
+        std::fs::create_dir_all(&paths.pids).unwrap();
+
+        let mut out = Vec::new();
+        let mut err = Vec::new();
+        let code = {
+            let mut streams = Streams {
+                out: &mut out,
+                err: &mut err,
+                style: crate::style::Presentation::BARE,
+                fmt: Format::Table,
+            };
+            reload(&mut streams, &paths, VersionGuard::Exempt).await
+        };
+
+        assert_eq!(code, ExitCode::DaemonUnreachable);
+        let text = String::from_utf8(err).unwrap();
+        assert!(text.contains("no shepherd"), "{text}");
     }
 }

--- a/crates/shep-cli/src/commands/dogs.rs
+++ b/crates/shep-cli/src/commands/dogs.rs
@@ -35,7 +35,7 @@ use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 
-use shep_client::Client;
+use shep_client::{Client, ConnectError};
 use shep_core::barks;
 use shep_core::paths::ShepPaths;
 use shep_core::protocol::{DogSource, Request, Response};
@@ -98,6 +98,40 @@ fn dog_source(cfg: &ShepToml, name: &str) -> DogSource {
         })
 }
 
+/// Connects to `paths.socket`, distinguishing a genuine absence from a
+/// shepherd that IS there and refused — the `dogs.rs` spelling of the same
+/// defect `crate::flock_command` fixes for `shep flock` (Task 6 / spec G4).
+///
+/// `Ok(None)` is the only case [`enable`]/[`disable`]/[`adopt`]/[`rehome`]
+/// were ever meant to tolerate silently: [`ConnectError::Connect`],
+/// `connect(2)` itself failing because nothing is listening (decision 11 —
+/// none of the four may autostart a shepherd to act on its own config
+/// edit). Every other [`ConnectError`] variant means a connection WAS
+/// established, so a shepherd is there; folding that into `None` too is
+/// what the old `Client::connect(..).ok()` did, and it reported a live
+/// refusal as "will start with the next shepherd" — the same shape of bug
+/// as the blanket `Err(_)` [`crate::flock_command`] used to have.
+///
+/// # Errors
+/// The exit code and message [`Streams::fail`] already wrote, when the
+/// shepherd answered and refused rather than being absent.
+async fn connect_or_absent(
+    paths: &ShepPaths,
+    streams: &mut Streams<'_>,
+) -> Result<Option<Client>, ExitCode> {
+    match Client::connect(&paths.socket).await {
+        Ok(client) => Ok(Some(client)),
+        Err(ConnectError::Connect { .. }) => Ok(None),
+        Err(err) => {
+            let code = ExitCode::from(&err);
+            Err(streams.fail(
+                code,
+                &format!("{err}; run `shep {}`", crate::VERSION_SKEW_REMEDY),
+            ))
+        }
+    }
+}
+
 /// `shep enable <name>`: writes the config, and starts the dog if a
 /// shepherd is running.
 pub async fn enable(streams: &mut Streams<'_>, paths: &ShepPaths, name: &str) -> ExitCode {
@@ -117,7 +151,10 @@ pub async fn enable(streams: &mut Streams<'_>, paths: &ShepPaths, name: &str) ->
         Ok(source) => source,
         Err(err) => return fail_config(streams, &err),
     };
-    let client = Client::connect(&paths.socket).await.ok();
+    let client = match connect_or_absent(paths, streams).await {
+        Ok(client) => client,
+        Err(code) => return code,
+    };
     enable_after_config(streams, name, &source, client.as_ref()).await
 }
 
@@ -127,11 +164,14 @@ pub async fn enable(streams: &mut Streams<'_>, paths: &ShepPaths, name: &str) ->
 /// [`crate::commands::lifecycle::resolve_target`] is split out of `start`
 /// for the same reason: hermetic testability of the part that has a seam.
 ///
-/// `client: None` is [`enable`]'s own `Client::connect(..).ok()` — every way
-/// a connection can fail is folded into "no shepherd running" here, matching
-/// decision 11: this verb does not distinguish a stale socket file from a
-/// genuinely absent daemon, because a provisioning script configuring a host
-/// before starting anything must not have to.
+/// `client: None` is [`enable`]'s own [`connect_or_absent`] reporting a
+/// genuine absence — matching decision 11: this verb does not distinguish a
+/// stale socket file with nothing listening from a daemon that was never
+/// started, because a provisioning script configuring a host before
+/// starting anything must not have to. A shepherd that IS there and
+/// refused is a different case ([`connect_or_absent`]'s own doc, Task 6) —
+/// that never reaches this function at all, since [`enable`] returns its
+/// refusal directly.
 async fn enable_after_config(
     streams: &mut Streams<'_>,
     name: &str,
@@ -204,7 +244,10 @@ pub async fn disable(streams: &mut Streams<'_>, paths: &ShepPaths, name: &str) -
         Ok(source) => source,
         Err(err) => return fail_config(streams, &err),
     };
-    let client = Client::connect(&paths.socket).await.ok();
+    let client = match connect_or_absent(paths, streams).await {
+        Ok(client) => client,
+        Err(code) => return code,
+    };
     disable_after_config(streams, name, &source, client.as_ref()).await
 }
 
@@ -681,7 +724,10 @@ pub async fn adopt(streams: &mut Streams<'_>, paths: &ShepPaths, args: &AdoptArg
     }) {
         return fail_config(streams, &err);
     }
-    let client = Client::connect(&paths.socket).await.ok();
+    let client = match connect_or_absent(paths, streams).await {
+        Ok(client) => client,
+        Err(code) => return code,
+    };
     adopt_after_config(streams, &name, &path, client.as_ref()).await
 }
 
@@ -943,7 +989,10 @@ pub async fn rehome(streams: &mut Streams<'_>, paths: &ShepPaths, name: &str) ->
         Ok(source) => source,
         Err(err) => return fail_config(streams, &err),
     };
-    let client = Client::connect(&paths.socket).await.ok();
+    let client = match connect_or_absent(paths, streams).await {
+        Ok(client) => client,
+        Err(code) => return code,
+    };
     rehome_after_config(streams, name, source, client.as_ref()).await
 }
 
@@ -1148,6 +1197,36 @@ mod tests {
             text.contains("adopted"),
             "the row must render an adopted dog as adopted: {text}"
         );
+    }
+
+    /// Task 6 / spec G4, the `dogs.rs` spelling of the same bug `shep flock`
+    /// had: `Client::connect(..).ok()` folded a handshake REFUSAL into
+    /// `None`, exactly as it folds a genuine absence into `None` — so a live
+    /// shepherd that refused was reported as "will start with the next
+    /// shepherd" instead of the refusal.
+    #[tokio::test]
+    async fn enable_reports_a_refusal_as_a_refusal_not_as_no_shepherd() {
+        let dir = tempfile::tempdir().unwrap();
+        let paths = ShepPaths::resolve(&|_| None, dir.path());
+        std::fs::create_dir_all(&paths.run).unwrap();
+        let refusal = shep_core::protocol::RpcError {
+            code: RpcErrorCode::ProtocolMismatch,
+            message: "this daemon speaks protocol 1, this client speaks 2".to_string(),
+            daemon_version: Some("0.1.8".to_string()),
+        };
+        let _daemon = shep_client::testing::fake_daemon(&paths.socket, Err(refusal)).await;
+
+        let mut out = Vec::new();
+        let mut err = Vec::new();
+        let code = enable(&mut streams(&mut out, &mut err), &paths, "metrics").await;
+
+        assert_ne!(code, ExitCode::Success);
+        let text = String::from_utf8(err).unwrap();
+        assert!(
+            !text.contains(NO_SHEPHERD_ENABLE_STATUS),
+            "a refusal is not an absence: {text}"
+        );
+        assert!(text.contains("shep daemon reload"), "{text}");
     }
 
     /// fails if a `shep enable` with no shepherd running is reported as a

--- a/crates/shep-cli/src/commands/foreground.rs
+++ b/crates/shep-cli/src/commands/foreground.rs
@@ -96,6 +96,7 @@ pub async fn run(streams: &mut Streams<'_>, quiet: bool, options: ForegroundOpti
     // daemon for readiness-reporting purposes, the same as `shep daemon
     // --foreground`, even though nothing here speaks the notify protocol.
     let daemon_args = DaemonArgs {
+        cmd: None,
         no_restore: true,
         foreground: true,
         log_json: None,

--- a/crates/shep-cli/src/commands/foreground.rs
+++ b/crates/shep-cli/src/commands/foreground.rs
@@ -71,6 +71,17 @@ enum Ending {
 /// supervisor's own logging writes from a tokio worker thread, in this same
 /// process. `daemon`, `bleats` and `lookout` are the existing three verbs
 /// this applies to; `runtime` and `dev` make five.
+/// Refuses `client` if its shepherd disagrees with this binary's crate
+/// version — the guard [`crate::refuse_version_skew`] applies at the three
+/// seams in `lib.rs`, reused here directly because [`run`] connects on its
+/// own rather than through one of them.
+///
+/// # Errors
+/// [`ExitCode::VersionSkew`], as [`crate::refuse_version_skew`].
+fn refuse_if_skewed(streams: &mut Streams<'_>, client: &Client) -> Result<(), ExitCode> {
+    crate::refuse_version_skew(streams, client, crate::VersionGuard::Enforce)
+}
+
 pub async fn run(streams: &mut Streams<'_>, quiet: bool, options: ForegroundOptions) -> ExitCode {
     let ForegroundOptions {
         paths,
@@ -116,7 +127,16 @@ pub async fn run(streams: &mut Streams<'_>, quiet: bool, options: ForegroundOpti
     // The listener is bound by the time `boot_supervisor` returns, so this
     // needs no retry.
     let client = match Client::connect(&paths.socket).await {
-        Ok(client) => client,
+        Ok(client) => {
+            // `foreground` registers a sheep with the shepherd it just
+            // booted or found already up — the opposite of a way out of a
+            // skew — so it can never be one of `RECOVERY_VERBS`.
+            if let Err(code) = refuse_if_skewed(streams, &client) {
+                supervisor.abort();
+                return code;
+            }
+            client
+        }
         Err(err) => {
             supervisor.abort();
             let code = ExitCode::from(&err);
@@ -244,5 +264,65 @@ pub async fn run(streams: &mut Streams<'_>, quiet: bool, options: ForegroundOpti
         Some(Ending::Empty(Sample::Busy)) | Some(Ending::SupervisorExited { .. }) | None => {
             ExitCode::Success
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::cli::Format;
+    use crate::exit::ExitCode;
+    use crate::output::Streams;
+    use crate::style;
+
+    fn buffered_streams<'a>(out: &'a mut Vec<u8>, err: &'a mut Vec<u8>) -> Streams<'a> {
+        Streams {
+            out,
+            err,
+            style: style::Presentation::BARE,
+            fmt: Format::Table,
+        }
+    }
+
+    /// `run`'s own connect (:118) guards the shepherd it just booted, same
+    /// as the seams in `lib.rs` guard every other verb — `foreground`
+    /// registers a sheep with that shepherd, so it can never be exempt.
+    /// This drives the guard directly against a client from a fake
+    /// shepherd, which is what Task 5 found actually works; `run` itself
+    /// boots a real supervisor and cannot be handed a scripted version.
+    #[tokio::test]
+    async fn a_version_skewed_shepherd_is_refused() {
+        let dir = tempfile::tempdir().unwrap();
+        let addr = shep_client::testing::control_address(dir.path());
+        let ack = shep_core::protocol::HelloAck {
+            daemon_version: "0.1.8".to_string(),
+            protocol: shep_core::protocol::PROTOCOL_VERSION,
+            pid: 4242,
+        };
+        let (client, _fake) = shep_client::testing::fake_client_with_ack(&addr, ack).await;
+
+        let mut out = Vec::new();
+        let mut err = Vec::new();
+        let mut streams = buffered_streams(&mut out, &mut err);
+        let code = super::refuse_if_skewed(&mut streams, &client)
+            .expect_err("a differing crate version must be refused");
+        assert_eq!(code, ExitCode::VersionSkew);
+    }
+
+    /// A shepherd of this binary's own version is not a skew.
+    #[tokio::test]
+    async fn a_matching_version_proceeds() {
+        let dir = tempfile::tempdir().unwrap();
+        let addr = shep_client::testing::control_address(dir.path());
+        let ack = shep_core::protocol::HelloAck {
+            daemon_version: env!("CARGO_PKG_VERSION").to_string(),
+            protocol: shep_core::protocol::PROTOCOL_VERSION,
+            pid: 4242,
+        };
+        let (client, _fake) = shep_client::testing::fake_client_with_ack(&addr, ack).await;
+
+        let mut out = Vec::new();
+        let mut err = Vec::new();
+        let mut streams = buffered_streams(&mut out, &mut err);
+        super::refuse_if_skewed(&mut streams, &client).expect("a matching version is not a skew");
     }
 }

--- a/crates/shep-cli/src/commands/serve.rs
+++ b/crates/shep-cli/src/commands/serve.rs
@@ -339,10 +339,15 @@ async fn register(
     app.args = sheep_args(root, auth, args);
     app.fold.clone_from(&args.fold);
 
-    let client = match crate::connect_or_spawn_client(streams, paths).await {
-        Ok(client) => client,
-        Err(code) => return code,
-    };
+    // Names the guard rather than being threaded one from `run`'s dispatch:
+    // `serve` is not one of `crate::RECOVERY_VERBS` and cannot become one —
+    // it registers a sheep, which is the opposite of a way out of a version
+    // skew — so there is no value here but `Enforce` to pass down.
+    let client =
+        match crate::connect_or_spawn_client(streams, paths, crate::VersionGuard::Enforce).await {
+            Ok(client) => client,
+            Err(code) => return code,
+        };
 
     request_and_render(
         &client,

--- a/crates/shep-cli/src/dog/mod.rs
+++ b/crates/shep-cli/src/dog/mod.rs
@@ -370,6 +370,7 @@ impl bark::FlockSource for ClientFlockSource {
                 message: "the shepherd answered ListFlock with something other than \
                           Response::Flock"
                     .to_owned(),
+                daemon_version: None,
             })),
         }
     }

--- a/crates/shep-cli/src/exit.rs
+++ b/crates/shep-cli/src/exit.rs
@@ -79,6 +79,21 @@ pub enum ExitCode {
     /// `dev` both share, once the empty-flock watcher settles on
     /// [`crate::commands::empty::Sample::EmptyFailed`].
     FlockEmpty = 11,
+    /// This binary and the running shepherd are different versions of shep.
+    ///
+    /// Distinct from [`ExitCode::ProtocolMismatch`], and the distinction is
+    /// the whole reason this code exists. That one is the daemon refusing a
+    /// handshake because the two speak different WIRE versions, which is a
+    /// question the wire can ask itself. This one is a handshake that
+    /// SUCCEEDED, against a daemon whose crate version differs — the state
+    /// `cargo install shep` leaves behind, since it replaces the binary and
+    /// never restarts the shepherd. Nothing on the wire has to disagree for
+    /// that to be dangerous, and collapsing the two would leave an operator
+    /// reading "protocol mismatch" about a protocol that matched.
+    ///
+    /// Never returned for `kill`, `daemon reload` or `ping`: those are how
+    /// an operator gets out of the state, so they are exempt.
+    VersionSkew = 12,
 }
 
 impl ExitCode {
@@ -104,6 +119,7 @@ impl ExitCode {
             Self::Internal => "internal",
             Self::DaemonAlreadyRunning => "daemon_already_running",
             Self::FlockEmpty => "flock_empty",
+            Self::VersionSkew => "version_skew",
         }
     }
 }
@@ -252,6 +268,7 @@ mod tests {
             ExitCode::Internal,
             ExitCode::DaemonAlreadyRunning,
             ExitCode::FlockEmpty,
+            ExitCode::VersionSkew,
         ];
         let strings: Vec<&str> = all.iter().map(|c| c.code_str()).collect();
         assert!(strings.iter().all(|s| !s.is_empty()));

--- a/crates/shep-cli/src/lib.rs
+++ b/crates/shep-cli/src/lib.rs
@@ -893,7 +893,33 @@ async fn run(cli: Cli, style: style::Presentation) -> ExitCode {
             let mut out = std::io::stdout().lock();
             return completions::completions(&mut out, args);
         }
-        Commands::Daemon(ref args) => return run_daemon_command(fmt, &cli.global, args).await,
+        Commands::Daemon(ref args) => {
+            // `daemon reload` is a different verb wearing the same word:
+            // it stops a shepherd and starts one rather than being one.
+            // Unlocked handles, for the reason `bleats` takes them -- this
+            // runs for as long as a shepherd's teardown ladder plus a boot,
+            // which is seconds, not the milliseconds the locked pair below
+            // is right for.
+            if let Some(cli::DaemonCmd::Reload) = args.cmd {
+                let paths = match resolve_paths(&cli.global) {
+                    Ok(paths) => paths,
+                    Err(code) => {
+                        emit_error_locked(fmt, code, UNRESOLVED_HOME);
+                        return code;
+                    }
+                };
+                let mut out = std::io::stdout();
+                let mut err = std::io::stderr();
+                let mut streams = Streams {
+                    out: &mut out,
+                    err: &mut err,
+                    style,
+                    fmt,
+                };
+                return commands::daemon::reload(&mut streams, &paths, guard).await;
+            }
+            return run_daemon_command(fmt, &cli.global, args).await;
+        }
         // Routed through `ensure_home` rather than reading `--home` raw:
         // this is the verb that installs a unit without starting anything,
         // so it is the one that needs `$SHEP_HOME` to exist beforehand, and
@@ -1449,7 +1475,9 @@ fn emit_error_locked(fmt: Format, code: ExitCode, message: &str) {
 /// either faking `connect_or_spawn` itself (testing nothing new) or spawning
 /// a real child from this test binary (the hang/flake risk this project
 /// avoids in unit tests).
-async fn connect_or_spawn_client(
+/// `pub(crate)`: `commands::daemon`'s reload starts the successor it just
+/// stopped through this same autostart, rather than growing a second one.
+pub(crate) async fn connect_or_spawn_client(
     streams: &mut Streams<'_>,
     paths: &ShepPaths,
     guard: VersionGuard,
@@ -1575,10 +1603,9 @@ fn unreachable_message(err: &shep_client::ConnectError) -> String {
 /// if it is a way out of that state, never merely one that is inconvenient
 /// to lose.
 ///
-/// `shep daemon reload` is the command [`refuse_version_skew`] names, and it
-/// is not built yet. Its name is listed now so the exemption is already
-/// right on the day the verb lands, rather than being remembered then;
-/// [`recovery_verb`] gains its arm at the same time.
+/// `shep daemon reload` is the command [`refuse_version_skew`] names, so the
+/// two are read out of this one list rather than spelled twice -- see
+/// [`VERSION_SKEW_REMEDY`].
 const RECOVERY_VERBS: [&str; 3] = ["kill", "daemon reload", "ping"];
 
 /// Which [`RECOVERY_VERBS`] entry `command` is, or `None` for an ordinary
@@ -1591,10 +1618,12 @@ fn recovery_verb(command: &Commands) -> Option<&'static str> {
     match command {
         Commands::Kill => Some("kill"),
         Commands::Ping => Some("ping"),
-        // `shep daemon reload` is pending. When it lands, its arm belongs
-        // here: `Commands::Daemon(args)` carrying the reload subcommand,
-        // answering `Some("daemon reload")`. A bare `shep daemon` is the
-        // hidden boot re-exec and is not a recovery verb.
+        // A bare `shep daemon` is the hidden boot re-exec, which reaches no
+        // shepherd and so has nothing to be exempt from.
+        Commands::Daemon(args) => match args.cmd {
+            Some(cli::DaemonCmd::Reload) => Some("daemon reload"),
+            None => None,
+        },
         _ => None,
     }
 }
@@ -3042,11 +3071,29 @@ mod tests {
         assert!(err.is_empty(), "{}", String::from_utf8_lossy(&err));
     }
 
+    /// A [`DaemonArgs`] carrying `cmd` and nothing else, for asking which
+    /// guard the `daemon` verb's two shapes get.
+    fn daemon_args(cmd: Option<cli::DaemonCmd>) -> DaemonArgs {
+        DaemonArgs {
+            cmd,
+            no_restore: false,
+            foreground: false,
+            log_json: None,
+            log_level: None,
+            socket: None,
+            max_cron_sleep: None,
+        }
+    }
+
     /// fails if a verb leaves [`RECOVERY_VERBS`], or if one arrives without
     /// being listed there with its reason.
     #[test]
     fn every_exempt_verb_is_one_of_the_documented_recovery_verbs() {
-        for command in [Commands::Kill, Commands::Ping] {
+        for command in [
+            Commands::Kill,
+            Commands::Ping,
+            Commands::Daemon(daemon_args(Some(cli::DaemonCmd::Reload))),
+        ] {
             let verb =
                 recovery_verb(&command).unwrap_or_else(|| panic!("{command:?} must stay exempt"));
             assert!(
@@ -3054,9 +3101,16 @@ mod tests {
                 "{verb} is exempt but undocumented"
             );
         }
-        assert!(
-            RECOVERY_VERBS.contains(&"daemon reload"),
-            "the verb the refusal names must stay on the list it is not yet built for"
+        assert_eq!(
+            recovery_verb(&Commands::Daemon(daemon_args(Some(cli::DaemonCmd::Reload)))),
+            Some("daemon reload"),
+            "the verb the skew refusal names must be the verb the skew guard exempts"
+        );
+        // The hidden boot re-exec, which reaches no shepherd at all.
+        assert_eq!(recovery_verb(&Commands::Daemon(daemon_args(None))), None);
+        assert_eq!(
+            VersionGuard::for_command(&Commands::Daemon(daemon_args(None))),
+            VersionGuard::Enforce
         );
         assert_eq!(recovery_verb(&Commands::Flock), None);
         assert_eq!(

--- a/crates/shep-cli/src/lib.rs
+++ b/crates/shep-cli/src/lib.rs
@@ -1726,6 +1726,14 @@ pub(crate) fn refuse_version_skew(
         // shape, kept identical so this refusal reads like every other one.
         Format::Table => {
             let cause = VERSION_SKEW_CAUSE.join("\n");
+            // `summary` interpolates `daemon_version`, which arrives over the
+            // socket and is therefore attacker-shaped: a daemon this client
+            // did not build can put a newline or an escape sequence in it and
+            // forge lines on the operator's terminal. `emit_error` sanitises
+            // for exactly this reason and this branch bypasses it to keep the
+            // multi-line layout, so it sanitises the interpolated value
+            // itself. The fixed text around it is ours and needs nothing.
+            let summary = crate::terminal_safe::sanitise(&summary).0;
             let _ = writeln!(
                 streams.err,
                 "error[{}]: {summary}\n\n{cause}\n\n  shep {VERSION_SKEW_REMEDY}",

--- a/crates/shep-cli/src/lib.rs
+++ b/crates/shep-cli/src/lib.rs
@@ -1286,22 +1286,12 @@ async fn run(cli: Cli, style: style::Presentation) -> ExitCode {
         // helper reports and gives up and this arm has a fallback to reach.
         // The version guard therefore has to be applied by hand here — the
         // one dispatch arm where it is not inherited from the helper.
-        Commands::Flock => match Client::connect(&paths.socket).await {
-            Ok(client) => match refuse_version_skew(&mut streams, &client, guard) {
-                Ok(()) => query::flock(&client, &mut streams).await,
-                // A skew is not an absence: the shepherd answered, so the
-                // roll fallback below would print a listing while hiding
-                // the reason every other verb is refusing.
-                Err(code) => code,
-            },
-            Err(_) if fmt == Format::Json => {
-                match connect_client(&mut streams, &paths, guard).await {
-                    Ok(client) => query::flock(&client, &mut streams).await,
-                    Err(code) => code,
-                }
-            }
-            Err(_) => query::flock_from_roll(&mut streams, &paths),
-        },
+        //
+        // Split into `flock_command` so a test can drive it directly against
+        // a real fixture socket without going through `run`'s own argv
+        // parsing (Task 5's own note: `run`'s dispatch arms were otherwise
+        // untested, held only by the compiler).
+        Commands::Flock => flock_command(&mut streams, &paths, guard).await,
         // The guard arm is what makes `--available` work with no shepherd
         // running at all: it never reaches `connect_client`, so a
         // community-index listing does not fail on a `$SHEP_HOME` where no
@@ -1738,6 +1728,74 @@ async fn connect_client(
             Err(streams.fail(code, &unreachable_message(&err)))
         }
     }
+}
+
+/// `shep flock`'s own dispatch, split out of [`run`] so a test can drive it
+/// directly against a real fixture socket (Task 5's own note: `run`'s
+/// dispatch arms were otherwise untested, held only by the compiler).
+///
+/// Uses its own `Client::connect`, not [`connect_client`], because that
+/// helper reports and gives up and this arm has a roll fallback to reach.
+/// The version guard therefore has to be applied by hand here — the one
+/// dispatch arm where it is not inherited from the helper.
+///
+/// # A refusal is not an absence (spec G4, Task 6)
+///
+/// The roll fallback below is for a genuine absence only —
+/// [`shep_client::ConnectError::Connect`], `connect(2)` itself failing
+/// because nothing is listening. Every other [`shep_client::ConnectError`]
+/// variant means a connection WAS established: the shepherd is there, and
+/// either refused the handshake outright ([`shep_client::ConnectError::
+/// ProtocolMismatch`]) or something went wrong reaching it cleanly after
+/// connecting ([`shep_client::ConnectError::Io`],
+/// [`shep_client::ConnectError::Wire`],
+/// [`shep_client::ConnectError::HandshakeClosed`],
+/// [`shep_client::ConnectError::HandshakeTimeout`] — that variant's own doc
+/// says outright "something is bound but not answering"). None of those
+/// five is an absence, so a blanket `Err(_) => flock_from_roll(..)`
+/// reported all of them as "no shepherd running". That is what sent the
+/// incident's operator to the muster-roll path instead of `shep daemon
+/// reload`, while the shepherd was alive and answering the refusal.
+async fn flock_command(
+    streams: &mut Streams<'_>,
+    paths: &ShepPaths,
+    guard: VersionGuard,
+) -> ExitCode {
+    match Client::connect(&paths.socket).await {
+        Ok(client) => match refuse_version_skew(streams, &client, guard) {
+            Ok(()) => query::flock(&client, streams).await,
+            // A skew is not an absence either: the shepherd answered, so
+            // the roll fallback below would print a listing while hiding
+            // the reason every other verb is refusing.
+            Err(code) => code,
+        },
+        // The roll fallback is a table-format affordance only. Under
+        // `--format json` a failed invocation must leave stdout empty and
+        // put an error envelope on stderr -- `exit_codes_and_stream_
+        // discipline` enforces that, and it is right to: a consumer that
+        // asked for machine output should not have to tell a real listing
+        // apart from a consolation prize. So JSON always reports through
+        // `connect_client`, absence included; humans get the roll below,
+        // absence only.
+        Err(_) if streams.fmt == Format::Json => {
+            match connect_client(streams, paths, guard).await {
+                Ok(client) => query::flock(&client, streams).await,
+                Err(code) => code,
+            }
+        }
+        Err(shep_client::ConnectError::Connect { .. }) => query::flock_from_roll(streams, paths),
+        Err(err) => {
+            let code = ExitCode::from(&err);
+            streams.fail(code, &flock_connect_refusal_message(&err))
+        }
+    }
+}
+
+/// Renders `err` for [`flock_command`]'s refusal arm: the shepherd IS
+/// there, so this reports what it did and names the fix rather than the
+/// roll's "no shepherd running", which would be the opposite of the truth.
+fn flock_connect_refusal_message(err: &shep_client::ConnectError) -> String {
+    format!("{err}; run `shep {VERSION_SKEW_REMEDY}`")
 }
 
 /// Resolves this invocation's own [`ShepPaths`] and runs the supervisor in
@@ -2890,6 +2948,62 @@ mod tests {
             "{text}"
         );
         assert!(text.contains("shep daemon reload"), "{text}");
+    }
+
+    /// Task 6 / spec G4: `lib.rs`'s old blanket `Err(_) =>
+    /// query::flock_from_roll(..)` treated every connect failure as an
+    /// absence, so a daemon that answered the handshake and refused it
+    /// (the incident case) was reported as "no shepherd running" -- sending
+    /// the operator to the roll instead of `shep daemon reload`.
+    #[tokio::test]
+    async fn flock_reports_a_refusal_as_a_refusal_not_as_no_daemon() {
+        let dir = tempfile::tempdir().unwrap();
+        let paths = ShepPaths::resolve(&|_| None, dir.path());
+        std::fs::create_dir_all(&paths.run).unwrap();
+        let refusal = shep_core::protocol::RpcError {
+            code: shep_core::protocol::RpcErrorCode::ProtocolMismatch,
+            message: "this daemon speaks protocol 1, this client speaks 2".to_string(),
+            daemon_version: Some("0.1.8".to_string()),
+        };
+        let _daemon = shep_client::testing::fake_daemon(&paths.socket, Err(refusal)).await;
+
+        let mut out = Vec::new();
+        let mut err = Vec::new();
+        let code = {
+            let mut streams = buffered_streams(&mut out, &mut err);
+            flock_command(&mut streams, &paths, VersionGuard::Enforce).await
+        };
+
+        assert_ne!(code, ExitCode::Success);
+        let text = String::from_utf8(err).unwrap();
+        assert!(
+            !text.contains("no shepherd running"),
+            "a refusal is not an absence: {text}"
+        );
+        assert!(text.contains("shep daemon reload"), "{text}");
+    }
+
+    /// The other half of Task 6: a genuinely absent daemon -- nothing
+    /// listening at all -- must still fall back to the muster roll. That
+    /// fallback is a real feature (a machine that just rebooted), not the
+    /// bug; narrowing the match must not remove it.
+    #[tokio::test]
+    async fn flock_still_falls_back_to_the_roll_for_a_genuine_absence() {
+        let dir = tempfile::tempdir().unwrap();
+        let paths = ShepPaths::resolve(&|_| None, dir.path());
+        std::fs::create_dir_all(&paths.run).unwrap();
+        // No socket bound at `paths.socket` -- `connect(2)` itself fails.
+
+        let mut out = Vec::new();
+        let mut err = Vec::new();
+        let code = {
+            let mut streams = buffered_streams(&mut out, &mut err);
+            flock_command(&mut streams, &paths, VersionGuard::Enforce).await
+        };
+
+        assert_eq!(code, ExitCode::DaemonUnreachable);
+        let text = String::from_utf8(err).unwrap();
+        assert!(text.contains("no shepherd running"), "{text}");
     }
 
     /// A daemon of this binary's own version is not a skew, so nothing is

--- a/crates/shep-cli/src/lib.rs
+++ b/crates/shep-cli/src/lib.rs
@@ -1610,8 +1610,13 @@ fn recovery_verb(command: &Commands) -> Option<&'static str> {
 }
 
 /// Whether a shepherd of a different version refuses this invocation.
+///
+/// `pub(crate)`: Task 5b's three verbs (`lookout`, `whistle`, `foreground`)
+/// bypass the seams in this file that would otherwise apply this for them,
+/// by calling `Client::connect` inside their own module — so each names
+/// this directly, always as [`Self::Enforce`], at its own connect site.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum VersionGuard {
+pub(crate) enum VersionGuard {
     /// Refuse: this verb needs a shepherd that agrees with this binary.
     Enforce,
     /// Never refuse, whatever the shepherd answers: one of
@@ -1662,11 +1667,14 @@ const VERSION_SKEW_REMEDY: &str = RECOVERY_VERBS[1];
 /// condition is what left an operator stuck: every verb refused, and no
 /// sentence anywhere saying that reloading the shepherd was the way out.
 ///
+/// `pub(crate)`, for the three sites Task 5b guards directly — see
+/// [`VersionGuard`]'s own doc.
+///
 /// # Errors
 /// [`ExitCode::VersionSkew`], after writing the refusal to `streams`, when
 /// `guard` is [`VersionGuard::Enforce`] and the shepherd reports a different
 /// version. A [`VersionGuard::Exempt`] verb is always `Ok`.
-fn refuse_version_skew(
+pub(crate) fn refuse_version_skew(
     streams: &mut Streams<'_>,
     client: &Client,
     guard: VersionGuard,

--- a/crates/shep-cli/src/lib.rs
+++ b/crates/shep-cli/src/lib.rs
@@ -1381,10 +1381,12 @@ async fn run(cli: Cli, style: style::Presentation) -> ExitCode {
         Commands::Set(ref args) => kv::set(&mut streams, &paths, args),
         Commands::Get(ref args) => kv::get(&mut streams, &paths, args),
         Commands::Unset(ref args) => kv::unset(&mut streams, &paths, args),
-        Commands::Kill => match connect_client(&mut streams, &paths).await {
-            Ok(client) => admin::kill(client, &mut streams).await,
-            Err(code) => code,
-        },
+        // The one verb that does its own connecting. `connect_client`'s
+        // contract is to report and give up, and giving up is what left an
+        // operator with a live daemon nothing could stop, so `kill` takes
+        // the paths and decides for itself — see `commands::admin`'s module
+        // doc.
+        Commands::Kill => admin::kill(&paths, &mut streams).await,
         Commands::Init(ref args) => init::init(&mut streams, args).await,
         // Reads a file and writes a file; starts nothing, so there is
         // nothing to ask the socket. `logs::flush_daemon` is the other arm

--- a/crates/shep-cli/src/lib.rs
+++ b/crates/shep-cli/src/lib.rs
@@ -835,6 +835,11 @@ fn scaffold_first_run_interpreters(paths: &ShepPaths) {
 /// still outranks it.
 async fn run(cli: Cli, style: style::Presentation) -> ExitCode {
     let fmt = cli.global.format;
+    // Resolved once, here, rather than at each of the seventeen call sites
+    // that reach a shepherd: `cli.command` is partially moved by the
+    // dispatch below, so an arm cannot borrow it to ask this question, and
+    // an arm that could would be an arm that could forget to.
+    let guard = VersionGuard::for_command(&cli.command);
 
     // `StdoutLock`/`StderrLock` are process-wide and are held for as long as
     // the guard lives, so the locked pair further down is right for exactly
@@ -1045,7 +1050,7 @@ async fn run(cli: Cli, style: style::Presentation) -> ExitCode {
             style,
             fmt,
         };
-        return match connect_client(&mut streams, &paths).await {
+        return match connect_client(&mut streams, &paths, guard).await {
             Ok(client) => bleats::bleats(&client, &mut streams, cli.global.quiet, args).await,
             Err(code) => code,
         };
@@ -1215,11 +1220,11 @@ async fn run(cli: Cli, style: style::Presentation) -> ExitCode {
                 None
             };
             if args.targets.is_empty() && discovered.is_none() {
-                return start_bare_shepherd(&mut streams, &paths).await;
+                return start_bare_shepherd(&mut streams, &paths, guard).await;
             }
             let shep_toml_text = std::fs::read_to_string(&paths.daemon_config).ok();
             let interpreters = interpreters_from_config(shep_toml_text.as_deref());
-            match connect_or_spawn_client(&mut streams, &paths).await {
+            match connect_or_spawn_client(&mut streams, &paths, guard).await {
                 Ok(client) => {
                     lifecycle::start(
                         &client,
@@ -1234,36 +1239,36 @@ async fn run(cli: Cli, style: style::Presentation) -> ExitCode {
             }
         }
         Commands::Stop(ref args) | Commands::Thatlldo(ref args) => {
-            match connect_client(&mut streams, &paths).await {
+            match connect_client(&mut streams, &paths, guard).await {
                 Ok(client) => lifecycle::stop(&client, &mut streams, args).await,
                 Err(code) => code,
             }
         }
-        Commands::Restart(ref args) => match connect_client(&mut streams, &paths).await {
+        Commands::Restart(ref args) => match connect_client(&mut streams, &paths, guard).await {
             Ok(client) => lifecycle::restart(&client, &mut streams, args).await,
             Err(code) => code,
         },
-        Commands::Reload(ref args) => match connect_client(&mut streams, &paths).await {
+        Commands::Reload(ref args) => match connect_client(&mut streams, &paths, guard).await {
             Ok(client) => lifecycle::reload(&client, &mut streams, args).await,
             Err(code) => code,
         },
-        Commands::Delete(ref args) => match connect_client(&mut streams, &paths).await {
+        Commands::Delete(ref args) => match connect_client(&mut streams, &paths, guard).await {
             Ok(client) => lifecycle::delete(&client, &mut streams, args).await,
             Err(code) => code,
         },
-        Commands::Stock(ref args) => match connect_client(&mut streams, &paths).await {
+        Commands::Stock(ref args) => match connect_client(&mut streams, &paths, guard).await {
             Ok(client) => lifecycle::stock(&client, &mut streams, args).await,
             Err(code) => code,
         },
-        Commands::Trigger(ref args) => match connect_client(&mut streams, &paths).await {
+        Commands::Trigger(ref args) => match connect_client(&mut streams, &paths, guard).await {
             Ok(client) => trigger::trigger(&client, &mut streams, args).await,
             Err(code) => code,
         },
-        Commands::Signal(ref args) => match connect_client(&mut streams, &paths).await {
+        Commands::Signal(ref args) => match connect_client(&mut streams, &paths, guard).await {
             Ok(client) => signal::signal(&client, &mut streams, args).await,
             Err(code) => code,
         },
-        Commands::Whisper(ref args) => match connect_client(&mut streams, &paths).await {
+        Commands::Whisper(ref args) => match connect_client(&mut streams, &paths, guard).await {
             Ok(client) => whisper::whisper(&client, &mut streams, args).await,
             Err(code) => code,
         },
@@ -1276,12 +1281,25 @@ async fn run(cli: Cli, style: style::Presentation) -> ExitCode {
         // enforces that, and it is right to: a consumer that asked for
         // machine output should not have to tell a real listing apart from a
         // consolation prize. So JSON keeps the refusal, humans get the roll.
+        //
+        // Its own `Client::connect`, not `connect_client`, because that
+        // helper reports and gives up and this arm has a fallback to reach.
+        // The version guard therefore has to be applied by hand here — the
+        // one dispatch arm where it is not inherited from the helper.
         Commands::Flock => match Client::connect(&paths.socket).await {
-            Ok(client) => query::flock(&client, &mut streams).await,
-            Err(_) if fmt == Format::Json => match connect_client(&mut streams, &paths).await {
-                Ok(client) => query::flock(&client, &mut streams).await,
+            Ok(client) => match refuse_version_skew(&mut streams, &client, guard) {
+                Ok(()) => query::flock(&client, &mut streams).await,
+                // A skew is not an absence: the shepherd answered, so the
+                // roll fallback below would print a listing while hiding
+                // the reason every other verb is refusing.
                 Err(code) => code,
             },
+            Err(_) if fmt == Format::Json => {
+                match connect_client(&mut streams, &paths, guard).await {
+                    Ok(client) => query::flock(&client, &mut streams).await,
+                    Err(code) => code,
+                }
+            }
             Err(_) => query::flock_from_roll(&mut streams, &paths),
         },
         // The guard arm is what makes `--available` work with no shepherd
@@ -1291,7 +1309,7 @@ async fn run(cli: Cli, style: style::Presentation) -> ExitCode {
         Commands::Dogs(ref args) if args.available => {
             query::available_dogs(&mut streams, args).await
         }
-        Commands::Dogs(ref args) => match connect_client(&mut streams, &paths).await {
+        Commands::Dogs(ref args) => match connect_client(&mut streams, &paths, guard).await {
             Ok(client) => query::dogs(&client, &mut streams, args).await,
             Err(code) => code,
         },
@@ -1326,11 +1344,11 @@ async fn run(cli: Cli, style: style::Presentation) -> ExitCode {
         Commands::Disable(ref args) => dogs::disable(&mut streams, &paths, &args.name).await,
         Commands::Adopt(ref args) => dogs::adopt(&mut streams, &paths, args).await,
         Commands::Rehome(ref args) => dogs::rehome(&mut streams, &paths, &args.name).await,
-        Commands::Describe(ref args) => match connect_client(&mut streams, &paths).await {
+        Commands::Describe(ref args) => match connect_client(&mut streams, &paths, guard).await {
             Ok(client) => query::describe(&client, &mut streams, args).await,
             Err(code) => code,
         },
-        Commands::Fold(ref args) => match connect_client(&mut streams, &paths).await {
+        Commands::Fold(ref args) => match connect_client(&mut streams, &paths, guard).await {
             Ok(client) => query::fold(&client, &mut streams, args).await,
             Err(code) => code,
         },
@@ -1346,15 +1364,15 @@ async fn run(cli: Cli, style: style::Presentation) -> ExitCode {
         // of a daemon that is not running is not a thing, and autostarting
         // one to save an empty flock would overwrite a good roll with an
         // empty one.
-        Commands::Save => match connect_client(&mut streams, &paths).await {
+        Commands::Save => match connect_client(&mut streams, &paths, guard).await {
             Ok(client) => muster::save(&client, &mut streams).await,
             Err(code) => code,
         },
-        Commands::Muster => match connect_or_spawn_client(&mut streams, &paths).await {
+        Commands::Muster => match connect_or_spawn_client(&mut streams, &paths, guard).await {
             Ok(client) => muster::muster(&client, &mut streams).await,
             Err(code) => code,
         },
-        Commands::Reopen(ref args) => match connect_client(&mut streams, &paths).await {
+        Commands::Reopen(ref args) => match connect_client(&mut streams, &paths, guard).await {
             Ok(client) => logs::reopen(&client, &mut streams, args).await,
             Err(code) => code,
         },
@@ -1366,7 +1384,7 @@ async fn run(cli: Cli, style: style::Presentation) -> ExitCode {
         // an operator reaches for this, and `connect_client` never autostarts
         // one to be told to do nothing.
         Commands::Flush(ref args) if args.daemon => logs::flush_daemon(&mut streams, &paths),
-        Commands::Flush(ref args) => match connect_client(&mut streams, &paths).await {
+        Commands::Flush(ref args) => match connect_client(&mut streams, &paths, guard).await {
             Ok(client) => logs::flush(&client, &mut streams, args).await,
             Err(code) => code,
         },
@@ -1444,10 +1462,18 @@ fn emit_error_locked(fmt: Format, code: ExitCode, message: &str) {
 async fn connect_or_spawn_client(
     streams: &mut Streams<'_>,
     paths: &ShepPaths,
+    guard: VersionGuard,
 ) -> Result<Client, ExitCode> {
     let launch_paths = paths.clone();
     match connect_or_spawn(&paths.socket, move || launch_daemon(&launch_paths)).await {
-        Ok(SpawnOutcome::Connected(client) | SpawnOutcome::Spawned(client)) => Ok(client),
+        // The guard applies to a shepherd this call CONNECTED to as much as
+        // to one it started: a daemon it just spawned is this same binary
+        // and can never skew, and one that was already up is exactly the
+        // case the guard exists for.
+        Ok(SpawnOutcome::Connected(client) | SpawnOutcome::Spawned(client)) => {
+            refuse_version_skew(streams, &client, guard)?;
+            Ok(client)
+        }
         Err(err) => {
             let code = ExitCode::from(&err);
             Err(streams.fail(code, &err.to_string()))
@@ -1465,7 +1491,11 @@ async fn connect_or_spawn_client(
 ///
 /// Reports rather than re-boots when one is already up, because typing
 /// `shep start` twice should say what happened, not silently do nothing.
-async fn start_bare_shepherd(streams: &mut Streams<'_>, paths: &ShepPaths) -> ExitCode {
+async fn start_bare_shepherd(
+    streams: &mut Streams<'_>,
+    paths: &ShepPaths,
+    guard: VersionGuard,
+) -> ExitCode {
     let before = status::ShepherdStatus::probe(paths).await;
     if let Some(online) = &before.online {
         let message = format!(
@@ -1475,7 +1505,7 @@ async fn start_bare_shepherd(streams: &mut Streams<'_>, paths: &ShepPaths) -> Ex
         streams.aside("start", &message);
         return ExitCode::Success;
     }
-    match connect_or_spawn_client(streams, paths).await {
+    match connect_or_spawn_client(streams, paths, guard).await {
         Ok(client) => {
             // Asked after the boot, not before: bringing the shepherd up
             // restores the muster roll, so a flock that looked empty a
@@ -1544,11 +1574,157 @@ fn unreachable_message(err: &shep_client::ConnectError) -> String {
     }
 }
 
+/// The verbs a version skew must never refuse, spelled the way an operator
+/// types them.
+///
+/// `kill` and `daemon reload` are how an operator gets OUT of a skew;
+/// `ping` is how they see what is running without being refused. A guard
+/// whose remedy is itself guarded is the trap this whole check exists to
+/// remove — the incident behind it left a live daemon, a live flock, and no
+/// command in shep able to touch either. So a verb belongs on this list only
+/// if it is a way out of that state, never merely one that is inconvenient
+/// to lose.
+///
+/// `shep daemon reload` is the command [`refuse_version_skew`] names, and it
+/// is not built yet. Its name is listed now so the exemption is already
+/// right on the day the verb lands, rather than being remembered then;
+/// [`recovery_verb`] gains its arm at the same time.
+const RECOVERY_VERBS: [&str; 3] = ["kill", "daemon reload", "ping"];
+
+/// Which [`RECOVERY_VERBS`] entry `command` is, or `None` for an ordinary
+/// verb the version guard applies to.
+///
+/// Returns the name rather than a bool so a test can hold this mapping and
+/// that documented list against each other, which is what keeps a verb from
+/// becoming exempt without its reason being written down.
+fn recovery_verb(command: &Commands) -> Option<&'static str> {
+    match command {
+        Commands::Kill => Some("kill"),
+        Commands::Ping => Some("ping"),
+        // `shep daemon reload` is pending. When it lands, its arm belongs
+        // here: `Commands::Daemon(args)` carrying the reload subcommand,
+        // answering `Some("daemon reload")`. A bare `shep daemon` is the
+        // hidden boot re-exec and is not a recovery verb.
+        _ => None,
+    }
+}
+
+/// Whether a shepherd of a different version refuses this invocation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum VersionGuard {
+    /// Refuse: this verb needs a shepherd that agrees with this binary.
+    Enforce,
+    /// Never refuse, whatever the shepherd answers: one of
+    /// [`RECOVERY_VERBS`].
+    Exempt,
+}
+
+impl VersionGuard {
+    /// The guard that applies to `command`.
+    fn for_command(command: &Commands) -> Self {
+        match recovery_verb(command) {
+            Some(_) => Self::Exempt,
+            None => Self::Enforce,
+        }
+    }
+}
+
+/// Why a skew happens, as the two lines the table form prints.
+///
+/// Held as its rendered lines rather than as one string, because the JSON
+/// form joins them with a space and the table form with a newline; one
+/// constant means the two renderings cannot drift into saying different
+/// things.
+const VERSION_SKEW_CAUSE: [&str; 2] = [
+    "`cargo install shep` replaced the binary. It did not restart the",
+    "shepherd, which is still running the old code.",
+];
+
+/// The one command that fixes a skew.
+///
+/// Read out of [`RECOVERY_VERBS`] rather than spelled again, because the two
+/// have to agree: a remedy the guard itself refused is exactly the trap this
+/// design exists to remove. Dropping `daemon reload` from that list changes
+/// what this refusal prints, and the test pinning the wording catches it.
+const VERSION_SKEW_REMEDY: &str = RECOVERY_VERBS[1];
+
+/// Refuses a shepherd whose crate version differs from this binary's.
+///
+/// Any difference, not only a protocol difference. A protocol-only check
+/// misses the case the incident actually hit: `cargo install shep` replaces
+/// the binary and leaves the shepherd running the old code, and the two can
+/// agree on every byte of the wire while disagreeing about what a verb does.
+/// So the comparison is [`shep_core::protocol::HelloAck::daemon_version`]
+/// against this crate's own `CARGO_PKG_VERSION`, on a handshake that
+/// SUCCEEDED. Nothing here crosses the wire that did not already.
+///
+/// The message names the fix rather than the condition, because naming the
+/// condition is what left an operator stuck: every verb refused, and no
+/// sentence anywhere saying that reloading the shepherd was the way out.
+///
+/// # Errors
+/// [`ExitCode::VersionSkew`], after writing the refusal to `streams`, when
+/// `guard` is [`VersionGuard::Enforce`] and the shepherd reports a different
+/// version. A [`VersionGuard::Exempt`] verb is always `Ok`.
+fn refuse_version_skew(
+    streams: &mut Streams<'_>,
+    client: &Client,
+    guard: VersionGuard,
+) -> Result<(), ExitCode> {
+    let running = client.daemon().daemon_version.as_str();
+    if guard == VersionGuard::Exempt || running == env!("CARGO_PKG_VERSION") {
+        return Ok(());
+    }
+    let code = ExitCode::VersionSkew;
+    let summary = format!(
+        "this shep is {}, the running shepherd is {running}",
+        env!("CARGO_PKG_VERSION")
+    );
+    match streams.fmt {
+        // One line, one envelope. A `--format json` consumer has no use for
+        // the layout below, and it still gets every fact in `error.message`.
+        Format::Json => {
+            let cause = VERSION_SKEW_CAUSE.join(" ");
+            streams.fail(
+                code,
+                &format!("{summary}. {cause} Run `shep {VERSION_SKEW_REMEDY}`."),
+            );
+        }
+        // Written straight to the stream rather than through
+        // [`Streams::fail`], which routes into `output::emit_error` and so
+        // through `terminal_safe::sanitise` — and that collapses every `\n`
+        // to a space. Right for daemon-supplied text, wrong for this fixed
+        // block: the remedy has to sit on a line of its own to be seen and
+        // copied. The `error[code]: message` first line is emit_error's own
+        // shape, kept identical so this refusal reads like every other one.
+        Format::Table => {
+            let cause = VERSION_SKEW_CAUSE.join("\n");
+            let _ = writeln!(
+                streams.err,
+                "error[{}]: {summary}\n\n{cause}\n\n  shep {VERSION_SKEW_REMEDY}",
+                code.code_str()
+            );
+        }
+    }
+    Err(code)
+}
+
 /// Connects to the daemon at `paths.socket`. Never autostarts — see
 /// [`run`]'s own doc for why that matters.
-async fn connect_client(streams: &mut Streams<'_>, paths: &ShepPaths) -> Result<Client, ExitCode> {
+///
+/// `guard` is this invocation's [`VersionGuard`]: a connected shepherd of a
+/// different version is refused here, at the one seam every verb that needs
+/// a [`Client`] passes through, so no verb has to remember to ask.
+async fn connect_client(
+    streams: &mut Streams<'_>,
+    paths: &ShepPaths,
+    guard: VersionGuard,
+) -> Result<Client, ExitCode> {
     match Client::connect(&paths.socket).await {
-        Ok(client) => Ok(client),
+        Ok(client) => {
+            refuse_version_skew(streams, &client, guard)?;
+            Ok(client)
+        }
         Err(err) => {
             let code = ExitCode::from(&err);
             Err(streams.fail(code, &unreachable_message(&err)))
@@ -2632,6 +2808,173 @@ mod tests {
         assert!(
             !text.contains("shep start"),
             "a permission failure must not send the operator to `shep start`, got {text:?}"
+        );
+    }
+
+    /// A [`Streams`] over two byte buffers, so a refusal's exact text can be
+    /// read back. `BARE`/`Table` because these tests assert on words, not on
+    /// colour.
+    fn buffered_streams<'a>(out: &'a mut Vec<u8>, err: &'a mut Vec<u8>) -> Streams<'a> {
+        Streams {
+            out,
+            err,
+            style: style::Presentation::BARE,
+            fmt: Format::Table,
+        }
+    }
+
+    /// A real [`Client`], past a real handshake, whose peer announced
+    /// `version`. The [`shep_client::testing::FakeDaemon`] is returned so it
+    /// outlives the client.
+    async fn client_announcing(
+        addr: &std::path::Path,
+        version: &str,
+    ) -> (Client, shep_client::testing::FakeDaemon) {
+        let ack = shep_core::protocol::HelloAck {
+            daemon_version: version.to_owned(),
+            protocol: shep_core::protocol::PROTOCOL_VERSION,
+            pid: 4242,
+        };
+        shep_client::testing::fake_client_with_ack(addr, ack).await
+    }
+
+    /// The case a protocol-only check misses entirely, and the one the
+    /// incident actually hit: the wire versions agree, the crate versions do
+    /// not, and `cargo install shep` left a new binary talking to an old
+    /// shepherd.
+    #[tokio::test]
+    async fn a_version_difference_with_no_protocol_difference_is_refused() {
+        let dir = tempfile::tempdir().unwrap();
+        let addr = shep_client::testing::control_address(dir.path());
+        let (client, _fake) = client_announcing(&addr, "0.1.8").await;
+
+        let mut out = Vec::new();
+        let mut err = Vec::new();
+        let mut streams = buffered_streams(&mut out, &mut err);
+        let code = refuse_version_skew(&mut streams, &client, VersionGuard::Enforce)
+            .expect_err("a differing crate version must be refused");
+        assert_eq!(code, ExitCode::VersionSkew);
+    }
+
+    /// fails if the refusal stops naming the fix. A message that names only
+    /// the condition is what this guard exists to replace: the operator whose
+    /// box this bricked could read every word of "protocol mismatch" and
+    /// still not know that reloading the shepherd was the way out.
+    #[tokio::test]
+    async fn the_error_names_the_command_that_fixes_it() {
+        let dir = tempfile::tempdir().unwrap();
+        let addr = shep_client::testing::control_address(dir.path());
+        let (client, _fake) = client_announcing(&addr, "0.1.8").await;
+
+        let mut out = Vec::new();
+        let mut err = Vec::new();
+        {
+            let mut streams = buffered_streams(&mut out, &mut err);
+            let _ = refuse_version_skew(&mut streams, &client, VersionGuard::Enforce);
+        }
+        let text = String::from_utf8(err).unwrap();
+        assert!(text.contains("error[version_skew]"), "{text}");
+        assert!(text.contains("this shep is"), "{text}");
+        assert!(text.contains(env!("CARGO_PKG_VERSION")), "{text}");
+        assert!(text.contains("the running shepherd is 0.1.8"), "{text}");
+        assert!(
+            text.contains("`cargo install shep` replaced the binary"),
+            "{text}"
+        );
+        assert!(text.contains("shep daemon reload"), "{text}");
+    }
+
+    /// A daemon of this binary's own version is not a skew, so nothing is
+    /// written and nothing is refused.
+    #[tokio::test]
+    async fn a_matching_version_passes_without_a_word() {
+        let dir = tempfile::tempdir().unwrap();
+        let addr = shep_client::testing::control_address(dir.path());
+        let (client, _fake) = client_announcing(&addr, env!("CARGO_PKG_VERSION")).await;
+
+        let mut out = Vec::new();
+        let mut err = Vec::new();
+        {
+            let mut streams = buffered_streams(&mut out, &mut err);
+            refuse_version_skew(&mut streams, &client, VersionGuard::Enforce)
+                .expect("a matching version is not a skew");
+        }
+        assert!(err.is_empty(), "{}", String::from_utf8_lossy(&err));
+    }
+
+    /// A guard whose remedy is itself guarded is the trap this design exists
+    /// to remove: an exempt verb reaches a skewed daemon and says nothing.
+    #[tokio::test]
+    async fn the_recovery_verbs_are_not_refused() {
+        let dir = tempfile::tempdir().unwrap();
+        let addr = shep_client::testing::control_address(dir.path());
+        let (client, _fake) = client_announcing(&addr, "0.1.8").await;
+
+        let mut out = Vec::new();
+        let mut err = Vec::new();
+        {
+            let mut streams = buffered_streams(&mut out, &mut err);
+            refuse_version_skew(&mut streams, &client, VersionGuard::Exempt)
+                .expect("a recovery verb is never refused on version skew");
+        }
+        assert!(err.is_empty(), "{}", String::from_utf8_lossy(&err));
+    }
+
+    /// fails if a verb leaves [`RECOVERY_VERBS`], or if one arrives without
+    /// being listed there with its reason.
+    #[test]
+    fn every_exempt_verb_is_one_of_the_documented_recovery_verbs() {
+        for command in [Commands::Kill, Commands::Ping] {
+            let verb =
+                recovery_verb(&command).unwrap_or_else(|| panic!("{command:?} must stay exempt"));
+            assert!(
+                RECOVERY_VERBS.contains(&verb),
+                "{verb} is exempt but undocumented"
+            );
+        }
+        assert!(
+            RECOVERY_VERBS.contains(&"daemon reload"),
+            "the verb the refusal names must stay on the list it is not yet built for"
+        );
+        assert_eq!(recovery_verb(&Commands::Flock), None);
+        assert_eq!(
+            VersionGuard::for_command(&Commands::Flock),
+            VersionGuard::Enforce
+        );
+        assert_eq!(
+            VersionGuard::for_command(&Commands::Kill),
+            VersionGuard::Exempt
+        );
+    }
+
+    /// Nothing else drives [`run`]'s dispatch arms, so the wiring behind each
+    /// verb is held only by the compiler — and `kill`'s arm is the one that
+    /// changed most recently, from a shared `connect_client` to its own
+    /// connect. This drives the arm end to end against a home no shepherd
+    /// owns and asserts the code that arm's own path produces.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn run_dispatches_kill_to_the_socket_free_path() {
+        use clap::Parser;
+
+        let dir = tempfile::tempdir().unwrap();
+        let home = dir.path().join("home");
+        // The two directories a booted shepherd would have made: `pids/`
+        // holds the lock `kill`'s socket-free path reads, and `run/` the
+        // control socket it first tries to connect over.
+        let paths = ShepPaths::resolve(
+            &|key| (key == "SHEP_HOME").then(|| home.to_string_lossy().into_owned()),
+            std::path::Path::new("/nonexistent"),
+        );
+        std::fs::create_dir_all(&paths.pids).unwrap();
+        std::fs::create_dir_all(&paths.run).unwrap();
+        let argv = ["shep", "--home", home.to_str().unwrap(), "kill"];
+        let cli = Cli::try_parse_from(argv).unwrap_or_else(|e| panic!("{argv:?} failed: {e}"));
+
+        assert_eq!(
+            run(cli, style::Presentation::BARE).await,
+            ExitCode::DaemonUnreachable,
+            "`kill` against an unowned home must reach its own socket-free path"
         );
     }
 }

--- a/crates/shep-cli/src/lookout/app.rs
+++ b/crates/shep-cli/src/lookout/app.rs
@@ -3374,6 +3374,7 @@ mod tests {
             result: Err(RequestError::Rpc(RpcError {
                 code: RpcErrorCode::NotFound,
                 message: "selector matched no registered sheep".to_string(),
+                daemon_version: None,
             })),
         });
         let said = app.notice().map(ToString::to_string).unwrap_or_default();

--- a/crates/shep-cli/src/lookout/frames.rs
+++ b/crates/shep-cli/src/lookout/frames.rs
@@ -829,6 +829,7 @@ fn scene_with(which: Scene, age: Duration) -> Buffer {
                     result: Err(RequestError::Rpc(RpcError {
                         code: RpcErrorCode::NotFound,
                         message: "selector matched no registered sheep".to_string(),
+                        daemon_version: None,
                     })),
                 });
             }

--- a/crates/shep-cli/src/lookout/mod.rs
+++ b/crates/shep-cli/src/lookout/mod.rs
@@ -88,13 +88,16 @@ pub const MIN_REDRAW: Duration = Duration::from_millis(33);
 
 /// Runs the dashboard, and returns the [`ExitCode`] to exit with.
 ///
-/// Three refusals, all of them before a single escape byte is written:
+/// Four refusals, all of them before a single escape byte is written:
 ///
 /// - [`ExitCode::Usage`] when stdout is not a terminal.
 /// - [`ExitCode::DaemonUnreachable`] (or [`ExitCode::ProtocolMismatch`]) when
 ///   the FIRST connection fails — see [`source::LinkError::exit_code`]. A
 ///   shepherd that was never running is not the case the maintainer's retry-then-freeze
 ///   ruling is about, and lookout refuses it exactly as `shep flock` would.
+/// - [`ExitCode::VersionSkew`] when that connection succeeds but the
+///   shepherd answering it is a different crate version — `lookout` is
+///   never exempt, since it drives the daemon for as long as it is open.
 /// - [`ExitCode::Failure`] when the terminal could not be put into raw mode.
 ///
 /// After that it does not exit on its own at all: the ladder and the freeze
@@ -130,6 +133,18 @@ pub async fn lookout(streams: &mut Streams<'_>, paths: &ShepPaths, args: &Lookou
             return streams.fail(code, &err.to_string());
         }
     };
+
+    // `lookout` drives the daemon for as long as the dashboard stays open —
+    // polling, subscribing, and (with `--allow-control`) acting on it — so
+    // it can never be one of `RECOVERY_VERBS`. Applied here, on the FIRST
+    // dial, rather than inside `link` itself: see `ClientFlock::client`'s
+    // own doc for why. A reconnect on the ladder is not re-checked; a
+    // shepherd cannot downgrade itself mid-run.
+    if let Err(code) =
+        crate::refuse_version_skew(streams, opened.0.client(), crate::VersionGuard::Enforce)
+    {
+        return code;
+    }
 
     let palette = Palette::detect(
         std::env::var_os("NO_COLOR").as_deref(),

--- a/crates/shep-cli/src/lookout/source.rs
+++ b/crates/shep-cli/src/lookout/source.rs
@@ -178,6 +178,23 @@ impl From<ConnectError> for LinkError {
 #[derive(Debug)]
 pub struct ClientFlock(Client);
 
+impl ClientFlock {
+    /// The wrapped connection, for [`super::lookout`]'s version guard.
+    ///
+    /// The guard is applied there, right after the first
+    /// [`Shepherd::link`] succeeds, rather than inside [`UnixShepherd::link`]
+    /// itself: `link`'s Future carries a `+ Send` bound that a `Streams`
+    /// (which holds `&mut dyn io::Write`, not `Send`) cannot cross, and
+    /// [`super::link::run_link`] holds this same `Shepherd` for the whole
+    /// reconnect ladder, spawned with `tokio::spawn` and so `'static` —
+    /// a borrowed `Streams` could not live in it. This accessor is what
+    /// lets the one call site that DOES have a `Streams`, the first dial,
+    /// reach the client the guard compares against.
+    pub(crate) fn client(&self) -> &Client {
+        &self.0
+    }
+}
+
 impl FlockSource for ClientFlock {
     async fn flock(&self) -> Result<Vec<ProcessInfo>, RequestError> {
         match self.0.request(Request::ListFlock).await? {
@@ -445,5 +462,60 @@ mod tests {
                 .ok()
                 .map(NonZeroUsize::get),
         );
+    }
+
+    /// fails if `mod.rs`'s guard, applied right after the first
+    /// [`Shepherd::link`] succeeds, loses the client it needs to compare
+    /// versions on. `ClientFlock::client` is what makes that reachable —
+    /// see its own doc for why the guard cannot live inside `link` itself.
+    #[tokio::test]
+    async fn a_version_skewed_shepherd_is_refused_through_client_flock() {
+        let dir = tempfile::tempdir().unwrap();
+        let addr = shep_client::testing::control_address(dir.path());
+        let ack = shep_core::protocol::HelloAck {
+            daemon_version: "0.1.8".to_string(),
+            protocol: shep_core::protocol::PROTOCOL_VERSION,
+            pid: 4242,
+        };
+        let (client, _fake) = shep_client::testing::fake_client_with_ack(&addr, ack).await;
+        let flock = ClientFlock(client);
+
+        let mut out = Vec::new();
+        let mut err = Vec::new();
+        let mut streams = crate::output::Streams {
+            out: &mut out,
+            err: &mut err,
+            style: crate::style::Presentation::BARE,
+            fmt: crate::cli::Format::Table,
+        };
+        let code =
+            crate::refuse_version_skew(&mut streams, flock.client(), crate::VersionGuard::Enforce)
+                .expect_err("a differing crate version must be refused");
+        assert_eq!(code, crate::exit::ExitCode::VersionSkew);
+    }
+
+    /// A shepherd of this binary's own version is not a skew.
+    #[tokio::test]
+    async fn a_matching_version_proceeds_through_client_flock() {
+        let dir = tempfile::tempdir().unwrap();
+        let addr = shep_client::testing::control_address(dir.path());
+        let ack = shep_core::protocol::HelloAck {
+            daemon_version: env!("CARGO_PKG_VERSION").to_string(),
+            protocol: shep_core::protocol::PROTOCOL_VERSION,
+            pid: 4242,
+        };
+        let (client, _fake) = shep_client::testing::fake_client_with_ack(&addr, ack).await;
+        let flock = ClientFlock(client);
+
+        let mut out = Vec::new();
+        let mut err = Vec::new();
+        let mut streams = crate::output::Streams {
+            out: &mut out,
+            err: &mut err,
+            style: crate::style::Presentation::BARE,
+            fmt: crate::cli::Format::Table,
+        };
+        crate::refuse_version_skew(&mut streams, flock.client(), crate::VersionGuard::Enforce)
+            .expect("a matching version is not a skew");
     }
 }

--- a/crates/shep-cli/src/whistle/control.rs
+++ b/crates/shep-cli/src/whistle/control.rs
@@ -218,6 +218,17 @@ mod tests {
     /// failed — IR-46: every await in a test needs a forcing mechanism.
     const TEST_TIMEOUT: Duration = Duration::from_secs(10);
 
+    /// A [`shep_core::protocol::HelloAck`] this binary's own version guard
+    /// never refuses — `shep_client::testing::sample_ack`'s fixed `"9.9.9"`
+    /// always would, now that every tool call in this file goes through
+    /// `Shepherd::call_with_ack`'s guard.
+    fn matching_ack() -> shep_core::protocol::HelloAck {
+        shep_core::protocol::HelloAck {
+            daemon_version: env!("CARGO_PKG_VERSION").to_string(),
+            ..shep_client::testing::sample_ack()
+        }
+    }
+
     fn whistle_at(socket: std::path::PathBuf) -> Whistle {
         // None of these four tools ever reads `barks.jsonl` — that path is
         // `read::list_barks`' alone — so a nonexistent one is fine here, and
@@ -258,7 +269,7 @@ mod tests {
     async fn answer_handshake(stream: &mut UnixStream) {
         let hello_bytes = read_frame(stream).await;
         let _hello: Hello = decode_frame(&hello_bytes).unwrap();
-        let ack: HelloReply = Ok(shep_client::testing::sample_ack());
+        let ack: HelloReply = Ok(matching_ack());
         write_frame(stream, &ack).await;
     }
 
@@ -346,8 +357,9 @@ mod tests {
         let socket = shep_client::testing::control_address(dir.path());
         // sample_info() is already Online, named "web" — exactly the
         // already-running case this test needs.
-        let (daemon, served) = shep_client::testing::fake_daemon_accepting_repeatedly(
+        let (daemon, served) = shep_client::testing::fake_daemon_accepting_repeatedly_with_ack(
             &socket,
+            matching_ack(),
             Response::Described(vec![shep_client::testing::sample_info()]),
         );
 
@@ -470,8 +482,9 @@ mod tests {
         })
         .collect();
 
-        let (daemon, served) = shep_client::testing::fake_daemon_accepting_repeatedly(
+        let (daemon, served) = shep_client::testing::fake_daemon_accepting_repeatedly_with_ack(
             &socket,
+            matching_ack(),
             Response::Described(rows),
         );
 

--- a/crates/shep-cli/src/whistle/control.rs
+++ b/crates/shep-cli/src/whistle/control.rs
@@ -295,7 +295,11 @@ mod tests {
                 let envelope: Envelope = decode_frame(&request_bytes).unwrap();
                 let reply = Reply {
                     id: envelope.id,
-                    result: result.map_err(|(code, message)| RpcError { code, message }),
+                    result: result.map_err(|(code, message)| RpcError {
+                        code,
+                        message,
+                        daemon_version: None,
+                    }),
                 };
                 write_frame(&mut stream, &reply).await;
                 envelopes.push(envelope);

--- a/crates/shep-cli/src/whistle/read.rs
+++ b/crates/shep-cli/src/whistle/read.rs
@@ -232,6 +232,17 @@ mod tests {
     /// failed — IR-46: every await in a test needs a forcing mechanism.
     const TEST_TIMEOUT: Duration = Duration::from_secs(10);
 
+    /// A [`shep_core::protocol::HelloAck`] this binary's own version guard
+    /// never refuses — `shep_client::testing::sample_ack`'s fixed `"9.9.9"`
+    /// always would, now that every tool call in this file goes through
+    /// `Shepherd::call_with_ack`'s guard.
+    fn matching_ack() -> shep_core::protocol::HelloAck {
+        shep_core::protocol::HelloAck {
+            daemon_version: env!("CARGO_PKG_VERSION").to_string(),
+            ..shep_client::testing::sample_ack()
+        }
+    }
+
     /// A `ShepPaths` naming only the two fields any test here reads — the
     /// socket `Shepherd::call` dials and the file `list_barks` opens
     /// directly. The rest are never touched (`Whistle::new` reaches
@@ -270,7 +281,7 @@ mod tests {
             .build();
         let served = shep_client::testing::serve_one_request(
             &socket,
-            shep_client::testing::sample_ack(),
+            matching_ack(),
             Response::Flock(vec![sheep, dog]),
         )
         .await;
@@ -308,7 +319,7 @@ mod tests {
         let socket = shep_client::testing::control_address(dir.path());
         let served = shep_client::testing::serve_one_request(
             &socket,
-            shep_client::testing::sample_ack(),
+            matching_ack(),
             Response::Described(vec![shep_client::testing::sample_info()]),
         )
         .await;
@@ -354,7 +365,7 @@ mod tests {
 
         let served = shep_client::testing::serve_one_request(
             &socket,
-            shep_client::testing::sample_ack(),
+            matching_ack(),
             Response::Described(vec![info]),
         )
         .await;

--- a/crates/shep-cli/src/whistle/shepherd.rs
+++ b/crates/shep-cli/src/whistle/shepherd.rs
@@ -74,6 +74,9 @@ impl Shepherd {
         let client = Client::connect(&self.socket)
             .await
             .map_err(|err| connect_refusal(&self.socket, &err))?;
+        // `whistle` drives the daemon on every tool call, so it can never be
+        // one of `RECOVERY_VERBS`.
+        refuse_if_skewed(&client)?;
         let ack = client.daemon().clone();
         let response = client.request(request).await.map_err(|err| refusal(&err));
         // Dropping the client ends its actor task and closes the socket. Done
@@ -82,6 +85,52 @@ impl Shepherd {
         let _ = client.close().await;
         response.map(|response| (ack, response))
     }
+}
+
+/// Refuses `client` if its shepherd disagrees with this binary's crate
+/// version, reusing [`crate::refuse_version_skew`] — the same guard the
+/// seams in `lib.rs` apply for every other verb.
+///
+/// **Never writes to stdout.** This module's own doc: stdout is the MCP
+/// transport, and one stray byte on it corrupts a JSON-RPC stream the peer
+/// cannot resynchronise. `refuse_version_skew`'s own two render branches
+/// only ever write to a `Streams`' `err` field (`Streams::fail` routes
+/// through `emit_error(&mut *self.err, ..)`; its `Format::Table` branch
+/// writes to `streams.err` directly), so handing it a `Streams` whose `out`
+/// is [`std::io::sink`] and whose `err` is the real stderr is safe: the
+/// human-readable refusal lands where an operator tailing this process's
+/// stderr can see it, and the transport is never touched. The MODEL sees a
+/// separate, in-band [`CallToolResult`] built here, the same shape
+/// [`connect_refusal`] and [`refusal`] already use for every other failure
+/// this call can meet.
+///
+/// # Errors
+/// A [`CallToolResult`] with `is_error: true`, carrying the same facts
+/// [`crate::refuse_version_skew`]'s own message does, when the shepherd's
+/// crate version differs from this binary's.
+fn refuse_if_skewed(client: &Client) -> Result<(), CallToolResult> {
+    let mut sink = std::io::sink();
+    let mut err = std::io::stderr();
+    let mut streams = crate::output::Streams {
+        out: &mut sink,
+        err: &mut err,
+        style: crate::style::Presentation::BARE,
+        fmt: crate::cli::Format::Table,
+    };
+    crate::refuse_version_skew(&mut streams, client, crate::VersionGuard::Enforce).map_err(
+        |_code| {
+            CallToolResult::structured_error(serde_json::json!({
+                "code": crate::exit::ExitCode::VersionSkew.code_str(),
+                "message": format!(
+                    "this shep is {}, the running shepherd is {}; \
+                     `cargo install shep` replaced the binary without \
+                     restarting it — run `shep daemon reload`",
+                    env!("CARGO_PKG_VERSION"),
+                    client.daemon().daemon_version,
+                ),
+            }))
+        },
+    )
 }
 
 /// A connect failure, as an in-band tool error naming the socket ONCE.
@@ -167,6 +216,16 @@ mod tests {
     use super::*;
     use shep_core::protocol::{RpcError, RpcErrorCode};
 
+    /// A [`HelloAck`] this binary's own [`refuse_if_skewed`] never refuses —
+    /// [`shep_client::testing::sample_ack`]'s `"9.9.9"` always would, now
+    /// that `call_with_ack` guards every call this fixture drives through.
+    fn matching_ack() -> HelloAck {
+        HelloAck {
+            daemon_version: env!("CARGO_PKG_VERSION").to_string(),
+            ..shep_client::testing::sample_ack()
+        }
+    }
+
     /// fails if a daemon-side refusal stops reaching the model verbatim, or
     /// stops being IN-BAND. shep does not paraphrase the shepherd: "api is
     /// already being reloaded" is actionable and a whistle-invented
@@ -242,8 +301,11 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let socket = shep_client::testing::control_address(dir.path());
 
-        let (first, first_served) =
-            shep_client::testing::fake_daemon_accepting_repeatedly(&socket, Response::Pong);
+        let (first, first_served) = shep_client::testing::fake_daemon_accepting_repeatedly_with_ack(
+            &socket,
+            matching_ack(),
+            Response::Pong,
+        );
         let shepherd = Shepherd::new(socket.clone());
         let one = tokio::time::timeout(
             std::time::Duration::from_secs(10),
@@ -282,7 +344,11 @@ mod tests {
         std::fs::remove_file(&socket).unwrap();
 
         let (second, _second_served) =
-            shep_client::testing::fake_daemon_accepting_repeatedly(&socket, Response::Pong);
+            shep_client::testing::fake_daemon_accepting_repeatedly_with_ack(
+                &socket,
+                matching_ack(),
+                Response::Pong,
+            );
         let two = tokio::time::timeout(
             std::time::Duration::from_secs(10),
             shepherd.call(Request::Ping),
@@ -291,5 +357,46 @@ mod tests {
         .expect("the second call finished within ten seconds");
         assert!(two.is_ok(), "a fresh connection per call needs no ladder");
         second.abort();
+    }
+
+    /// fails if `call_with_ack`'s guard stops refusing a skewed shepherd, or
+    /// starts doing it by writing to stdout — the one byte this module's
+    /// own doc says must never happen. `whistle` drives the daemon on every
+    /// tool call, so it can never be one of `RECOVERY_VERBS`.
+    #[tokio::test]
+    async fn a_version_skewed_shepherd_is_an_in_band_refusal() {
+        let dir = tempfile::tempdir().unwrap();
+        let addr = shep_client::testing::control_address(dir.path());
+        let ack = HelloAck {
+            daemon_version: "0.1.8".to_string(),
+            protocol: shep_core::protocol::PROTOCOL_VERSION,
+            pid: 4242,
+        };
+        let (client, _fake) = shep_client::testing::fake_client_with_ack(&addr, ack).await;
+
+        let result = super::refuse_if_skewed(&client).expect_err("a skew must be refused");
+        assert_eq!(result.is_error, Some(true));
+        let structured = result
+            .structured_content
+            .expect("a refusal carries structured content a model can branch on");
+        assert_eq!(structured["code"], "version_skew");
+        let message = structured["message"].as_str().expect("a string message");
+        assert!(message.contains(env!("CARGO_PKG_VERSION")), "{message}");
+        assert!(message.contains("0.1.8"), "{message}");
+    }
+
+    /// A shepherd of this binary's own version is not a skew.
+    #[tokio::test]
+    async fn a_matching_version_proceeds() {
+        let dir = tempfile::tempdir().unwrap();
+        let addr = shep_client::testing::control_address(dir.path());
+        let ack = HelloAck {
+            daemon_version: env!("CARGO_PKG_VERSION").to_string(),
+            protocol: shep_core::protocol::PROTOCOL_VERSION,
+            pid: 4242,
+        };
+        let (client, _fake) = shep_client::testing::fake_client_with_ack(&addr, ack).await;
+
+        super::refuse_if_skewed(&client).expect("a matching version is not a skew");
     }
 }

--- a/crates/shep-cli/src/whistle/shepherd.rs
+++ b/crates/shep-cli/src/whistle/shepherd.rs
@@ -180,6 +180,7 @@ mod tests {
         let result = refusal(&RequestError::Rpc(RpcError {
             code: RpcErrorCode::Internal,
             message: "api is already being reloaded".to_string(),
+            daemon_version: None,
         }));
         assert_eq!(result.is_error, Some(true));
         let structured = result

--- a/crates/shep-client/src/connection.rs
+++ b/crates/shep-client/src/connection.rs
@@ -72,11 +72,19 @@ pub enum ConnectError {
     },
     /// The daemon refused the handshake on protocol-version skew. `client`
     /// is our own [`PROTOCOL_VERSION`]; `message` is the daemon's own
-    /// sentence, verbatim — do not parse it (the daemon's version exists
-    /// only inside this prose, never as a separate field).
+    /// sentence, verbatim — still not for parsing, and no longer the only
+    /// thing a caller gets: `daemon_version` carries the running daemon's
+    /// version as data.
     ProtocolMismatch {
         /// This client's own protocol version.
         client: u32,
+        /// The daemon's own crate version, when it named one.
+        ///
+        /// `None` from a daemon built before the refusal carried it, which
+        /// no upgrade can change: read it as "unknown" and take the
+        /// conservative path rather than assuming an old daemon or a new
+        /// one.
+        daemon_version: Option<String>,
         /// The daemon's refusal message, verbatim.
         message: String,
     },
@@ -96,7 +104,12 @@ impl fmt::Display for ConnectError {
             Self::HandshakeTimeout { after } => {
                 write!(f, "the handshake did not complete within {after:?}")
             }
-            Self::ProtocolMismatch { client, message } => {
+            // `daemon_version` is deliberately not rendered here: the
+            // daemon's `message` already names its side of the skew, and a
+            // caller that wants the version as data has the field.
+            Self::ProtocolMismatch {
+                client, message, ..
+            } => {
                 write!(
                     f,
                     "protocol mismatch (this client speaks {client}): {message}"
@@ -189,6 +202,10 @@ impl Connection {
         // and always sends `ProtocolMismatch` (shep-daemon/src/server.rs:387-397).
         let ack = reply.map_err(|err| ConnectError::ProtocolMismatch {
             client: PROTOCOL_VERSION,
+            // Carried through rather than dropped with the rest of the
+            // `RpcError`: this is the only rebuild between the wire and the
+            // caller, so a field lost here is lost entirely.
+            daemon_version: err.daemon_version,
             message: err.message,
         })?;
 
@@ -244,6 +261,7 @@ mod tests {
         let refusal = RpcError {
             code: RpcErrorCode::ProtocolMismatch,
             message: "daemon speaks protocol 2, client speaks 1".into(),
+            daemon_version: None,
         };
         let _served = fake_daemon(&path, Err(refusal)).await;
 
@@ -251,7 +269,10 @@ mod tests {
             .await
             .unwrap_err();
 
-        let ConnectError::ProtocolMismatch { client, message } = err else {
+        let ConnectError::ProtocolMismatch {
+            client, message, ..
+        } = err
+        else {
             panic!("a protocol refusal must not be flattened into a generic error, got {err:?}");
         };
         assert_eq!(
@@ -261,6 +282,69 @@ mod tests {
         assert!(
             message.contains("protocol 2"),
             "the daemon's own message must survive: {message}"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_refusal_carries_the_daemon_version_past_the_flattening() {
+        // `open_inner` rebuilds the `RpcError` into a `ConnectError`, so a
+        // field the daemon sends is only useful if the rebuild carries it.
+        // The daemon-side test cannot see this half.
+        let dir = tempfile::tempdir().unwrap();
+        let path = crate::testing::control_address(dir.path());
+        let refusal = RpcError {
+            code: RpcErrorCode::ProtocolMismatch,
+            message: "daemon speaks protocol 2, client speaks 1".into(),
+            daemon_version: Some("0.1.16".into()),
+        };
+        let _served = fake_daemon(&path, Err(refusal)).await;
+
+        let err = Connection::open(&path, HANDSHAKE_TIMEOUT)
+            .await
+            .unwrap_err();
+
+        let ConnectError::ProtocolMismatch { daemon_version, .. } = err else {
+            panic!("expected a protocol refusal, got {err:?}");
+        };
+        assert_eq!(daemon_version.as_deref(), Some("0.1.16"));
+    }
+
+    #[tokio::test]
+    async fn an_old_daemons_refusal_still_connects_and_reports_no_version() {
+        // A daemon predating this field sends no `daemon_version`, and
+        // `skip_serializing_if` means `None` puts exactly those bytes on the
+        // wire — the old daemon's frame, byte for byte. It must decode
+        // cleanly and read as `None` rather than failing the handshake, or
+        // this field breaks the one upgrade it exists to smooth.
+        let dir = tempfile::tempdir().unwrap();
+        let path = crate::testing::control_address(dir.path());
+        let refusal = RpcError {
+            code: RpcErrorCode::ProtocolMismatch,
+            message: "daemon speaks protocol 2, client speaks 1".into(),
+            daemon_version: None,
+        };
+        // That `None` really is absent from the wire, and not a `null` key,
+        // is pinned byte-for-byte next to the field itself
+        // (`shep-core/src/protocol/request.rs`); this crate has no
+        // `serde_json` to assert it with and does not need one.
+        let _served = fake_daemon(&path, Err(refusal)).await;
+
+        let err = Connection::open(&path, HANDSHAKE_TIMEOUT)
+            .await
+            .unwrap_err();
+
+        let ConnectError::ProtocolMismatch {
+            daemon_version,
+            message,
+            ..
+        } = err
+        else {
+            panic!("expected a protocol refusal, got {err:?}");
+        };
+        assert_eq!(daemon_version, None);
+        assert!(
+            message.contains("protocol 2"),
+            "the daemon's own message must still survive: {message}"
         );
     }
 

--- a/crates/shep-client/src/testing.rs
+++ b/crates/shep-client/src/testing.rs
@@ -272,7 +272,11 @@ async fn write_reply(frames: &mut Frames, id: u64, response: Response) {
 async fn write_err(frames: &mut Frames, id: u64, code: RpcErrorCode, message: String) {
     let reply = Reply {
         id,
-        result: Err(RpcError { code, message }),
+        result: Err(RpcError {
+            code,
+            message,
+            daemon_version: None,
+        }),
     };
     frames.send(encode_frame(&reply).unwrap()).await.unwrap();
 }
@@ -310,8 +314,8 @@ async fn send_sample_event(frames: &mut Frames) {
 /// enum carries the remaining scripted behaviors, each armed at most once,
 /// by the `fake_client_*` constructor or `FakeDaemon` method that needs it.
 enum ScriptCommand {
-    /// Arms the next request (of any kind) to receive
-    /// `RpcError { code, message }` instead of a normal response.
+    /// Arms the next request (of any kind) to receive an [`RpcError`] with
+    /// this `code` and `message` instead of a normal response.
     ReplyErr(RpcErrorCode, String),
     /// Arms the next request to receive a [`sample_info`]-based
     /// `BusEvent::Process` BEFORE its `Pong` reply.
@@ -889,8 +893,8 @@ pub async fn fake_client_capturing_envelopes(path: &Path) -> (Client, mpsc::Rece
 }
 
 /// Binds `path`, handshakes with [`sample_ack`], and answers the one
-/// request that arrives with `RpcError { code, message }` instead of a
-/// normal response — for testing that a daemon-side error reply surfaces
+/// request that arrives with an [`RpcError`] carrying `code` and `message`
+/// instead of a normal response — for testing that a daemon-side error reply surfaces
 /// through `Client::request` as `RequestError::Rpc`.
 ///
 /// Backed by a [`FakeDaemon`] (armed with a private `ScriptCommand::ReplyErr`)

--- a/crates/shep-client/src/testing.rs
+++ b/crates/shep-client/src/testing.rs
@@ -172,13 +172,28 @@ pub fn fake_daemon_accepting_repeatedly(
     path: &Path,
     reply: Response,
 ) -> (JoinHandle<()>, Arc<AtomicU32>) {
+    fake_daemon_accepting_repeatedly_with_ack(path, sample_ack(), reply)
+}
+
+/// As [`fake_daemon_accepting_repeatedly`], but with a caller-chosen
+/// [`HelloAck`] — for a caller whose own version-skew guard would otherwise
+/// refuse [`sample_ack`]'s fixed `"9.9.9"` on every one of these repeated
+/// connections.
+///
+/// Panics if `path` cannot be bound — test scaffolding, the same failure mode
+/// [`fake_daemon`] documents.
+pub fn fake_daemon_accepting_repeatedly_with_ack(
+    path: &Path,
+    ack: HelloAck,
+    reply: Response,
+) -> (JoinHandle<()>, Arc<AtomicU32>) {
     let mut listener = Listener::bind(path).unwrap();
     let served = Arc::new(AtomicU32::new(0));
     let counter = Arc::clone(&served);
     let handle = tokio::spawn(async move {
         while let Ok(stream) = listener.accept().await {
             let mut frames = Framed::new(stream, codec());
-            handshake(&mut frames, sample_ack()).await;
+            handshake(&mut frames, ack.clone()).await;
             let envelope = read_envelope(&mut frames).await;
             // `write_reply` wraps the value in `Ok` itself — its signature is
             // `(&mut Frames, u64, Response)`, testing.rs:155 — so passing an

--- a/crates/shep-client/tests/spawn.rs
+++ b/crates/shep-client/tests/spawn.rs
@@ -194,6 +194,7 @@ async fn a_protocol_mismatch_propagates_instead_of_spawning_a_second_daemon() {
         Err(RpcError {
             code: RpcErrorCode::ProtocolMismatch,
             message: "daemon speaks protocol 2, client speaks 1".into(),
+            daemon_version: None,
         }),
     )
     .await;
@@ -239,6 +240,7 @@ async fn a_protocol_mismatch_on_a_loop_probe_propagates_instead_of_looping_to_th
                     Err(RpcError {
                         code: RpcErrorCode::ProtocolMismatch,
                         message: "daemon speaks protocol 2, client speaks 1".into(),
+                        daemon_version: None,
                     }),
                 ));
                 long_lived()

--- a/crates/shep-core/src/protocol/frame.rs
+++ b/crates/shep-core/src/protocol/frame.rs
@@ -112,6 +112,7 @@ mod tests {
             result: Err(RpcError {
                 code: RpcErrorCode::DeadlineExceeded,
                 message: "request deadline of 5000 ms expired".to_string(),
+                daemon_version: None,
             }),
         };
         let json = serde_json::to_string(&err).unwrap();

--- a/crates/shep-core/src/protocol/request.rs
+++ b/crates/shep-core/src/protocol/request.rs
@@ -1334,6 +1334,23 @@ pub struct RpcError {
     pub code: RpcErrorCode,
     /// Human-readable message (plain English, no theme)
     pub message: String,
+    /// The daemon's own crate version, when it chose to name it.
+    ///
+    /// Set on a [`RpcErrorCode::ProtocolMismatch`] refusal, where it is the
+    /// only place a client can learn it: the refusal reports the daemon's
+    /// PROTOCOL, and [`HelloAck::daemon_version`] never arrives. `shep
+    /// daemon reload` picks its mechanism by version, and a protocol bump is
+    /// exactly when that choice matters.
+    ///
+    /// `None` on every other error, and on any refusal from a daemon built
+    /// before this field existed — which no upgrade can change, so a reader
+    /// must treat `None` as "unknown" and take the conservative path.
+    ///
+    /// Additive by construction: absent on the wire rather than `null`, and
+    /// ignored by a client too old to know it, so
+    /// [`crate::protocol::PROTOCOL_VERSION`] does not move for it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub daemon_version: Option<String>,
 }
 
 /// Machine-readable RPC error codes
@@ -2032,6 +2049,7 @@ mod tests {
                 result: Err(RpcError {
                     code: RpcErrorCode::NotFound,
                     message: "no sheep matches `web`".to_string(),
+                    daemon_version: None,
                 }),
             },
             // Unlike `Reopened`/`Flushed`/`Reloading` above (all wire-identical
@@ -2390,6 +2408,7 @@ mod tests {
         let refusal: HelloReply = Err(RpcError {
             code: RpcErrorCode::ProtocolMismatch,
             message: "daemon speaks protocol 1, client sent 2".to_string(),
+            daemon_version: None,
         });
         let json = serde_json::to_string(&refusal).unwrap();
         assert_eq!(
@@ -2461,6 +2480,61 @@ mod tests {
         let old: V1ProcessInfo = serde_json::from_str(&current).unwrap();
         assert_eq!(old.id, 3);
         assert_eq!(old.fold.as_deref(), Some("backend"));
+    }
+
+    #[test]
+    fn an_rpc_error_without_a_daemon_version_serializes_exactly_as_before() {
+        // `skip_serializing_if` is what makes this addition free: a daemon
+        // with nothing to say puts the same bytes on the wire it always did,
+        // not a `"daemon_version":null` key an older client would have to
+        // ignore. Pinned as an exact string, because "additive" is a claim
+        // about bytes.
+        let plain = RpcError {
+            code: RpcErrorCode::NotFound,
+            message: "no sheep".to_string(),
+            daemon_version: None,
+        };
+        assert_eq!(
+            serde_json::to_string(&plain).unwrap(),
+            r#"{"code":"not_found","message":"no sheep"}"#
+        );
+    }
+
+    #[test]
+    fn a_v1_rpc_error_fixture_deserializes_with_no_daemon_version() {
+        // Committed byte fixture from before this field existed (IR-35): the
+        // skew direction that matters, a CURRENT client reading an OLD
+        // daemon's refusal. It must read as `None` rather than failing to
+        // decode, or the field breaks the upgrade it exists to smooth.
+        let fixture =
+            r#"{"code":"protocol_mismatch","message":"daemon speaks protocol 1, client sent 2"}"#;
+        let err: RpcError = serde_json::from_str(fixture).unwrap();
+        assert_eq!(err.code, RpcErrorCode::ProtocolMismatch);
+        assert_eq!(err.daemon_version, None);
+    }
+
+    #[test]
+    fn an_old_client_ignores_an_rpc_error_field_it_has_never_seen() {
+        // Step 1 of the handover work: proof that `RpcError` may grow an
+        // optional field WITHOUT moving `PROTOCOL_VERSION`. Like
+        // `ProcessInfo` above, `RpcError` carries no `deny_unknown_fields`,
+        // so a client built before a field decodes a daemon that sends it
+        // rather than failing the handshake on it.
+        #[derive(Deserialize)]
+        struct OldRpcError {
+            code: RpcErrorCode,
+            message: String,
+        }
+
+        let current = serde_json::to_string(&RpcError {
+            code: RpcErrorCode::ProtocolMismatch,
+            message: "daemon speaks protocol 1, client sent 2".to_string(),
+            daemon_version: Some("0.1.16".to_string()),
+        })
+        .unwrap();
+        let old: OldRpcError = serde_json::from_str(&current).expect("must tolerate");
+        assert_eq!(old.code, RpcErrorCode::ProtocolMismatch);
+        assert_eq!(old.message, "daemon speaks protocol 1, client sent 2");
     }
 
     #[test]

--- a/crates/shep-daemon/src/boot.rs
+++ b/crates/shep-daemon/src/boot.rs
@@ -1463,6 +1463,13 @@ fn install_signals(
         SignalKind::terminate(),
         SignalKind::interrupt(),
         SignalKind::quit(),
+        // SIGHUP is here as a floor, not as its final meaning. It becomes
+        // the handover trigger, and until it does its kernel default is an
+        // unhandled terminate that would drop the flock's pipes rather than
+        // walk the ladder. A daemon that treats it as a graceful stop can be
+        // signalled by a newer client without the flock paying for the
+        // version gap.
+        SignalKind::hangup(),
     ] {
         // An early return here drops `signals`, whose own `Drop` aborts
         // every task already pushed — registering the 2nd or 3rd kind
@@ -2782,6 +2789,38 @@ mod tests {
         // `boot` returns — well before `run()`'s own task is ever polled.
         let run = tokio::spawn(daemon.run());
         nix::sys::signal::raise(nix::sys::signal::Signal::SIGTERM).unwrap();
+        tokio::time::timeout(Duration::from_secs(5), run)
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap();
+        assert!(!paths.socket.exists());
+    }
+
+    #[tokio::test]
+    async fn sighup_triggers_the_same_graceful_shutdown() {
+        // Task 3 (2026-08-29): SIGHUP's default disposition is to
+        // terminate the process, and this handler is what replaces that
+        // default. Phase 2 makes SIGHUP the handover trigger; until it
+        // does, a stray or mistaken SIGHUP must still walk the same
+        // graceful path SIGTERM does rather than drop the flock's pipes.
+        // Mirrors `sigterm_triggers_the_same_graceful_shutdown` above —
+        // see that test's own comments for why raising a real signal here
+        // is safe only because the handler is installed first, and for
+        // why `SIGNAL_TEST_LOCK` is required.
+        let _guard = SIGNAL_TEST_LOCK.lock().await;
+        let dir = tempfile::tempdir().unwrap();
+        let paths = test_paths(&dir);
+        init_dirs(&paths).unwrap();
+        let daemon = boot(
+            ScriptedRunner::new(vec![]),
+            paths.clone(),
+            BootOptions::default(),
+        )
+        .await
+        .unwrap();
+        let run = tokio::spawn(daemon.run());
+        nix::sys::signal::raise(nix::sys::signal::Signal::SIGHUP).unwrap();
         tokio::time::timeout(Duration::from_secs(5), run)
             .await
             .unwrap()

--- a/crates/shep-daemon/src/boot.rs
+++ b/crates/shep-daemon/src/boot.rs
@@ -472,20 +472,13 @@ impl PidfileLock {
     }
 }
 
-/// Whether a live shepherd owns this home, and what pid it recorded.
+/// What, if anything, owns this home's pidfile lock.
 ///
 /// Proof of life is the pidfile LOCK, never the pidfile's contents. A live
 /// daemon holds that lock for its whole run and the kernel drops it on
 /// process death, `SIGKILL` included, so a failure to acquire it is the only
 /// evidence that cannot be faked by a stale file whose pid has since been
-/// reused. `Ok(None)` therefore means the lock was free, whatever the file
-/// says.
-///
-/// The pid comes from the file the holder wrote, so it is the one weak part
-/// of the answer: a daemon that holds the lock but has not reached
-/// `PidfileLock::record` yet is a live daemon with no pid to report, and
-/// reads here as `Ok(None)`. That window is the few statements between
-/// `acquire` and `record` inside [`boot`].
+/// reused.
 ///
 /// Answers a question; never claims the home. A lock this acquires is
 /// released before the call returns.
@@ -497,8 +490,9 @@ impl PidfileLock {
 ///
 /// # Errors
 /// - [`BootError::Io`] — the pidfile could not be opened, created or read.
-///   A contended lock is NOT an error here; it is the `Some` case.
-pub fn daemon_liveness(paths: &ShepPaths) -> Result<Option<u32>, BootError> {
+///   A contended lock is NOT an error here; it is [`Shepherd::Running`] or
+///   [`Shepherd::Booting`].
+pub fn daemon_liveness(paths: &ShepPaths) -> Result<Shepherd, BootError> {
     match PidfileLock::acquire(paths) {
         // We took it, so nobody else holds it. Released by this `drop`
         // rather than at the end of the scope, so that the window in which
@@ -506,11 +500,45 @@ pub fn daemon_liveness(paths: &ShepPaths) -> Result<Option<u32>, BootError> {
         // short as the type allows.
         Ok(lock) => {
             drop(lock);
-            Ok(None)
+            Ok(Shepherd::Absent)
         }
-        Err(BootError::AlreadyRunning { pid }) => Ok(pid),
+        Err(BootError::AlreadyRunning { pid: Some(pid) }) => Ok(Shepherd::Running(pid)),
+        Err(BootError::AlreadyRunning { pid: None }) => Ok(Shepherd::Booting),
         Err(other) => Err(other),
     }
+}
+
+/// What [`daemon_liveness`] found holding a home's pidfile lock.
+///
+/// Three states, not two, because "nothing is running" and "something is
+/// starting up" call for opposite actions and an `Option<u32>` cannot tell
+/// them apart. Both would read as `None`: [`boot`] takes the lock at
+/// `PidfileLock::acquire` and records its pid a few statements later, and
+/// binding the socket happens in between, stale-socket recovery included.
+/// A caller that read that window as an absence would refuse with the wrong
+/// reason, or start a second daemon that then dies unable to take the lock.
+///
+/// Deliberately NOT `#[non_exhaustive]`, unlike [`BootError`]. The set is
+/// closed by the mechanism rather than by today's implementation: the lock
+/// is either free or held, and a holder either has written its pid or has
+/// not. There is no fourth thing for a future boot step to add, and callers
+/// get exhaustiveness checking on a decision where a missed arm means
+/// signalling the wrong process.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Shepherd {
+    /// Nothing holds this home's pidfile lock.
+    ///
+    /// A stale pidfile naming a long-dead pid still reads as this, which is
+    /// the whole point of asking the lock rather than the file.
+    Absent,
+    /// A shepherd holds the lock and recorded this pid.
+    Running(u32),
+    /// A shepherd holds the lock but has not recorded a pid yet.
+    ///
+    /// It is alive and owns the home, so it must not be treated as absent,
+    /// but there is no pid to signal. A caller should report that a
+    /// shepherd is starting rather than guess at either.
+    Booting,
 }
 
 /// The socket this daemon binds: the layout default, or a config override
@@ -1836,7 +1864,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let paths = test_paths(&dir);
         init_dirs(&paths).unwrap();
-        assert_eq!(daemon_liveness(&paths).unwrap(), None);
+        assert_eq!(daemon_liveness(&paths).unwrap(), Shepherd::Absent);
     }
 
     #[test]
@@ -1847,7 +1875,7 @@ mod tests {
         std::fs::write(pidfile(&paths), "999999").unwrap();
         // The file exists and names a pid. Nothing holds the lock, so this is
         // NOT a live daemon and must not be reported as one.
-        assert_eq!(daemon_liveness(&paths).unwrap(), None);
+        assert_eq!(daemon_liveness(&paths).unwrap(), Shepherd::Absent);
     }
 
     #[test]
@@ -1857,13 +1885,28 @@ mod tests {
         init_dirs(&paths).unwrap();
         let mut held = PidfileLock::acquire(&paths).unwrap();
         held.record(&paths, 4242).unwrap();
-        assert_eq!(daemon_liveness(&paths).unwrap(), Some(4242));
+        assert_eq!(daemon_liveness(&paths).unwrap(), Shepherd::Running(4242));
         drop(held);
         assert_eq!(
             daemon_liveness(&paths).unwrap(),
-            None,
+            Shepherd::Absent,
             "a released lock is not a live daemon, whatever the file still says"
         );
+    }
+
+    #[test]
+    fn liveness_reports_booting_for_a_holder_that_has_not_recorded_a_pid_yet() {
+        let dir = tempfile::tempdir().unwrap();
+        let paths = test_paths(&dir);
+        init_dirs(&paths).unwrap();
+        // `boot` takes the lock and records its pid a few statements later,
+        // binding the socket in between. A caller that read this window as
+        // an absence would start a second daemon that then dies unable to
+        // take the lock.
+        let held = PidfileLock::acquire(&paths).unwrap();
+        assert_eq!(daemon_liveness(&paths).unwrap(), Shepherd::Booting);
+        drop(held);
+        assert_eq!(daemon_liveness(&paths).unwrap(), Shepherd::Absent);
     }
 
     #[test]

--- a/crates/shep-daemon/src/boot.rs
+++ b/crates/shep-daemon/src/boot.rs
@@ -504,6 +504,22 @@ pub fn daemon_liveness(paths: &ShepPaths) -> Result<Shepherd, BootError> {
         }
         Err(BootError::AlreadyRunning { pid: Some(pid) }) => Ok(Shepherd::Running(pid)),
         Err(BootError::AlreadyRunning { pid: None }) => Ok(Shepherd::Booting),
+        // A home whose layout was never created cannot be holding a lock, so
+        // this is an absence and not a failure. `init_dirs` makes `pids/` on
+        // every boot, so its absence means no daemon has ever run here, which
+        // is precisely what `Absent` says. Reported as an error instead, a
+        // `shep kill` against a fresh `$SHEP_HOME` exits `Failure` rather than
+        // `DaemonUnreachable`, which is a worse answer to a correct question.
+        //
+        // Narrow on purpose. Only `NotFound`, and only for a path under
+        // `pids/`. A permissions error or a corrupt lock file is a real
+        // failure and must still say so.
+        Err(BootError::Io {
+            ref path,
+            ref source,
+        }) if source.kind() == ErrorKind::NotFound && path.starts_with(&paths.pids) => {
+            Ok(Shepherd::Absent)
+        }
         Err(other) => Err(other),
     }
 }

--- a/crates/shep-daemon/src/boot.rs
+++ b/crates/shep-daemon/src/boot.rs
@@ -472,6 +472,47 @@ impl PidfileLock {
     }
 }
 
+/// Whether a live shepherd owns this home, and what pid it recorded.
+///
+/// Proof of life is the pidfile LOCK, never the pidfile's contents. A live
+/// daemon holds that lock for its whole run and the kernel drops it on
+/// process death, `SIGKILL` included, so a failure to acquire it is the only
+/// evidence that cannot be faked by a stale file whose pid has since been
+/// reused. `Ok(None)` therefore means the lock was free, whatever the file
+/// says.
+///
+/// The pid comes from the file the holder wrote, so it is the one weak part
+/// of the answer: a daemon that holds the lock but has not reached
+/// `PidfileLock::record` yet is a live daemon with no pid to report, and
+/// reads here as `Ok(None)`. That window is the few statements between
+/// `acquire` and `record` inside [`boot`].
+///
+/// Answers a question; never claims the home. A lock this acquires is
+/// released before the call returns.
+///
+/// Both platform arms of `PidfileLock` are reachable through this, and it
+/// needs no `cfg` of its own: unix contends on the pidfile's `flock` and
+/// Windows on a sibling `.lock` file's share mode, and both report a
+/// contended lock as [`BootError::AlreadyRunning`].
+///
+/// # Errors
+/// - [`BootError::Io`] — the pidfile could not be opened, created or read.
+///   A contended lock is NOT an error here; it is the `Some` case.
+pub fn daemon_liveness(paths: &ShepPaths) -> Result<Option<u32>, BootError> {
+    match PidfileLock::acquire(paths) {
+        // We took it, so nobody else holds it. Released by this `drop`
+        // rather than at the end of the scope, so that the window in which
+        // a question-asker holds a claim on someone else's home is as
+        // short as the type allows.
+        Ok(lock) => {
+            drop(lock);
+            Ok(None)
+        }
+        Err(BootError::AlreadyRunning { pid }) => Ok(pid),
+        Err(other) => Err(other),
+    }
+}
+
 /// The socket this daemon binds: the layout default, or a config override
 #[must_use]
 pub(crate) fn socket_path(paths: &ShepPaths, override_path: Option<&Path>) -> PathBuf {
@@ -1788,6 +1829,41 @@ mod tests {
         write_pidfile(&paths, 4242).unwrap();
         assert_eq!(read_pidfile(&paths).unwrap(), Some(4242));
         assert_eq!(pidfile(&paths), paths.pids.join("shepd.pid"));
+    }
+
+    #[test]
+    fn liveness_reports_none_when_no_daemon_holds_the_lock() {
+        let dir = tempfile::tempdir().unwrap();
+        let paths = test_paths(&dir);
+        init_dirs(&paths).unwrap();
+        assert_eq!(daemon_liveness(&paths).unwrap(), None);
+    }
+
+    #[test]
+    fn liveness_reports_none_for_a_stale_pidfile_nobody_holds() {
+        let dir = tempfile::tempdir().unwrap();
+        let paths = test_paths(&dir);
+        init_dirs(&paths).unwrap();
+        std::fs::write(pidfile(&paths), "999999").unwrap();
+        // The file exists and names a pid. Nothing holds the lock, so this is
+        // NOT a live daemon and must not be reported as one.
+        assert_eq!(daemon_liveness(&paths).unwrap(), None);
+    }
+
+    #[test]
+    fn liveness_reports_the_pid_a_lock_holder_recorded() {
+        let dir = tempfile::tempdir().unwrap();
+        let paths = test_paths(&dir);
+        init_dirs(&paths).unwrap();
+        let mut held = PidfileLock::acquire(&paths).unwrap();
+        held.record(&paths, 4242).unwrap();
+        assert_eq!(daemon_liveness(&paths).unwrap(), Some(4242));
+        drop(held);
+        assert_eq!(
+            daemon_liveness(&paths).unwrap(),
+            None,
+            "a released lock is not a live daemon, whatever the file still says"
+        );
     }
 
     #[test]

--- a/crates/shep-daemon/src/kill.rs
+++ b/crates/shep-daemon/src/kill.rs
@@ -24,7 +24,11 @@ use crate::runner::{ExitOutcome, RunningProcess, StopSignal};
 ///    `stop_signal` parser from `app.kill_signal`) to the sheep's whole
 ///    process group — lambs included, see [`RunningProcess::signal`].
 /// 2. Waits up to `grace` for the process to exit.
-/// 3. On timeout, SIGKILLs the whole process tree and waits for that to land.
+/// 3. On timeout, `SIGKILL`s that SAME process group and waits for that to
+///    land — not the whole process tree, which is what the block comment
+///    below spends a paragraph explaining this rung cannot reach. On
+///    Windows it is the sheep's whole job, which nothing escapes; see
+///    `RunningProcess::kill_tree`'s two arms.
 ///
 /// `grace` is the caller's, not the app's, because an app configures two of
 /// them for two different asks: `kill_timeout` for an ordinary stop, and

--- a/crates/shep-daemon/src/rpc.rs
+++ b/crates/shep-daemon/src/rpc.rs
@@ -207,6 +207,7 @@ async fn with_deadline<F: Future<Output = Outcome> + Send>(
                     "the request deadline of {} ms expired before the daemon finished",
                     budget.as_millis()
                 ),
+                daemon_version: None,
             }),
         }),
     }
@@ -261,6 +262,7 @@ async fn run(id: u64, conn: ConnId, request: Request, ctx: &RpcContext) -> Outco
             Err(err) => reply(Err(RpcError {
                 code: RpcErrorCode::InvalidConfig,
                 message: err.to_string(),
+                daemon_version: None,
             })),
             Ok(resolved) => {
                 ctx.registry.record(&resolved);
@@ -283,6 +285,7 @@ async fn run(id: u64, conn: ConnId, request: Request, ctx: &RpcContext) -> Outco
             Err(err) => reply(Err(RpcError {
                 code: RpcErrorCode::InvalidConfig,
                 message: err.to_string(),
+                daemon_version: None,
             })),
             Ok(resolved) => match ctx.supervisor.config_drift(resolved).await {
                 Ok(drifted) => reply(Ok(Response::Drifted(drifted))),
@@ -347,6 +350,7 @@ async fn run(id: u64, conn: ConnId, request: Request, ctx: &RpcContext) -> Outco
                     message: "a line may not contain a newline or a carriage return; \
                               send one line per request"
                         .to_string(),
+                    daemon_version: None,
                 }));
             }
             match selector_of(selector) {
@@ -391,6 +395,7 @@ async fn run(id: u64, conn: ConnId, request: Request, ctx: &RpcContext) -> Outco
                             "scaled {name} to {achieved} of {requested} requested; \
                              the next instance would not spawn: {message}"
                         ),
+                        daemon_version: None,
                     })),
                 }
             }
@@ -420,10 +425,12 @@ async fn run(id: u64, conn: ConnId, request: Request, ctx: &RpcContext) -> Outco
             Ok(None) => reply(Err(RpcError {
                 code: RpcErrorCode::Internal,
                 message: "the supervisor engine has stopped; no roll was written".to_string(),
+                daemon_version: None,
             })),
             Err(err) => reply(Err(RpcError {
                 code: RpcErrorCode::Internal,
                 message: err.to_string(),
+                daemon_version: None,
             })),
         },
         // The same restore `boot` runs, called the same way — see
@@ -434,6 +441,7 @@ async fn run(id: u64, conn: ConnId, request: Request, ctx: &RpcContext) -> Outco
                 Err(err) => reply(Err(RpcError {
                     code: RpcErrorCode::Internal,
                     message: err.to_string(),
+                    daemon_version: None,
                 })),
                 Ok(names) => match ctx.supervisor.list_checked().await {
                     Err(err) => reply(Err(rpc_error(&err))),
@@ -456,6 +464,7 @@ async fn run(id: u64, conn: ConnId, request: Request, ctx: &RpcContext) -> Outco
             Err(err) => reply(Err(RpcError {
                 code: RpcErrorCode::InvalidConfig,
                 message: err.to_string(),
+                daemon_version: None,
             })),
         },
         Request::EnableDog { name, source } => {
@@ -464,6 +473,7 @@ async fn run(id: u64, conn: ConnId, request: Request, ctx: &RpcContext) -> Outco
                 Err(err) => reply(Err(RpcError {
                     code: RpcErrorCode::InvalidConfig,
                     message: err.to_string(),
+                    daemon_version: None,
                 })),
                 Ok(app) => match ctx.supervisor.start_dog(app, spec.source).await {
                     // `start_dog` is idempotent by NAME, so what comes back
@@ -480,6 +490,7 @@ async fn run(id: u64, conn: ConnId, request: Request, ctx: &RpcContext) -> Outco
                             "a sheep is already registered as `{}`; rename it or give the dog another name",
                             spec.name
                         ),
+                        daemon_version: None,
                     })),
                     Ok(info) => reply(Ok(Response::DogStarted(info))),
                     Err(err) => reply(Err(rpc_error(&err))),
@@ -508,6 +519,7 @@ async fn run(id: u64, conn: ConnId, request: Request, ctx: &RpcContext) -> Outco
             Err(err) => reply(Err(RpcError {
                 code: RpcErrorCode::InvalidConfig,
                 message: err.to_string(),
+                daemon_version: None,
             })),
         },
         Request::KillDaemon => Outcome::Shutdown(Reply {
@@ -519,6 +531,7 @@ async fn run(id: u64, conn: ConnId, request: Request, ctx: &RpcContext) -> Outco
         _ => reply(Err(RpcError {
             code: RpcErrorCode::Internal,
             message: "this daemon does not implement that request".to_string(),
+            daemon_version: None,
         })),
     }
 }
@@ -603,6 +616,7 @@ fn rpc_error(err: &SupervisorError) -> RpcError {
         SupervisorError::SpawnFailed(msg) => RpcError {
             code: RpcErrorCode::SpawnFailed,
             message: msg.clone(),
+            daemon_version: None,
         },
         // The same code as `SpawnFailed` above, on the rule this function
         // already applies twice below: `RpcErrorCode` is versioned, a client
@@ -617,6 +631,7 @@ fn rpc_error(err: &SupervisorError) -> RpcError {
         SupervisorError::CannotStart(msg) => RpcError {
             code: RpcErrorCode::SpawnFailed,
             message: msg.clone(),
+            daemon_version: None,
         },
         // `Internal` — an "unexpected daemon-side failure", which a log path
         // the daemon can no longer open, or can no longer empty, both are.
@@ -630,6 +645,7 @@ fn rpc_error(err: &SupervisorError) -> RpcError {
         SupervisorError::ReopenFailed(_) | SupervisorError::FlushFailed(_) => RpcError {
             code: RpcErrorCode::Internal,
             message: err.to_string(),
+            daemon_version: None,
         },
         // `Internal` under protest, and the wire verb should revisit it
         // rather than inherit it: an app already being reloaded is a CONFLICT
@@ -645,6 +661,7 @@ fn rpc_error(err: &SupervisorError) -> RpcError {
         SupervisorError::ReloadInFlight(_) => RpcError {
             code: RpcErrorCode::Internal,
             message: err.to_string(),
+            daemon_version: None,
         },
         // Every `InvalidScale` is something the caller asked for that it can
         // ask differently — a count of `0`, a dog, an app whose earlier scale
@@ -661,10 +678,12 @@ fn rpc_error(err: &SupervisorError) -> RpcError {
         SupervisorError::InvalidScale(msg) => RpcError {
             code: RpcErrorCode::InvalidConfig,
             message: msg.clone(),
+            daemon_version: None,
         },
         SupervisorError::EngineStopped => RpcError {
             code: RpcErrorCode::Internal,
             message: "the supervisor engine has stopped".to_string(),
+            daemon_version: None,
         },
     }
 }
@@ -673,6 +692,7 @@ fn not_found() -> RpcError {
     RpcError {
         code: RpcErrorCode::NotFound,
         message: "selector matched no registered sheep".to_string(),
+        daemon_version: None,
     }
 }
 
@@ -680,6 +700,7 @@ fn selector_of(spec: SelectorSpec) -> Result<ProcessSelector, RpcError> {
     ProcessSelector::try_from(spec).map_err(|err| RpcError {
         code: RpcErrorCode::InvalidConfig,
         message: err.to_string(),
+        daemon_version: None,
     })
 }
 
@@ -753,6 +774,7 @@ async fn signal_request(id: u64, spec: SelectorSpec, signal: String, ctx: &RpcCo
                 "`{signal}` is not a signal shep will send; accepted: {}",
                 OperatorSignal::ACCEPTED.join(", ")
             ),
+            daemon_version: None,
         }),
         Some(sig) => match selector_of(spec) {
             Err(err) => Err(err),

--- a/crates/shep-daemon/src/server.rs
+++ b/crates/shep-daemon/src/server.rs
@@ -480,6 +480,12 @@ async fn handshake(
                 "daemon speaks protocol {PROTOCOL_VERSION}, client sent {}",
                 hello.protocol
             ),
+            // The refusal names our PROTOCOL, which does not say which shep
+            // is running. `shep daemon reload` chooses its mechanism by
+            // version, and this is the one path where the ack that would
+            // have carried it never arrives. Same field the ack uses, so a
+            // client cannot learn two versions for one daemon.
+            daemon_version: Some(ctx.daemon_version.clone()),
         });
         send(out, &refusal).await?;
         return Err(ConnError::ProtocolMismatch {
@@ -612,6 +618,29 @@ mod tests {
             client.closed().await,
             "the daemon must close after refusing"
         );
+    }
+
+    #[tokio::test]
+    async fn a_protocol_refusal_carries_the_daemon_version() {
+        // The refusal reports the daemon's PROTOCOL, which says nothing
+        // about which crate version is running. `shep daemon reload` picks
+        // between a handover and a stop-and-start by version, and a protocol
+        // bump is exactly when it is needed, so the refusal has to name it.
+        let h = harness(vec![]);
+        let mut client = connected(h.ctx.clone()).await;
+        client
+            .send(&Hello {
+                client_version: "9.9.9".to_string(),
+                protocol: PROTOCOL_VERSION + 1,
+            })
+            .await;
+        let refusal: HelloReply = client.recv().await;
+        let err = refusal.expect_err("skew must be refused");
+        assert_eq!(err.code, RpcErrorCode::ProtocolMismatch);
+        // The same string the ack would have carried, from the same field:
+        // a client must never learn two different versions for one daemon
+        // depending on whether its handshake was accepted.
+        assert_eq!(err.daemon_version.as_deref(), Some(&*h.ctx.daemon_version));
     }
 
     #[tokio::test]

--- a/crates/shep-daemon/src/supervisor.rs
+++ b/crates/shep-daemon/src/supervisor.rs
@@ -1639,8 +1639,23 @@ enum ReloadMode {
     /// It also fixes a failure the overlap never worked around. An app that
     /// does NOT set `SO_REUSEPORT` cannot have two instances bound to one
     /// port, so an overlapping reload of one spawns a replacement that takes
-    /// `EADDRINUSE` and crash-loops — including on macOS, where Node cannot
-    /// set the option at all (`ENOTSUP`).
+    /// `EADDRINUSE`, including on macOS, where Node cannot set the option at
+    /// all (`ENOTSUP`).
+    ///
+    /// This said "and crash-loops" until 2026-08-29, and that is not what
+    /// happens. Measured twice independently, on macOS, one instance, no
+    /// probe, `autorestart = true`: the replacement takes `EADDRINUSE` and
+    /// dies EXACTLY ONCE, the reload aborts, and the original instance is
+    /// still online afterwards on its original pid with `RESTARTS` at 0. The
+    /// ordering is why. `SpawnNew` comes before `DrainOld`, so a replacement
+    /// that never reaches `AwaitReady` means `DrainOld` never runs and the
+    /// instance being replaced was never dropped.
+    ///
+    /// That is better behaviour than the old wording claimed, and worth
+    /// stating correctly: an operator told to expect a crash loop will go
+    /// looking for a restart storm that is not there. The real gap is
+    /// quieter. The daemon logs NOTHING about the aborted reload, so the only
+    /// evidence is `EADDRINUSE` in the sheep's own stderr file.
     ///
     /// A single-instance app loses its name-group watch and cron worker for
     /// the width of the gap — they are armed per RUNNING instance, and for

--- a/crates/shep-daemon/src/supervisor.rs
+++ b/crates/shep-daemon/src/supervisor.rs
@@ -1642,6 +1642,13 @@ enum ReloadMode {
     /// `EADDRINUSE`, including on macOS, where Node cannot set the option at
     /// all (`ENOTSUP`).
     ///
+    /// Note which app this is about, because it is NOT one that ever takes
+    /// `Serial`. `ReloadMode::of` sends a probed app without `reuse_port`
+    /// here; the measured case below has NO probe, so it takes `Overlap` and
+    /// meets `EADDRINUSE` there. `Serial` is what spares a PROBED app the
+    /// same collision. The paragraph sits here because it is the failure
+    /// this variant exists to avoid, not one it can produce.
+    ///
     /// This said "and crash-loops" until 2026-08-29, and that is not what
     /// happens. Measured twice independently, on macOS, one instance, no
     /// probe, `autorestart = true`: the replacement takes `EADDRINUSE` and

--- a/docs/brainstorming/specs/2026-08-29-daemon-handover-design.md
+++ b/docs/brainstorming/specs/2026-08-29-daemon-handover-design.md
@@ -1,0 +1,576 @@
+# Design: replace the shepherd without stopping the flock
+
+Status: approved direction, not yet planned.
+
+Supersedes the version-skew guard draft of the same date, which treated the
+handover as a deferred direction and specified a stop-and-start `daemon
+reload` around it. The handover is the requirement; the guard is what makes
+it discoverable. Written in that order.
+
+## Why this exists
+
+Two things arrived on the same day and turned out to be one problem.
+
+**An upgrade bricked a running box.** `cargo install shep` replaced the
+binary and left the old daemon running. Every verb that reaches the daemon
+was then refused at the handshake, `shep kill` included, so no command in
+shep could stop the daemon shep was refusing to talk to. Live daemon, live
+flock, no path forward.
+
+**A restart is not always cheap.** Some sheep hold a pool of external
+resources that enters a long cooldown when the process exits, measured in
+hours rather than seconds. For those a restart is not a brief interruption,
+it is a large block of lost capacity. Any process manager whose upgrade path
+stops the flock cannot be upgraded on a box running that workload, so it
+simply never gets upgraded, which is the worse outcome.
+
+The second one settles the design. If a daemon upgrade must stop the flock,
+shep is not upgradeable where it matters most. So the goal is not a better
+error message about a stopped flock. It is not stopping it.
+
+**The sheep that costs the most to restart usually has no version
+relationship with shep at all.** A sheep in this class is an ordinary
+binary that does not link shep-client and does not use the shepherd
+channel. Nothing about upgrading shep, or a dog, or the protocol can make
+it incompatible. The only reason a shep upgrade disturbs it is that shep
+stops it, which is a cost entirely of shep's own making.
+
+## The shape
+
+```mermaid
+flowchart LR
+    subgraph before["stop and start"]
+        direction TB
+        A1["daemon (pid 100)"] -->|"SIGTERM"| A2["kill ladder<br/>every sheep dies"]
+        A2 --> A3["new daemon (pid 200)"]
+        A3 --> A4["muster: every sheep respawned<br/>new pids, log gap, cooldown"]
+    end
+    subgraph after["exec in place"]
+        direction TB
+        B1["daemon (pid 100)"] -->|"SIGHUP"| B2["serialize state<br/>clear CLOEXEC on what must live"]
+        B2 -->|"execve"| B3["daemon (pid 100, new image)"]
+        B3 --> B4["sheep never noticed<br/>same pids, no gap"]
+    end
+```
+
+The sheep are children of the daemon's pid. `execve` keeps the pid, the
+open descriptors and the child relationships, and replaces only the program
+image. Nothing a sheep holds is disturbed because from the sheep's side
+nothing happened.
+
+## Part 1: the handover
+
+### H1. `execve` in place, because nothing cheaper works
+
+The obvious approach is to leave the sheep alive and let a NEW daemon adopt
+them by pid. That breaks on two independent facts.
+
+Sheep are spawned with `Stdio::piped()` (`tokio_runner.rs:608`) and the
+daemon holds a `Child` it calls `.wait()` on. So the daemon is both the
+owner of every sheep's log pipes and its parent. The pipes die with the old
+process, so output goes nowhere. And a process that did not spawn a child
+cannot `wait()` on it, so a new daemon can never learn that a sheep exited
+or reap it.
+
+`execve` keeps both. This is how nginx, HAProxy and Envoy do a binary
+upgrade, and shep's case is smaller than any of them: shep never holds an
+app's listening socket, only pipes, child handles and its own control
+socket.
+
+### H2. What crosses the exec, and what is rebuilt
+
+Three categories, and getting the boundary right is most of the work.
+
+**Descriptors that must survive.** Rust opens descriptors close-on-exec, so
+every one of these needs `FD_CLOEXEC` cleared deliberately, and every other
+descriptor must keep it. Getting this backwards either leaks descriptors
+into the new image or silently loses a sheep's output.
+
+- each sheep's stdout and stderr pipe read ends
+- each sheep's log file write ends
+- the control socket listener, so no client sees a closed socket during
+  the swap
+- the pidfile lock, which is held on a descriptor and survives with it, so
+  the successor keeps proving liveness without a window where a second
+  daemon could win the lock
+
+**A blob describing them.** Written to `$SHEP_HOME/run/handover.json` at
+mode 0600, its path passed in an environment variable, unlinked by the
+successor once read. It carries each sheep's identity, its pid, which
+descriptor numbers belong to it, its restart counters, its epoch and its
+start time. It carries no environment values: a sheep's env may hold
+secrets, and the successor can re-read them from config rather than having
+them transit a file.
+
+**Everything else is rebuilt.** Cron schedules, watchers and debouncers all
+derive from config. The bus, every `mpsc` and every `oneshot` are rebuilt
+empty.
+
+What is genuinely lost, and why each is acceptable:
+
+| lost | consequence | why it is fine |
+|---|---|---|
+| `tokio::process::Child` handles | reaping becomes SIGCHLD plus `waitpid`, on raw pids | the successor is still the parent, so the kernel still delivers |
+| in-flight RPCs | the client sees the connection drop | clients already retry a dropped connection |
+| bus subscriptions | subscribers resubscribe | `lookout` already repairs drift on a two-second poll |
+| pending action waiters | a caller awaiting a custom action gets no reply | these already carry a timeout |
+
+The supervisor's live state is channels, `Child` handles and oneshot
+waiters. **None of it is serializable, and none of it should be.** What
+crosses is the small factual core: which pid is which sheep, which
+descriptor carries its output, what its counters were. The machinery around
+that is rebuilt from scratch on the far side.
+
+### H3. The trigger is a signal, never the socket
+
+A socket request cannot be the trigger, because the case that most needs a
+reload is the case where the socket refuses the client. The daemon rejects a
+mismatched protocol at the handshake (`server.rs:475`), and the CLI cannot
+exempt itself from a refusal the daemon issues. A remedy delivered over the
+channel it is meant to repair is not a remedy.
+
+So `daemon reload` reads `$SHEP_HOME/pids/shepd.pid`, proves the pid is
+shep's, and sends **SIGHUP**.
+
+The pidfile alone is not proof. A stale pidfile from a crash still exists
+and the pid may have been reused. `boot.rs` already documents the lock that
+answers this: a live daemon holds it, the kernel drops it on death, so
+failing to acquire it proves a live daemon owns that pidfile. The signal
+path uses the lock, not the file's contents.
+
+SIGHUP because SIGUSR2 is already the log-reopen signal (`boot.rs:1437`)
+and SIGHUP is otherwise unhandled by the daemon. Every other daemon signal
+today is a shutdown: terminate, interrupt, quit.
+
+A signal carries no reply, which costs nothing here. The daemon is about to
+replace its own image, so it could not answer afterwards anyway. The CLI
+confirms by polling the control socket until a handshake reports the new
+version, which is a stronger check than a reply would have been: it proves
+the successor is serving, not merely that the predecessor received
+something.
+
+### H4. `shep daemon reload` is the one verb
+
+It reports what happened to each sheep rather than announcing that the
+flock stopped, because under the handover the flock did not stop and the
+same output shape has to be true under both arms.
+
+Nothing in the CLI may assume a reload implies new pids. A sheep that kept
+running keeps its pid, and a caller treating a reload as a restart would be
+wrong.
+
+### H5. Two arms, and the stop arm is not throwaway
+
+`daemon reload` has a handover arm and a stop-and-start arm. The stop arm
+is not scaffolding to be replaced later; it is the permanent answer to
+three cases that the handover cannot serve:
+
+- **Windows**, which has no `exec`. Handle inheritance into a successor
+  process is a separate design and guessing at it here would be worse than
+  leaving it open.
+- **Any daemon predating the handover**, which cannot be taught to hand
+  over after the fact (H6).
+- **A failed handover.** If the successor cannot rehydrate, the operator
+  needs a working reload rather than a wedged one.
+
+It is also small: SIGTERM the proven pid, wait for exit, spawn a new
+daemon, muster. SIGTERM is already the right signal, since the daemon's
+handler drives the graceful teardown that runs the kill ladder over every
+sheep before stopping. Three existing pieces composed by one verb.
+
+### H6. The bootstrap constraint, and the one string that bounds it
+
+**The handover has to exist in the OLD daemon.** A daemon already running
+cannot learn to hand over, so the handover only ever helps upgrades
+starting from the first release that carries it. The first upgrade past
+this point still stops the flock. Every one after it does not.
+
+That makes the version arithmetic load-bearing, and there is a gap in it
+worth closing now while it is cheap.
+
+To choose an arm, `daemon reload` must know whether the running daemon
+supports handover, which means knowing its version:
+
+| what the CLI can reach | how it learns the version | arm |
+|---|---|---|
+| a clean handshake | `HelloAck.daemon_version`, which already exists | handover if new enough |
+| a protocol refusal | nothing today | stop and start |
+| no socket at all | nothing | stop and start |
+
+Row 2 is the gap. A protocol bump is exactly when an operator most needs a
+reload, and it is the one case where the CLI is told the daemon's PROTOCOL
+and not its version. So the refusal is deaf about the one fact that would
+let it be hot.
+
+**The protocol-mismatch refusal must carry the daemon's crate version.**
+It costs one field today and buys a hot reload across every future protocol
+bump. It cannot help the upgrade that introduces it, because daemons
+already shipped will never send it, and that is the same one-time cost as
+the handover itself rather than a second one.
+
+Two ways to carry it, and the plan should confirm which the codec tolerates
+before choosing: an optional structured field on `RpcError`, which is
+additive and survives an old client only if the codec ignores unknown
+fields; or the version embedded in the refusal's message string, which
+always works and makes the CLI parse prose. Prefer the field, verify first.
+
+### H7. Sequencing, and the one thing worth landing early
+
+The handover's value is entirely in the daemon it upgrades FROM, so the
+skeleton is worth landing before the mechanism is complete. Concretely: the
+signal handler, the arm selection, the version in the refusal, and the stop
+arm can ship as one release that hands over nothing. Every daemon installed
+from that release forward is then upgradeable hot, even though that release
+itself cannot upgrade hot from what preceded it.
+
+Waiting for the complete mechanism costs one more cold upgrade on every box.
+
+## Part 2: the guard
+
+Nothing above helps an operator who does not know the daemon is stale. The
+guard is what sends them to `daemon reload`.
+
+### G1. The CLI refuses any daemon whose crate version differs
+
+Not just a protocol mismatch. Any difference.
+
+The maintainer's reasoning, recorded because it inverts what the incident
+first suggests: the dangerous state was believing `cargo install shep`
+upgrades a running system. It does not, it never did, and a check that says
+so out loud is worth more than one that lets a mixed pair limp along.
+
+`HelloAck` already carries `daemon_version` and `Client::daemon()` already
+exposes it, so this is a client-side comparison against the CLI's own
+`CARGO_PKG_VERSION` with no wire change.
+
+The message names the fix rather than the condition:
+
+```
+error[version_skew]: this shep is 0.1.15, the running shepherd is 0.1.8
+
+`cargo install shep` replaced the binary. It did not restart the
+shepherd, which is still running the old code.
+
+  shep daemon reload
+```
+
+What actually differed across 0.1.8 to 0.1.15 is worth recording, because
+it shows how little it takes. `Request` gained no new variants, and
+`SelectorSpec` gained exactly one, `Instance`. Reply-side, `ProcessInfo`
+gained `instance`, which is additive. So the only thing a new CLI could
+send that a 0.1.8 daemon cannot parse is a `name:slot` selector. `flock`,
+`muster` and `kill` all send shapes that daemon already understood. One
+narrow incompatibility became a total lockout.
+
+### G2. Three verbs stay exempt
+
+`kill`, `daemon reload` and `ping`. The first two are how an operator gets
+out; `ping` is how they see what is running without being refused.
+
+This is the constraint that shaped everything above: a guard whose remedy
+is itself guarded is the trap this design exists to remove.
+
+### G3. `shep kill` gets the same socket-free path
+
+Today `kill` handshakes, so it cannot stop a daemon that refuses the
+handshake. It gains the H3 path: prove the pid via the lock, send SIGTERM.
+
+This is the same machinery `daemon reload`'s stop arm needs. One piece of
+work, two verbs, two signals.
+
+### G4. `shep flock` stops reporting the opposite of the truth
+
+`lib.rs:1285` is a blanket `Err(_) => flock_from_roll(...)`, so any connect
+failure prints "no shepherd running". During the incident the daemon was
+alive and answering; it answered the refusal. That sent the operator to the
+muster-roll path rather than the reload path.
+
+A refusal is not an absence and must not be reported as one.
+
+### G5. The docs say the thing nobody knew
+
+`cargo install shep` upgrades the binary and nothing else. The running
+daemon keeps the old code until it is reloaded, and every dog keeps its own
+until it is reinstalled. That belongs on the install page and in `shep
+--help`'s upgrade note.
+
+## Part 3: dogs
+
+Dogs speak the socket protocol, so they are the one component that can
+genuinely mismatch. All three findings below were measured on 2026-08-29 by
+building `shep-log-rotate` against protocol 1 and running it under a
+protocol 2 daemon, not reasoned about.
+
+### G6. What a mismatched dog does today
+
+**It does not crash-loop, and it does not fail loudly.** It starts, is
+refused at the handshake, prints one line, sleeps its interval and retries
+forever. Throughout, `shep dogs` reports it ONLINE with a normal uptime:
+
+```
+ID  NAME        STATUS  PID    RESTARTS  EXIT  CPU   MEM   UPTIME  SOURCE
+0   log-rotate  online  46015  1         -     0.0%  6.3M  1m 32s  adopted
+```
+
+That is the worst available shape. A crash loop is at least visible in the
+restart count; this looks healthy and does nothing.
+
+**The evidence lands where nobody looks.** The refusal goes to the dog's
+own stderr file, one line per interval, 60 seconds by default. Measured:
+126 bytes at t=0, 252 at t=70s. About 1440 lines a day, growing without
+bound, and the dog that would rotate that file is the one that cannot run.
+The daemon's log recorded nothing at all.
+
+**A rebuild is the whole fix.** `cargo install shep-log-rotate` then `shep
+restart log-rotate`. Verified: stderr stayed at 0 bytes afterwards.
+
+### G7. A handover restarts only the dogs that are actually broken
+
+This is where the handover pays off a second time, and it is the answer to
+"the least dog downtime possible".
+
+Dog processes are children of the daemon, so they survive the exec exactly
+as sheep do. What does not survive is their accepted connection, because
+carrying an accepted connection would mean carrying mid-stream codec state
+and pending requests across the image swap. So every dog sees its
+connection drop and reconnects, which it already does today.
+
+The reconnect re-handshakes against the new daemon. A compatible dog is
+back in seconds with **no process restart at all**. An incompatible one is
+refused at exactly the moment the daemon can see it, which is the trigger
+G8 needs.
+
+Contrast the stop arm, which respawns every dog from disk whether it needed
+it or not.
+
+### G8. A refused dog is restarted once, then reported, never looped
+
+Measured behaviour today is that a refused dog retries forever and the
+daemon logs nothing. Both halves are wrong, and the daemon is the only
+party that can fix it, because the daemon is what refused the handshake.
+
+1. The daemon records it. Today `server.rs:475` reads `hello.protocol` and
+   drops the rest; the refusal is not logged at any level.
+2. It restarts that dog ONCE, from disk. This is the whole of the automatic
+   fix, and it is enough for the common case: the binary on disk is already
+   correct and the running process is merely stale.
+3. If the restarted dog is refused again, the disk binary is old too. Stop.
+   Mark it stale and say so. A dog that cannot possibly succeed must not be
+   respawned in a loop.
+
+The one-restart rule is the entire difference between an automatic fix and
+a crash loop, and it falls out of the state rather than being a tuning
+choice: a second refusal PROVES the disk binary cannot satisfy this daemon,
+so retrying is not optimism, it is a spin.
+
+### G9. A dog's protocol is decided by when it was compiled
+
+Found by getting the experiment wrong first. Pinning `shep-client
+= "=0.1.14"` did NOT produce a protocol 1 dog, because `PROTOCOL_VERSION`
+lives in shep-core and shep-client's dependency on it floats within 0.1.x.
+Forcing protocol 1 needed `cargo update -p shep-core --precise 0.1.14`.
+
+Two consequences, in opposite directions:
+
+- Good: a plain `cargo install <dog>` genuinely does fix the protocol,
+  because shep-core resolves forward on every rebuild.
+- Bad: nothing an operator can read tells them which protocol an installed
+  dog speaks. Its manifest does not say, its lockfile is not shipped, and
+  the answer depends on the day it was last compiled.
+
+So `Hello.client_version`, which the daemon already receives and discards,
+is not a convenience. It is the only thing that knows.
+
+### G10. Why `cargo install` can replace a running dog at all
+
+Recorded because the whole matrix rests on it and it is counterintuitive
+enough to write down once.
+
+`cargo install` writes a temporary file and `rename`s it over the target.
+Rename does not modify the old file, it repoints the directory entry at a
+NEW inode. Measured 2026-08-29: the inode moved from 187581425 to 187581426
+while the running process continued undisturbed. The running process holds
+the old inode open, so it stays mapped and alive even though nothing in the
+filesystem refers to it any more.
+
+That is why there is no "text file busy" error, and exactly why a restart
+is still required: the upgrade produced a new file and a process still
+executing the old code.
+
+### G11. Dogs answer `--version`, and `adopt` checks it
+
+Because of G9, staleness is otherwise only knowable after a dog connects
+and gets refused. `shep-log-rotate` today accepts `--print-config` and
+`--help` and answers everything else with "shep-log-rotate does not
+understand --version".
+
+That is a gap in the dog contract rather than a bug in one dog. So it
+becomes part of what a dog is: **a dog answers `--version` on stdout and
+exits 0.**
+
+`shep adopt` vets it. Adopt already spawns the candidate to prove the
+kernel can exec it, so asking its version costs one more argument on a
+process it was already going to start. A dog that cannot satisfy the
+running daemon is refused at adopt time rather than becoming a silent
+online-and-idle entry, which is what happens today.
+
+Dogs predating the convention stay adoptable. One that does not answer is
+recorded as unknown rather than refused, and prediction degrades to G8's
+post-connection detection for that dog alone.
+
+### G12. Every mismatch state
+
+Four things carry a version and drift independently: the CLI binary, the
+running daemon, each dog's RUNNING process, and each dog's binary ON DISK.
+The last two are separate because `cargo install` replaces a file and never
+touches a process (G10).
+
+Read against the running daemon, since it is what everything else must
+agree with:
+
+| # | CLI | dog running | dog on disk | what the operator sees | what fixes it |
+|---|---|---|---|---|---|
+| 1 | same | same | same | healthy | nothing |
+| 2 | DIFFERS | same | same | every verb refused | `daemon reload` |
+| 3 | same | DIFFERS | same | dog online, does nothing, stderr grows | shep restarts it once (G8) |
+| 4 | same | DIFFERS | DIFFERS | as 3, and a restart will not fix it | `cargo install <dog>`, then restart |
+| 5 | same | same | DIFFERS | healthy NOW, next dog restart breaks it | upgrade the daemon, or reinstall the dog back |
+| 6 | DIFFERS | DIFFERS | DIFFERS | the incident | `cargo install` everything, then `daemon reload` |
+
+Row 5 is the trap nobody expects, because nothing is wrong yet. Upgrading
+only a dog leaves a working system that breaks the next time that dog
+restarts, which may be days later and for an unrelated reason. G11's disk
+check is the only way to see it, and `shep restart <dog>` warns before
+creating that state.
+
+Row 2 is worth reading twice. Under the stop arm, fixing the CLI/daemon
+axis CREATES the dog problem, because a reload respawns every dog from disk
+against a newer daemon. Under the handover it does not: only genuinely
+incompatible dogs are touched (G7).
+
+Which gives the happy path for the docs, since it collapses 6 straight to 1
+in a single reload:
+
+```
+cargo install shep
+cargo install shep-log-rotate   # and every other dog
+shep daemon reload
+```
+
+### G13. Reload reports dog staleness after the dogs reconnect
+
+The daemon's recorded `client_version` describes the RUNNING dog, not the
+binary on disk, and after a `cargo install` those diverge. So before a
+reload, the recorded value is evidence about a process about to be
+replaced.
+
+`daemon reload` reports staleness AFTER the dogs have reconnected, when the
+answer is a fact. That is still immediate, since the reconnect happens
+inside the same command. Where G11's `--version` is available it can also
+say what it EXPECTS beforehand, but the report that matters is the one
+taken after.
+
+## Part 4: sheep
+
+Stated so nobody extends the dog guard to a place it does not belong.
+
+A sheep is an arbitrary executable. It does not link shep-client, does not
+handshake, and has no version relationship with the daemon whatsoever.
+Nothing about upgrading shep can make an ordinary sheep incompatible,
+because there was never a contract to break.
+
+The one exception is the shepherd channel. An app that opts in receives
+`SHEP_CHANNEL_VERSION` in its environment, currently `"1"`, set at SPAWN
+time (`tokio_runner.rs:740`). A running sheep therefore carries the value
+it was spawned with, and because it arrives as an env var rather than a
+handshake the daemon cannot ask a running sheep what it speaks.
+
+| sheep kind | daemon upgrade | channel bump |
+|---|---|---|
+| ordinary | nothing to break | nothing to break |
+| shepherd channel | nothing to break | mismatched at its next spawn, silently |
+
+`CHANNEL_VERSION` has never moved. When it does, a sheep spawned under the
+old one is worth reporting. A hook to remember, not code to write now.
+
+**And the cheapest win is already shipped.** An app that re-reads its
+configuration on SIGHUP, and shuts down only on SIGTERM or SIGINT, can be
+reconfigured with `shep signal <name> HUP` without disturbing anything it
+holds. Any sheep in this class wants that documented, because a config
+change and a binary upgrade have completely different costs and shep
+presents them identically today.
+
+Running several such processes side by side needs nothing new: separate
+`[[app]]` entries with their own `cwd`, `args` and config paths. That is
+deliberately NOT the instances feature, which runs N copies of one app.
+
+## Considered and rejected
+
+**A separate anchor process** that owns every sheep, with the daemon as its
+client. Upgrading the daemon would then be an ordinary stop-and-start.
+Rejected: the anchor itself eventually needs upgrading, so it needs
+exec-in-place anyway, and the daemon-to-anchor protocol becomes a second
+version axis with exactly the skew problem this spec exists to solve. It
+moves the problem and doubles the surface.
+
+**Sheep writing directly to their log files**, so the daemon holds no
+pipes. Rejected: the daemon needs the stream to timestamp lines, split
+stdout from stderr and publish the `log.*` bus topic, and it does not
+address the `wait()` half at all.
+
+**Making a mismatched pair work.** The client could tolerate an older
+daemon for the verbs that did not change, which is most of them. Rejected:
+it is a compatibility surface to carry on every future bump, and it
+preserves exactly the silent mixed state the incident showed to be the real
+hazard.
+
+**A `restart_cost` Flockfile field** letting a sheep declare a restart
+expensive so `daemon reload` excluded it. Rejected: the plan is to stop
+restarting sheep at all, so it would be grammar to soften a behaviour we
+are removing, and Flockfile keys are forever. The idea is aimed at the
+wrong trigger anyway. Sheep are already restarted automatically by memory
+limits, cron restarts and watch triggers, none of which involve version
+skew, and protecting an expensive sheep from THOSE is a real feature that
+wants its own spec.
+
+## Testing
+
+The two assertions that separate a hot restart from a fast one, and without
+which this is just the stop arm:
+
+- a sheep's pid is UNCHANGED across a `daemon reload`
+- its log file gains no gap across the same reload
+
+Then:
+
+- the handover survives a sheep exiting DURING the swap, which is the race
+  the `Child`-to-`waitpid` transition creates
+- a descriptor not meant to survive does not, so the successor leaks
+  nothing
+- `daemon reload` picks the stop arm against a daemon too old to hand over,
+  and the handover arm against one new enough
+- the arm choice is correct when the handshake is refused, which is the
+  case H6 closes
+- the control socket accepts throughout the swap, so no client sees a
+  closed socket
+- the version check fires on a version difference with NO protocol
+  difference, which is the case a protocol-only check misses
+- `kill` stops a daemon whose handshake refuses, and refuses to signal a
+  pid the lock does not prove is shep's
+- `shep flock` reports a refusal as a refusal, not as an absent daemon
+- a compatible dog is NOT restarted by a handover, only reconnected
+- G8's one-restart rule from both sides: a dog whose disk binary is current
+  recovers with no operator action, and one whose disk binary is stale is
+  restarted once and then left alone rather than spun
+- a stale dog is reported stale while its own status is `online`, since
+  that is the state measured on 2026-08-29 and the one a status column
+  alone cannot show
+- every row of G12, since the rows differ in what fixes them and a guard
+  handling five of six would strand the sixth silently
+- row 5 specifically: the warning fires BEFORE the restart that breaks it
+- a dog that does not answer `--version` is still adoptable, recorded as
+  unknown rather than refused
+- the reproduction itself, so the scenario stays buildable: pin shep-core
+  rather than shep-client, because pinning the client does not pin the
+  protocol (G9)
+- the exact strings, since a message naming the fix is the feature

--- a/docs/brainstorming/specs/2026-08-29-daemon-handover-design.md
+++ b/docs/brainstorming/specs/2026-08-29-daemon-handover-design.md
@@ -144,8 +144,9 @@ installed it as a graceful stop, deliberately: SIGHUP's default disposition
 terminates the process, so a daemon too old to hand over that is signalled
 by a newer client walks the kill ladder instead of dropping its flock with
 broken pipes. The handover replaces that meaning; it does not introduce the
-handler. Every other daemon signal
-today is a shutdown: terminate, interrupt, quit.
+handler. The daemon's other SHUTDOWN signals are terminate, interrupt and
+quit; SIGUSR2 is a daemon signal too and is not one of them, which is the
+whole reason SIGHUP rather than SIGUSR2 carries the handover.
 
 A signal carries no reply, which costs nothing here. The daemon is about to
 replace its own image, so it could not answer afterwards anyway. The CLI

--- a/docs/brainstorming/specs/2026-08-29-daemon-handover-design.md
+++ b/docs/brainstorming/specs/2026-08-29-daemon-handover-design.md
@@ -139,7 +139,12 @@ failing to acquire it proves a live daemon owns that pidfile. The signal
 path uses the lock, not the file's contents.
 
 SIGHUP because SIGUSR2 is already the log-reopen signal (`boot.rs:1437`)
-and SIGHUP is otherwise unhandled by the daemon. Every other daemon signal
+and SIGHUP was otherwise unhandled when this was written. Phase 1 has since
+installed it as a graceful stop, deliberately: SIGHUP's default disposition
+terminates the process, so a daemon too old to hand over that is signalled
+by a newer client walks the kill ladder instead of dropping its flock with
+broken pipes. The handover replaces that meaning; it does not introduce the
+handler. Every other daemon signal
 today is a shutdown: terminate, interrupt, quit.
 
 A signal carries no reply, which costs nothing here. The daemon is about to

--- a/docs/specs/shep-v1.md
+++ b/docs/specs/shep-v1.md
@@ -159,8 +159,24 @@ of two overlapping instances answered it. Serialising costs a gap you can
 see, the drain plus the replacement's start, and buys a success you can
 trust. It also fixes a failure the overlap never worked around: an app that
 does not set `SO_REUSEPORT` cannot have two instances bound to one port, so
-overlapping it spawns a replacement that takes `EADDRINUSE` and crash-loops.
-That includes every Node app on macOS, where the option is `ENOTSUP`.
+overlapping it spawns a replacement that takes `EADDRINUSE` and dies. That
+includes every Node app on macOS, where the option is `ENOTSUP`.
+
+The replacement dies ONCE. This paragraph said "crash-loops" until
+2026-08-30 and that is not what happens. Measured twice independently, with
+`autorestart = true`: the reload aborts and the instance being replaced is
+still online afterwards, on its original pid, with its restart count still
+at zero. The ordering is why. `SpawnNew` precedes `DrainOld`, so a
+replacement that never reaches `AwaitReady` means `DrainOld` never runs and
+nothing was ever dropped. The overlap fails safe.
+
+Recorded in that direction deliberately. The old wording described worse
+behaviour than shep has, and an operator told to expect a crash loop goes
+looking for a restart storm that was never there. The real defect is the
+opposite kind and is still open: the daemon logs NOTHING about the aborted
+reload, so the only evidence is `EADDRINUSE` in the sheep's own stderr file.
+That silence is the same shape as a version-mismatched dog reporting
+`online` while doing nothing.
 
 `reuse_port` is the app's own claim that it sets `SO_REUSEPORT` before its
 own `bind()`. shep never binds a listen socket on an app's behalf and cannot

--- a/docs/writing-plans/plans/2026-08-29-handover-phase1.md
+++ b/docs/writing-plans/plans/2026-08-29-handover-phase1.md
@@ -540,7 +540,7 @@ None of the three is a recovery verb, so each passes `VersionGuard::Enforce` dir
 
 **`commands/dogs.rs` has the same defect in a different shape, at four sites.** Each does `Client::connect(&paths.socket).await.ok()`, and that `.ok()` turns a refusal into `None` exactly as the blanket `Err(_)` turns it into a roll fallback. Fix both here; they are one bug wearing two spellings. Task 5b deliberately left these alone as belonging to this task. During the incident the daemon was alive and answering; it answered the refusal. That sent the operator to the muster-roll path rather than the reload path.
 
-- [ ] **Step 1: Write the failing test**
+- [x] **Step 1: Write the failing test**
 
 ```rust
 #[tokio::test]
@@ -552,15 +552,15 @@ async fn flock_reports_a_refusal_as_a_refusal_not_as_no_daemon() {
 }
 ```
 
-- [ ] **Step 2: Run to verify it fails**
+- [x] **Step 2: Run to verify it fails**
 
 Expected: FAIL, the output contains "no shepherd running"
 
-- [ ] **Step 3: Implement**
+- [x] **Step 3: Implement**
 
 Narrow the blanket catch so it distinguishes "could not connect at all", which is genuinely no daemon and keeps the roll fallback, from "connected and was refused", which is a live daemon and must say so. Match on the error, not on `_`.
 
-- [ ] **Step 4: Run to verify it passes, then task gate and commit**
+- [x] **Step 4: Run to verify it passes, then task gate and commit**
 
 ---
 

--- a/docs/writing-plans/plans/2026-08-29-handover-phase1.md
+++ b/docs/writing-plans/plans/2026-08-29-handover-phase1.md
@@ -274,7 +274,7 @@ kill ladder over every sheep before exiting."
 
 SIGHUP's default disposition terminates the process. Phase 2 uses SIGHUP as the handover trigger, and a phase 2 CLI picks its arm by version so it should never signal a daemon too old to hand over. This task is the floor under that: a stray or mistaken SIGHUP takes the graceful path instead of dropping the flock with broken pipes.
 
-- [ ] **Step 1: Write the failing test**
+- [x] **Step 1: Write the failing test**
 
 ```rust
 #[test]
@@ -287,12 +287,12 @@ fn sighup_is_installed_alongside_the_shutdown_signals() {
 }
 ```
 
-- [ ] **Step 2: Run to verify it fails**
+- [x] **Step 2: Run to verify it fails**
 
 Run: `cargo test -p shep-daemon --lib --all-features -- --skip ::slow:: sighup`
 Expected: FAIL
 
-- [ ] **Step 3: Implement**
+- [x] **Step 3: Implement**
 
 Add `SignalKind::hangup()` to the existing list at :1394 alongside `terminate`, `interrupt` and `quit`. The comment at :1317 says the list is not iterated because each is parameterised by a `SignalKind`; keep that shape and add one entry.
 
@@ -306,12 +306,12 @@ Document at the call site why hangup is in a list of shutdown signals:
 // client without the flock paying for the version gap.
 ```
 
-- [ ] **Step 4: Run to verify it passes**
+- [x] **Step 4: Run to verify it passes**
 
 Run: `cargo test -p shep-daemon --lib --all-features -- --skip ::slow:: sighup`
 Expected: PASS
 
-- [ ] **Step 5: Task gate, then commit**
+- [x] **Step 5: Task gate, then commit**
 
 ---
 

--- a/docs/writing-plans/plans/2026-08-29-handover-phase1.md
+++ b/docs/writing-plans/plans/2026-08-29-handover-phase1.md
@@ -650,7 +650,7 @@ The stop arm composes three things that already exist: SIGTERM the proven pid, w
 
 Per the repo's docs trigger, this task changed what an operator types and sees, so the CLI reference must be regenerated and the site must build.
 
-- [ ] **Step 0: Make `shep daemon reload` discoverable, which spec G5 asks for**
+- [x] **Step 0: Make `shep daemon reload` discoverable, which spec G5 asks for**
 
 Task 7 shipped the verb and reported the problem it leaves behind: **the version-skew refusal names a verb that `shep --help` does not list.** `daemon` is `#[command(hide = true)]` because it is the internal re-exec path, so its subcommand is hidden with it. An operator who reads the refusal is told the fix; one who goes looking for it cannot find it. That is the incident's shape again, in a smaller costume.
 
@@ -669,7 +669,7 @@ That one line does three jobs: it makes the verb discoverable, it distinguishes 
 
 Update the exact-string test rather than deleting it. Then run the generator, since this changes `--help` output.
 
-- [ ] **Step 1: Add the upgrade note and the happy path**
+- [x] **Step 1: Add the upgrade note and the happy path**
 
 ```
 cargo install shep
@@ -679,7 +679,7 @@ shep daemon reload
 
 **No pm2 comparison anywhere.** Direct comparison lives only in `from-pm2.astro`; link there if a migrating reader would want it.
 
-- [ ] **Step 2: Regenerate the CLI reference**
+- [x] **Step 2: Regenerate the CLI reference**
 
 ```bash
 cargo build --release
@@ -690,7 +690,7 @@ cargo build --release
 
 `git diff` afterwards is the check. A stale copy fails no build, which is why it drifts.
 
-- [ ] **Step 3: Build and typecheck the site**
+- [x] **Step 3: Build and typecheck the site**
 
 ```bash
 cd web && npx astro check
@@ -701,7 +701,7 @@ cd web && npx astro build
 
 Both must exit 0. `astro check` is the one that catches a wrong component prop; `astro build` is green on a prop that does not exist.
 
-- [ ] **Step 4: Commit**
+- [x] **Step 4: Commit**
 
 ---
 

--- a/docs/writing-plans/plans/2026-08-29-handover-phase1.md
+++ b/docs/writing-plans/plans/2026-08-29-handover-phase1.md
@@ -432,7 +432,11 @@ Not just a protocol mismatch. Any difference. The dangerous state was believing 
 
 **Three verbs stay exempt: `kill`, `daemon reload`, `ping`.** The first two are how an operator gets out, `ping` is how they see what is running. A guard whose remedy is itself guarded is the trap this design exists to remove.
 
-- [ ] **Step 1: Write the failing tests**
+**`EXIT_VERSION_SKEW` is not a name the code had, and the exit code is a new one.** The enum is `ExitCode` in `crates/shep-cli/src/exit.rs`, and none of its twelve variants fitted: `ProtocolMismatch` (6) is the daemon REFUSING a handshake over differing wire versions, which is a question the wire asks itself, and this guard fires on a handshake that SUCCEEDED. Collapsing the two would print "protocol mismatch" about a protocol that matched. So `ExitCode::VersionSkew = 12` is a new row, `code_str()` is `"version_skew"`, and `output::emit_error`'s own `error[{code}]: {message}` shape produces the spec's first line for free.
+
+**The refusal writes its own block rather than going through `Streams::fail`, under `--format table` only.** `fail` routes into `output::emit_error`, which sanitises through `terminal_safe::sanitise`, and that collapses every `\n` to a space — right for daemon-supplied text, wrong for a fixed block whose remedy has to sit on its own line to be copied. Under `--format json` it is one envelope with one `error.message` carrying the same facts. The two renderings share `VERSION_SKEW_CAUSE`, held as its two rendered lines and joined with `"\n"` or `" "`, so they cannot drift.
+
+- [x] **Step 1: Write the failing tests**
 
 ```rust
 #[tokio::test]
@@ -460,12 +464,12 @@ async fn the_three_recovery_verbs_are_not_refused() {
 }
 ```
 
-- [ ] **Step 2: Run to verify they fail**
+- [x] **Step 2: Run to verify they fail**
 
 Run: `cargo test -p shep --lib --bins --all-features -- --skip ::slow:: version_`
 Expected: FAIL
 
-- [ ] **Step 3: Implement**
+- [x] **Step 3: Implement**
 
 The message names the fix rather than the condition. Exact text, and Step 1's tests pin it:
 
@@ -480,7 +484,7 @@ shepherd, which is still running the old code.
 
 Put the exempt list in one named constant with a doc comment giving the reason, not an inline match arm. A future verb added to it should have to read why.
 
-- [ ] **Step 4: Run to verify they pass, then task gate and commit**
+- [x] **Step 4: Run to verify they pass, then task gate and commit**
 
 ---
 

--- a/docs/writing-plans/plans/2026-08-29-handover-phase1.md
+++ b/docs/writing-plans/plans/2026-08-29-handover-phase1.md
@@ -650,6 +650,25 @@ The stop arm composes three things that already exist: SIGTERM the proven pid, w
 
 Per the repo's docs trigger, this task changed what an operator types and sees, so the CLI reference must be regenerated and the site must build.
 
+- [ ] **Step 0: Make `shep daemon reload` discoverable, which spec G5 asks for**
+
+Task 7 shipped the verb and reported the problem it leaves behind: **the version-skew refusal names a verb that `shep --help` does not list.** `daemon` is `#[command(hide = true)]` because it is the internal re-exec path, so its subcommand is hidden with it. An operator who reads the refusal is told the fix; one who goes looking for it cannot find it. That is the incident's shape again, in a smaller costume.
+
+`shep --help`'s verb listing is hand-rolled, not clap's: `VERB_GROUPS` near the top of `crates/shep-cli/src/cli.rs`, rendered into the block a few lines below it. Both need to agree, and there is an exact-string test over that output.
+
+**Do not simply append `daemon reload` to the "The shepherd" group.** Those entries are bare words, and `reload` ALREADY appears in "Run things", where it means reloading a sheep. Inline it would read as two more verbs, one of which collides with a different verb that does a different thing.
+
+Give it its own labelled line instead, in the same style as the existing `Aliases` footer, and use it to carry the upgrade sentence G5 asks for. Something in this shape, wording yours:
+
+```
+Aliases          flock: list, ls   bleats: logs   lookout: dash   stock: scale   whisper: sendline
+Upgrading        cargo install shep replaces the binary, not the running shepherd: shep daemon reload
+```
+
+That one line does three jobs: it makes the verb discoverable, it distinguishes it from the sheep-level `reload` by spelling out the whole path, and it is the `shep --help` half of G5.
+
+Update the exact-string test rather than deleting it. Then run the generator, since this changes `--help` output.
+
 - [ ] **Step 1: Add the upgrade note and the happy path**
 
 ```

--- a/docs/writing-plans/plans/2026-08-29-handover-phase1.md
+++ b/docs/writing-plans/plans/2026-08-29-handover-phase1.md
@@ -54,11 +54,13 @@ The `execve` handover itself. Phase 1 ships the guard, the recovery path, and th
 - Test: same file, in its existing `mod tests`
 
 **Interfaces:**
-- Produces: `pub fn daemon_liveness(paths: &ShepPaths) -> Result<Option<u32>, BootError>` — `Ok(Some(pid))` when a live daemon holds the lock, `Ok(None)` when nothing does, `Err` only on a real IO failure. Tasks 2 and 7 both consume this.
+- Produces: `pub fn daemon_liveness(paths: &ShepPaths) -> Result<Shepherd, BootError>` and `pub enum Shepherd { Absent, Running(u32), Booting }`. Tasks 2 and 7 both consume this.
+
+**Delivered with three states, not the two this plan first specified.** `Option<u32>` collapsed "nothing is running" and "a daemon is booting" into the same `None`: `boot` takes the lock at `PidfileLock::acquire` and records its pid several statements later, binding the socket in between, stale-socket recovery included. A caller reading that window as an absence would refuse with the wrong reason, or start a second daemon that then dies unable to take the lock. `Shepherd` is deliberately exhaustive rather than `#[non_exhaustive]`: the set is closed by the mechanism, and a missed arm here means signalling the wrong process.
 
 The pidfile alone is not proof: a stale pidfile from a crash still exists and its pid may have been reused. A live daemon HOLDS the lock, and the kernel drops it on process death, so **failing to acquire the lock is the proof of life** and the pid to report is the one recorded in the file.
 
-- [ ] **Step 1: Write the failing tests**
+- [x] **Step 1: Write the failing tests**
 
 ```rust
 #[test]
@@ -95,12 +97,12 @@ fn liveness_reports_the_pid_a_lock_holder_recorded() {
 
 Reuse whatever `tempdir`/`test_paths` helper `boot.rs`'s existing `mod tests` already uses; do not add a new one. Read `pidfile_round_trips_and_reports_absence` at :1783 first and follow its setup exactly.
 
-- [ ] **Step 2: Run to verify they fail**
+- [x] **Step 2: Run to verify they fail**
 
 Run: `cargo test -p shep-daemon --lib --all-features -- --skip ::slow:: liveness`
 Expected: FAIL, `cannot find function daemon_liveness`
 
-- [ ] **Step 3: Implement**
+- [x] **Step 3: Implement**
 
 ```rust
 /// Whether a live shepherd owns this home, and what pid it recorded.
@@ -134,12 +136,12 @@ Verify `BootError::AlreadyRunning`'s real field shape at its definition before w
 
 Also widen `read_pidfile` from `pub(crate)` to `pub` if `daemon_liveness` ends up needing it, and give it a doc comment saying it reports what was RECORDED and is not evidence of life.
 
-- [ ] **Step 4: Run to verify they pass**
+- [x] **Step 4: Run to verify they pass**
 
 Run: `cargo test -p shep-daemon --lib --all-features -- --skip ::slow:: liveness`
 Expected: PASS, 3 tests
 
-- [ ] **Step 5: Task gate, then commit**
+- [x] **Step 5: Task gate, then commit**
 
 ```bash
 git add crates/shep-daemon/src/boot.rs
@@ -196,6 +198,8 @@ async fn kill_refuses_a_pid_the_lock_does_not_prove_is_sheps() {
 }
 ```
 
+Add a third case: `Shepherd::Booting` must report that a shepherd is starting, not that none is running, and must signal nothing.
+
 Follow the fixture style already in `admin.rs`'s `mod tests`. Note its comment at :200 explaining that `cfg(unix)` there is about the FAKE's mechanism, not the feature.
 
 - [ ] **Step 2: Run to verify they fail**
@@ -217,8 +221,14 @@ Add a socket-free path that runs when the socket cannot be used for any reason, 
 /// # Errors
 /// Reports, and exits non-zero, when no live shepherd owns this home.
 async fn kill_socket_free(paths: &ShepPaths, streams: &mut Streams<'_>) -> ExitCode {
-    let Some(pid) = boot::daemon_liveness(paths).unwrap_or(None) else {
-        return streams.fail(EXIT_NO_DAEMON, "no shepherd running");
+    let pid = match boot::daemon_liveness(paths)? {
+        Shepherd::Running(pid) => pid,
+        // Alive and owns the home, but there is no pid to signal yet. Must
+        // not be reported as an absence, and must not be guessed at.
+        Shepherd::Booting => {
+            return streams.fail(EXIT_NO_DAEMON, "a shepherd is starting up; try again");
+        }
+        Shepherd::Absent => return streams.fail(EXIT_NO_DAEMON, "no shepherd running"),
     };
     // SIGTERM, not SIGKILL: the daemon's own handler runs the kill ladder
     // over every sheep before it exits, so the flock stops cleanly.

--- a/docs/writing-plans/plans/2026-08-29-handover-phase1.md
+++ b/docs/writing-plans/plans/2026-08-29-handover-phase1.md
@@ -1,0 +1,608 @@
+# Daemon handover, phase 1: guard and recovery
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make a version-skewed shep say so, name the fix, and always be recoverable without the socket, and ship `shep daemon reload` as the one command that fix names.
+
+**Architecture:** Three seams. A public liveness helper in `shep-daemon::boot` that proves a pid belongs to shep by failing to take its pidfile lock, which both `shep kill` and `shep daemon reload` use to reach a daemon the socket cannot. A client-side version comparison against `HelloAck.daemon_version`, which already crosses the wire, with three verbs exempt so the remedy is never itself guarded. And `shep daemon reload` as a verb whose stop-and-start arm ships now and whose handover arm lands in phase 2.
+
+**Tech Stack:** Rust 2024, MSRV 1.88. `nix` for signals and `flock` on unix, `std::fs` share-mode on Windows. `clap` derive for the CLI. No new dependencies.
+
+**Spec:** [docs/brainstorming/specs/2026-08-29-daemon-handover-design.md](../../brainstorming/specs/2026-08-29-daemon-handover-design.md)
+
+## What this phase deliberately does NOT build
+
+The `execve` handover itself. Phase 1 ships the guard, the recovery path, and the verb; phase 2 replaces that verb's mechanism from underneath without changing its name or its output shape.
+
+**One refinement to the spec's H7, made while planning and worth stating.** H7 lists "the signal handler" among the things worth landing early. Taken literally that means a SIGHUP handler that hands over nothing, which buys nothing on its own, because a phase 2 CLI picks its arm by version and would never signal a phase 1 daemon anyway. It is still worth building, for a different reason: SIGHUP's default disposition is to terminate the process. A phase 1 daemon that installs SIGHUP as an alias for its existing graceful stop can never be killed uncleanly by a stray or mistaken handover signal, and the flock goes down the kill ladder instead of being orphaned with broken pipes. That is defence in depth rather than the load-bearing reason, so Task 3 states it that way.
+
+## Global Constraints
+
+- MSRV 1.88, edition 2024. No new crate dependencies in any task.
+- `#![forbid(unsafe_code)]` holds in shep-core, shep-client and shep-cli. Unsafe belongs only in `shep-daemon/src/sys.rs` and `sys_windows.rs`, with per-block `// SAFETY:`.
+- Every new public item needs a doc comment, a `# Errors` section if it returns `Result`, and a deliberate `Debug` decision. Redact anything carrying env or secrets, with an exact-string test (IR-41).
+- `core::error::Error`, never `std::error::Error`.
+- Do not widen an input grammar beyond what this plan states.
+- **Invoke the `shep-idiomatic-rust` skill before writing any Rust.** Cite rules as `IR-<n>` in review.
+- Every task's inner loop is `cargo test -p shep-daemon --lib --all-features -- --skip ::slow::` for daemon-side work and `cargo test -p shep --lib --bins --all-features -- --skip ::slow::` for CLI-side work. **One cargo shape per task.** Do not alternate `--workspace` with `-p`; the feature unification churn costs minutes each way.
+- The package is `shep`, not `shep-cli`. `-p shep-cli` runs zero tests and exits 0.
+- Task gate, once per task, each from its own command with `$?` captured directly and never through a pipe: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`, `cargo test --workspace --all-features`, `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features`.
+- **`PROTOCOL_VERSION` does not move in this phase.** Task 4 adds an optional field to an existing error type, which is additive. Confirm the codec tolerates unknown fields before relying on that; if it does not, Task 4's fallback applies.
+- Repo-relative paths only, in code, comments and commit messages. Never an absolute local path.
+- Do not name any person in code, comments, commit messages or docs.
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `crates/shep-daemon/src/boot.rs` | gains `daemon_liveness`, the public proof-of-life helper, and makes `read_pidfile` reachable |
+| `crates/shep-daemon/src/boot.rs` (signals) | gains SIGHUP as an alias for the existing graceful stop |
+| `crates/shep-daemon/src/server.rs` | the protocol refusal gains the daemon's crate version |
+| `crates/shep-core/src/protocol/*` | `RpcError` gains one optional field |
+| `crates/shep-cli/src/commands/admin.rs` | `kill` gains its socket-free fallback |
+| `crates/shep-cli/src/commands/daemon.rs` | hosts the new `daemon reload` subcommand |
+| `crates/shep-cli/src/cli.rs` | `DaemonArgs` gains an optional subcommand |
+| `crates/shep-cli/src/lib.rs` | the version guard, the exempt list, and the `flock` blanket-catch fix |
+| `web/src/pages/docs/*` | the upgrade note |
+
+---
+
+### Task 1: prove a pid belongs to shep
+
+**Files:**
+- Modify: `crates/shep-daemon/src/boot.rs` (`read_pidfile` at :240, `PidfileLock` at :313)
+- Test: same file, in its existing `mod tests`
+
+**Interfaces:**
+- Produces: `pub fn daemon_liveness(paths: &ShepPaths) -> Result<Option<u32>, BootError>` — `Ok(Some(pid))` when a live daemon holds the lock, `Ok(None)` when nothing does, `Err` only on a real IO failure. Tasks 2 and 7 both consume this.
+
+The pidfile alone is not proof: a stale pidfile from a crash still exists and its pid may have been reused. A live daemon HOLDS the lock, and the kernel drops it on process death, so **failing to acquire the lock is the proof of life** and the pid to report is the one recorded in the file.
+
+- [ ] **Step 1: Write the failing tests**
+
+```rust
+#[test]
+fn liveness_reports_none_when_no_daemon_holds_the_lock() {
+    let tmp = tempdir().unwrap();
+    let paths = test_paths(&tmp);
+    init_dirs(&paths).unwrap();
+    assert_eq!(daemon_liveness(&paths).unwrap(), None);
+}
+
+#[test]
+fn liveness_reports_none_for_a_stale_pidfile_nobody_holds() {
+    let tmp = tempdir().unwrap();
+    let paths = test_paths(&tmp);
+    init_dirs(&paths).unwrap();
+    std::fs::write(pidfile(&paths), "999999").unwrap();
+    // The file exists and names a pid. Nothing holds the lock, so this is
+    // NOT a live daemon and must not be reported as one.
+    assert_eq!(daemon_liveness(&paths).unwrap(), None);
+}
+
+#[test]
+fn liveness_reports_the_pid_a_lock_holder_recorded() {
+    let tmp = tempdir().unwrap();
+    let paths = test_paths(&tmp);
+    init_dirs(&paths).unwrap();
+    let mut held = PidfileLock::acquire(&paths).unwrap();
+    held.record(&paths, 4242).unwrap();
+    assert_eq!(daemon_liveness(&paths).unwrap(), Some(4242));
+    drop(held);
+    assert_eq!(daemon_liveness(&paths).unwrap(), None);
+}
+```
+
+Reuse whatever `tempdir`/`test_paths` helper `boot.rs`'s existing `mod tests` already uses; do not add a new one. Read `pidfile_round_trips_and_reports_absence` at :1783 first and follow its setup exactly.
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `cargo test -p shep-daemon --lib --all-features -- --skip ::slow:: liveness`
+Expected: FAIL, `cannot find function daemon_liveness`
+
+- [ ] **Step 3: Implement**
+
+```rust
+/// Whether a live shepherd owns this home, and what pid it recorded.
+///
+/// Proof of life is the pidfile LOCK, never the pidfile's contents. A live
+/// daemon holds that lock for its whole run and the kernel drops it on
+/// process death, `SIGKILL` included, so a failure to acquire it is the
+/// only evidence that cannot be faked by a stale file whose pid has since
+/// been reused.
+///
+/// Returns `Ok(None)` when the lock is free, whatever the file says.
+///
+/// # Errors
+/// - [`BootError::Io`] — the lock directory could not be read or created.
+///   A contended lock is NOT an error here; it is the `Some` case.
+pub fn daemon_liveness(paths: &ShepPaths) -> Result<Option<u32>, BootError> {
+    match PidfileLock::acquire(paths) {
+        // We took it, so nobody else holds it. Release immediately: this
+        // helper answers a question, it does not claim the home.
+        Ok(lock) => {
+            drop(lock);
+            Ok(None)
+        }
+        Err(BootError::AlreadyRunning { pid, .. }) => Ok(pid),
+        Err(other) => Err(other),
+    }
+}
+```
+
+Verify `BootError::AlreadyRunning`'s real field shape at its definition before writing this match; the plan's `{ pid, .. }` is the expected shape, not a confirmed one. If it carries `Option<u32>` the arm returns it directly; if it carries a bare `u32`, wrap it in `Some`.
+
+Also widen `read_pidfile` from `pub(crate)` to `pub` if `daemon_liveness` ends up needing it, and give it a doc comment saying it reports what was RECORDED and is not evidence of life.
+
+- [ ] **Step 4: Run to verify they pass**
+
+Run: `cargo test -p shep-daemon --lib --all-features -- --skip ::slow:: liveness`
+Expected: PASS, 3 tests
+
+- [ ] **Step 5: Task gate, then commit**
+
+```bash
+git add crates/shep-daemon/src/boot.rs
+git commit -m "feat(daemon): expose whether a live shepherd owns this home
+
+The pidfile lock is the only proof of life that a stale file cannot fake.
+A live daemon holds it for its whole run and the kernel drops it on death,
+so failing to acquire it is evidence and reading the file is not.
+
+Exposed because shep kill and shep daemon reload both need to reach a
+daemon whose socket is refusing them, and both must refuse to signal a pid
+they cannot prove is shep's."
+```
+
+---
+
+### Task 2: `shep kill` stops a daemon that will not talk
+
+**Files:**
+- Modify: `crates/shep-cli/src/commands/admin.rs`
+- Test: same file, in its existing `mod tests`
+
+**Interfaces:**
+- Consumes: `shep_daemon::boot::daemon_liveness` from Task 1.
+
+Today `kill` handshakes, so it cannot stop a daemon that refuses the handshake. That is what bricked a box: a live daemon, a live flock, and no command in shep able to stop it.
+
+SIGTERM is already the right signal. The daemon's handler drives the graceful teardown that runs the kill ladder over every online sheep before stopping, so the flock stops cleanly rather than being orphaned.
+
+- [ ] **Step 1: Write the failing tests**
+
+```rust
+#[tokio::test]
+async fn kill_falls_back_to_the_pidfile_when_the_handshake_refuses() {
+    // A daemon that answers the socket but refuses at the handshake is
+    // the incident case: kill must still stop it.
+    let fixture = refusing_daemon().await;
+    let code = kill_with_wait(fixture.client(), &mut streams, SHORT_WAIT).await;
+    assert_eq!(code, ExitCode::SUCCESS);
+    assert!(fixture.received_sigterm());
+}
+
+#[tokio::test]
+async fn kill_refuses_a_pid_the_lock_does_not_prove_is_sheps() {
+    let tmp = tempdir().unwrap();
+    let paths = test_paths(&tmp);
+    init_dirs(&paths).unwrap();
+    std::fs::write(boot::pidfile(&paths), "999999").unwrap();
+    // Stale file, nothing holds the lock. Signalling 999999 could hit an
+    // unrelated process, so this must refuse rather than guess.
+    let code = kill_socket_free(&paths, &mut streams).await;
+    assert_ne!(code, ExitCode::SUCCESS);
+    assert!(streams.err_contains("no shepherd"));
+}
+```
+
+Follow the fixture style already in `admin.rs`'s `mod tests`. Note its comment at :200 explaining that `cfg(unix)` there is about the FAKE's mechanism, not the feature.
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `cargo test -p shep --lib --bins --all-features -- --skip ::slow:: kill_`
+Expected: FAIL, unresolved function
+
+- [ ] **Step 3: Implement**
+
+Add a socket-free path that runs when the socket cannot be used for any reason, refusal included:
+
+```rust
+/// Stops a shepherd without the socket, for when the socket is the problem.
+///
+/// Proves the pid via [`boot::daemon_liveness`] before signalling, because
+/// a stale pidfile's pid may since have been reused and shep must never
+/// signal a process it cannot show is its own.
+///
+/// # Errors
+/// Reports, and exits non-zero, when no live shepherd owns this home.
+async fn kill_socket_free(paths: &ShepPaths, streams: &mut Streams<'_>) -> ExitCode {
+    let Some(pid) = boot::daemon_liveness(paths).unwrap_or(None) else {
+        return streams.fail(EXIT_NO_DAEMON, "no shepherd running");
+    };
+    // SIGTERM, not SIGKILL: the daemon's own handler runs the kill ladder
+    // over every sheep before it exits, so the flock stops cleanly.
+    signal::kill(Pid::from_raw(pid as i32), Signal::SIGTERM)?;
+    wait_for_socket_to_disappear(&socket, KILL_TEARDOWN_WAIT).await;
+    ...
+}
+```
+
+Reuse the existing `wait_for_socket_to_disappear` so the socket-free path gets the same two-armed unix/Windows completion check the socket path already has. Do not write a second waiter.
+
+Windows has no SIGTERM. Gate the signal send `#[cfg(unix)]` and on Windows report that the socket-free stop is not available, naming what the operator can do instead. Do not guess at a Windows equivalent.
+
+- [ ] **Step 4: Run to verify they pass**
+
+Run: `cargo test -p shep --lib --bins --all-features -- --skip ::slow:: kill_`
+Expected: PASS
+
+- [ ] **Step 5: Task gate, then commit**
+
+```bash
+git add crates/shep-cli/src/commands/admin.rs
+git commit -m "fix(cli): shep kill can stop a daemon that refuses the handshake
+
+Every verb that reaches the daemon went through the handshake, kill
+included, so a protocol-skewed daemon could not be stopped by any command
+in shep. That left a live daemon, a live flock and no path forward.
+
+kill now falls back to the pidfile when the socket cannot be used, and
+proves the pid via the lock before signalling: a stale pidfile's pid may
+have been reused, and shep must never signal a process it cannot show is
+its own. SIGTERM rather than SIGKILL, because the daemon's handler runs the
+kill ladder over every sheep before exiting."
+```
+
+---
+
+### Task 3: SIGHUP can never kill the shepherd uncleanly
+
+**Files:**
+- Modify: `crates/shep-daemon/src/boot.rs` (signal installer, around :1394)
+- Test: same file
+
+SIGHUP's default disposition terminates the process. Phase 2 uses SIGHUP as the handover trigger, and a phase 2 CLI picks its arm by version so it should never signal a daemon too old to hand over. This task is the floor under that: a stray or mistaken SIGHUP takes the graceful path instead of dropping the flock with broken pipes.
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+#[test]
+fn sighup_is_installed_alongside_the_shutdown_signals() {
+    // Phase 2 sends SIGHUP to hand over. Until that exists, SIGHUP must be
+    // a graceful stop rather than the kernel default, which is an
+    // unhandled terminate that would orphan the flock.
+    let installed = shutdown_signal_kinds();
+    assert!(installed.contains(&SignalKind::hangup()));
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cargo test -p shep-daemon --lib --all-features -- --skip ::slow:: sighup`
+Expected: FAIL
+
+- [ ] **Step 3: Implement**
+
+Add `SignalKind::hangup()` to the existing list at :1394 alongside `terminate`, `interrupt` and `quit`. The comment at :1317 says the list is not iterated because each is parameterised by a `SignalKind`; keep that shape and add one entry.
+
+Document at the call site why hangup is in a list of shutdown signals:
+
+```rust
+// SIGHUP is here as a floor, not as its final meaning. It becomes the
+// handover trigger, and until it does its kernel default is an unhandled
+// terminate that would drop the flock's pipes rather than walk the ladder.
+// A daemon that treats it as a graceful stop can be signalled by a newer
+// client without the flock paying for the version gap.
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `cargo test -p shep-daemon --lib --all-features -- --skip ::slow:: sighup`
+Expected: PASS
+
+- [ ] **Step 5: Task gate, then commit**
+
+---
+
+### Task 4: the protocol refusal names the daemon's version
+
+**Files:**
+- Modify: `crates/shep-core/src/protocol/` (the `RpcError` definition)
+- Modify: `crates/shep-daemon/src/server.rs` (:475)
+- Test: both files
+
+**Interfaces:**
+- Produces: `RpcError.daemon_version: Option<String>`, consumed by Task 7's arm selection.
+
+To choose between the handover arm and the stop arm, the CLI must know the running daemon's version. `HelloAck.daemon_version` answers it on a clean handshake, but a protocol refusal reports the daemon's PROTOCOL and not its version, and a protocol bump is exactly when a reload matters most.
+
+This cannot help the upgrade that introduces it, since daemons already shipped will never send it. That is the same one-time cost the handover carries, and it is why the field is worth adding a phase early.
+
+- [ ] **Step 1: Confirm the codec tolerates unknown fields**
+
+Before writing anything, prove that an OLD client deserializing a NEW `RpcError` with an extra field does not error. Write a test that serializes the new shape and deserializes it into a struct without the field.
+
+```rust
+#[test]
+fn an_old_client_ignores_a_field_it_has_never_seen() {
+    #[derive(serde::Deserialize)]
+    struct OldRpcError { code: RpcErrorCode, message: String }
+    let new = serde_json::json!({
+        "code": "protocol_mismatch",
+        "message": "...",
+        "daemon_version": "0.1.16"
+    });
+    let old: OldRpcError = serde_json::from_value(new).expect("must tolerate");
+    assert_eq!(old.message, "...");
+}
+```
+
+**If this test cannot pass** because the type carries `deny_unknown_fields`, do NOT remove that attribute. Fall back to embedding the version in the refusal's `message` and have Task 7 parse it, and record the reason in the commit message.
+
+- [ ] **Step 2: Write the failing test for the refusal**
+
+```rust
+#[tokio::test]
+async fn a_protocol_refusal_carries_the_daemon_version() {
+    let refusal = handshake_with_protocol(PROTOCOL_VERSION + 1).await.unwrap_err();
+    assert_eq!(refusal.code, RpcErrorCode::ProtocolMismatch);
+    assert_eq!(refusal.daemon_version.as_deref(), Some(env!("CARGO_PKG_VERSION")));
+}
+```
+
+- [ ] **Step 3: Run to verify it fails**
+
+Run: `cargo test -p shep-daemon --lib --all-features -- --skip ::slow:: protocol_refusal`
+Expected: FAIL, no field `daemon_version`
+
+- [ ] **Step 4: Implement**
+
+Add the field with `#[serde(default, skip_serializing_if = "Option::is_none")]` so a daemon that has nothing to say serializes exactly as before, then populate it at `server.rs:475`, which today reads `hello.protocol` and discards the rest.
+
+- [ ] **Step 5: Run to verify it passes, then task gate and commit**
+
+---
+
+### Task 5: the CLI refuses a daemon whose version differs
+
+**Files:**
+- Modify: `crates/shep-cli/src/lib.rs`
+- Test: same file
+
+Not just a protocol mismatch. Any difference. The dangerous state was believing `cargo install shep` upgrades a running system. It does not, it never did, and a check that says so is worth more than one that lets a mixed pair limp along.
+
+`HelloAck` already carries `daemon_version` and `Client::daemon()` already exposes it, so this is a client-side comparison against `CARGO_PKG_VERSION` with no wire change.
+
+**Three verbs stay exempt: `kill`, `daemon reload`, `ping`.** The first two are how an operator gets out, `ping` is how they see what is running. A guard whose remedy is itself guarded is the trap this design exists to remove.
+
+- [ ] **Step 1: Write the failing tests**
+
+```rust
+#[tokio::test]
+async fn a_version_difference_with_no_protocol_difference_is_refused() {
+    // The case a protocol-only check misses entirely.
+    let client = fake_daemon().version("0.1.8").protocol(PROTOCOL_VERSION).await;
+    let code = run_verb(Commands::Flock(..), client).await;
+    assert_eq!(code, EXIT_VERSION_SKEW);
+}
+
+#[tokio::test]
+async fn the_error_names_the_command_that_fixes_it() {
+    let out = refused_output().await;
+    assert!(out.contains("this shep is"), "{out}");
+    assert!(out.contains("the running shepherd is 0.1.8"), "{out}");
+    assert!(out.contains("shep daemon reload"), "{out}");
+}
+
+#[tokio::test]
+async fn the_three_recovery_verbs_are_not_refused() {
+    for verb in [Verb::Kill, Verb::DaemonReload, Verb::Ping] {
+        let client = fake_daemon().version("0.1.8").await;
+        assert_ne!(run_verb(verb, client).await, EXIT_VERSION_SKEW, "{verb:?}");
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `cargo test -p shep --lib --bins --all-features -- --skip ::slow:: version_`
+Expected: FAIL
+
+- [ ] **Step 3: Implement**
+
+The message names the fix rather than the condition. Exact text, and Step 1's tests pin it:
+
+```
+error[version_skew]: this shep is 0.1.15, the running shepherd is 0.1.8
+
+`cargo install shep` replaced the binary. It did not restart the
+shepherd, which is still running the old code.
+
+  shep daemon reload
+```
+
+Put the exempt list in one named constant with a doc comment giving the reason, not an inline match arm. A future verb added to it should have to read why.
+
+- [ ] **Step 4: Run to verify they pass, then task gate and commit**
+
+---
+
+### Task 6: a refusal is not an absence
+
+**Files:**
+- Modify: `crates/shep-cli/src/lib.rs` (:1285)
+- Test: same file
+
+`lib.rs:1285` is a blanket `Err(_) => query::flock_from_roll(&mut streams, &paths)`, so any connect failure prints "no shepherd running". During the incident the daemon was alive and answering; it answered the refusal. That sent the operator to the muster-roll path rather than the reload path.
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+#[tokio::test]
+async fn flock_reports_a_refusal_as_a_refusal_not_as_no_daemon() {
+    let client = fake_daemon().refusing_handshake().await;
+    let out = run_flock(client).await;
+    assert!(!out.contains("no shepherd running"), "a refusal is not an absence: {out}");
+    assert!(out.contains("shep daemon reload"), "{out}");
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Expected: FAIL, the output contains "no shepherd running"
+
+- [ ] **Step 3: Implement**
+
+Narrow the blanket catch so it distinguishes "could not connect at all", which is genuinely no daemon and keeps the roll fallback, from "connected and was refused", which is a live daemon and must say so. Match on the error, not on `_`.
+
+- [ ] **Step 4: Run to verify it passes, then task gate and commit**
+
+---
+
+### Task 7: `shep daemon reload`
+
+**Files:**
+- Modify: `crates/shep-cli/src/cli.rs` (`DaemonArgs`)
+- Create: `crates/shep-cli/src/commands/daemon.rs` if the verb needs its own module, otherwise extend the existing one
+- Test: alongside
+
+**Interfaces:**
+- Consumes: `daemon_liveness` (Task 1), `RpcError.daemon_version` (Task 4).
+
+`DaemonArgs` is a flat flags struct today, and `shep daemon` with no subcommand is how the binary re-execs itself to daemonize. So it gains `#[command(subcommand)] pub cmd: Option<DaemonCmd>` where `None` keeps today's boot behaviour exactly. **A bare `shep daemon` must still boot.** Test that explicitly; breaking it breaks daemonization itself.
+
+Phase 1 ships the stop arm only. It reports what happened to each sheep rather than announcing that the flock stopped, because phase 2's handover does not stop it and the same output shape has to be true under both.
+
+- [ ] **Step 1: Write the failing tests**
+
+```rust
+#[test]
+fn a_bare_shep_daemon_still_boots_and_is_not_a_subcommand_error() {
+    let parsed = Cli::try_parse_from(["shep", "daemon"]).expect("must still parse");
+    let Commands::Daemon(args) = parsed.command else { panic!() };
+    assert!(args.cmd.is_none(), "bare `shep daemon` must remain the boot path");
+}
+
+#[tokio::test]
+async fn reload_picks_the_stop_arm_against_a_daemon_too_old_to_hand_over() {
+    let client = fake_daemon().version("0.1.8").await;
+    assert_eq!(reload_arm_for(&client).await, Arm::StopAndStart);
+}
+
+#[tokio::test]
+async fn reload_picks_the_stop_arm_when_the_handshake_is_refused_without_a_version() {
+    // An old daemon's refusal carries no daemon_version (Task 4 cannot
+    // reach backwards). Unknown must mean the safe arm, never the fast one.
+    let client = fake_daemon().refusing_handshake().without_version().await;
+    assert_eq!(reload_arm_for(&client).await, Arm::StopAndStart);
+}
+
+#[tokio::test]
+async fn reload_reports_each_sheep_rather_than_announcing_the_flock_stopped() {
+    let out = run_reload(two_sheep()).await;
+    // NOTE: sheep DO stop under phase 1's stop arm. This asserts the output
+    // SHAPE, which must stay true when phase 2 stops stopping them.
+    assert!(out.contains("web"), "{out}");
+    assert!(!out.to_lowercase().contains("flock stopped"), "{out}");
+}
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `cargo test -p shep --lib --bins --all-features -- --skip ::slow:: reload`
+
+- [ ] **Step 3: Implement**
+
+Arm selection, with unknown always meaning the safe arm:
+
+```rust
+/// Which mechanism a reload will use.
+///
+/// `StopAndStart` is not a fallback to be removed later. It is the
+/// permanent answer for Windows, which has no `exec`; for any daemon
+/// predating the handover, which cannot be taught to hand over after the
+/// fact; and for a handover that fails to rehydrate.
+#[derive(Debug, PartialEq, Eq)]
+enum Arm { Handover, StopAndStart }
+```
+
+The stop arm composes three things that already exist: SIGTERM the proven pid, wait for it using the existing waiter, spawn a new daemon, then muster. Do not write a fourth mechanism.
+
+`Arm::Handover` is unreachable in phase 1. Return it from nothing yet, and leave the variant with a doc comment saying phase 2 fills it. Do NOT add a stub that pretends to hand over.
+
+- [ ] **Step 4: Run to verify they pass, then task gate and commit**
+
+---
+
+### Task 8: the docs say the thing nobody knew
+
+**Files:**
+- Modify: `web/src/pages/docs/getting-started.astro` (install step)
+- Modify: whichever page carries the upgrade guidance, found by grep rather than assumed
+- Regenerate: `web/src/content/cli/` via the script
+
+`cargo install shep` upgrades the binary and nothing else. The running daemon keeps the old code until it is reloaded, and every dog keeps its own until it is reinstalled.
+
+Per the repo's docs trigger, this task changed what an operator types and sees, so the CLI reference must be regenerated and the site must build.
+
+- [ ] **Step 1: Add the upgrade note and the happy path**
+
+```
+cargo install shep
+cargo install shep-log-rotate   # and every other dog
+shep daemon reload
+```
+
+**No pm2 comparison anywhere.** Direct comparison lives only in `from-pm2.astro`; link there if a migrating reader would want it.
+
+- [ ] **Step 2: Regenerate the CLI reference**
+
+```bash
+cargo build --release
+```
+```bash
+./web/scripts/generate-cli-reference.sh
+```
+
+`git diff` afterwards is the check. A stale copy fails no build, which is why it drifts.
+
+- [ ] **Step 3: Build and typecheck the site**
+
+```bash
+cd web && npx astro check
+```
+```bash
+cd web && npx astro build
+```
+
+Both must exit 0. `astro check` is the one that catches a wrong component prop; `astro build` is green on a prop that does not exist.
+
+- [ ] **Step 4: Commit**
+
+---
+
+## Phase gate
+
+After Task 8, and not per task:
+
+```bash
+cargo test --workspace --all-features -- --test-threads=1
+```
+```bash
+cargo check -p shep-daemon --all-targets --all-features --target x86_64-unknown-linux-gnu
+```
+```bash
+cargo check --workspace --all-targets --all-features --target x86_64-pc-windows-gnu
+```
+
+Give the cross-checks their own `CARGO_TARGET_DIR` so they do not invalidate the host cache.
+
+**Read the CI result before calling the branch green.** The local gate does not run Linux or Windows tests: `cargo test` on a Mac never compiles a `cfg(windows)` item, and the windows-gnu cross-check is `cargo check`, which executes nothing.
+
+## Self-review checklist
+
+- Every spec decision in Part 1 (H3, H4, H5, H6) and Part 2 (G1 through G5) maps to a task above. Part 3 (dogs) and the `execve` handover itself are deliberately out of scope and get their own plans.
+- Task 4 is the only one that touches the wire, and it is additive. `PROTOCOL_VERSION` does not move.
+- `SCHEMA_VERSION` does not move either. Nothing here renames, removes or retypes a JSON field.
+- Task 7 depends on Tasks 1 and 4. Task 2 depends on Task 1. Tasks 3, 5, 6 are independent and can run in parallel with each other.

--- a/docs/writing-plans/plans/2026-08-29-handover-phase1.md
+++ b/docs/writing-plans/plans/2026-08-29-handover-phase1.md
@@ -488,13 +488,57 @@ Put the exempt list in one named constant with a doc comment giving the reason, 
 
 ---
 
+### Task 5b: the verbs that connect on their own are guarded too
+
+**Files:**
+- Modify: `crates/shep-cli/src/lookout/source.rs` (:235)
+- Modify: `crates/shep-cli/src/whistle/shepherd.rs` (:74)
+- Modify: `crates/shep-cli/src/commands/foreground.rs` (:118)
+- Modify: `crates/shep-cli/src/lib.rs` (make the guard reachable)
+- Test: alongside each
+
+**Added after Task 5, which reported the gap rather than silently widening its own scope.** Task 5 guarded the three seams in `lib.rs` that hand back a `Client`. Three operator-facing verbs bypass those seams entirely by calling `Client::connect` inside their own module, so they connect to a version-skewed daemon and proceed as if nothing were wrong.
+
+Spec G1 says the CLI refuses any daemon whose crate version differs. It does not say most verbs do. A `shep lookout` that renders a dashboard against a daemon it cannot agree with is exactly the silent mixed state this design exists to remove.
+
+**Interfaces:**
+- Consumes: `refuse_version_skew(streams, client, guard) -> Result<(), ExitCode>` and `VersionGuard`, both currently private in `lib.rs`. Widen to `pub(crate)` rather than duplicating the check. `serve.rs` already names `crate::VersionGuard::Enforce` at its call site, so that precedent exists.
+
+**Out of scope, with reasons, so a later reader does not think they were missed:**
+
+- `crates/shep-cli/src/dog/mod.rs:186` is a DOG's own connection to the daemon, not an operator verb. The dog version axis is Phase 3's whole subject and has its own rules there, including the one-restart-then-report behaviour. Guarding it here would pre-empt that design.
+- `crates/shep-cli/src/commands/dogs.rs` calls `Client::connect(..).ok()` at four sites, deliberately tolerating an absent daemon. That `.ok()` swallows a refusal and reports it as an absence, which is the same defect as Task 6's, not this one. Task 6 covers it.
+- `status.rs:70` is `ping` and `admin.rs:61` is `kill`. Both are exempt by design; leave them.
+
+- [ ] **Step 1: Write the failing tests**
+
+One per verb, each asserting the verb refuses with `ExitCode::VersionSkew` against a daemon reporting a different version, and proceeds normally against a matching one. Use `shep_client::testing::fake_client_with_ack`, which is the fixture Task 5 found works; the plan's earlier `fake_daemon().version(..)` shape does not exist.
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `cargo test -p shep --lib --bins --all-features -- --skip ::slow:: version_skew`
+
+- [ ] **Step 3: Widen the guard and call it at each site**
+
+`refuse_version_skew` and `VersionGuard` become `pub(crate)`. Each of the three sites calls it immediately after its `Client::connect` succeeds, before doing anything with the client.
+
+None of the three is a recovery verb, so each passes `VersionGuard::Enforce` directly rather than being threaded one, matching what `serve.rs` already does. Put a one-line comment at each site saying why that verb can never be exempt: `lookout` and `whistle` both drive the daemon, and `foreground` registers a sheep.
+
+- [ ] **Step 4: Run to verify they pass**
+
+- [ ] **Step 5: Task gate, then commit**
+
+---
+
 ### Task 6: a refusal is not an absence
 
 **Files:**
 - Modify: `crates/shep-cli/src/lib.rs` (:1285)
 - Test: same file
 
-`lib.rs:1285` is a blanket `Err(_) => query::flock_from_roll(&mut streams, &paths)`, so any connect failure prints "no shepherd running". During the incident the daemon was alive and answering; it answered the refusal. That sent the operator to the muster-roll path rather than the reload path.
+`lib.rs:1285` is a blanket `Err(_) => query::flock_from_roll(&mut streams, &paths)`, so any connect failure prints "no shepherd running".
+
+**`commands/dogs.rs` has the same defect in a different shape, at four sites.** Each does `Client::connect(&paths.socket).await.ok()`, and that `.ok()` turns a refusal into `None` exactly as the blanket `Err(_)` turns it into a roll fallback. Fix both here; they are one bug wearing two spellings. Task 5b deliberately left these alone as belonging to this task. During the incident the daemon was alive and answering; it answered the refusal. That sent the operator to the muster-roll path rather than the reload path.
 
 - [ ] **Step 1: Write the failing test**
 

--- a/docs/writing-plans/plans/2026-08-29-handover-phase1.md
+++ b/docs/writing-plans/plans/2026-08-29-handover-phase1.md
@@ -510,23 +510,23 @@ Spec G1 says the CLI refuses any daemon whose crate version differs. It does not
 - `crates/shep-cli/src/commands/dogs.rs` calls `Client::connect(..).ok()` at four sites, deliberately tolerating an absent daemon. That `.ok()` swallows a refusal and reports it as an absence, which is the same defect as Task 6's, not this one. Task 6 covers it.
 - `status.rs:70` is `ping` and `admin.rs:61` is `kill`. Both are exempt by design; leave them.
 
-- [ ] **Step 1: Write the failing tests**
+- [x] **Step 1: Write the failing tests**
 
 One per verb, each asserting the verb refuses with `ExitCode::VersionSkew` against a daemon reporting a different version, and proceeds normally against a matching one. Use `shep_client::testing::fake_client_with_ack`, which is the fixture Task 5 found works; the plan's earlier `fake_daemon().version(..)` shape does not exist.
 
-- [ ] **Step 2: Run to verify they fail**
+- [x] **Step 2: Run to verify they fail**
 
 Run: `cargo test -p shep --lib --bins --all-features -- --skip ::slow:: version_skew`
 
-- [ ] **Step 3: Widen the guard and call it at each site**
+- [x] **Step 3: Widen the guard and call it at each site**
 
 `refuse_version_skew` and `VersionGuard` become `pub(crate)`. Each of the three sites calls it immediately after its `Client::connect` succeeds, before doing anything with the client.
 
 None of the three is a recovery verb, so each passes `VersionGuard::Enforce` directly rather than being threaded one, matching what `serve.rs` already does. Put a one-line comment at each site saying why that verb can never be exempt: `lookout` and `whistle` both drive the daemon, and `foreground` registers a sheep.
 
-- [ ] **Step 4: Run to verify they pass**
+- [x] **Step 4: Run to verify they pass**
 
-- [ ] **Step 5: Task gate, then commit**
+- [x] **Step 5: Task gate, then commit**
 
 ---
 

--- a/docs/writing-plans/plans/2026-08-29-handover-phase1.md
+++ b/docs/writing-plans/plans/2026-08-29-handover-phase1.md
@@ -68,7 +68,7 @@ fn liveness_reports_none_when_no_daemon_holds_the_lock() {
     let tmp = tempdir().unwrap();
     let paths = test_paths(&tmp);
     init_dirs(&paths).unwrap();
-    assert_eq!(daemon_liveness(&paths).unwrap(), None);
+    assert_eq!(daemon_liveness(&paths).unwrap(), Shepherd::Absent);
 }
 
 #[test]
@@ -79,7 +79,7 @@ fn liveness_reports_none_for_a_stale_pidfile_nobody_holds() {
     std::fs::write(pidfile(&paths), "999999").unwrap();
     // The file exists and names a pid. Nothing holds the lock, so this is
     // NOT a live daemon and must not be reported as one.
-    assert_eq!(daemon_liveness(&paths).unwrap(), None);
+    assert_eq!(daemon_liveness(&paths).unwrap(), Shepherd::Absent);
 }
 
 #[test]
@@ -89,9 +89,9 @@ fn liveness_reports_the_pid_a_lock_holder_recorded() {
     init_dirs(&paths).unwrap();
     let mut held = PidfileLock::acquire(&paths).unwrap();
     held.record(&paths, 4242).unwrap();
-    assert_eq!(daemon_liveness(&paths).unwrap(), Some(4242));
+    assert_eq!(daemon_liveness(&paths).unwrap(), Shepherd::Running(4242));
     drop(held);
-    assert_eq!(daemon_liveness(&paths).unwrap(), None);
+    assert_eq!(daemon_liveness(&paths).unwrap(), Shepherd::Absent);
 }
 ```
 
@@ -118,15 +118,16 @@ Expected: FAIL, `cannot find function daemon_liveness`
 /// # Errors
 /// - [`BootError::Io`] — the lock directory could not be read or created.
 ///   A contended lock is NOT an error here; it is the `Some` case.
-pub fn daemon_liveness(paths: &ShepPaths) -> Result<Option<u32>, BootError> {
+pub fn daemon_liveness(paths: &ShepPaths) -> Result<Shepherd, BootError> {
     match PidfileLock::acquire(paths) {
         // We took it, so nobody else holds it. Release immediately: this
         // helper answers a question, it does not claim the home.
         Ok(lock) => {
             drop(lock);
-            Ok(None)
+            Ok(Shepherd::Absent)
         }
-        Err(BootError::AlreadyRunning { pid, .. }) => Ok(pid),
+        Err(BootError::AlreadyRunning { pid: Some(pid) }) => Ok(Shepherd::Running(pid)),
+        Err(BootError::AlreadyRunning { pid: None }) => Ok(Shepherd::Booting),
         Err(other) => Err(other),
     }
 }
@@ -644,7 +645,7 @@ The stop arm composes three things that already exist: SIGTERM the proven pid, w
 **Files:**
 - Modify: `web/src/pages/docs/getting-started.astro` (install step)
 - Modify: whichever page carries the upgrade guidance, found by grep rather than assumed
-- Regenerate: `web/src/content/cli/` via the script
+- Regenerate: `web/src/data/cli-reference.generated.txt`, which is what `web/scripts/generate-cli-reference.sh` actually writes
 
 `cargo install shep` upgrades the binary and nothing else. The running daemon keeps the old code until it is reloaded, and every dog keeps its own until it is reinstalled.
 

--- a/docs/writing-plans/plans/2026-08-29-handover-phase1.md
+++ b/docs/writing-plans/plans/2026-08-29-handover-phase1.md
@@ -336,7 +336,7 @@ To choose between the handover arm and the stop arm, the CLI must know the runni
 
 This cannot help the upgrade that introduces it, since daemons already shipped will never send it. That is the same one-time cost the handover carries, and it is why the field is worth adding a phase early.
 
-- [ ] **Step 1: Confirm the codec tolerates unknown fields**
+- [x] **Step 1: Confirm the codec tolerates unknown fields**
 
 Before writing anything, prove that an OLD client deserializing a NEW `RpcError` with an extra field does not error. Write a test that serializes the new shape and deserializes it into a struct without the field.
 
@@ -357,7 +357,7 @@ fn an_old_client_ignores_a_field_it_has_never_seen() {
 
 **If this test cannot pass** because the type carries `deny_unknown_fields`, do NOT remove that attribute. Fall back to embedding the version in the refusal's `message` and have Task 7 parse it, and record the reason in the commit message.
 
-- [ ] **Step 2: Write the failing test for the refusal**
+- [x] **Step 2: Write the failing test for the refusal**
 
 ```rust
 #[tokio::test]
@@ -368,12 +368,12 @@ async fn a_protocol_refusal_carries_the_daemon_version() {
 }
 ```
 
-- [ ] **Step 3: Run to verify it fails**
+- [x] **Step 3: Run to verify it fails**
 
 Run: `cargo test -p shep-daemon --lib --all-features -- --skip ::slow:: protocol_refusal`
 Expected: FAIL, no field `daemon_version`
 
-- [ ] **Step 4: Implement, both halves**
+- [x] **Step 4: Implement, both halves**
 
 Daemon and wire side: add the field with `#[serde(default, skip_serializing_if = "Option::is_none")]` so a daemon that has nothing to say serializes exactly as before, then populate it at `server.rs:475`, which today reads `hello.protocol` and discards the rest.
 
@@ -389,7 +389,7 @@ let ack = reply.map_err(|err| ConnectError::ProtocolMismatch {
 
 Then rewrite `ConnectError::ProtocolMismatch`'s doc at `connection.rs:77`. It says the daemon's version lives only in the prose and must not be parsed; that is exactly what this task stops being true.
 
-- [ ] **Step 4b: Test the client half separately**
+- [x] **Step 4b: Test the client half separately**
 
 The daemon-side test does not cover the flattening, which is where the field would be lost.
 
@@ -414,7 +414,7 @@ async fn an_old_daemons_refusal_still_connects_and_reports_no_version() {
 }
 ```
 
-- [ ] **Step 5: Run to verify it passes, then task gate and commit**
+- [x] **Step 5: Run to verify it passes, then task gate and commit**
 
 ---
 

--- a/docs/writing-plans/plans/2026-08-29-handover-phase1.md
+++ b/docs/writing-plans/plans/2026-08-29-handover-phase1.md
@@ -171,7 +171,7 @@ Today `kill` handshakes, so it cannot stop a daemon that refuses the handshake. 
 
 SIGTERM is already the right signal. The daemon's handler drives the graceful teardown that runs the kill ladder over every online sheep before stopping, so the flock stops cleanly rather than being orphaned.
 
-- [ ] **Step 1: Write the failing tests**
+- [x] **Step 1: Write the failing tests**
 
 ```rust
 #[tokio::test]
@@ -202,12 +202,12 @@ Add a third case: `Shepherd::Booting` must report that a shepherd is starting, n
 
 Follow the fixture style already in `admin.rs`'s `mod tests`. Note its comment at :200 explaining that `cfg(unix)` there is about the FAKE's mechanism, not the feature.
 
-- [ ] **Step 2: Run to verify they fail**
+- [x] **Step 2: Run to verify they fail**
 
 Run: `cargo test -p shep --lib --bins --all-features -- --skip ::slow:: kill_`
 Expected: FAIL, unresolved function
 
-- [ ] **Step 3: Implement**
+- [x] **Step 3: Implement**
 
 Add a socket-free path that runs when the socket cannot be used for any reason, refusal included:
 
@@ -242,12 +242,12 @@ Reuse the existing `wait_for_socket_to_disappear` so the socket-free path gets t
 
 Windows has no SIGTERM. Gate the signal send `#[cfg(unix)]` and on Windows report that the socket-free stop is not available, naming what the operator can do instead. Do not guess at a Windows equivalent.
 
-- [ ] **Step 4: Run to verify they pass**
+- [x] **Step 4: Run to verify they pass**
 
 Run: `cargo test -p shep --lib --bins --all-features -- --skip ::slow:: kill_`
 Expected: PASS
 
-- [ ] **Step 5: Task gate, then commit**
+- [x] **Step 5: Task gate, then commit**
 
 ```bash
 git add crates/shep-cli/src/commands/admin.rs

--- a/docs/writing-plans/plans/2026-08-29-handover-phase1.md
+++ b/docs/writing-plans/plans/2026-08-29-handover-phase1.md
@@ -578,7 +578,7 @@ Narrow the blanket catch so it distinguishes "could not connect at all", which i
 
 Phase 1 ships the stop arm only. It reports what happened to each sheep rather than announcing that the flock stopped, because phase 2's handover does not stop it and the same output shape has to be true under both.
 
-- [ ] **Step 1: Write the failing tests**
+- [x] **Step 1: Write the failing tests**
 
 ```rust
 #[test]
@@ -612,11 +612,11 @@ async fn reload_reports_each_sheep_rather_than_announcing_the_flock_stopped() {
 }
 ```
 
-- [ ] **Step 2: Run to verify they fail**
+- [x] **Step 2: Run to verify they fail**
 
 Run: `cargo test -p shep --lib --bins --all-features -- --skip ::slow:: reload`
 
-- [ ] **Step 3: Implement**
+- [x] **Step 3: Implement**
 
 Arm selection, with unknown always meaning the safe arm:
 
@@ -635,7 +635,7 @@ The stop arm composes three things that already exist: SIGTERM the proven pid, w
 
 `Arm::Handover` is unreachable in phase 1. Return it from nothing yet, and leave the variant with a doc comment saying phase 2 fills it. Do NOT add a stub that pretends to hand over.
 
-- [ ] **Step 4: Run to verify they pass, then task gate and commit**
+- [x] **Step 4: Run to verify they pass, then task gate and commit**
 
 ---
 

--- a/docs/writing-plans/plans/2026-08-29-handover-phase1.md
+++ b/docs/writing-plans/plans/2026-08-29-handover-phase1.md
@@ -320,10 +320,17 @@ Expected: PASS
 **Files:**
 - Modify: `crates/shep-core/src/protocol/` (the `RpcError` definition)
 - Modify: `crates/shep-daemon/src/server.rs` (:475)
-- Test: both files
+- Modify: `crates/shep-client/src/connection.rs` (the variant at :77, the flattening at :190)
+- Test: all three
 
 **Interfaces:**
-- Produces: `RpcError.daemon_version: Option<String>`, consumed by Task 7's arm selection.
+- Produces: `RpcError.daemon_version: Option<String>` AND `ConnectError::ProtocolMismatch.daemon_version: Option<String>`, consumed by Task 7's arm selection.
+
+**Both halves are required, and this plan originally specified only the first.** Found while reviewing Task 2. `crates/shep-client/src/connection.rs:190` flattens the whole `RpcError` into `ConnectError::ProtocolMismatch { client, message }`, keeping `err.message` and dropping everything else, so a field added to `RpcError` alone is discarded four lines after it arrives and Task 7 never sees it.
+
+`ConnectError::ProtocolMismatch`'s own doc at `connection.rs:77` also has to change. It currently reads "the daemon's version exists only inside this prose, never as a separate field" and tells callers not to parse the message. That was a deliberate design statement, and Task 7 needs it reversed: the version becomes a field precisely so nobody has to parse prose for it. Update the doc in the same commit rather than leaving it contradicting the type beneath it.
+
+Also add to `crates/shep-daemon/src/server.rs`'s side: the comment at `connection.rs:187` notes the flattening is "sound only because `server.rs` is the sole producer today and always sends `ProtocolMismatch`". That stays true; do not widen it.
 
 To choose between the handover arm and the stop arm, the CLI must know the running daemon's version. `HelloAck.daemon_version` answers it on a clean handshake, but a protocol refusal reports the daemon's PROTOCOL and not its version, and a protocol bump is exactly when a reload matters most.
 
@@ -366,9 +373,46 @@ async fn a_protocol_refusal_carries_the_daemon_version() {
 Run: `cargo test -p shep-daemon --lib --all-features -- --skip ::slow:: protocol_refusal`
 Expected: FAIL, no field `daemon_version`
 
-- [ ] **Step 4: Implement**
+- [ ] **Step 4: Implement, both halves**
 
-Add the field with `#[serde(default, skip_serializing_if = "Option::is_none")]` so a daemon that has nothing to say serializes exactly as before, then populate it at `server.rs:475`, which today reads `hello.protocol` and discards the rest.
+Daemon and wire side: add the field with `#[serde(default, skip_serializing_if = "Option::is_none")]` so a daemon that has nothing to say serializes exactly as before, then populate it at `server.rs:475`, which today reads `hello.protocol` and discards the rest.
+
+Client side: carry it through the flattening at `connection.rs:190`, which currently keeps only `err.message`:
+
+```rust
+let ack = reply.map_err(|err| ConnectError::ProtocolMismatch {
+    client: PROTOCOL_VERSION,
+    daemon_version: err.daemon_version,
+    message: err.message,
+})?;
+```
+
+Then rewrite `ConnectError::ProtocolMismatch`'s doc at `connection.rs:77`. It says the daemon's version lives only in the prose and must not be parsed; that is exactly what this task stops being true.
+
+- [ ] **Step 4b: Test the client half separately**
+
+The daemon-side test does not cover the flattening, which is where the field would be lost.
+
+```rust
+#[tokio::test]
+async fn a_refusal_carries_the_daemon_version_past_the_flattening() {
+    let err = connect_to_refusing_daemon().await.unwrap_err();
+    let ConnectError::ProtocolMismatch { daemon_version, .. } = err else {
+        panic!("expected a protocol refusal, got {err:?}");
+    };
+    assert_eq!(daemon_version.as_deref(), Some("0.1.16"));
+}
+
+#[tokio::test]
+async fn an_old_daemons_refusal_still_connects_and_reports_no_version() {
+    // A daemon predating this field sends no `daemon_version`. That must
+    // deserialize cleanly and read as None, not fail the handshake, or
+    // this field breaks the exact upgrade it exists to smooth.
+    let err = connect_to_refusing_daemon_without_version().await.unwrap_err();
+    let ConnectError::ProtocolMismatch { daemon_version, .. } = err else { panic!() };
+    assert_eq!(daemon_version, None);
+}
+```
 
 - [ ] **Step 5: Run to verify it passes, then task gate and commit**
 
@@ -379,6 +423,8 @@ Add the field with `#[serde(default, skip_serializing_if = "Option::is_none")]` 
 **Files:**
 - Modify: `crates/shep-cli/src/lib.rs`
 - Test: same file
+
+**Task 2 left a gap here worth closing while you are in this file.** It moved `Commands::Kill`'s dispatch from `connect_client` + `admin::kill(client, ..)` to `admin::kill(&paths, ..)`, because a handshake refusal is raised inside `Client::connect` and never yields a `Client` to hand onward. Nothing tests `run`'s dispatch arms, so that wiring is held only by the compiler. A fixture that drives `run` for one arm would cover it and would serve Task 6 too.
 
 Not just a protocol mismatch. Any difference. The dangerous state was believing `cargo install shep` upgrades a running system. It does not, it never did, and a check that says so is worth more than one that lets a mixed pair limp along.
 

--- a/web/src/data/cli-reference.generated.txt
+++ b/web/src/data/cli-reference.generated.txt
@@ -1,5 +1,5 @@
 @@VERSION@@
-shep 0.1.15
+shep 0.1.16
 @@TOPLEVEL@@
 A process manager for your flock
 
@@ -23,6 +23,7 @@ Coming from pm2  import
 Help             welcome init help completions style
 
 Aliases          flock: list, ls   bleats: logs   lookout: dash   stock: scale   whisper: sendline
+Upgrading        cargo install shep replaces the binary, not the running shepherd: shep daemon reload
 
       --format <FORMAT>
           Output format

--- a/web/src/pages/docs/getting-started.astro
+++ b/web/src/pages/docs/getting-started.astro
@@ -63,6 +63,25 @@ import CodeBlock from "../../components/docs/CodeBlock.astro";
       set up, and the five commands worth knowing.
     </p>
 
+    <h3>Upgrading later</h3>
+    <p>
+      <code>cargo install shep</code> replaces the binary on disk. It does
+      not touch anything already running: the shepherd keeps the code it
+      booted with until you reload it, and each dog keeps its own until you
+      reinstall it separately.
+    </p>
+    <div class="terminal">
+      <div><span class="prompt">$</span> cargo install shep</div>
+      <div><span class="prompt">$</span> cargo install shep-log-rotate<span class="muted"> # and every other dog</span></div>
+      <div><span class="prompt">$</span> shep daemon reload</div>
+    </div>
+    <Callout variant="careful">
+      Skip <code>shep daemon reload</code> and the new binary answers
+      <code>shep --version</code> while the running shepherd is still the
+      old one. shep refuses most verbs against a version-skewed shepherd and
+      names this exact command as the fix.
+    </Callout>
+
     <h2>2. Write a Flockfile</h2>
     <p>
       Two fields is a complete one. <code>Flockfile.toml</code>,


### PR DESCRIPTION
A box was bricked by `cargo install shep`. The binary was replaced, the old daemon kept running, and every verb that reaches the daemon was refused at the handshake. `shep kill` included, so no command in shep could stop the daemon shep was refusing to talk to.

Three failures, in order of what they cost:

- the tool could not recover itself
- `shep flock` printed "no shepherd running" about a daemon that was alive and answering. It answered the refusal
- the refusal named the problem and not the fix

This closes all three, and adds the verb the fix now points at.

What changed:

- `shep kill` falls back to the pidfile when the socket cannot be used, proving the pid via the lock before signalling. SIGTERM, so the daemon's own handler still runs the kill ladder over every sheep
- any crate-version difference is refused, not just a protocol one, and the message names `shep daemon reload` rather than describing the condition
- `kill`, `ping` and `daemon reload` are exempt. A guard whose remedy is itself guarded is the trap this exists to remove
- `shep daemon reload` stops the old shepherd, starts a new one and musters the flock back
- a refusal is no longer reported as an absence, in `flock` and in four `dogs` verbs that swallowed it through `.ok()`
- the protocol-mismatch refusal carries the daemon's version, so a future reload can pick its arm even when the handshake fails
- SIGHUP is a graceful stop, so a stray handover signal can never drop a flock uncleanly
- `shep --help` gained an `Upgrading` line, because the refusal named a verb the listing did not

Verified against two real binaries rather than fakes. 0.1.99 running as the installed daemon, 0.1.16 as the freshly installed CLI:

```
$ shep flock                          exit 12
error[version_skew]: this shep is 0.1.16, the running shepherd is 0.1.99
  shep daemon reload
$ shep ping                           exit 0   reports 0.1.99
$ shep kill                           exit 0   the command that could not run
$ shep daemon reload                  exit 0
notice[reload]: the shepherd is now 0.1.16 (pid 94272)
```

935 lib tests, 1962 workspace. Serial suite, Linux cross-check and Windows cross-check all exit 0.

Three fixes to the daemon's own docs, each found by writing something against them:

- `kill.rs` said the last rung SIGKILLs the whole process tree. It calls `signal_group(pid, SIGKILL)`, which is a process group, and a lamb that called `setsid` survives. The block comment twenty lines below already said so
- `ReloadMode` said a `reuse_port`-less overlapping reload crash-loops. Measured with `autorestart = true`: one panic, the reload aborts, and the original instance is still online on its original pid with `RESTARTS` at 0. `SpawnNew` precedes `DrainOld`, so a replacement that never reaches `AwaitReady` means `DrainOld` never runs. It fails safe
- the spec carried the same claim and now agrees

One defect found and left open, because it wants its own work: the daemon logs nothing at all about an aborted reload, so the only evidence is `EADDRINUSE` in the sheep's own stderr. That is the same shape as a version-mismatched dog reporting `online` while doing nothing.

The handover this is groundwork for is not here. `Arm::Handover` is defined, unreachable, and carries `#[expect(dead_code)]` so that constructing it in phase 2 without removing the attribute is a compile error.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `shep daemon reload` to safely stop and restart the daemon.
  * Added daemon liveness detection and improved recovery when normal connections fail.
  * Added version-skew detection with clear, machine-readable errors and recovery guidance.
* **Bug Fixes**
  * Improved handling of refused, unavailable, booting, and stale daemon connections.
  * Enhanced graceful shutdown behavior across supported platforms.
* **Documentation**
  * Added upgrade guidance and clarified reload failure behavior.
* **Tests**
  * Expanded coverage for reloads, version compatibility, shutdown, and connection errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->