### PR TITLE
chore: add FUNDING.yml for the sponsor button

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,3 @@
+# These are supported funding model platforms
+
+github: TurtIeSocks


### PR DESCRIPTION
- Adds `.github/FUNDING.yml` so the repo shows a sponsor button
- Committed here rather than relying on an account-level default, since forks inherit a committed file and the default only covers repos I own

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added GitHub Sponsors funding configuration for the project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->