### PR TITLE
feat(daemon): replace the shepherd in place, keeping the flock running

### DIFF
--- a/crates/shep-cli/src/commands/daemon.rs
+++ b/crates/shep-cli/src/commands/daemon.rs
@@ -717,10 +717,17 @@ async fn hand_over(
         Ok(pid) => pid,
         Err(code) => return code,
     };
+    // Opened BEFORE the signal, and held across it. The predecessor's
+    // accepted connections are not carried across its `execve`, so this one
+    // closing is the proof that the old image is gone. Without it there is
+    // no way to tell a successor from a predecessor that has been signalled
+    // and has not execed yet: both answer, on the same pid, at the same
+    // version.
+    let witness = Client::connect(&paths.socket).await.ok();
     if let Err((code, message)) = signal_handover(pid) {
         return streams.fail(code, &message);
     }
-    match await_successor(paths, wait).await {
+    match await_successor(paths, witness, wait).await {
         // The successor carried the flock; nothing to restore.
         Some(client) => report_reload(&client, streams, false).await,
         None => {
@@ -779,8 +786,36 @@ fn signal_handover(pid: u32) -> Result<(), (ExitCode, String)> {
 /// A connect failure inside the window is expected, not a fault: the
 /// successor is mid-boot and has not accepted yet.
 #[cfg(unix)]
-async fn await_successor(paths: &ShepPaths, wait: std::time::Duration) -> Option<Client> {
+async fn await_successor(
+    paths: &ShepPaths,
+    witness: Option<Client>,
+    wait: std::time::Duration,
+) -> Option<Client> {
     let deadline = tokio::time::Instant::now() + wait;
+
+    // Stage one: wait out the predecessor. A request answered on `witness`
+    // says the OLD image is still serving, because that connection cannot
+    // survive its exec. Only once it stops answering is a fresh connection
+    // worth trusting.
+    //
+    // Skipped when no witness could be opened, which means nothing was
+    // answering before the signal either, so there is no predecessor to
+    // outlive.
+    if let Some(witness) = witness {
+        while witness
+            .request(shep_core::protocol::Request::ListFlock)
+            .await
+            .is_ok()
+        {
+            if tokio::time::Instant::now() >= deadline {
+                return None;
+            }
+            tokio::time::sleep(SUCCESSOR_POLL_INTERVAL).await;
+        }
+    }
+
+    // Stage two: the old image is gone. Now an answered request can only
+    // have come from the successor.
     loop {
         // A handshake proves a daemon answered. It does NOT prove the
         // answer came from the successor, and the two are genuinely

--- a/crates/shep-cli/src/commands/daemon.rs
+++ b/crates/shep-cli/src/commands/daemon.rs
@@ -384,6 +384,14 @@ pub fn boot_options(
         // `true` — this function has no `tidy_up`/`dev` concept of its own
         // to read it from.
         delete_flock_on_shutdown: false,
+        // This process IS the shep binary, which is the assertion that
+        // field is about (see its own doc). Both callers of this function
+        // are that binary, so the opt-in belongs here rather than in each
+        // of them: `run_daemon` is the autostarted shepherd and
+        // `commands::foreground::run` is `shep runtime`/`shep dev`, and an
+        // init system's SIGHUP should reach the same handover an operator's
+        // `shep daemon reload` does.
+        handover: true,
     }
 }
 
@@ -431,37 +439,113 @@ enum Arm {
     /// Phase 2's `execve` handover: the shepherd replaces its own image and
     /// the flock never stops.
     ///
-    /// Nothing returns this yet, deliberately. A stub that pretended to
-    /// hand over and quietly stopped the flock instead would be worse than
-    /// a variant that is honestly unreachable, because the whole value of
-    /// the handover is the promise that a sheep keeps its pid.
-    #[expect(
-        dead_code,
-        reason = "phase 2 constructs this; phase 1 ships no handover for any version to support"
-    )]
+    /// Unix only, and the whole handover is: Windows has no `execve`, so
+    /// there is no image for a successor to become and
+    /// [`Self::for_daemon`] never returns this there.
+    #[cfg(unix)]
     Handover,
     /// Stop the shepherd the way `kill` does, wait out its teardown, start a
     /// successor, and muster the roll back.
     StopAndStart,
 }
 
+/// The first shep release whose shepherd can hand its flock to a successor.
+///
+/// Read only by the unix arm of [`Arm::for_daemon`] and by this module's own
+/// tests, so a non-test Windows build has no caller at all;
+/// `#[cfg_attr(windows, allow(dead_code))]` says so explicitly rather than
+/// inventing a call site.
+///
+/// The handover has to exist in the OLD shepherd (spec H6): a shepherd
+/// already running cannot be taught it after the fact, so this is a floor on
+/// the version the CLI finds running, never on its own. `0.1.17` is the last
+/// release that shipped without it, which makes the next possible release
+/// the floor. Early rather than late: a version below this genuinely cannot
+/// carry a flock, while a version above it that somehow cannot simply
+/// refuses the fitness query and falls back.
+///
+/// This is the whole of what keeps `PROTOCOL_VERSION` where it is.
+/// `Request::HandoverFitness` is a variant a shepherd below the floor has
+/// never seen, and one asked it would end the connection on a decode error
+/// rather than answering. The floor is why none is ever asked.
+#[cfg_attr(windows, allow(dead_code))]
+const HANDOVER_SINCE: &str = "0.1.18";
+
+/// `major.minor.patch` as three numbers, or `None` for anything this cannot
+/// read.
+///
+/// Hand-rolled rather than a semver dependency, because the whole question
+/// is "is this three-number version at least that one" and the answer is a
+/// tuple comparison. Any pre-release or build suffix is dropped with the
+/// patch component it hangs off, so `0.1.18-rc.1` reads as `0.1.18`: a
+/// pre-release of the version that carries the handover carries it too.
+///
+/// `None` for a version with fewer than three components, a non-numeric one,
+/// or anything else unrecognised, and every caller treats `None` as the safe
+/// arm.
+#[cfg_attr(windows, allow(dead_code))]
+fn version_parts(version: &str) -> Option<(u64, u64, u64)> {
+    let mut parts = version.split('.');
+    let major = parts.next()?.parse().ok()?;
+    let minor = parts.next()?.parse().ok()?;
+    let patch = parts.next()?;
+    let patch = patch
+        .split_once(['-', '+'])
+        .map_or(patch, |(number, _suffix)| number);
+    Some((major, minor, patch.parse().ok()?))
+}
+
 impl Arm {
     /// The arm that reloads a shepherd reporting `daemon_version`, or `None`
     /// where the CLI could not learn it.
     ///
-    /// Always [`Self::StopAndStart`] in phase 1, and the parameter is unused
-    /// rather than removed because it is the whole of phase 2's decision.
-    /// The handover has to exist in the OLD shepherd (spec H6), so no
-    /// version a running shepherd can report today supports it.
+    /// [`Self::Handover`] needs the shepherd being replaced to carry the
+    /// mechanism, so this compares its version against [`HANDOVER_SINCE`]
+    /// (spec H6). It says nothing about whether that shepherd's particular
+    /// FLOCK can be carried, which is a question only the shepherd can
+    /// answer and `reload` asks it over the socket.
+    ///
+    /// A shepherd reporting this binary's OWN version is treated as
+    /// carrying the handover too, whatever the floor says, and that matters
+    /// for exactly one window: the branch that builds the handover is
+    /// itself below the floor until the release carrying it exists, and
+    /// without this its own end-to-end tests could never reach the arm they
+    /// are there to prove. From the first release at or past
+    /// [`HANDOVER_SINCE`] the two conditions coincide and this one decides
+    /// nothing. The exposure while it does not is a development build of
+    /// `0.1.17` meeting an INSTALLED `0.1.17`, which is asked a query it
+    /// cannot parse, ends the connection, and is stopped and started, which is
+    /// the same outcome the floor alone would have reached by a longer road.
     ///
     /// **Unknown always means the safe arm, never the fast one.** `None`
     /// arrives from a shepherd whose refusal named no version — one built
     /// before the refusal carried the field, which no upgrade can reach
     /// backwards to fix — and from a home where nothing answered at all.
     /// Guessing at either would hand a flock to a mechanism the shepherd
-    /// holding it does not have.
-    fn for_daemon(_daemon_version: Option<&str>) -> Self {
-        Self::StopAndStart
+    /// holding it does not have. A version string this CLI cannot parse is
+    /// unknown on the same terms.
+    fn for_daemon(daemon_version: Option<&str>) -> Self {
+        #[cfg(unix)]
+        {
+            let Some(running) = daemon_version.and_then(version_parts) else {
+                return Self::StopAndStart;
+            };
+            let floor = version_parts(HANDOVER_SINCE)
+                .expect("HANDOVER_SINCE is a literal three-number version");
+            let own = version_parts(env!("CARGO_PKG_VERSION"))
+                .expect("this crate's own version is a three-number version");
+            if running >= floor || running == own {
+                Self::Handover
+            } else {
+                Self::StopAndStart
+            }
+        }
+        // No `execve`, so no handover, whatever the shepherd's version says.
+        #[cfg(windows)]
+        {
+            let _ = daemon_version;
+            Self::StopAndStart
+        }
     }
 }
 
@@ -505,19 +589,229 @@ async fn reload_with_wait(
     guard: crate::VersionGuard,
     wait: std::time::Duration,
 ) -> ExitCode {
-    // Connected only to ask who is there, and dropped before anything is
-    // signalled: this connection is to the process about to be stopped.
-    let running_version = match Client::connect(&paths.socket).await {
-        Ok(client) => Some(client.daemon().daemon_version.clone()),
-        Err(err) => version_from_refusal(&err).map(str::to_owned),
+    // Connected to ask who is there, and, on the handover arm, whether
+    // this flock can be carried. Dropped before anything is signalled: this
+    // connection is to the process about to be replaced.
+    let connected = match Client::connect(&paths.socket).await {
+        Ok(client) => Ok(client),
+        Err(err) => Err(version_from_refusal(&err).map(str::to_owned)),
     };
-    match Arm::for_daemon(running_version.as_deref()) {
-        // Unreachable by construction: `Arm::for_daemon` never returns it in
-        // phase 1. Left as a panic rather than a silent fall-through to the
-        // stop arm, because a handover that quietly stopped the flock would
-        // be a lie about the one thing it promises.
-        Arm::Handover => unreachable!("the handover arm lands in phase 2"),
-        Arm::StopAndStart => stop_and_start(streams, paths, guard, wait).await,
+    let running_version = match &connected {
+        Ok(client) => Some(client.daemon().daemon_version.clone()),
+        Err(from_refusal) => from_refusal.clone(),
+    };
+    #[cfg(unix)]
+    if Arm::for_daemon(running_version.as_deref()) == Arm::Handover
+        // A version learned from a protocol refusal cannot reach the
+        // handover arm, and spec H3a is explicit about why: the decision
+        // needs a fitness answer, a refused handshake has no connection to
+        // ask over, and a stop-and-start is the right arm for a shepherd the
+        // socket will not talk to anyway.
+        && let Ok(client) = connected
+    {
+        match ask_fitness(&client).await {
+            Fitness::Carryable => {
+                // Before the signal, never after: the shepherd is about to
+                // replace its own image, and a connection held across that
+                // is a connection to a process that no longer exists.
+                drop(client);
+                return hand_over(streams, paths, guard, wait).await;
+            }
+            // Not a failure. The flock carries something this shepherd
+            // cannot move in place, so the reload happens the other way and
+            // the operator is told which sheep and why (spec H3a), in front
+            // of the person who typed the verb, not in the daemon's log.
+            Fitness::Refused(reason) => {
+                streams.aside("reload", &reason);
+            }
+        }
+    }
+    stop_and_start(streams, paths, guard, wait).await
+}
+
+/// What a shepherd says about carrying its own flock.
+///
+/// The daemon owns both the gate and the wording; this is only the two
+/// answers the CLI acts on. The refusal reaches the operator verbatim.
+#[cfg(unix)]
+#[derive(Debug)]
+enum Fitness {
+    /// Every sheep can be carried across the exec.
+    Carryable,
+    /// At least one cannot, and this sentence says which and why.
+    Refused(String),
+}
+
+/// Asks `client`'s shepherd whether its flock can be handed over in place.
+///
+/// **Every failure is a refusal**, and none of them is reported as an error.
+/// A shepherd that answers the wrong reply, refuses the request, or drops
+/// the connection has told this CLI nothing it can act on, and the stop arm
+/// works against all three. The alternative, signalling on a maybe, is the
+/// one outcome spec H3a exists to prevent, since a signal carries no reply
+/// and a shepherd that refuses after being signalled leaves the flock down.
+#[cfg(unix)]
+async fn ask_fitness(client: &Client) -> Fitness {
+    match client
+        .request(shep_core::protocol::Request::HandoverFitness)
+        .await
+    {
+        Ok(shep_core::protocol::Response::HandoverFitness { refusal: None }) => Fitness::Carryable,
+        Ok(shep_core::protocol::Response::HandoverFitness {
+            refusal: Some(reason),
+        }) => Fitness::Refused(reason),
+        Ok(other) => Fitness::Refused(format!(
+            "this shepherd answered a handover question with {other:?}, so its flock is being \
+             stopped and started instead"
+        )),
+        Err(err) => Fitness::Refused(format!(
+            "this shepherd could not say whether its flock can be handed over ({err}), so it is \
+             being stopped and started instead"
+        )),
+    }
+}
+
+/// Signals the shepherd to replace its own image in place, then waits for
+/// the successor to serve and reports the flock.
+///
+/// The flock never stops here. A carried sheep keeps its pid, its log file
+/// handles and its place in the shepherd's registry, so the report at the
+/// end names the same processes that were running before the verb was typed.
+///
+/// The signal is SIGHUP, and the shepherd's own handler is what decides what
+/// to do with it. That is the trigger for the reason spec H3 gives: the case
+/// that most needs a reload is the one where the shepherd refuses this
+/// client at the handshake, and a remedy delivered over the channel it is
+/// meant to repair is not a remedy. The DECISION already happened over the
+/// socket, before this was called.
+///
+/// **The wait is what makes this recoverable.** A handover can still fail
+/// after the signal (a binary that will not exec, a successor that cannot
+/// rehydrate) and a shepherd that meets one falls back to its own graceful
+/// stop. So this waits for a shepherd of THIS binary's version to answer,
+/// and takes the stop arm's own tail when none does: connect or spawn, then
+/// muster. An operator gets a working reload either way.
+#[cfg(unix)]
+async fn hand_over(
+    streams: &mut Streams<'_>,
+    paths: &ShepPaths,
+    guard: crate::VersionGuard,
+    wait: std::time::Duration,
+) -> ExitCode {
+    let pid = match proven_shepherd(streams, paths) {
+        Ok(pid) => pid,
+        Err(code) => return code,
+    };
+    if let Err((code, message)) = signal_handover(pid) {
+        return streams.fail(code, &message);
+    }
+    match await_successor(paths, wait).await {
+        Some(client) => report_reload(&client, streams).await,
+        None => {
+            // Said out loud rather than silently repaired: the flock is
+            // about to be started rather than carried, so an operator who
+            // was promised unchanged pids needs to know they did not get
+            // them.
+            let message = "the shepherd did not come back on this version after the handover \
+                           signal; starting one instead";
+            streams.aside("reload", message);
+            let client = match crate::connect_or_spawn_client(streams, paths, guard).await {
+                Ok(client) => client,
+                Err(code) => return code,
+            };
+            report_reload(&client, streams).await
+        }
+    }
+}
+
+/// Asks the shepherd at `pid` to hand its flock to a successor.
+///
+/// SIGHUP, because SIGUSR2 is already the log-reopen signal and SIGHUP was
+/// otherwise unhandled when the handover was designed. A shepherd too old to
+/// hand over installs it as a graceful stop instead, which is why this is
+/// never sent to one: the arm selection decides that before this is reached.
+///
+/// # Errors
+/// The exit code and the sentence to report, when the pid is not one this
+/// platform can name or the signal itself failed. The caller prints it; this
+/// function writes nothing.
+#[cfg(unix)]
+fn signal_handover(pid: u32) -> Result<(), (ExitCode, String)> {
+    use nix::sys::signal::{self, Signal};
+    use nix::unistd::Pid;
+
+    let Ok(target) = i32::try_from(pid) else {
+        let message = format!("the recorded pid {pid} is not one this platform can signal");
+        return Err((ExitCode::Internal, message));
+    };
+    signal::kill(Pid::from_raw(target), Signal::SIGHUP).map_err(|errno| {
+        let message = format!("could not signal the shepherd at pid {pid}: {errno}");
+        (ExitCode::Failure, message)
+    })
+}
+
+/// Polls the control socket until a shepherd running THIS binary's version
+/// answers, or `wait` expires.
+///
+/// A handshake is a stronger confirmation than a reply to the signal would
+/// have been: it proves the successor is serving, not merely that the
+/// predecessor received something. The version is what tells the two images
+/// apart: the predecessor is still answering on the same socket right up
+/// until the moment it execs, and the whole point of the verb is that the
+/// version moved.
+///
+/// A connect failure inside the window is expected, not a fault: the
+/// successor is mid-boot and has not accepted yet.
+#[cfg(unix)]
+async fn await_successor(paths: &ShepPaths, wait: std::time::Duration) -> Option<Client> {
+    let deadline = tokio::time::Instant::now() + wait;
+    loop {
+        if let Ok(client) = Client::connect(&paths.socket).await
+            && client.daemon().daemon_version == env!("CARGO_PKG_VERSION")
+        {
+            return Some(client);
+        }
+        if tokio::time::Instant::now() >= deadline {
+            return None;
+        }
+        tokio::time::sleep(SUCCESSOR_POLL_INTERVAL).await;
+    }
+}
+
+/// Gap between [`await_successor`]'s probes. Short, because an `execve` plus
+/// a rehydrate is milliseconds of work and the operator is waiting.
+#[cfg(unix)]
+const SUCCESSOR_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_millis(20);
+
+/// The pid of the shepherd owning this home, or the code and sentence
+/// saying why there is none to act on.
+///
+/// The pidfile alone is not proof, since a stale one from a crash still
+/// exists and the pid may have been reused, so this reads the lock the daemon
+/// holds for its whole life instead. Shared by both arms: they act on the
+/// same shepherd, with the same three ways of not finding one.
+fn proven_shepherd(streams: &mut Streams<'_>, paths: &ShepPaths) -> Result<u32, ExitCode> {
+    match boot::daemon_liveness(paths) {
+        Ok(Shepherd::Running(pid)) => Ok(pid),
+        // Alive and owns the home, but has not recorded a pid yet. Not an
+        // absence, and not a pid to guess at.
+        Ok(Shepherd::Booting) => {
+            let message = "a shepherd is starting up and has not recorded its pid yet; try again";
+            Err(streams.fail(ExitCode::DaemonUnreachable, message))
+        }
+        // Nothing to replace. Says what starts one instead, rather than
+        // starting it unasked: `reload` is how an operator makes a RUNNING
+        // system match the binary, and a home with no shepherd has no
+        // running system to make match.
+        Ok(Shepherd::Absent) => {
+            let message = format!(
+                "no shepherd is running, so there is nothing to reload (nothing holds the lock \
+                 on `{}`). `shep muster` brings the flock up from the roll",
+                boot::pidfile(paths).display()
+            );
+            Err(streams.fail(ExitCode::DaemonUnreachable, &message))
+        }
+        Err(err) => Err(streams.fail(ExitCode::Failure, &err.to_string())),
     }
 }
 
@@ -533,27 +827,9 @@ async fn stop_and_start(
     guard: crate::VersionGuard,
     wait: std::time::Duration,
 ) -> ExitCode {
-    let pid = match boot::daemon_liveness(paths) {
-        Ok(Shepherd::Running(pid)) => pid,
-        // Alive and owns the home, but has not recorded a pid yet. Not an
-        // absence, and not a pid to guess at.
-        Ok(Shepherd::Booting) => {
-            let message = "a shepherd is starting up and has not recorded its pid yet; try again";
-            return streams.fail(ExitCode::DaemonUnreachable, message);
-        }
-        // Nothing to replace. Says what starts one instead, rather than
-        // starting it unasked: `reload` is how an operator makes a RUNNING
-        // system match the binary, and a home with no shepherd has no
-        // running system to make match.
-        Ok(Shepherd::Absent) => {
-            let message = format!(
-                "no shepherd is running, so there is nothing to reload (nothing holds the lock \
-                 on `{}`). `shep muster` brings the flock up from the roll",
-                boot::pidfile(paths).display()
-            );
-            return streams.fail(ExitCode::DaemonUnreachable, &message);
-        }
-        Err(err) => return streams.fail(ExitCode::Failure, &err.to_string()),
+    let pid = match proven_shepherd(streams, paths) {
+        Ok(pid) => pid,
+        Err(code) => return code,
     };
     if let Err((code, message)) = admin::signal_graceful_stop(pid) {
         return streams.fail(code, &message);
@@ -598,7 +874,7 @@ mod tests {
     use crate::VersionGuard;
     use crate::cli::Format;
     use shep_core::config::LogLevel;
-    use shep_core::protocol::Response;
+    use shep_core::protocol::{Request, Response};
 
     /// fails if `run_daemon` builds its overrides from the wrong fields, or
     /// drops one. Drives the config assembly, not the boot — booting a real
@@ -983,14 +1259,31 @@ otel = "/usr/local/bin/shep-otel"
         assert_eq!(Arm::for_daemon(Some("0.1.8")), Arm::StopAndStart);
     }
 
-    /// Not even this binary's own version selects the handover, which is
-    /// what makes the arm honest rather than a stub: phase 1 ships no
-    /// handover for any version to support.
+    /// The floor itself, from the other side: the last release that cannot
+    /// hand over still takes the stop arm, and the version arithmetic is
+    /// component-wise rather than lexical, which `0.1.9` against `0.1.18`
+    /// is the case that tells apart.
     #[test]
-    fn reload_picks_the_stop_arm_against_a_daemon_of_this_very_version() {
+    fn reload_picks_the_stop_arm_at_every_version_below_the_floor() {
+        assert_eq!(Arm::for_daemon(Some("0.1.9")), Arm::StopAndStart);
+        assert_eq!(Arm::for_daemon(Some("0.1.16")), Arm::StopAndStart);
+        assert_eq!(
+            Arm::for_daemon(Some("not a version")),
+            Arm::StopAndStart,
+            "a version this CLI cannot read is unknown, and unknown is the safe arm"
+        );
+    }
+
+    /// The one allowance the floor makes, and the reason this branch can
+    /// test its own handover at all: a shepherd reporting this binary's own
+    /// version is this binary. See [`Arm::for_daemon`]'s own doc for the
+    /// window it is open in and what it costs while it is.
+    #[cfg(unix)]
+    #[test]
+    fn a_shepherd_of_this_binarys_own_version_answers_for_itself() {
         assert_eq!(
             Arm::for_daemon(Some(env!("CARGO_PKG_VERSION"))),
-            Arm::StopAndStart
+            Arm::Handover
         );
     }
 
@@ -1094,5 +1387,149 @@ otel = "/usr/local/bin/shep-otel"
         assert_eq!(code, ExitCode::DaemonUnreachable);
         let text = String::from_utf8(err).unwrap();
         assert!(text.contains("no shepherd"), "{text}");
+    }
+    /// A handshake that names a version at or past [`HANDOVER_SINCE`] is the
+    /// only thing that selects the handover.
+    #[cfg(unix)]
+    #[test]
+    fn reload_picks_the_handover_against_a_daemon_new_enough_to_carry_its_flock() {
+        assert_eq!(Arm::for_daemon(Some("9.9.9")), Arm::Handover);
+        assert_eq!(Arm::for_daemon(Some(HANDOVER_SINCE)), Arm::Handover);
+    }
+
+    /// What keeps `PROTOCOL_VERSION` where it is.
+    ///
+    /// `Request::HandoverFitness` is a variant an older daemon has never
+    /// seen, so asking one would be a parse error rather than a refusal it
+    /// could answer. The version gate is what makes that unreachable: the
+    /// arm is chosen from the handshake, and a daemon predating the handover
+    /// takes the stop arm with the query never sent. This drives the whole
+    /// verb and reads the wire, because the claim is about what is on it.
+    #[tokio::test]
+    async fn a_reload_against_an_older_daemon_never_sends_the_query() {
+        let dir = tempfile::tempdir().unwrap();
+        let paths = ShepPaths::resolve(&|_| None, dir.path());
+        std::fs::create_dir_all(&paths.run).unwrap();
+        std::fs::create_dir_all(&paths.pids).unwrap();
+        let mut sent = shep_client::testing::fake_daemon_answering_with_ack(
+            &paths.socket,
+            ack_naming("0.1.8"),
+            |_| Response::Pong,
+        )
+        .await;
+
+        let mut out = Vec::new();
+        let mut err = Vec::new();
+        {
+            let mut streams = Streams {
+                out: &mut out,
+                err: &mut err,
+                style: crate::style::Presentation::BARE,
+                fmt: Format::Table,
+            };
+            reload(&mut streams, &paths, VersionGuard::Exempt).await;
+        }
+
+        let asked: Vec<Request> = std::iter::from_fn(|| sent.try_recv().ok())
+            .map(|envelope| envelope.body)
+            .collect();
+        assert!(
+            !asked
+                .iter()
+                .any(|req| matches!(req, Request::HandoverFitness)),
+            "a daemon that cannot parse the query must never be asked it: {asked:?}"
+        );
+    }
+
+    /// The other half, and what makes the test above non-vacuous: a daemon
+    /// new enough IS asked, exactly once, before anything is signalled.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn a_reload_against_a_newer_daemon_asks_before_it_signals() {
+        let dir = tempfile::tempdir().unwrap();
+        let paths = ShepPaths::resolve(&|_| None, dir.path());
+        std::fs::create_dir_all(&paths.run).unwrap();
+        std::fs::create_dir_all(&paths.pids).unwrap();
+        let mut sent = shep_client::testing::fake_daemon_answering_with_ack(
+            &paths.socket,
+            ack_naming("9.9.9"),
+            |_| Response::HandoverFitness { refusal: None },
+        )
+        .await;
+
+        let mut out = Vec::new();
+        let mut err = Vec::new();
+        {
+            let mut streams = Streams {
+                out: &mut out,
+                err: &mut err,
+                style: crate::style::Presentation::BARE,
+                fmt: Format::Table,
+            };
+            reload(&mut streams, &paths, VersionGuard::Exempt).await;
+        }
+
+        let asked: Vec<Request> = std::iter::from_fn(|| sent.try_recv().ok())
+            .map(|envelope| envelope.body)
+            .collect();
+        assert_eq!(
+            asked
+                .iter()
+                .filter(|req| matches!(req, Request::HandoverFitness))
+                .count(),
+            1,
+            "exactly one fitness query, and it is the first thing asked: {asked:?}"
+        );
+    }
+
+    /// A refused flock is told to the operator who typed the verb, in words
+    /// naming the sheep and the feature, not left in the daemon's log
+    /// (spec H3a).
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn a_refused_flock_prints_the_reason_and_falls_back() {
+        let dir = tempfile::tempdir().unwrap();
+        let paths = ShepPaths::resolve(&|_| None, dir.path());
+        std::fs::create_dir_all(&paths.run).unwrap();
+        std::fs::create_dir_all(&paths.pids).unwrap();
+        let _sent = shep_client::testing::fake_daemon_answering_with_ack(
+            &paths.socket,
+            ack_naming("9.9.9"),
+            |_| Response::HandoverFitness {
+                refusal: Some("sheep 'chatty' has a shepherd channel".to_string()),
+            },
+        )
+        .await;
+
+        let mut out = Vec::new();
+        let mut err = Vec::new();
+        let code = {
+            let mut streams = Streams {
+                out: &mut out,
+                err: &mut err,
+                style: crate::style::Presentation::BARE,
+                fmt: Format::Table,
+            };
+            reload(&mut streams, &paths, VersionGuard::Exempt).await
+        };
+
+        let text = format!(
+            "{}{}",
+            String::from_utf8(out).unwrap(),
+            String::from_utf8(err).unwrap()
+        );
+        assert!(text.contains("shepherd channel"), "{text}");
+        // No shepherd owns this home, so the stop arm it fell back to has
+        // nothing to stop -- which is what proves it took that arm at all.
+        assert_eq!(code, ExitCode::DaemonUnreachable, "{text}");
+    }
+
+    /// A [`HelloAck`] naming `version`, for the arm-selection tests.
+    fn ack_naming(version: &str) -> shep_core::protocol::HelloAck {
+        shep_core::protocol::HelloAck {
+            daemon_version: version.to_string(),
+            protocol: shep_core::protocol::PROTOCOL_VERSION,
+            pid: 4242,
+        }
     }
 }

--- a/crates/shep-cli/src/commands/daemon.rs
+++ b/crates/shep-cli/src/commands/daemon.rs
@@ -723,11 +723,26 @@ async fn hand_over(
     // no way to tell a successor from a predecessor that has been signalled
     // and has not execed yet: both answer, on the same pid, at the same
     // version.
-    let witness = Client::connect(&paths.socket).await.ok();
+    let Ok(witness) = Client::connect(&paths.socket).await else {
+        // No witness, no handover. Signalling without one would leave
+        // `await_successor` with nothing to outlive, so it would accept the
+        // first answer it got, which is the predecessor's, which is the
+        // whole hole the witness exists to close.
+        //
+        // Reaching here at all is anomalous rather than informative: the
+        // fitness query a moment ago needed a connection of its own, so a
+        // daemon WAS answering. A transient failure here says something is
+        // wrong, not that nothing is running, and the stop arm is correct
+        // under either reading.
+        let message = "could not hold a connection across the handover signal; \
+                       stopping and starting instead";
+        streams.aside("reload", message);
+        return stop_and_start(streams, paths, guard, wait).await;
+    };
     if let Err((code, message)) = signal_handover(pid) {
         return streams.fail(code, &message);
     }
-    match await_successor(paths, witness, wait).await {
+    match await_successor(paths, &witness, wait).await {
         // The successor carried the flock; nothing to restore.
         Some(client) => report_reload(&client, streams, false).await,
         None => {
@@ -788,7 +803,7 @@ fn signal_handover(pid: u32) -> Result<(), (ExitCode, String)> {
 #[cfg(unix)]
 async fn await_successor(
     paths: &ShepPaths,
-    witness: Option<Client>,
+    witness: &Client,
     wait: std::time::Duration,
 ) -> Option<Client> {
     let deadline = tokio::time::Instant::now() + wait;
@@ -798,20 +813,18 @@ async fn await_successor(
     // survive its exec. Only once it stops answering is a fresh connection
     // worth trusting.
     //
-    // Skipped when no witness could be opened, which means nothing was
-    // answering before the signal either, so there is no predecessor to
-    // outlive.
-    if let Some(witness) = witness {
-        while witness
-            .request(shep_core::protocol::Request::ListFlock)
-            .await
-            .is_ok()
-        {
-            if tokio::time::Instant::now() >= deadline {
-                return None;
-            }
-            tokio::time::sleep(SUCCESSOR_POLL_INTERVAL).await;
+    // Never skipped. A caller without a witness must not reach here at all,
+    // because a handover with nothing to outlive accepts the predecessor's
+    // own answer as the successor's.
+    while witness
+        .request(shep_core::protocol::Request::ListFlock)
+        .await
+        .is_ok()
+    {
+        if tokio::time::Instant::now() >= deadline {
+            return None;
         }
+        tokio::time::sleep(SUCCESSOR_POLL_INTERVAL).await;
     }
 
     // Stage two: the old image is gone. Now an answered request can only

--- a/crates/shep-cli/src/commands/daemon.rs
+++ b/crates/shep-cli/src/commands/daemon.rs
@@ -596,6 +596,11 @@ async fn reload_with_wait(
         Ok(client) => Ok(client),
         Err(err) => Err(version_from_refusal(&err).map(str::to_owned)),
     };
+    // `cfg(unix)`, like its only reader below. Windows has no `execve`, so
+    // the arm is never in question there and the binding would be an
+    // `unused_variables` warning on live code rather than a value nothing
+    // happens to read yet.
+    #[cfg(unix)]
     let running_version = match &connected {
         Ok(client) => Some(client.daemon().daemon_version.clone()),
         Err(from_refusal) => from_refusal.clone(),

--- a/crates/shep-cli/src/commands/daemon.rs
+++ b/crates/shep-cli/src/commands/daemon.rs
@@ -721,7 +721,8 @@ async fn hand_over(
         return streams.fail(code, &message);
     }
     match await_successor(paths, wait).await {
-        Some(client) => report_reload(&client, streams).await,
+        // The successor carried the flock; nothing to restore.
+        Some(client) => report_reload(&client, streams, false).await,
         None => {
             // Said out loud rather than silently repaired: the flock is
             // about to be started rather than carried, so an operator who
@@ -734,7 +735,7 @@ async fn hand_over(
                 Ok(client) => client,
                 Err(code) => return code,
             };
-            report_reload(&client, streams).await
+            report_reload(&client, streams, true).await
         }
     }
 }
@@ -781,8 +782,25 @@ fn signal_handover(pid: u32) -> Result<(), (ExitCode, String)> {
 async fn await_successor(paths: &ShepPaths, wait: std::time::Duration) -> Option<Client> {
     let deadline = tokio::time::Instant::now() + wait;
     loop {
+        // A handshake proves a daemon answered. It does NOT prove the
+        // answer came from the successor, and the two are genuinely
+        // indistinguishable here: `execve` keeps the pid, and the arm that
+        // reaches this code can be selected against a shepherd of this very
+        // version, so neither the pid nor the version in the ack separates
+        // them. Connecting to the PREDECESSOR is therefore normal, not a
+        // race to be narrowed, and its connection dies at the exec.
+        //
+        // So the readiness test is a REQUEST, not a handshake: an answered
+        // request can only have come from a daemon that is serving, which
+        // the outgoing image stops doing the moment it execs. Four Linux CI
+        // jobs found this by way of `daemon reload` reporting a successful
+        // handover and then exiting 5 on the very next call.
         if let Ok(client) = Client::connect(&paths.socket).await
             && client.daemon().daemon_version == env!("CARGO_PKG_VERSION")
+            && client
+                .request(shep_core::protocol::Request::ListFlock)
+                .await
+                .is_ok()
         {
             return Some(client);
         }
@@ -858,7 +876,7 @@ async fn stop_and_start(
         Ok(client) => client,
         Err(code) => return code,
     };
-    report_reload(&client, streams).await
+    report_reload(&client, streams, true).await
 }
 
 /// Reports the shepherd now serving, then what happened to each sheep.
@@ -869,18 +887,41 @@ async fn stop_and_start(
 /// line above the table names the SHEPHERD's version and pid, which is true
 /// under both arms and is the fact the operator ran this verb for.
 ///
-/// `Request::Muster` rather than a plain list: under the stop arm the
-/// successor has already restored the roll by the time this runs, so the
-/// muster spawns nothing new and reports the flock that restore produced —
-/// see `commands::muster::muster`'s own doc on why that is idempotent.
-async fn report_reload(client: &Client, streams: &mut Streams<'_>) -> ExitCode {
+/// `restored` says which arm ran, and it decides how the flock is asked for.
+///
+/// Under the STOP arm the successor has already restored the roll by the
+/// time this runs, so `Request::Muster` spawns nothing new and reports the
+/// flock that restore produced. See `commands::muster::muster`'s own doc on
+/// why that is idempotent.
+///
+/// Under the HANDOVER arm it must NOT muster, for two reasons that arrived
+/// together. Semantically there is nothing to restore: the sheep never
+/// stopped, so a muster is being asked to bring back processes that are
+/// already running, off a roll the predecessor never had a chance to
+/// rewrite. And in practice it fails, which is how this was found. Four
+/// Linux CI jobs caught `shep daemon reload` reporting a successful handover
+/// and then exiting 5:
+///
+/// ```text
+/// notice[reload]: the shepherd is now 0.1.17 (pid 10579)
+/// error[daemon_unreachable]: the connection closed before a reply arrived
+/// ```
+///
+/// A successor answers its socket as soon as the listener is carried, which
+/// is before its rehydrate has finished, so a muster arriving in that window
+/// meets a daemon not yet ready to serve one. A plain `ListFlock` is what
+/// the handover arm actually wants: it reports, and asks for nothing.
+async fn report_reload(client: &Client, streams: &mut Streams<'_>, restored: bool) -> ExitCode {
     let shepherd = client.daemon();
     let message = format!(
         "the shepherd is now {} (pid {})",
         shepherd.daemon_version, shepherd.pid
     );
     streams.aside("reload", &message);
-    muster::muster(client, streams).await
+    if restored {
+        return muster::muster(client, streams).await;
+    }
+    crate::commands::query::flock(client, streams).await
 }
 
 #[cfg(test)]
@@ -1363,7 +1404,7 @@ otel = "/usr/local/bin/shep-otel"
                 style: crate::style::Presentation::BARE,
                 fmt: Format::Table,
             };
-            report_reload(&client, &mut streams).await
+            report_reload(&client, &mut streams, true).await
         };
 
         assert_eq!(code, ExitCode::Success);

--- a/crates/shep-cli/src/commands/daemon.rs
+++ b/crates/shep-cli/src/commands/daemon.rs
@@ -607,14 +607,14 @@ async fn reload_with_wait(
         // needs a fitness answer, a refused handshake has no connection to
         // ask over, and a stop-and-start is the right arm for a shepherd the
         // socket will not talk to anyway.
-        && let Ok(client) = connected
+        && let Ok(client) = &connected
     {
-        match ask_fitness(&client).await {
+        match ask_fitness(client).await {
             Fitness::Carryable => {
                 // Before the signal, never after: the shepherd is about to
                 // replace its own image, and a connection held across that
                 // is a connection to a process that no longer exists.
-                drop(client);
+                drop(connected);
                 return hand_over(streams, paths, guard, wait).await;
             }
             // Not a failure. The flock carries something this shepherd
@@ -626,6 +626,16 @@ async fn reload_with_wait(
             }
         }
     }
+    // Before the stop arm too, and for a sharper reason than the handover's.
+    // `stop_and_start` signals the shepherd and then waits for its control
+    // address to stop answering. On Windows that address is a named pipe and
+    // the wait probes it, treating `ERROR_PIPE_BUSY` as a daemon that has not
+    // finished; a client handle held open here keeps the pipe instance alive
+    // past the daemon's exit, so the wait can run out its whole budget and
+    // the reload fails `DeadlineExceeded` without ever starting a successor.
+    // `admin::kill_with_wait` drops its own client before the same wait for
+    // the same reason.
+    drop(connected);
     stop_and_start(streams, paths, guard, wait).await
 }
 

--- a/crates/shep-cli/tests/cli_e2e.rs
+++ b/crates/shep-cli/tests/cli_e2e.rs
@@ -7342,3 +7342,128 @@ fn the_control_socket_accepts_throughout_a_handover() {
 
     graceful_kill(dir.path());
 }
+
+/// Reads `roll` until it records exactly `want` apps, or [`FLOCK_DEADLINE`]
+/// expires, and returns the bytes it held on the last read.
+///
+/// The muster roll is written by a debounced task, so "the flock changed"
+/// and "the roll on disk says so" are two events and the second is the one a
+/// caller here needs. Returns rather than panicking on expiry, so the
+/// failure that reaches CI is the caller's own assertion.
+#[cfg(unix)]
+fn roll_recording(roll: &Path, want: usize) -> Vec<u8> {
+    let start = Instant::now();
+    loop {
+        let bytes = std::fs::read(roll).unwrap_or_default();
+        let apps = serde_json::from_slice::<serde_json::Value>(&bytes)
+            .ok()
+            .and_then(|value| value["apps"].as_array().map(Vec::len));
+        if apps == Some(want) || start.elapsed() >= FLOCK_DEADLINE {
+            return bytes;
+        }
+        std::thread::sleep(FLOCK_POLL_INTERVAL);
+    }
+}
+
+/// A successor that inherited an EMPTY flock must not fall back to the roll.
+///
+/// The two things a boot can do with a muster roll are mutually exclusive,
+/// and which one it does turns on a single fact: was this image handed a
+/// flock, or did it start fresh? A successor was handed one, so it installs
+/// what it was handed and skips the restore. The SIZE of that flock is not
+/// the question and must never be mistaken for it, because a handover skips
+/// the predecessor's teardown: the roll on disk is whatever the last
+/// debounced write left, not the flock as it was at the exec.
+///
+/// The empty case is the one where the two questions give different answers.
+/// `ghost` is started, saved into the roll, then deleted, and the stale roll
+/// is put back under an idle shepherd that has no sheep left to write over
+/// it. The handover from there carries nothing, so a boot deriving "was I a
+/// successor?" from the count of what it carried decides it was a fresh boot
+/// and starts `ghost` again from a roll describing a flock the operator has
+/// already thrown away.
+///
+/// SIGHUP directly, not `shep daemon reload`. The verb runs `shep muster`
+/// against the shepherd it gets back, which would start `ghost` from the
+/// same stale roll through the CLI whatever the boot decided, and a test
+/// that cannot tell those two apart proves nothing about either. The signal
+/// is the whole of the daemon-side handover and nothing else.
+///
+/// The pid check at the end is what keeps this from passing vacuously.
+/// SIGHUP has exactly two outcomes and no third: this image execs into a
+/// successor, or it cannot and stops gracefully instead. On the second, the
+/// polling below finds no shepherd and spawns a fresh one, which is a NEW
+/// pid and a boot that does restore the roll. So a shepherd still answering
+/// on the original pid is a successor and nothing else.
+///
+/// The final wait is on the WRONG outcome deliberately. A restore that is
+/// going to happen happens inside the successor's own boot, and nothing in
+/// this tier is synchronous with that boot, so asserting emptiness once
+/// could pass by looking too early. Waiting [`FLOCK_DEADLINE`] for a sheep
+/// to appear and then asserting none did is the version that cannot pass by
+/// being quick.
+#[cfg(unix)]
+#[test]
+fn a_successor_inheriting_an_empty_flock_does_not_restore_the_roll() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path();
+    let script = write_test_script(&dir);
+    let mut guard = DaemonGuard::default();
+
+    let started = shep(home)
+        .arg("start")
+        .arg(&script)
+        .arg("--name")
+        .arg("ghost")
+        .output()
+        .unwrap();
+    guard.adopt_home(home);
+    assert_success(&started);
+    let _ = poll_flock(home, |info| info["status"] == "online");
+    let shepherd = wait_for_daemon_pid(home).expect("the shepherd must record a pid");
+
+    assert_success(&shep(home).arg("save").output().unwrap());
+    let roll = home.join("flock.json");
+    let stale = roll_recording(&roll, 1);
+    assert!(
+        !stale.is_empty(),
+        "the roll must record `ghost` before it can go stale: {}",
+        String::from_utf8_lossy(&stale)
+    );
+
+    assert_success(&shep(home).arg("delete").arg("ghost").output().unwrap());
+    let emptied = poll_flock_data(home, FLOCK_DEADLINE, |data| {
+        data.as_array().is_some_and(Vec::is_empty)
+    });
+    assert_eq!(
+        emptied.as_array().map(Vec::len),
+        Some(0),
+        "the delete must leave an idle shepherd: {emptied}"
+    );
+    // Waited out rather than assumed: the debounced writer is about to
+    // record the empty flock, and a stale roll put back before that write
+    // lands would simply be overwritten by it.
+    let _ = roll_recording(&roll, 0);
+    std::fs::write(&roll, &stale).unwrap();
+
+    nix::sys::signal::kill(shepherd, nix::sys::signal::Signal::SIGHUP).unwrap();
+
+    let after = poll_flock_data(home, FLOCK_DEADLINE, |data| {
+        data.as_array().is_some_and(|rows| !rows.is_empty())
+    });
+    assert_eq!(
+        after.as_array().map(Vec::len),
+        Some(0),
+        "a successor must install the flock it was handed and nothing else; \
+         this one restored a stale roll: {after}"
+    );
+    assert_eq!(
+        wait_for_daemon_pid(home),
+        Some(shepherd),
+        "the shepherd must have been replaced in place; a moved pid means \
+         SIGHUP stopped it and the polling above started a fresh one, which \
+         is not the boot this test is about"
+    );
+
+    graceful_kill(home);
+}

--- a/crates/shep-cli/tests/cli_e2e.rs
+++ b/crates/shep-cli/tests/cli_e2e.rs
@@ -7290,9 +7290,16 @@ fn the_control_socket_accepts_throughout_a_handover() {
     let _ = poll_flock(dir.path(), |info| info["status"] == "online");
 
     let home = dir.path().to_path_buf();
+    // The prober says when it is really probing, and the reload waits for
+    // that. Without the handshake the reload could finish before the first
+    // `ping` ever ran, and the case would pass with every probe served by the
+    // successor alone, which proves nothing about the address staying bound
+    // across the exec.
+    let (probing, started_probing) = std::sync::mpsc::channel();
     let prober = std::thread::spawn(move || {
         let deadline = Instant::now() + Duration::from_secs(8);
         let mut refused = Vec::new();
+        let mut announced = false;
         while Instant::now() < deadline {
             let out = shep(&home).arg("ping").output().unwrap();
             if !out.status.success() {
@@ -7302,9 +7309,16 @@ fn the_control_socket_accepts_throughout_a_handover() {
                     String::from_utf8_lossy(&out.stderr)
                 ));
             }
+            if !announced {
+                announced = true;
+                let _ = probing.send(());
+            }
         }
         refused
     });
+    started_probing
+        .recv_timeout(FLOCK_DEADLINE)
+        .expect("the prober must reach the shepherd before the reload starts");
 
     let reloaded = shep(dir.path())
         .arg("daemon")

--- a/crates/shep-cli/tests/cli_e2e.rs
+++ b/crates/shep-cli/tests/cli_e2e.rs
@@ -7023,3 +7023,300 @@ fn a_multi_instance_flock_gets_distinct_slots_a_grouped_table_and_undoubled_blea
 
     graceful_kill(home);
 }
+
+// --- Daemon handover -----------------------------------------------------
+
+/// How long [`counting_lines`] waits for a counter sheep to reach a line
+/// count, and [`wait_for_pid`] for a sheep to be online with a pid.
+///
+/// Sized like [`FLOCK_DEADLINE`] rather than shorter: the counter emits five
+/// lines a second, so any wait here that is not satisfied in the first
+/// hundred milliseconds is a loaded machine rather than a slow sheep.
+#[cfg(unix)]
+const HANDOVER_DEADLINE: Duration = Duration::from_secs(20);
+
+/// Gap between [`counting_lines`]'s reads.
+#[cfg(unix)]
+const HANDOVER_POLL_INTERVAL: Duration = Duration::from_millis(50);
+
+/// Writes a script that counts from 1 upwards on stdout, one number per
+/// line, forever.
+///
+/// The sequence is what makes a log gap visible. A sheep printing the same
+/// marker over and over proves only that it is still alive; a sheep counting
+/// proves that nothing between it and the file was lost, reordered, or cut
+/// in half, which is the failure a handover can introduce and a restart
+/// cannot (a restarted sheep starts again at 1, which is a different and
+/// equally visible break).
+#[cfg(unix)]
+fn write_counting_script(dir: &TempDir) -> PathBuf {
+    write_script(
+        dir,
+        "counter.sh",
+        &format!(
+            "{}{}i=1\nwhile :; do\n  echo \"$i\"\n  i=$((i+1))\n  sleep 0.05\ndone\n",
+            script_header(),
+            record_pid_line(dir),
+        ),
+    )
+}
+
+/// Reads `path` until it holds at least `want` lines, or
+/// [`HANDOVER_DEADLINE`] expires, and returns what it held on the last read.
+///
+/// Returns rather than panicking on expiry, so the failure that reaches CI is
+/// the caller's own assertion naming what it wanted.
+#[cfg(unix)]
+fn counting_lines(path: &Path, want: usize) -> Vec<String> {
+    let start = Instant::now();
+    loop {
+        let text = std::fs::read_to_string(path).unwrap_or_default();
+        let lines: Vec<String> = text.lines().map(str::to_owned).collect();
+        if lines.len() >= want || start.elapsed() >= HANDOVER_DEADLINE {
+            return lines;
+        }
+        std::thread::sleep(HANDOVER_POLL_INTERVAL);
+    }
+}
+
+/// Fails unless `lines` is `1, 2, 3, …`, one number per line, with nothing
+/// missing, nothing repeated and nothing cut in half.
+///
+/// A torn line is the reason this is stricter than "the file grew". The log
+/// pump reads its sheep's pipe through a `BufReader`, so bytes it has
+/// consumed without yet forming a line die with the process image; the
+/// successor's fresh reader then starts mid-line and appends the remainder as
+/// a line of its own. That shows up here as a number that is not the one
+/// expected next, and not as a shorter file, which is why counting lines
+/// alone would pass over it.
+///
+/// **The tear is real, and this is what measured it.** With the counter's
+/// `sleep` removed so it emits as fast as the pipe will take it, three runs
+/// out of three broke here: `7385` was followed by `2`, `4872` by `00`, and
+/// `10917` by `1916`. The last of those is the shape of the whole problem:
+/// `1916` is not a suffix of `10918`, so what died was not one line but
+/// every line the reader had consumed and not yet emitted, and the resume
+/// landed in the middle of a number a thousand further on. The flush a
+/// handover performs empties the log file's write buffer; nothing empties
+/// the reader's. Carrying it is 2b's, and until then a sheep that fills the
+/// reader between the flush and the exec loses what is in it.
+///
+/// The counter therefore emits five lines a second rather than as fast as it
+/// can. That is not the assertion being weakened, since it is still every
+/// number, once, in order. It is the difference between exercising the
+/// handover and exercising a gap that is already known, measured and
+/// written down.
+#[cfg(unix)]
+fn assert_unbroken_sequence(lines: &[String], what: &str) {
+    for (index, line) in lines.iter().enumerate() {
+        let want = index + 1;
+        let got: usize = line.trim().parse().unwrap_or_else(|_| {
+            panic!("{what}: line {want} is not a whole number, so it was torn: {line:?}")
+        });
+        assert_eq!(
+            got,
+            want,
+            "{what}: expected {want} on line {want}, got {got}; the sequence so far is {:?}",
+            &lines[..=index]
+        );
+    }
+}
+
+/// The two assertions that define the whole handover: a sheep keeps its pid
+/// across `shep daemon reload`, and its log gains no gap.
+///
+/// A version passing neither is the stop arm, which restarts the flock:
+/// every sheep gets a new pid and a counter starts again at 1. Both halves
+/// are therefore load-bearing and neither is implied by the other: a
+/// handover that respawned the sheep would keep the log growing while
+/// moving the pid, and one that carried the pid while dropping the pipe
+/// would leave the sheep blocked on `write()` with the log frozen.
+///
+/// Unix only, as the whole handover is: Windows has no `execve`, and the arm
+/// selection there never chooses one.
+#[cfg(unix)]
+#[test]
+fn a_sheep_keeps_its_pid_and_its_log_across_a_daemon_reload() {
+    let dir = tempfile::tempdir().unwrap();
+    let script = write_counting_script(&dir);
+    let mut guard = DaemonGuard::default();
+
+    let started = shep(dir.path())
+        .arg("--format")
+        .arg("json")
+        .arg("start")
+        .arg(&script)
+        .arg("--name")
+        .arg("counter")
+        .output()
+        .unwrap();
+    guard.adopt_home(dir.path());
+    assert_success(&started);
+
+    let before = poll_flock(dir.path(), |info| {
+        info["status"] == "online" && !info["pid"].is_null()
+    });
+    let pid_before = before["pid"]
+        .as_u64()
+        .unwrap_or_else(|| panic!("an online sheep reports a pid: {before}"));
+    let out_file = PathBuf::from(
+        before["out_file"]
+            .as_str()
+            .unwrap_or_else(|| panic!("an online sheep reports its out file: {before}")),
+    );
+    let seen_before = counting_lines(&out_file, 3);
+    assert!(
+        seen_before.len() >= 3,
+        "the counter must be logging before the reload: {seen_before:?}"
+    );
+
+    let reloaded = shep(dir.path())
+        .arg("daemon")
+        .arg("reload")
+        .output()
+        .unwrap();
+    assert_success(&reloaded);
+
+    let after = poll_flock(dir.path(), |info| {
+        info["status"] == "online" && !info["pid"].is_null()
+    });
+    assert_eq!(
+        after["pid"].as_u64(),
+        Some(pid_before),
+        "a moved pid means the sheep was respawned, which is the stop arm: {after}"
+    );
+
+    let seen = counting_lines(&out_file, seen_before.len() + 3);
+    assert!(
+        seen.len() > seen_before.len(),
+        "the sheep stopped logging across the handover: {seen:?}"
+    );
+    assert_unbroken_sequence(&seen, "the counter's log across a handover");
+
+    graceful_kill(dir.path());
+}
+
+/// A flock carrying something this phase cannot move takes the stop arm, and
+/// the operator is told which sheep and why.
+///
+/// The gate doing its job, and not a failure: the reload still happens, the
+/// flock still comes back, and the refusal is a sentence in front of the
+/// person who typed the verb rather than a line in the daemon's log. The
+/// moved pid is what proves the stop arm was the one taken.
+#[cfg(unix)]
+#[test]
+fn a_flock_with_a_channel_sheep_takes_the_stop_arm() {
+    let dir = tempfile::tempdir().unwrap();
+    let script = write_test_script(&dir);
+    let flockfile = write_flockfile(
+        &dir,
+        &format!(
+            "[[app]]\nname = \"chatty\"\nscript = '{}'\nchannel = true\n",
+            script.display()
+        ),
+    );
+    let mut guard = DaemonGuard::default();
+
+    let started = shep(dir.path())
+        .arg("start")
+        .arg(&flockfile)
+        .output()
+        .unwrap();
+    guard.adopt_home(dir.path());
+    assert_success(&started);
+
+    let before = poll_flock(dir.path(), |info| {
+        info["status"] == "online" && !info["pid"].is_null()
+    });
+    let pid_before = before["pid"].as_u64();
+
+    let reloaded = shep(dir.path())
+        .arg("daemon")
+        .arg("reload")
+        .output()
+        .unwrap();
+    assert_success(&reloaded);
+    let text = format!(
+        "{}{}",
+        String::from_utf8_lossy(&reloaded.stdout),
+        String::from_utf8_lossy(&reloaded.stderr)
+    );
+    assert!(
+        text.contains("shepherd channel"),
+        "the refusal must name the feature that blocked the handover: {text}"
+    );
+    assert!(
+        text.contains("chatty"),
+        "and the sheep it blocked on: {text}"
+    );
+
+    let after = poll_flock(dir.path(), |info| {
+        info["status"] == "online" && !info["pid"].is_null()
+    });
+    assert_ne!(
+        after["pid"].as_u64(),
+        pid_before,
+        "the stop arm restarts the flock, so the pid must move: {after}"
+    );
+
+    graceful_kill(dir.path());
+}
+
+/// The control socket answers throughout a handover.
+///
+/// The successor inherits the listening descriptor rather than binding the
+/// address again, so a client that connects while the image is being
+/// replaced waits in the kernel's backlog and is served by whichever image
+/// gets to it. Nothing may be refused, and the socket file may never
+/// disappear, since a rebind would race the predecessor's socket file and
+/// lose whatever connection a client had already made.
+#[cfg(unix)]
+#[test]
+fn the_control_socket_accepts_throughout_a_handover() {
+    let dir = tempfile::tempdir().unwrap();
+    let script = write_test_script(&dir);
+    let mut guard = DaemonGuard::default();
+
+    let started = shep(dir.path())
+        .arg("start")
+        .arg(&script)
+        .arg("--name")
+        .arg("sheep")
+        .output()
+        .unwrap();
+    guard.adopt_home(dir.path());
+    assert_success(&started);
+    let _ = poll_flock(dir.path(), |info| info["status"] == "online");
+
+    let home = dir.path().to_path_buf();
+    let prober = std::thread::spawn(move || {
+        let deadline = Instant::now() + Duration::from_secs(8);
+        let mut refused = Vec::new();
+        while Instant::now() < deadline {
+            let out = shep(&home).arg("ping").output().unwrap();
+            if !out.status.success() {
+                refused.push(format!(
+                    "exit {:?}: {}",
+                    out.status.code(),
+                    String::from_utf8_lossy(&out.stderr)
+                ));
+            }
+        }
+        refused
+    });
+
+    let reloaded = shep(dir.path())
+        .arg("daemon")
+        .arg("reload")
+        .output()
+        .unwrap();
+    assert_success(&reloaded);
+
+    let refused = prober.join().unwrap();
+    assert!(
+        refused.is_empty(),
+        "every ping across the handover must be answered: {refused:?}"
+    );
+
+    graceful_kill(dir.path());
+}

--- a/crates/shep-cli/tests/cli_e2e.rs
+++ b/crates/shep-cli/tests/cli_e2e.rs
@@ -7312,10 +7312,32 @@ fn the_control_socket_accepts_throughout_a_handover() {
         .unwrap();
     assert_success(&reloaded);
 
+    // What the listener crossing the exec actually buys, and what it does
+    // not. The listener's descriptor is carried, so no client ever finds the
+    // address unbound. An ACCEPTED connection is not carried, deliberately:
+    // rebuilding a half-read frame's protocol state is not something the
+    // successor can do, and the spec's H2 records the consequence as a client
+    // seeing its connection drop and retrying.
+    //
+    // So a ping whose reply was in flight at the instant of the exec fails,
+    // and must be tolerated. A ping that could not connect at all means the
+    // address went away, which is the property this test exists to defend.
+    //
+    // Asserting the stronger thing was wrong rather than merely strict, and
+    // it passed on macOS purely because the window is narrow: the four Linux
+    // jobs on the first CI run of this test all caught it.
     let refused = prober.join().unwrap();
+    let (dropped, unreachable): (Vec<_>, Vec<_>) = refused
+        .into_iter()
+        .partition(|line| line.contains("the connection closed before a reply arrived"));
     assert!(
-        refused.is_empty(),
-        "every ping across the handover must be answered: {refused:?}"
+        unreachable.is_empty(),
+        "the control address must stay bound across the handover: {unreachable:?}"
+    );
+    assert!(
+        dropped.len() <= 1,
+        "at most the one request in flight at the exec may drop, got {}: {dropped:?}",
+        dropped.len()
     );
 
     graceful_kill(dir.path());

--- a/crates/shep-cli/tests/cli_e2e.rs
+++ b/crates/shep-cli/tests/cli_e2e.rs
@@ -7029,9 +7029,10 @@ fn a_multi_instance_flock_gets_distinct_slots_a_grouped_table_and_undoubled_blea
 /// How long [`counting_lines`] waits for a counter sheep to reach a line
 /// count, and [`wait_for_pid`] for a sheep to be online with a pid.
 ///
-/// Sized like [`FLOCK_DEADLINE`] rather than shorter: the counter emits five
-/// lines a second, so any wait here that is not satisfied in the first
-/// hundred milliseconds is a loaded machine rather than a slow sheep.
+/// Sized like [`FLOCK_DEADLINE`] rather than shorter. The counter emits five
+/// lines a second, so the longest wait any caller here asks for is six lines,
+/// which an idle machine satisfies in a little over a second. Twenty seconds
+/// is therefore a loaded runner's margin and not the sheep's own pace.
 #[cfg(unix)]
 const HANDOVER_DEADLINE: Duration = Duration::from_secs(20);
 
@@ -7054,7 +7055,7 @@ fn write_counting_script(dir: &TempDir) -> PathBuf {
         dir,
         "counter.sh",
         &format!(
-            "{}{}i=1\nwhile :; do\n  echo \"$i\"\n  i=$((i+1))\n  sleep 0.05\ndone\n",
+            "{}{}i=1\nwhile :; do\n  echo \"$i\"\n  i=$((i+1))\n  sleep 0.2\ndone\n",
             script_header(),
             record_pid_line(dir),
         ),

--- a/crates/shep-cli/tests/cli_e2e.rs
+++ b/crates/shep-cli/tests/cli_e2e.rs
@@ -7031,8 +7031,8 @@ fn a_multi_instance_flock_gets_distinct_slots_a_grouped_table_and_undoubled_blea
 ///
 /// Sized like [`FLOCK_DEADLINE`] rather than shorter. The counter emits five
 /// lines a second, so the longest wait any caller here asks for is six lines,
-/// which an idle machine satisfies in a little over a second. Twenty seconds
-/// is therefore a loaded runner's margin and not the sheep's own pace.
+/// which an idle machine satisfies in a little over a second. Ten seconds is
+/// therefore a loaded runner's margin and not the sheep's own pace.
 #[cfg(unix)]
 const HANDOVER_DEADLINE: Duration = Duration::from_secs(20);
 

--- a/crates/shep-client/src/testing.rs
+++ b/crates/shep-client/src/testing.rs
@@ -819,6 +819,54 @@ pub async fn fake_client_with_push(path: &Path) -> (Client, FakeDaemon) {
     fake_client_on(path).await
 }
 
+/// Binds `path` and serves EVERY connection made to it, handshaking with
+/// `ack`, answering each request through `answer`, and forwarding each
+/// decoded [`Envelope`] onto the returned channel.
+///
+/// The multi-connection sibling of [`fake_client_answering`], and the
+/// difference is the whole reason it exists. That helper accepts exactly one
+/// connection, which is right for a test that drives the [`Client`] it hands
+/// back; a test that instead drives a whole CLI verb has the verb open its
+/// own connections, and a second connect against a one-shot fake sits in the
+/// kernel's backlog until the client's own deadline expires. `ack` is a
+/// parameter for the same reason: the verb under test reads
+/// [`HelloAck::daemon_version`] and decides what to do from it, so a fixed
+/// [`sample_ack`] would pin the test to one branch.
+///
+/// The task is detached and runs until the listener errors, which happens
+/// when the caller's `TempDir` goes away.
+pub async fn fake_daemon_answering_with_ack(
+    path: &Path,
+    ack: HelloAck,
+    answer: impl Fn(&Request) -> Response + Send + Sync + Clone + 'static,
+) -> mpsc::UnboundedReceiver<Envelope> {
+    let mut listener = Listener::bind(path).unwrap();
+    let (tx, rx) = mpsc::unbounded_channel();
+    tokio::spawn(async move {
+        while let Ok(stream) = listener.accept().await {
+            let tx = tx.clone();
+            let ack = ack.clone();
+            let answer = answer.clone();
+            tokio::spawn(async move {
+                let mut frames = Framed::new(stream, codec());
+                handshake(&mut frames, ack).await;
+                while let Some(Ok(frame)) = frames.next().await {
+                    let Ok(envelope) = decode_frame::<Envelope>(&frame) else {
+                        break;
+                    };
+                    let id = envelope.id;
+                    let reply = answer(&envelope.body);
+                    if tx.send(envelope).is_err() {
+                        break;
+                    }
+                    write_reply(&mut frames, id, reply).await;
+                }
+            });
+        }
+    });
+    rx
+}
+
 /// As [`fake_client_capturing_envelopes`], but the caller decides what each
 /// request is answered with — for a test asserting on what a MULTI-REQUEST
 /// caller puts on the wire.

--- a/crates/shep-core/src/protocol/request.rs
+++ b/crates/shep-core/src/protocol/request.rs
@@ -425,6 +425,33 @@ pub enum Request {
         /// The dog's name
         name: String,
     },
+    /// Ask whether this daemon could hand its flock to a successor in place,
+    /// rather than stopping it and starting it again (`shep daemon reload`).
+    ///
+    /// Read-only, and nothing here triggers a handover. The trigger is a
+    /// signal and always was: a socket request cannot be the trigger, because
+    /// the case that most needs a reload is the one where the daemon refuses
+    /// the client at the handshake. What travels over the socket is the
+    /// DECISION, for a reason a signal cannot serve (spec H3a) -- a signal
+    /// carries no reply, so a daemon that took one, refused, and fell back to
+    /// its own graceful stop would leave the client polling for a successor
+    /// nobody started, with the flock down and staying down.
+    ///
+    /// Answers [`Response::HandoverFitness`]. Every refusal is a feature the
+    /// running daemon cannot yet carry, not an error: the caller falls back
+    /// to a stop-and-start, which is correct behaviour rather than a degraded
+    /// one, and prints the reason to the operator who asked for the reload.
+    ///
+    /// # Why this variant does not move `PROTOCOL_VERSION`
+    ///
+    /// An older daemon cannot deserialize a variant it has never seen, which
+    /// is normally what a bump is for. It is never sent to one. `daemon
+    /// reload` is an exempt verb, so it connects to a mismatched daemon
+    /// deliberately, learns the daemon's crate version from the handshake,
+    /// and takes the stop arm for anything predating the handover without
+    /// ever asking. shep-cli's `commands::daemon` holds that gate and a test
+    /// of its own pins it.
+    HandoverFitness,
     /// Graceful daemon shutdown
     KillDaemon,
     /// Subscribe this connection to bus topics (glob patterns)
@@ -1289,6 +1316,21 @@ pub enum Response {
     },
     /// Answer to `EnableDog` — the dog as it stands now
     DogStarted(ProcessInfo),
+    /// Answer to `HandoverFitness`: `None` when the whole flock can be
+    /// carried across a daemon handover, and otherwise the sentence saying
+    /// which sheep cannot be and why.
+    ///
+    /// A rendered sentence rather than a structured reason, deliberately. The
+    /// set of things a handover cannot yet carry is exactly the set of things
+    /// that phase has not built, so it changes with every phase that widens
+    /// it, and a wire enum would make each of those a protocol change for a
+    /// string the client does nothing with but print. The daemon owns the
+    /// wording because the daemon owns the gate.
+    HandoverFitness {
+        /// Why the flock cannot be handed over in place, or `None` when it
+        /// can.
+        refusal: Option<String>,
+    },
     /// Answer to `Subscribe`
     Subscribed,
     /// Answer to `KillDaemon`
@@ -2029,6 +2071,15 @@ mod tests {
                     },
                 },
             },
+            // The one request in this enum that an older daemon must never
+            // be sent, so the one whose exact tag matters most: shep-cli
+            // gates it on the daemon's crate version, and a rename here
+            // would be a variant nothing on either side recognises.
+            Envelope {
+                id: 24,
+                deadline_ms: None,
+                body: Request::HandoverFitness,
+            },
         ];
         insta::assert_json_snapshot!("request_wire_v2", requests);
     }
@@ -2303,6 +2354,20 @@ mod tests {
                         .instance(Some(2))
                         .build(),
                 ])),
+            },
+            // Both shapes of the handover answer, because the difference
+            // between them is a `null` and a caller that read the key's
+            // presence rather than its value would pass on one and refuse
+            // every flock on the other.
+            Reply {
+                id: 28,
+                result: Ok(Response::HandoverFitness { refusal: None }),
+            },
+            Reply {
+                id: 29,
+                result: Ok(Response::HandoverFitness {
+                    refusal: Some("sheep 'web' has a shepherd channel".to_string()),
+                }),
             },
         ];
         insta::assert_json_snapshot!("reply_wire_v2", replies);

--- a/crates/shep-core/src/protocol/snapshots/shep_core__protocol__request__tests__reply_wire_v2.snap
+++ b/crates/shep-core/src/protocol/snapshots/shep_core__protocol__request__tests__reply_wire_v2.snap
@@ -499,5 +499,27 @@ expression: replies
         ]
       }
     }
+  },
+  {
+    "id": 28,
+    "result": {
+      "Ok": {
+        "kind": "handover_fitness",
+        "data": {
+          "refusal": null
+        }
+      }
+    }
+  },
+  {
+    "id": 29,
+    "result": {
+      "Ok": {
+        "kind": "handover_fitness",
+        "data": {
+          "refusal": "sheep 'web' has a shepherd channel"
+        }
+      }
+    }
   }
 ]

--- a/crates/shep-core/src/protocol/snapshots/shep_core__protocol__request__tests__request_wire_v2.snap
+++ b/crates/shep-core/src/protocol/snapshots/shep_core__protocol__request__tests__request_wire_v2.snap
@@ -268,5 +268,12 @@ expression: requests
         }
       }
     }
+  },
+  {
+    "id": 24,
+    "deadline_ms": null,
+    "body": {
+      "kind": "handover_fitness"
+    }
   }
 ]

--- a/crates/shep-core/src/transport.rs
+++ b/crates/shep-core/src/transport.rs
@@ -444,11 +444,26 @@ mod tests {
             stream.write_all(b"still here\n").await.unwrap();
         });
 
-        let mut served = listener.accept().await.unwrap();
+        // Every await bounded, as `dialing_an_address_with_no_listener_
+        // fails_rather_than_hanging` above already does. An adopted listener
+        // that stopped accepting would otherwise hang this case, and a hang
+        // stops the whole test binary rather than failing one test, so CI
+        // times out with no assertion to point at.
+        let bound = std::time::Duration::from_secs(10);
+        let mut served = tokio::time::timeout(bound, listener.accept())
+            .await
+            .expect("an adopted listener must accept")
+            .unwrap();
         let mut said = [0_u8; 11];
-        served.read_exact(&mut said).await.unwrap();
+        tokio::time::timeout(bound, served.read_exact(&mut said))
+            .await
+            .expect("the bytes the client wrote must arrive")
+            .unwrap();
         assert_eq!(&said, b"still here\n");
-        client.await.unwrap();
+        tokio::time::timeout(bound, client)
+            .await
+            .expect("the client task must finish")
+            .unwrap();
     }
 
     /// fails if the transport cannot carry bytes both ways on this platform.

--- a/crates/shep-core/src/transport.rs
+++ b/crates/shep-core/src/transport.rs
@@ -280,6 +280,24 @@ impl Listener {
         }
     }
 
+    /// Wraps a socket this process was handed rather than one it bound.
+    ///
+    /// The successor's half of a daemon handover. The control socket is one
+    /// of the descriptors an outgoing shepherd passes across its `execve`,
+    /// so the image that takes over adopts the listener instead of binding
+    /// the address again: a rebind would race the predecessor's socket file
+    /// and lose whatever connection a client had already made.
+    ///
+    /// Unix only, and the whole handover is. Windows has no `execve`, and
+    /// its arm of [`Self::bind`] makes the bind itself the daemon's mutual
+    /// exclusion, so a second image could not create the pipe to hand on in
+    /// the first place.
+    #[cfg(unix)]
+    #[must_use]
+    pub fn from_unix_listener(listener: tokio::net::UnixListener) -> Self {
+        Self { listener }
+    }
+
     /// Waits for the next peer and returns its connected stream.
     ///
     /// # Errors
@@ -387,6 +405,33 @@ mod tests {
                 std::process::id()
             ))
         }
+    }
+
+    /// fails if a listener rebuilt around an inherited socket cannot serve.
+    ///
+    /// The successor half of a daemon handover: the control socket is one
+    /// descriptor the outgoing shepherd hands on, so its replacement binds
+    /// nothing and wraps what it was given. A `bind` here instead would
+    /// meet the socket file the predecessor left behind, and the connection
+    /// a client had already made to it would be dropped on the floor.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn a_listener_built_around_an_inherited_socket_still_accepts() {
+        let dir = tempfile::tempdir().unwrap();
+        let addr = address(dir.path(), "adopted");
+        let inherited = tokio::net::UnixListener::bind(&addr).unwrap();
+
+        let mut listener = Listener::from_unix_listener(inherited);
+        let client = tokio::spawn(async move {
+            let mut stream = connect(&addr).await.unwrap();
+            stream.write_all(b"still here\n").await.unwrap();
+        });
+
+        let mut served = listener.accept().await.unwrap();
+        let mut said = [0_u8; 11];
+        served.read_exact(&mut said).await.unwrap();
+        assert_eq!(&said, b"still here\n");
+        client.await.unwrap();
     }
 
     /// fails if the transport cannot carry bytes both ways on this platform.

--- a/crates/shep-core/src/transport.rs
+++ b/crates/shep-core/src/transport.rs
@@ -298,6 +298,23 @@ impl Listener {
         Self { listener }
     }
 
+    /// The descriptor this listener is bound on.
+    ///
+    /// The predecessor's half of a daemon handover, and the counterpart to
+    /// [`Self::from_unix_listener`]: an outgoing shepherd has to name this
+    /// number in the blob it hands on, since a descriptor number is only
+    /// meaningful in the process that owns it and the successor adopts it by
+    /// number. Borrowed, never owned: closing it would close the control
+    /// socket out from under a daemon that is still serving.
+    ///
+    /// Unix only, as the whole handover is.
+    #[cfg(unix)]
+    #[must_use]
+    pub fn as_raw_fd(&self) -> std::os::fd::RawFd {
+        use std::os::fd::AsRawFd as _;
+        self.listener.as_raw_fd()
+    }
+
     /// Waits for the next peer and returns its connected stream.
     ///
     /// # Errors

--- a/crates/shep-daemon/src/boot.rs
+++ b/crates/shep-daemon/src/boot.rs
@@ -1207,6 +1207,13 @@ pub async fn boot<R: ProcessRunner>(
     // each sheep's own side the shepherd was never away.
     #[cfg(unix)]
     let mut carried_apps = Vec::new();
+    // Read before the match consumes `inherited`, and deliberately not
+    // derived from `carried_apps` afterwards: a successor that inherited an
+    // EMPTY flock is still a successor, and the two are only the same
+    // question when the predecessor had at least one sheep. See the restore
+    // guard below for what the difference costs.
+    #[cfg(unix)]
+    let inherited_flock = inherited.is_some();
     #[cfg(unix)]
     let supervisor = match inherited {
         Some((flock, counters)) => {
@@ -1271,8 +1278,13 @@ pub async fn boot<R: ProcessRunner>(
     // one within seconds of taking over. And a restore would START whatever
     // the roll records as running, which for a flock that never stopped
     // means a second copy of every sheep that happens to be down.
-    #[cfg(unix)]
-    let inherited_flock = !carried_apps.is_empty();
+    //
+    // An EMPTY inherited flock is the case that makes `inherited_flock` a
+    // fact about the boot rather than a count of the sheep. `shep daemon
+    // reload` against an idle shepherd carries nothing, and a handover skips
+    // the predecessor's teardown, so the roll on disk is whatever the last
+    // periodic write left. Deriving the flag from `carried_apps` would run
+    // the restore there and start sheep that had just been deleted.
     #[cfg(unix)]
     for app in &carried_apps {
         registry.record_config(app);

--- a/crates/shep-daemon/src/boot.rs
+++ b/crates/shep-daemon/src/boot.rs
@@ -3398,6 +3398,16 @@ mod tests {
     /// the message is what tells the two failures apart.
     #[tokio::test]
     async fn a_sighup_over_a_flock_it_cannot_carry_refuses_before_it_execs() {
+        // Real time + real signal listeners. This case raises nothing
+        // itself, but `SIGNAL_TEST_LOCK`'s rule is "calls `boot()`
+        // successfully", not "calls `raise()`": a successful `boot()`
+        // installs SIGTERM, SIGHUP and SIGUSR2 listeners that run for this
+        // test's whole duration, and a concurrent `raise()` in one of the
+        // shutdown cases reaches them too. This daemon would then shut down
+        // ahead of its own `ctx.shutdown()` while absorbing a delivery the
+        // other test needed, which is the way a real regression there gets
+        // masked.
+        let _guard = SIGNAL_TEST_LOCK.lock().await;
         let dir = tempfile::tempdir().unwrap();
         let paths = test_paths(&dir);
         init_dirs(&paths).unwrap();
@@ -3433,7 +3443,13 @@ mod tests {
         );
 
         ctx.shutdown();
-        daemon.run().await.unwrap();
+        // Bounded, like the sibling above. The lock this case now holds is
+        // held across this await, so a teardown that hung would stop every
+        // other signal test in the module rather than failing this one.
+        tokio::time::timeout(Duration::from_secs(5), daemon.run())
+            .await
+            .unwrap()
+            .unwrap();
     }
 
     #[tokio::test]

--- a/crates/shep-daemon/src/boot.rs
+++ b/crates/shep-daemon/src/boot.rs
@@ -1884,7 +1884,9 @@ fn install_signals(
             tracing::warn!(
                 %refusal,
                 "SIGHUP: this flock could not be handed to a successor; stopping gracefully \
-                 instead, and a client that asked first has already been told why"
+                 instead. This line may be the only record of the reason: a signal carries no \
+                 sender, and the case this gate exists for is a flock that changed between a \
+                 client's question and the signal, where that client was told nothing"
             );
             let _ = hup_shutdown.send(true);
         }
@@ -2104,8 +2106,11 @@ impl fmt::Display for BootError {
             Self::Adopt(reason) => write!(
                 f,
                 "this shepherd was handed a flock it could not take over: {reason}. The flock is \
-                 still running and nothing is supervising it; `shep daemon reload` starts a \
-                 shepherd for it"
+                 still running and nothing is supervising it. `shep daemon reload` is not the \
+                 way back: it needs a live shepherd to ask and to signal, and this process is \
+                 about to exit without ever serving. It holds the pidfile until it does, so the \
+                 home is claimable straight afterwards and `shep muster` starts a shepherd from \
+                 the roll"
             ),
         }
     }

--- a/crates/shep-daemon/src/boot.rs
+++ b/crates/shep-daemon/src/boot.rs
@@ -363,6 +363,18 @@ impl UnixLock {
             Self::Adopted(file) => file,
         }
     }
+
+    /// The descriptor carrying the lock, for the blob a handover hands on.
+    ///
+    /// Borrowed, never owned. Closing this would release the `flock` that is
+    /// the only thing keeping a second daemon out of this `$SHEP_HOME`.
+    fn as_raw_fd(&self) -> std::os::fd::RawFd {
+        use std::os::fd::AsRawFd as _;
+        match self {
+            Self::Taken(flock) => flock.as_raw_fd(),
+            Self::Adopted(file) => file.as_raw_fd(),
+        }
+    }
 }
 
 /// The sibling file the Windows arm locks: the pidfile with `.lock` appended.
@@ -506,15 +518,19 @@ impl PidfileLock {
     /// The pidfile's contents need no update either. An `execve` keeps the
     /// pid, so the number the predecessor recorded is this process's own.
     #[cfg(unix)]
-    #[allow(
-        dead_code,
-        reason = "task 8c installs the adopted flock and is what calls this; the arm it holds \
-                  the home with has to exist before there is a caller for it"
-    )]
     fn from_locked(file: std::fs::File) -> Self {
         Self {
             flock: UnixLock::Adopted(file),
         }
+    }
+
+    /// The descriptor the lock lives on, for a handover blob to name.
+    ///
+    /// See [`UnixLock::as_raw_fd`]: borrowed, and closing it would hand this
+    /// `$SHEP_HOME` to whoever asks next.
+    #[cfg(unix)]
+    fn as_raw_fd(&self) -> std::os::fd::RawFd {
+        self.flock.as_raw_fd()
     }
 
     #[cfg(unix)]
@@ -582,15 +598,43 @@ impl PidfileLock {
 /// successor.
 #[cfg(unix)]
 #[must_use]
-#[expect(
-    dead_code,
-    reason = "task 8 calls this from `boot`; detecting a successor before there is anything to \
-              hand it is the half of the job this task ships"
-)]
 pub(crate) fn successor_handover() -> Option<Successor> {
     let path = PathBuf::from(std::env::var_os(crate::handover::HANDOVER_ENV)?);
     let blob = successor_handover_at(&path)?;
     Some(Successor { path, blob })
+}
+
+/// Rebuild everything a successor was handed: the lock, the listener, and
+/// every sheep's plumbing.
+///
+/// The blob is removed once its descriptors are adopted, and only then. One
+/// left behind after a refusal is evidence an operator can read; one left
+/// after a success is a picture of a handover that has already happened, and
+/// the next boot would adopt it again.
+///
+/// # Errors
+///
+/// - [`BootError::Adopt`]: a descriptor the blob names is not open in this
+///   process, or is not the kind of object it was named as.
+///
+/// There is no partial success and no fallback here. By the time this runs
+/// the predecessor has already `execve`d itself away, so there is no image
+/// left to hand the flock back to: a successor that cannot rehydrate refuses
+/// to boot rather than serving a flock it only half holds, and the operator's
+/// own `shep daemon reload` starts one in its place.
+#[cfg(unix)]
+fn rehydrate(carried: Successor, paths: &ShepPaths) -> Result<Rehydrated, BootError> {
+    let Successor { path, blob } = carried;
+    let counters = blob.counters();
+    let adopted = crate::handover::adopt::adopt(&blob)
+        .map_err(|source| BootError::Adopt(source.to_string()))?;
+    crate::handover::adopt::discard_blob(&path);
+    let _ = paths;
+    Ok((
+        PidfileLock::from_locked(adopted.pidfile),
+        Listener::from_unix_listener(adopted.listener),
+        (adopted.sheep, counters),
+    ))
 }
 
 /// A handover blob, and where it was read from.
@@ -601,10 +645,6 @@ pub(crate) fn successor_handover() -> Option<Successor> {
 /// adopted again by the next boot.
 #[cfg(unix)]
 #[derive(Debug)]
-#[expect(
-    dead_code,
-    reason = "task 8 reads both fields: the blob to adopt, and the path to unlink afterwards"
-)]
 pub(crate) struct Successor {
     /// Where the blob was read from.
     pub path: PathBuf,
@@ -988,6 +1028,26 @@ pub struct BootOptions {
     /// `crate::snapshot::FlockRegistry::clear`'s own doc for the shutdown
     /// gap this closes.
     pub delete_flock_on_shutdown: bool,
+    /// Let SIGHUP replace this process's image with a successor holding the
+    /// same flock, rather than stopping gracefully.
+    ///
+    /// `true` for every boot the `shep` binary performs, which is what makes
+    /// `shep daemon reload` a handover rather than a stop-and-start.
+    ///
+    /// **Defaults to `false`, and the default is the safe direction rather
+    /// than the polite one.** A handover `execve`s the file this process was
+    /// launched from, so it is only ever correct where that file IS the shep
+    /// binary. A test harness, or any program embedding this crate, is
+    /// launched from something else entirely, and a SIGHUP there would
+    /// replace the whole program with a fresh copy of itself, which is not a
+    /// subtle failure but a process that re-runs from the top forever.
+    /// A caller that opts in is asserting it is the shepherd binary.
+    ///
+    /// The graceful stop is what a boot that has not opted in does with
+    /// SIGHUP, which is also what a handover that cannot proceed falls back
+    /// to. Unix only in effect: Windows has no `execve` and every arm of the
+    /// reload there is a stop-and-start (spec H5).
+    pub handover: bool,
 }
 
 /// Brings the daemon up: signal handlers, layout, roll restore, bus,
@@ -1066,6 +1126,10 @@ pub async fn boot<R: ProcessRunner>(
     //    observable) exists — see this fn's own doc.
     let (shutdown, shutdown_rx) = watch::channel(false);
     let shutdown = Arc::new(shutdown);
+    #[cfg(unix)]
+    let (signals, connect_supervisor, connect_handover) =
+        install_signals(Arc::clone(&shutdown), paths.clone())?;
+    #[cfg(windows)]
     let (signals, connect_supervisor) = install_signals(Arc::clone(&shutdown), paths.clone())?;
 
     // 2. Layout, then claim exclusive ownership of $SHEP_HOME BEFORE
@@ -1075,9 +1139,26 @@ pub async fn boot<R: ProcessRunner>(
     //    bind-and-recover sequence, and for the rest of this daemon's life
     //    (kept in `RunningDaemon`, dropped only at the end of `run`).
     init_dirs(&paths)?;
-    let mut pidfile_lock = PidfileLock::acquire(&paths)?;
     let socket = socket_path(&paths, options.socket.as_deref());
-    let listener = bind_socket(&paths, &socket)?;
+    // A successor takes neither the lock nor the address: it inherited both,
+    // still held, in the same act that made it this process. Rebinding would
+    // race the predecessor's own socket file and lose whatever connection a
+    // client had already made, and re-locking would mean releasing first.
+    #[cfg(unix)]
+    let (mut pidfile_lock, listener, inherited) = match successor_handover() {
+        Some(carried) => {
+            let (lock, listener, flock) = rehydrate(carried, &paths)?;
+            (lock, listener, Some(flock))
+        }
+        None => (
+            PidfileLock::acquire(&paths)?,
+            bind_socket(&paths, &socket)?,
+            None,
+        ),
+    };
+    #[cfg(windows)]
+    let (mut pidfile_lock, listener) =
+        (PidfileLock::acquire(&paths)?, bind_socket(&paths, &socket)?);
     let pid = std::process::id();
     pidfile_lock.record(&paths, pid)?;
 
@@ -1119,9 +1200,27 @@ pub async fn boot<R: ProcessRunner>(
     // baseline, the RPC layer reads a live sample against it, and a second
     // state would leave one of the two reading an empty watch set.
     let stats = Arc::clone(&extras.stats);
-    let supervisor = SupervisorBuilder::new(runner, paths.clone(), events.clone())
-        .extras(extras)
-        .spawn();
+    let builder = SupervisorBuilder::new(runner, paths.clone(), events.clone()).extras(extras);
+    // A successor installs the flock it inherited rather than spawning one:
+    // every sheep keeps the pid, the id, the epoch and the history it had a
+    // moment ago, and nothing here signals, spawns or reopens anything. From
+    // each sheep's own side the shepherd was never away.
+    #[cfg(unix)]
+    let mut carried_apps = Vec::new();
+    #[cfg(unix)]
+    let supervisor = match inherited {
+        Some((flock, counters)) => {
+            // Read before the flock is moved: the registry below is rebuilt
+            // from these, and the roll would otherwise be written empty.
+            carried_apps.extend(flock.iter().map(|sheep| sheep.carried.app().clone()));
+            builder
+                .spawn_adopted(flock, counters)
+                .map_err(|source| BootError::Adopt(source.to_string()))?
+        }
+        None => builder.spawn(),
+    };
+    #[cfg(windows)]
+    let supervisor = builder.spawn();
     // Ordered, not stylistic: the reporter needs the handle the builder
     // returns, and the actor must never own a receiver a subsystem feeds.
     //
@@ -1148,9 +1247,40 @@ pub async fn boot<R: ProcessRunner>(
     // still alive.
     let _ = connect_supervisor.send(supervisor.clone());
 
+    // The other half of step 1's SIGHUP task, parked on this since before
+    // the socket existed. It carries the two descriptors a handover blob has
+    // to name, which only this function knows: an fd number means nothing
+    // outside the process that owns it, and the supervisor has never seen
+    // either of them.
+    #[cfg(unix)]
+    let _ = connect_handover.send(options.handover.then(|| HandoverSeam {
+        supervisor: supervisor.clone(),
+        fds: crate::handover::DaemonFds {
+            listener: listener.as_raw_fd(),
+            pidfile: pidfile_lock.as_raw_fd(),
+        },
+        paths: paths.clone(),
+    }));
+
     let registry = FlockRegistry::new();
 
-    if options.restore {
+    // A successor rebuilds the registry from the blob rather than from the
+    // roll, and skips the restore entirely. Both halves matter. The registry
+    // is what the snapshot writer builds the muster roll from, so a
+    // successor that left it empty would overwrite a good roll with an empty
+    // one within seconds of taking over. And a restore would START whatever
+    // the roll records as running, which for a flock that never stopped
+    // means a second copy of every sheep that happens to be down.
+    #[cfg(unix)]
+    let inherited_flock = !carried_apps.is_empty();
+    #[cfg(unix)]
+    for app in &carried_apps {
+        registry.record_config(app);
+    }
+    #[cfg(windows)]
+    let inherited_flock = false;
+
+    if options.restore && !inherited_flock {
         restore_flock(&paths, &registry, &supervisor).await?;
     }
 
@@ -1640,7 +1770,7 @@ fn install_signals(
 fn install_signals(
     shutdown: Arc<watch::Sender<bool>>,
     paths: ShepPaths,
-) -> Result<(SignalTasks, oneshot::Sender<SupervisorHandle>), BootError> {
+) -> Result<InstalledSignals, BootError> {
     let mut signals = SignalTasks {
         tasks: Vec::with_capacity(4),
     };
@@ -1649,13 +1779,6 @@ fn install_signals(
         SignalKind::terminate(),
         SignalKind::interrupt(),
         SignalKind::quit(),
-        // SIGHUP is here as a floor, not as its final meaning. It becomes
-        // the handover trigger, and until it does its kernel default is an
-        // unhandled terminate that would drop the flock's pipes rather than
-        // walk the ladder. A daemon that treats it as a graceful stop can be
-        // signalled by a newer client without the flock paying for the
-        // version gap.
-        SignalKind::hangup(),
     ] {
         // An early return here drops `signals`, whose own `Drop` aborts
         // every task already pushed — registering the 2nd or 3rd kind
@@ -1696,6 +1819,65 @@ fn install_signals(
         }));
     }
 
+    // SIGHUP is the handover trigger, and it is a signal rather than a
+    // request for the reason spec H3 gives: the case that most needs a
+    // reload is the one where the daemon refuses the client at the
+    // handshake, and a remedy delivered over the channel it is meant to
+    // repair is not a remedy. It has its own task rather than riding in the
+    // loop above, because the two dispositions are different: the shutdown
+    // signals stop this daemon, and this one replaces it.
+    //
+    // The graceful stop stays as the arm taken when a handover cannot
+    // proceed. SIGHUP's kernel default is an unhandled terminate that would
+    // drop the flock's pipes rather than walk the ladder, so a stray or
+    // mistaken one, or one whose handover is refused, must still end the way
+    // every other shutdown signal does.
+    let mut hup = signal(SignalKind::hangup()).map_err(|source| BootError::Io {
+        path: paths.home.clone(),
+        source,
+    })?;
+    let (connect_handover, handover_rx) = oneshot::channel::<Option<HandoverSeam>>();
+    let hup_shutdown = Arc::clone(&shutdown);
+    signals.tasks.push(tokio::spawn(async move {
+        // Parked until `boot` reaches step 4, exactly as the SIGUSR2 task
+        // below is, and for the same reason: the descriptors and the
+        // supervisor a handover needs do not exist when signals are
+        // installed. A signal that arrives before then is buffered by the
+        // stream, which was registered above.
+        //
+        // `None` is a boot that did not arm the handover
+        // ([`BootOptions::handover`]), and an `Err` is a boot that never got
+        // that far. Both mean this task has no image to hand anything to,
+        // and both still have to answer SIGHUP: its kernel default is an
+        // unhandled terminate, so a task that simply returned here would
+        // leave a stray signal killing the daemon outright and dropping
+        // every sheep's pipes.
+        let seam = handover_rx.await.ok().flatten();
+        // `if`, not `while`: this task handles at most one SIGHUP, unlike
+        // the shutdown listeners above, which stay armed for the process's
+        // life. On the success arm there is no image left to loop in, and on
+        // every other arm this daemon is now stopping, and a second SIGHUP
+        // during that teardown would find the same graceful stop already
+        // underway.
+        if hup.recv().await.is_some() {
+            let refusal = match &seam {
+                Some(seam) => match hand_over_now(seam).await {
+                    // No successor statement on the success arm, because
+                    // there is no successor image running this code.
+                    Ok(never) => match never {},
+                    Err(refusal) => refusal,
+                },
+                None => "this shepherd was not booted with the handover armed".to_string(),
+            };
+            tracing::warn!(
+                %refusal,
+                "SIGHUP: this flock could not be handed to a successor; stopping gracefully \
+                 instead, and a client that asked first has already been told why"
+            );
+            let _ = hup_shutdown.send(true);
+        }
+    }));
+
     let mut usr2 = signal(SignalKind::user_defined2()).map_err(|source| BootError::Io {
         path: paths.home.clone(),
         source,
@@ -1704,6 +1886,7 @@ fn install_signals(
     signals.tasks.push(tokio::spawn(async move {
         // Parked until `boot` reaches step 4 — see this fn's own doc for why
         // the wait loses no signal, and for what an `Err` here means.
+
         let Ok(supervisor) = supervisor_rx.await else {
             return;
         };
@@ -1731,7 +1914,85 @@ fn install_signals(
         }
     }));
 
-    Ok((signals, connect_supervisor))
+    Ok((signals, connect_supervisor, connect_handover))
+}
+
+/// What [`install_signals`] hands back: the live listener tasks, and the two
+/// senders that connect them to state `boot` has not built yet.
+///
+/// The SIGUSR2 task needs a [`SupervisorHandle`] to reopen through, and the
+/// SIGHUP task needs a whole [`HandoverSeam`] or the `None` that says this
+/// boot did not arm one. Both are parked on their receivers from the moment
+/// the handlers are installed, which is before the socket exists.
+#[cfg(unix)]
+type InstalledSignals = (
+    SignalTasks,
+    oneshot::Sender<SupervisorHandle>,
+    oneshot::Sender<Option<HandoverSeam>>,
+);
+
+/// What [`rehydrate`] rebuilds from a blob: the home's lock, the control
+/// listener, and the flock to install with the counters it ran under.
+#[cfg(unix)]
+type Rehydrated = (
+    PidfileLock,
+    Listener,
+    (
+        Vec<crate::handover::adopt::AdoptedSheep>,
+        crate::handover::Counters,
+    ),
+);
+
+/// Everything the SIGHUP task needs to replace this daemon's image.
+///
+/// A struct handed over a channel rather than three arguments, because none
+/// of it exists when [`install_signals`] runs: the descriptors are opened
+/// two steps later and the supervisor a step after that.
+///
+/// `Debug` is derived and carries nothing sensitive: two descriptor numbers,
+/// a mailbox and the home's own paths. The blob those descriptors end up in
+/// carries no environment value either (see [`crate::handover::Handover`]).
+#[cfg(unix)]
+#[derive(Debug)]
+pub(crate) struct HandoverSeam {
+    /// The flock to carry.
+    supervisor: SupervisorHandle,
+    /// The daemon's own two descriptors, which the actor never sees.
+    fds: crate::handover::DaemonFds,
+    /// The home, for the blob's path.
+    paths: ShepPaths,
+}
+
+/// Replace this process with a successor holding `seam`'s flock.
+///
+/// The gate runs HERE as well as in the client that asked before signalling,
+/// and both are load-bearing. The client asks so that a refusal reaches the
+/// operator and the flock is stopped-and-started rather than left down (spec
+/// H3a); this one asks because a signal is a signal: anyone can send one,
+/// peer input is untrusted, and the flock can change between the question
+/// and the signal.
+///
+/// # Errors
+///
+/// The sentence to log, when the flock cannot be carried, when the actor is
+/// gone, or when the exec itself failed. Every one of them leaves this
+/// process still itself, with no blob on disk, and the caller falls back to
+/// a graceful stop.
+#[cfg(unix)]
+async fn hand_over_now(seam: &HandoverSeam) -> Result<core::convert::Infallible, String> {
+    let (candidates, blob) = seam
+        .supervisor
+        .handover_snapshot(seam.fds)
+        .await
+        .map_err(|err| format!("the supervisor could not describe its flock: {err}"))?;
+    let borrowed: Vec<crate::handover::Candidate<'_>> = candidates
+        .iter()
+        .map(crate::handover::OwnedCandidate::as_candidate)
+        .collect();
+    if let crate::handover::Fitness::Refused(reason) = crate::handover::fitness(&borrowed) {
+        return Err(reason.to_string());
+    }
+    crate::handover::hand_over(&blob, &seam.paths).map_err(|err| err.to_string())
 }
 
 /// Error type returned from this module's boot steps
@@ -1751,6 +2012,16 @@ fn install_signals(
 #[non_exhaustive]
 #[derive(Debug)]
 pub enum BootError {
+    /// A flock this image inherited across a handover could not be
+    /// installed.
+    ///
+    /// The descriptor a blob named is not open here, is not the kind of
+    /// object it was named as, or the supervisor would not take it. A
+    /// `String` rather than the underlying error, because the two sources
+    /// are different types in different modules and neither is part of this
+    /// crate's public surface; what a caller needs is the sentence naming
+    /// which sheep is now unsupervised.
+    Adopt(String),
     /// A filesystem step failed (carries the path and the OS error)
     ///
     /// Deliberately has no `From<std::io::Error>`, and neither does any
@@ -1818,6 +2089,12 @@ impl fmt::Display for BootError {
                 path.display()
             ),
             Self::ReadyWrite(err) => write!(f, "writing the readiness line failed: {err}"),
+            Self::Adopt(reason) => write!(
+                f,
+                "this shepherd was handed a flock it could not take over: {reason}. The flock is \
+                 still running and nothing is supervising it; `shep daemon reload` starts a \
+                 shepherd for it"
+            ),
         }
     }
 }
@@ -1832,6 +2109,9 @@ impl core::error::Error for BootError {
             Self::SocketPathTooLong { .. } => None,
             Self::Snapshot(err) => Some(err),
             Self::ReadyWrite(err) => Some(err),
+            // No source: both underlying types are module-private, so the
+            // sentence is the whole report (see the variant's own doc).
+            Self::Adopt(_) => None,
         }
     }
 }
@@ -3053,11 +3333,20 @@ mod tests {
 
     #[tokio::test]
     async fn sighup_triggers_the_same_graceful_shutdown() {
-        // Task 3 (2026-08-29): SIGHUP's default disposition is to
-        // terminate the process, and this handler is what replaces that
-        // default. Phase 2 makes SIGHUP the handover trigger; until it
-        // does, a stray or mistaken SIGHUP must still walk the same
-        // graceful path SIGTERM does rather than drop the flock's pipes.
+        // SIGHUP's default disposition is to terminate the process, and
+        // this handler is what replaces that default. SIGHUP is the
+        // handover trigger now, but a boot that has not opted in
+        // (`BootOptions::handover`, left `false` by the default below) has
+        // no successor to become, and a stray or mistaken SIGHUP must still
+        // walk the same graceful path SIGTERM does rather than drop the
+        // flock's pipes.
+        //
+        // That default is also what keeps this test from replacing the test
+        // binary with a fresh copy of itself, which is what an opted-in boot
+        // would do here: `exec_target` resolves the file this process was
+        // launched from, and in a test that file is the harness. See
+        // `BootOptions::handover`'s own doc.
+        //
         // Mirrors `sigterm_triggers_the_same_graceful_shutdown` above —
         // see that test's own comments for why raising a real signal here
         // is safe only because the handler is installed first, and for
@@ -3083,6 +3372,58 @@ mod tests {
         assert!(!paths.socket.exists());
     }
 
+    /// The daemon-side gate, and why a client asking first is not enough.
+    ///
+    /// A signal is a signal: anyone can send one, and the flock can change
+    /// between the client's question and the signal. So the SIGHUP path runs
+    /// [`crate::handover::fitness`] again and refuses on its own, which is
+    /// what makes the fallback to a graceful stop reachable at all.
+    ///
+    /// **The descriptors are deliberately invalid.** If the gate ever
+    /// stopped refusing, `hand_over` would go on to clear `FD_CLOEXEC` on
+    /// them, meet `EBADF`, and return, rather than exec'ing this test binary
+    /// into an endless re-run of the whole suite. The assertion on
+    /// the message is what tells the two failures apart.
+    #[tokio::test]
+    async fn a_sighup_over_a_flock_it_cannot_carry_refuses_before_it_execs() {
+        let dir = tempfile::tempdir().unwrap();
+        let paths = test_paths(&dir);
+        init_dirs(&paths).unwrap();
+        let daemon = boot(
+            ScriptedRunner::new(vec![ProcScript::never_exits()]),
+            paths.clone(),
+            BootOptions::default(),
+        )
+        .await
+        .unwrap();
+        let ctx = daemon.context();
+        let mut app = AppConfig::minimal("chatty", "./srv");
+        app.channel = true;
+        ctx.supervisor
+            .start(vec![normalize(app).unwrap()])
+            .await
+            .unwrap();
+
+        let seam = HandoverSeam {
+            supervisor: ctx.supervisor.clone(),
+            fds: crate::handover::DaemonFds {
+                listener: -1,
+                pidfile: -1,
+            },
+            paths: paths.clone(),
+        };
+        let refusal = hand_over_now(&seam)
+            .await
+            .expect_err("a flock with a shepherd channel cannot be carried");
+        assert!(
+            refusal.contains("shepherd channel"),
+            "the gate must refuse before anything is exec'd: {refusal}"
+        );
+
+        ctx.shutdown();
+        daemon.run().await.unwrap();
+    }
+
     #[tokio::test]
     async fn a_repeat_sigterm_is_observed_not_swallowed() {
         // Pins Decision 3 (2026-08-08): each shutdown-signal listener
@@ -3101,11 +3442,12 @@ mod tests {
         let paths = test_paths(&dir);
         let (shutdown, mut shutdown_rx) = watch::channel(false);
         let shutdown = Arc::new(shutdown);
-        // The SIGUSR2 half of the return is dropped unused: this case drives
-        // the shutdown listeners only, and a dropped sender simply ends the
-        // SIGUSR2 listener that is parked on its receiver (see
+        // The SIGUSR2 and SIGHUP halves of the return are dropped unused:
+        // this case drives the shutdown listeners only, and a dropped sender
+        // simply ends the task parked on its receiver (see
         // `install_signals`'s own doc) without disturbing the three below.
-        let (signals, _connect_supervisor) = install_signals(shutdown, paths).unwrap();
+        let (signals, _connect_supervisor, _connect_handover) =
+            install_signals(shutdown, paths).unwrap();
 
         // First SIGTERM: starts shutdown, exactly as before this decision.
         nix::sys::signal::raise(nix::sys::signal::Signal::SIGTERM).unwrap();

--- a/crates/shep-daemon/src/boot.rs
+++ b/crates/shep-daemon/src/boot.rs
@@ -472,6 +472,97 @@ impl PidfileLock {
     }
 }
 
+/// The handover blob this process was handed, if it is a successor.
+///
+/// A successor is a shep image an outgoing daemon `execve`d in its own
+/// place, handing it a live flock. Its only marker is `SHEP_HANDOVER` in the
+/// environment, naming the blob to adopt; an image started any other way has
+/// no variable, no blob, and boots normally.
+///
+/// # Why a refusal is not an error
+///
+/// By the time this runs the predecessor has already replaced itself, so
+/// there is no image left to fall back to and no stop arm to take. That
+/// leaves exactly two outcomes for a blob that cannot be used, and this
+/// function chooses the second:
+///
+/// 1. refuse to boot at all, which leaves the operator no shepherd and a
+///    flock nothing is watching;
+/// 2. say so at `error` level and continue as an ordinary boot, which is
+///    correct for the case this actually happens in.
+///
+/// The case it actually happens in is a STALE VARIABLE: something inherited
+/// `SHEP_HANDOVER` from a process that has long since finished its handover,
+/// and the blob it names was unlinked at the time. There is no live flock
+/// behind it, and a fresh boot is exactly right.
+///
+/// A genuinely lost blob is the other case, and it is self-limiting rather
+/// than dangerous. A real successor inherited the pidfile descriptor too,
+/// with its `flock` still held, so the fresh boot this returns to cannot
+/// take that lock and stops at [`BootError::AlreadyRunning`] before it
+/// restores a thing. The one way a fresh boot proceeds is the one way it
+/// should: no pidfile descriptor was inherited, so this was never a real
+/// handover.
+///
+/// Silence is the outcome neither case may have, which is why every refusal
+/// logs at `error` with the blob's path and what was wrong with it.
+///
+/// Unix only, as the whole handover is: Windows has no `execve`, so
+/// `Arm::for_daemon` never chooses a handover there and no image can be a
+/// successor.
+#[cfg(unix)]
+#[must_use]
+#[expect(
+    dead_code,
+    reason = "task 8 calls this from `boot`; detecting a successor before there is anything to \
+              hand it is the half of the job this task ships"
+)]
+pub(crate) fn successor_handover() -> Option<Successor> {
+    let path = PathBuf::from(std::env::var_os(crate::handover::HANDOVER_ENV)?);
+    let blob = successor_handover_at(&path)?;
+    Some(Successor { path, blob })
+}
+
+/// A handover blob, and where it was read from.
+///
+/// The path is kept because the successor unlinks the blob once it has
+/// adopted what it describes, and only then: a blob left behind after a
+/// refusal is evidence, while one left behind after a success would be
+/// adopted again by the next boot.
+#[cfg(unix)]
+#[derive(Debug)]
+#[expect(
+    dead_code,
+    reason = "task 8 reads both fields: the blob to adopt, and the path to unlink afterwards"
+)]
+pub(crate) struct Successor {
+    /// Where the blob was read from.
+    pub path: PathBuf,
+    /// What it said.
+    pub blob: crate::handover::Handover,
+}
+
+/// [`successor_handover`], against a caller-named path.
+///
+/// Split out so a test can drive every refusal without touching the
+/// environment, which is process-global and, since edition 2024, unsafe to
+/// write.
+#[cfg(unix)]
+fn successor_handover_at(path: &Path) -> Option<crate::handover::Handover> {
+    match crate::handover::Handover::read(path) {
+        Ok(blob) => Some(blob),
+        Err(error) => {
+            tracing::error!(
+                path = %path.display(),
+                %error,
+                "this process was handed a handover blob it cannot use, and is booting as if \
+                 it were fresh; if a flock was running, it is no longer supervised"
+            );
+            None
+        }
+    }
+}
+
 /// What, if anything, owns this home's pidfile lock.
 ///
 /// Proof of life is the pidfile LOCK, never the pidfile's contents. A live
@@ -3114,5 +3205,61 @@ mod tests {
             .unwrap()
             .unwrap()
             .unwrap();
+    }
+
+    /// A blob written by hand rather than by `Handover::write`, so this
+    /// module's tests pin the on-disk shape a successor has to read rather
+    /// than round-tripping whatever the writer happens to emit.
+    fn write_blob(path: &Path, version: u32) {
+        std::fs::write(
+            path,
+            format!(
+                r#"{{"version":{version},"sheep":[],"listener_fd":3,"pidfile_fd":4,"next_id":0,"next_deadline":0,"next_action_stamp":0}}"#
+            ),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn a_blob_on_disk_makes_this_process_a_successor() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("handover.json");
+        write_blob(&path, 1);
+
+        assert!(successor_handover_at(&path).is_some());
+    }
+
+    #[test]
+    fn a_missing_blob_is_refused_out_loud_rather_than_silently() {
+        // A stale inherited variable and a lost blob look the same from
+        // here, and neither may pass for a fresh boot without a word.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("never-written.json");
+
+        let logs = capture_logs(|| assert!(successor_handover_at(&path).is_none()));
+
+        assert!(logs.contains("never-written.json"), "{logs}");
+    }
+
+    #[test]
+    fn a_blob_of_an_unknown_version_is_refused_out_loud() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("handover.json");
+        write_blob(&path, u32::MAX);
+
+        let logs = capture_logs(|| assert!(successor_handover_at(&path).is_none()));
+
+        assert!(logs.contains("version"), "{logs}");
+    }
+
+    #[test]
+    fn a_refused_blob_is_left_on_disk_for_an_operator_to_read() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("handover.json");
+        write_blob(&path, u32::MAX);
+
+        capture_logs(|| assert!(successor_handover_at(&path).is_none()));
+
+        assert!(path.exists(), "a refused blob is evidence, not litter");
     }
 }

--- a/crates/shep-daemon/src/boot.rs
+++ b/crates/shep-daemon/src/boot.rs
@@ -2010,8 +2010,31 @@ mod tests {
         // And it is a lock rather than a descriptor nobody can ever release:
         // a successor that exits closes the only handle left, and the kernel
         // frees the home for the next daemon.
+        //
+        // Retried rather than demanded on the first attempt, for the reason
+        // `stale_socket_leftover` spells out at length a few tests below: a
+        // `fork` copies the whole descriptor table, so any child another test
+        // in this binary spawns concurrently holds a duplicate of this
+        // descriptor until its own `exec` runs — and a duplicate holds the
+        // `flock` with it. That is a lying fixture rather than a lock this
+        // arm failed to release, and it was reproducible the moment a
+        // supervisor test began spawning a real child. The assertion is
+        // unweakened: the home must become claimable, and a lock genuinely
+        // still held fails this loop just as flatly as it failed the single
+        // attempt.
         drop(adopted);
-        PidfileLock::acquire(&paths).expect("a successor that exits must leave the home claimable");
+        let deadline = std::time::Instant::now() + Duration::from_secs(5);
+        let claimed = loop {
+            match PidfileLock::acquire(&paths) {
+                Ok(claimed) => break claimed,
+                Err(error) => assert!(
+                    std::time::Instant::now() < deadline,
+                    "a successor that exits must leave the home claimable: {error:?}"
+                ),
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        };
+        drop(claimed);
     }
 
     /// Serializes every test in this module that calls `boot()` and expects

--- a/crates/shep-daemon/src/boot.rs
+++ b/crates/shep-daemon/src/boot.rs
@@ -888,6 +888,15 @@ pub async fn boot<R: ProcessRunner>(
     paths: ShepPaths,
     mut options: BootOptions,
 ) -> Result<RunningDaemon, BootError> {
+    // Before anything else, because it reads the current directory and
+    // that is only the startup directory until something moves it. A
+    // handover execs this path rather than `current_exe()`; see
+    // `handover::exec_target` for why those differ exactly when an
+    // operator has upgraded. `#[cfg(unix)]` because the whole handover
+    // module is: Windows has no `execve` and takes the stop arm.
+    #[cfg(unix)]
+    crate::handover::record_launch_path();
+
     // Copied out up front, purely a `bool`, so nothing later in this fn has
     // to remember to read it off `options` before that struct is consumed.
     let delete_flock_on_shutdown = options.delete_flock_on_shutdown;

--- a/crates/shep-daemon/src/boot.rs
+++ b/crates/shep-daemon/src/boot.rs
@@ -1965,7 +1965,8 @@ type Rehydrated = (
 ///
 /// `Debug` is derived and carries nothing sensitive: two descriptor numbers,
 /// a mailbox and the home's own paths. The blob those descriptors end up in
-/// carries no environment value either (see [`crate::handover::Handover`]).
+/// is a different matter and does carry each sheep's environment; see
+/// [`crate::handover::Handover`]'s own doc for what protects it.
 #[cfg(unix)]
 #[derive(Debug)]
 pub(crate) struct HandoverSeam {

--- a/crates/shep-daemon/src/boot.rs
+++ b/crates/shep-daemon/src/boot.rs
@@ -309,15 +309,60 @@ pub(crate) fn read_pidfile(paths: &ShepPaths) -> Result<Option<u32>, BootError> 
 /// `ERROR_SHARING_VIOLATION`. Both are immediate — this is the one lock in
 /// the workspace that must NOT wait, unlike the kv and bark rings, whose
 /// Windows arms retry precisely because their unix arms block.
+///
+/// # The adopted arm
+///
+/// A successor does not take this lock: it inherits the descriptor that
+/// already holds it. See [`UnixLock`] for why it must not take it again.
 #[derive(Debug)]
 struct PidfileLock {
     #[cfg(unix)]
-    flock: nix::fcntl::Flock<std::fs::File>,
+    flock: UnixLock,
     /// The sibling lock file, held open with every share flag cleared.
     /// Named with a leading underscore because it is held, never read —
     /// [`PidfileLock::record`] writes the pidfile itself.
     #[cfg(windows)]
     _handle: std::fs::File,
+}
+
+/// How this process came to hold the pidfile's `flock`, which is the one
+/// thing the two ways of starting a shepherd differ on.
+///
+/// # Why an adopted descriptor is never re-locked
+///
+/// A `flock` lock belongs to the open file DESCRIPTION, not to the process
+/// and not to the path, so it crosses an `execve` still held: a successor
+/// inherits the descriptor and the lock on it in one act, before it runs a
+/// line of its own code. Taking the lock again would mean releasing it
+/// first, since `nix` offers no constructor for an already-locked file that
+/// does not lock it, and that window is exactly long enough for a second
+/// daemon to claim this `$SHEP_HOME` while the only process supervising its
+/// flock is mid-boot. So the adopted arm holds the file and does nothing
+/// else with it.
+///
+/// The release rules stay identical either way. The kernel drops the lock
+/// when the last descriptor on the description closes, process death
+/// included, so a successor that crashes leaves the home claimable exactly
+/// as a predecessor that crashed did.
+#[cfg(unix)]
+#[derive(Debug)]
+enum UnixLock {
+    /// Taken here, by this process, with `flock(LOCK_EX | LOCK_NB)`.
+    Taken(nix::fcntl::Flock<std::fs::File>),
+    /// Inherited across a handover `execve`, still locked, never re-locked.
+    Adopted(std::fs::File),
+}
+
+#[cfg(unix)]
+impl UnixLock {
+    /// The locked pidfile itself, which [`PidfileLock::record`] writes
+    /// through.
+    fn file(&mut self) -> &mut std::fs::File {
+        match self {
+            Self::Taken(flock) => flock,
+            Self::Adopted(file) => file,
+        }
+    }
 }
 
 /// The sibling file the Windows arm locks: the pidfile with `.lock` appended.
@@ -358,7 +403,9 @@ impl PidfileLock {
                 source,
             })?;
         match nix::fcntl::Flock::lock(file, nix::fcntl::FlockArg::LockExclusiveNonblock) {
-            Ok(flock) => Ok(Self { flock }),
+            Ok(flock) => Ok(Self {
+                flock: UnixLock::Taken(flock),
+            }),
             Err((_file, nix::errno::Errno::EWOULDBLOCK)) => Err(BootError::AlreadyRunning {
                 pid: read_pidfile(paths)?,
             }),
@@ -447,12 +494,35 @@ impl PidfileLock {
             .map_err(|source| BootError::Io { path, source })
     }
 
+    /// Holds a pidfile descriptor this image inherited, already locked.
+    ///
+    /// Nothing here locks, unlocks, truncates or writes. `file` crossed an
+    /// `execve` from the predecessor with its `flock` intact, and taking
+    /// ownership of it is the whole job: it keeps the descriptor open for
+    /// the rest of this process's life, which is what keeps the lock held.
+    /// See [`UnixLock`] for why re-acquiring would be a bug rather than
+    /// belt and braces.
+    ///
+    /// The pidfile's contents need no update either. An `execve` keeps the
+    /// pid, so the number the predecessor recorded is this process's own.
+    #[cfg(unix)]
+    #[allow(
+        dead_code,
+        reason = "task 8c installs the adopted flock and is what calls this; the arm it holds \
+                  the home with has to exist before there is a caller for it"
+    )]
+    fn from_locked(file: std::fs::File) -> Self {
+        Self {
+            flock: UnixLock::Adopted(file),
+        }
+    }
+
     #[cfg(unix)]
     fn record(&mut self, paths: &ShepPaths, pid: u32) -> Result<(), BootError> {
         use std::io::{Seek, SeekFrom, Write};
 
         let path = pidfile(paths);
-        let file = &mut *self.flock;
+        let file = self.flock.file();
         file.set_len(0).map_err(|source| BootError::Io {
             path: path.clone(),
             source,
@@ -1897,6 +1967,51 @@ mod tests {
 
     fn mode_of(path: &Path) -> u32 {
         std::fs::metadata(path).unwrap().permissions().mode() & 0o777
+    }
+
+    /// fails if adopting the pidfile descriptor ever leaves the lock free.
+    ///
+    /// The failure it prevents: an arm that re-locked would have to release
+    /// first, and that window is exactly long enough for a second daemon to
+    /// win this home while the only one supervising its flock is mid-boot.
+    ///
+    /// What makes the assertion possible at all is that `flock` conflicts
+    /// between separate open file DESCRIPTIONS even inside one process, so
+    /// this process can ask for the lock it already holds and be refused.
+    ///
+    /// `mem::forget` plus `sys::adopt_handover_fd` stands in for the
+    /// `execve` a successor arrives through, and is as close to it as one
+    /// process can get: forgetting the lock skips the `flock(fd, LOCK_UN)`
+    /// its drop would run, exactly as an exec does, and adopting the number
+    /// back gives the descriptor a single new owner, exactly as the
+    /// successor gives it one. Duplicating it instead would leave a second
+    /// descriptor holding the same lock, and both assertions below would
+    /// then hold whatever the adopted arm did with its own.
+    #[test]
+    fn the_adopted_pidfile_arm_does_not_release_the_lock() {
+        let dir = tempfile::tempdir().unwrap();
+        let paths = test_paths(&dir);
+        init_dirs(&paths).unwrap();
+
+        let mut held = PidfileLock::acquire(&paths).expect("the predecessor must win");
+        let fd = std::os::fd::AsRawFd::as_raw_fd(held.flock.file());
+        core::mem::forget(held);
+        let inherited = crate::sys::adopt_handover_fd(fd)
+            .expect("the successor adopts the number the blob named");
+
+        let adopted = PidfileLock::from_locked(inherited);
+        let refusal = PidfileLock::acquire(&paths)
+            .expect_err("the lock must never be free while a successor holds it");
+        assert!(
+            matches!(refusal, BootError::AlreadyRunning { .. }),
+            "a contended lock must report AlreadyRunning, got {refusal:?}"
+        );
+
+        // And it is a lock rather than a descriptor nobody can ever release:
+        // a successor that exits closes the only handle left, and the kernel
+        // frees the home for the next daemon.
+        drop(adopted);
+        PidfileLock::acquire(&paths).expect("a successor that exits must leave the home claimable");
     }
 
     /// Serializes every test in this module that calls `boot()` and expects

--- a/crates/shep-daemon/src/fake.rs
+++ b/crates/shep-daemon/src/fake.rs
@@ -650,6 +650,35 @@ impl ScriptedRunner {
     }
 }
 
+/// Four real, distinct, open descriptors for a fake pump to report, and the
+/// handles that keep them open.
+///
+/// `/dev/null` because the fake never writes anything to them: what a caller
+/// asserts about a handover blob is that the numbers in it name something
+/// open, not what is on the far side.
+///
+/// # Panics
+///
+/// If `/dev/null` cannot be opened four times, which on any unix a test
+/// suite runs on means the process is out of descriptors.
+#[cfg(unix)]
+#[track_caller]
+fn open_reportable_fds() -> ([std::fs::File; 4], crate::handover::CarriedFds) {
+    use std::os::fd::AsRawFd as _;
+
+    let files = core::array::from_fn(|_| {
+        std::fs::File::open("/dev/null").expect("a test host must be able to open /dev/null")
+    });
+    let files: [std::fs::File; 4] = files;
+    let fds = crate::handover::CarriedFds {
+        out_pipe: Some(files[0].as_raw_fd()),
+        err_pipe: Some(files[1].as_raw_fd()),
+        out_log: Some(files[2].as_raw_fd()),
+        err_log: Some(files[3].as_raw_fd()),
+    };
+    (files, fds)
+}
+
 impl ProcessRunner for ScriptedRunner {
     type Proc = FakeProc;
 
@@ -749,6 +778,11 @@ impl ProcessRunner for ScriptedRunner {
         let lamb_holds_the_pipe = script.lamb_holds_the_pipe;
         let logs_for_pump = logs_tx.clone();
         tokio::spawn(async move {
+            #[cfg(unix)]
+            let mut reportable_fds: Option<(
+                [std::fs::File; 4],
+                crate::handover::CarriedFds,
+            )> = None;
             loop {
                 tokio::select! {
                     ctl = log_ctl_rx.recv() => match ctl {
@@ -771,6 +805,20 @@ impl ProcessRunner for ScriptedRunner {
                             // handle there is nothing queued that could
                             // fail to land.
                             let _ = done.send(Ok(()));
+                        }
+                        // The fake writes no files, so it holds no
+                        // descriptors of its own. A caller assembling a
+                        // handover still asserts that the numbers it gets
+                        // are really open, so four `/dev/null` handles stand
+                        // in — opened on the first request and held for the
+                        // rest of this task's life, so a suite full of tests
+                        // that never ask for a handover opens nothing. That
+                        // the numbers are the PUMP's own is
+                        // `tokio_runner`'s tier, against a real pipe.
+                        #[cfg(unix)]
+                        Some(LogCtl::ReportFds { done }) => {
+                            let fds = reportable_fds.get_or_insert_with(open_reportable_fds);
+                            let _ = done.send(fds.1);
                         }
                         None => break, // nothing holds ProcIo::log_ctl
                     },

--- a/crates/shep-daemon/src/handover/adopt.rs
+++ b/crates/shep-daemon/src/handover/adopt.rs
@@ -97,11 +97,11 @@ pub struct AdoptedSheep {
 ///
 /// # Errors
 ///
-/// Any descriptor the blob names is not open in this process, is not the
-/// kind of object it was named as (a read end that is not a pipe), or could
-/// not be registered with the runtime. The error names the sheep and the
-/// stream, because that is what an operator needs in order to know which
-/// process is now unsupervised.
+/// The blob names one descriptor number twice, or any descriptor it names is
+/// not open in this process, is not the kind of object it was named as (a
+/// read end that is not a pipe), or could not be registered with the
+/// runtime. The error names the sheep and the stream, because that is what
+/// an operator needs in order to know which process is now unsupervised.
 ///
 /// There is no partial success and no fallback. By the time this runs the
 /// predecessor has already `execve`d itself away, so there is no image left
@@ -115,6 +115,7 @@ pub struct AdoptedSheep {
 /// happen without one.
 #[track_caller]
 pub fn adopt(blob: &Handover) -> io::Result<Adopted> {
+    refuse_repeated_fds(blob)?;
     let listener = adopt_listener(blob.listener_fd)?;
     let sheep = blob
         .sheep
@@ -130,6 +131,41 @@ pub fn adopt(blob: &Handover) -> io::Result<Adopted> {
         sheep,
         pidfile,
     })
+}
+
+/// Refuses a blob naming one descriptor number more than once.
+///
+/// Before the first adoption, never during. Each adoption builds an owner of
+/// its number, and `sys::adopt_handover_fd`'s safety argument rests on that
+/// owner being the only one: a second owner of the same number closes it a
+/// second time on drop, and whatever this process opened in between is what
+/// the second close reaches.
+///
+/// A blob the daemon wrote cannot contain a repeat, since every number in it
+/// is a distinct open descriptor at the moment of the snapshot. This is for
+/// the residual `adopt_handover_fd`'s doc already names: a blob that was
+/// edited, or one left by a handover that never completed. Refusing costs one
+/// pass over at most a few dozen numbers and makes the sole-owner claim true
+/// rather than merely expected.
+///
+/// # Errors
+///
+/// Names the repeated number. There is nothing to say about which of the two
+/// mentions is the wrong one, because nothing here can know.
+fn refuse_repeated_fds(blob: &Handover) -> io::Result<()> {
+    let mut seen = std::collections::BTreeSet::new();
+    for fd in blob.named_fds() {
+        if !seen.insert(fd) {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!(
+                    "the handover blob names descriptor {fd} more than once, so adopting it \
+                     would build two owners of one number"
+                ),
+            ));
+        }
+    }
+    Ok(())
 }
 
 /// Remove the blob at `path`, now that its descriptors are adopted.
@@ -290,6 +326,41 @@ mod tests {
             .expect("the adopted listener must accept")
             .unwrap()
             .expect("the adopted listener accepts");
+    }
+
+    /// A blob naming one number twice is refused before anything is adopted.
+    ///
+    /// Two owners of one descriptor close it twice, and the second close
+    /// lands on whatever this process opened in between. That is precisely
+    /// the recycling hazard `sys::adopt_handover_fd` argues cannot arise, and
+    /// its argument holds only while each number has a single owner.
+    ///
+    /// The listener's own number is the one repeated, because the refusal has
+    /// to come before the first adoption rather than at the field that
+    /// happens to collide: reaching a duplicate mid-way would already have
+    /// built the first owner.
+    #[tokio::test]
+    async fn a_blob_naming_one_descriptor_twice_is_refused() {
+        let dir = tempfile::tempdir().unwrap();
+        let socket = dir.path().join("shep.sock");
+        let mut blob = blob_with(
+            &socket,
+            vec![carried(CarriedFds {
+                out_pipe: None,
+                err_pipe: None,
+                out_log: None,
+                err_log: None,
+            })],
+        );
+        blob.sheep[0].fds.out_log = Some(blob.listener_fd);
+
+        let err = adopt(&blob).unwrap_err();
+
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput, "{err}");
+        assert!(
+            err.to_string().contains("more than once"),
+            "the refusal must say what is wrong with the blob: {err}"
+        );
     }
 
     #[tokio::test]

--- a/crates/shep-daemon/src/handover/adopt.rs
+++ b/crates/shep-daemon/src/handover/adopt.rs
@@ -225,6 +225,7 @@ fn adopt_log(fd: Option<RawFd>, sheep: &str, stream: &str) -> io::Result<Option<
 mod tests {
     use std::os::fd::{IntoRawFd as _, RawFd};
     use std::path::Path;
+    use std::time::Duration;
 
     use tokio::io::{AsyncSeekExt as _, AsyncWriteExt as _};
 
@@ -281,7 +282,14 @@ mod tests {
         let listener = adopted.listener;
         let accept = tokio::spawn(async move { listener.accept().await });
         let _client = tokio::net::UnixStream::connect(&socket).await.unwrap();
-        accept.await.unwrap().expect("the adopted listener accepts");
+        // Bounded, as every await in `reap.rs` is. An adopted listener that
+        // never became readable would otherwise hang, and a hang stops the
+        // whole test binary rather than failing this one case.
+        tokio::time::timeout(Duration::from_secs(10), accept)
+            .await
+            .expect("the adopted listener must accept")
+            .unwrap()
+            .expect("the adopted listener accepts");
     }
 
     #[tokio::test]
@@ -403,7 +411,13 @@ mod tests {
 
         let out = adopted.sheep[0].out_pipe.take().expect("an adopted pipe");
         let mut lines = tokio::io::AsyncBufReadExt::lines(tokio::io::BufReader::new(out));
-        assert_eq!(lines.next_line().await.unwrap().as_deref(), Some("a line"));
+        // Bounded for the reason the listener case above is: an adopted pipe
+        // that produced nothing would hang the binary instead of failing here.
+        let line = tokio::time::timeout(Duration::from_secs(10), lines.next_line())
+            .await
+            .expect("the adopted pipe must produce the line written before it")
+            .unwrap();
+        assert_eq!(line.as_deref(), Some("a line"));
     }
 
     #[tokio::test]

--- a/crates/shep-daemon/src/handover/adopt.rs
+++ b/crates/shep-daemon/src/handover/adopt.rs
@@ -246,6 +246,7 @@ mod tests {
             last_exit: None,
             credentials: SpawnIdentity::Resolved(None),
             fds,
+            app: crate::testing::app_with("web", |_| {}).into_config(),
         }
     }
 

--- a/crates/shep-daemon/src/handover/adopt.rs
+++ b/crates/shep-daemon/src/handover/adopt.rs
@@ -213,7 +213,7 @@ fn adopt_pipe(fd: Option<RawFd>, sheep: &str, stream: &str) -> io::Result<Option
 
 /// Rebuild one log handle, if the blob named one.
 ///
-/// Wrapped, never reopened, which is what preserves `O_APPEND` — see this
+/// Wrapped, never reopened, which is what preserves `O_APPEND`. See this
 /// module's own docs for why that is load-bearing rather than tidy.
 fn adopt_log(fd: Option<RawFd>, sheep: &str, stream: &str) -> io::Result<Option<tokio::fs::File>> {
     let Some(fd) = fd else { return Ok(None) };

--- a/crates/shep-daemon/src/handover/adopt.rs
+++ b/crates/shep-daemon/src/handover/adopt.rs
@@ -1,0 +1,433 @@
+//! Rebuilding a successor's Rust-side objects around descriptors it did not
+//! open.
+//!
+//! Every descriptor named here crossed an `execve`: the predecessor cleared
+//! `FD_CLOEXEC` on it (see [`super::fds`]) and wrote its number into the
+//! blob. Nothing in this module opens a file, binds a socket or creates a
+//! pipe. It takes numbers and wraps them, which is what keeps a sheep's
+//! output flowing through the same kernel objects it was flowing through
+//! before the exec.
+//!
+//! # Three rules, each with a reason that is easy to lose
+//!
+//! **`O_APPEND` survives, because nothing is reopened.** A log handle is
+//! wrapped, never opened again by path. `O_APPEND` is a file status flag on
+//! the open file description, so it crosses the exec with the descriptor and
+//! is still set. That matters more than "the handle is writable":
+//! [`super::super::tokio_runner`]'s `open_append` records that a handle
+//! without `O_APPEND` writes at its own tracked offset, so a `copytruncate`
+//! rotator's truncation leaves a sparse hole the size of everything rotated
+//! away. A reopen here would pass a naive write test and corrupt the next
+//! rotation.
+//!
+//! **The pidfile lock is adopted, never re-acquired.** `flock` is a property
+//! of the open file description too, so the lock crossed the exec and is
+//! still held. Taking it again would mean releasing it first, and that
+//! window is exactly long enough for a second daemon to win this home while
+//! the only one supervising its flock is mid-boot. All this module does is
+//! take ownership of the descriptor, so nothing closes it for the rest of
+//! the process's life.
+//!
+//! **A descriptor the blob names and the process does not have refuses the
+//! whole rehydrate.** Not a fresh one in its place, and not a `None`.
+//! Supervising a flock with one sheep's output going nowhere is worse than
+//! refusing, because the sheep does not lose its output: it blocks on
+//! `write()` once the 64KiB pipe buffer fills, and hangs, which reads as an
+//! application bug rather than a shep one.
+//!
+//! # What a failure here leaves behind
+//!
+//! The pidfile is adopted LAST. Any refusal before that point leaves its
+//! descriptor open and unowned, which is what keeps its `flock` held: a
+//! successor that cannot rehydrate must not hand this home to a second
+//! daemon on its way out. See [`adopt`]'s own doc for what the caller does
+//! with the refusal.
+
+use std::fs::File;
+use std::io;
+use std::os::fd::{OwnedFd, RawFd};
+
+use tokio::net::unix::pipe;
+
+use super::{CarriedFds, CarriedSheep, Handover};
+use crate::sys;
+
+/// Everything a successor was handed, rebuilt into objects it can use.
+///
+/// `Debug` is derived: this carries descriptor numbers, a socket and a
+/// sheep's name and pid, all of which an operator can read out of `ps`, and
+/// no environment value ever reaches it (see [`Handover`]).
+#[derive(Debug)]
+pub struct Adopted {
+    /// The control listener, on the same socket the predecessor was serving.
+    pub listener: tokio::net::UnixListener,
+    /// Every sheep the blob described, in the blob's own order.
+    pub sheep: Vec<AdoptedSheep>,
+    /// The pidfile, held for the process's life so its `flock` is not
+    /// released. Never written through here: an `execve` keeps the pid, so
+    /// the number already in the file is this process's own.
+    pub pidfile: File,
+}
+
+/// One sheep's output plumbing, rebuilt.
+///
+/// `None` on all four means an instance that is registered and not running,
+/// which is the only reason a blob names no descriptor for it. A descriptor
+/// that is named and missing is a refusal, not a `None`; see this module's
+/// own docs.
+#[derive(Debug)]
+pub struct AdoptedSheep {
+    /// What the blob said about this sheep.
+    pub carried: CarriedSheep,
+    /// The read end of its stdout pipe, as an async reader.
+    pub out_pipe: Option<pipe::Receiver>,
+    /// The read end of its stderr pipe, as an async reader.
+    pub err_pipe: Option<pipe::Receiver>,
+    /// The appending handle on its stdout log file.
+    pub out_log: Option<tokio::fs::File>,
+    /// The appending handle on its stderr log file.
+    pub err_log: Option<tokio::fs::File>,
+}
+
+/// Rebuild everything `blob` describes, around descriptors this process
+/// inherited rather than opened.
+///
+/// Order is deliberate: the listener, then every sheep, then the pidfile.
+/// See this module's own docs for why the pidfile goes last.
+///
+/// # Errors
+///
+/// Any descriptor the blob names is not open in this process, is not the
+/// kind of object it was named as (a read end that is not a pipe), or could
+/// not be registered with the runtime. The error names the sheep and the
+/// stream, because that is what an operator needs in order to know which
+/// process is now unsupervised.
+///
+/// There is no partial success and no fallback. By the time this runs the
+/// predecessor has already `execve`d itself away, so there is no image left
+/// to hand the flock back to; a caller that cannot rehydrate refuses to boot
+/// rather than starting a second copy of a flock that is still running.
+///
+/// # Panics
+///
+/// Panics if called outside a tokio runtime with IO enabled. Every object
+/// built here registers with the runtime's reactor, which has nowhere to
+/// happen without one.
+#[track_caller]
+pub fn adopt(blob: &Handover) -> io::Result<Adopted> {
+    let listener = adopt_listener(blob.listener_fd)?;
+    let sheep = blob
+        .sheep
+        .iter()
+        .map(adopt_sheep)
+        .collect::<io::Result<Vec<_>>>()?;
+    // Last, and the whole reason this function has an order worth writing
+    // down: an earlier refusal leaves this descriptor open and unowned, so
+    // the `flock` it carries stays held.
+    let pidfile = adopt_fd(blob.pidfile_fd, "the pidfile lock")?;
+    Ok(Adopted {
+        listener,
+        sheep,
+        pidfile,
+    })
+}
+
+/// Remove the blob at `path`, now that its descriptors are adopted.
+///
+/// Called only after [`adopt`] has succeeded: a blob left on disk after a
+/// refusal is evidence an operator can read, while one left after a success
+/// is a picture of a handover that has already happened and would be adopted
+/// again by the next boot.
+///
+/// A failure to remove it is logged rather than returned. The flock is
+/// already rehydrated by this point, and refusing to serve it over a leftover
+/// file would be a worse trade than the stale blob is a risk.
+pub fn discard_blob(path: &std::path::Path) {
+    if let Err(error) = std::fs::remove_file(path) {
+        tracing::warn!(
+            path = %path.display(),
+            %error,
+            "the handover blob could not be removed after it was adopted"
+        );
+    }
+}
+
+/// Take ownership of `fd`, reporting what it was for when it is not open.
+fn adopt_fd(fd: RawFd, what: &str) -> io::Result<File> {
+    sys::adopt_handover_fd(fd).map_err(|error| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("{what} did not survive the handover: {error}"),
+        )
+    })
+}
+
+/// Rebuild the control listener on the descriptor it was already bound to.
+///
+/// Non-blocking mode is set here rather than assumed. It is a file status
+/// flag and does survive the exec, but `tokio::net::UnixListener::from_std`
+/// REFUSES a blocking socket rather than fixing one, so a listener that
+/// somehow arrived blocking would take down the successor's whole control
+/// plane; one `fcntl` is cheaper than depending on an inherited flag.
+fn adopt_listener(fd: RawFd) -> io::Result<tokio::net::UnixListener> {
+    let file = adopt_fd(fd, "the control listener")?;
+    let listener = std::os::unix::net::UnixListener::from(OwnedFd::from(file));
+    listener.set_nonblocking(true)?;
+    tokio::net::UnixListener::from_std(listener)
+}
+
+/// Rebuild one sheep's four handles.
+fn adopt_sheep(carried: &CarriedSheep) -> io::Result<AdoptedSheep> {
+    let CarriedFds {
+        out_pipe,
+        err_pipe,
+        out_log,
+        err_log,
+    } = carried.fds;
+    let name = &carried.name;
+    Ok(AdoptedSheep {
+        out_pipe: adopt_pipe(out_pipe, name, "stdout")?,
+        err_pipe: adopt_pipe(err_pipe, name, "stderr")?,
+        out_log: adopt_log(out_log, name, "stdout")?,
+        err_log: adopt_log(err_log, name, "stderr")?,
+        carried: carried.clone(),
+    })
+}
+
+/// Rebuild one pipe read end as an async reader, if the blob named one.
+///
+/// `pipe::Receiver::from_file` checks that the descriptor really is a pipe
+/// open for reading and puts it in non-blocking mode itself, so a blob that
+/// crossed two numbers is refused here rather than pumped from a file that
+/// never produces a line.
+fn adopt_pipe(fd: Option<RawFd>, sheep: &str, stream: &str) -> io::Result<Option<pipe::Receiver>> {
+    let Some(fd) = fd else { return Ok(None) };
+    let file = adopt_fd(fd, &format!("sheep '{sheep}' {stream} pipe"))?;
+    pipe::Receiver::from_file(file).map(Some).map_err(|error| {
+        io::Error::new(
+            error.kind(),
+            format!("sheep '{sheep}' {stream} pipe is not a readable pipe: {error}"),
+        )
+    })
+}
+
+/// Rebuild one log handle, if the blob named one.
+///
+/// Wrapped, never reopened, which is what preserves `O_APPEND` — see this
+/// module's own docs for why that is load-bearing rather than tidy.
+fn adopt_log(fd: Option<RawFd>, sheep: &str, stream: &str) -> io::Result<Option<tokio::fs::File>> {
+    let Some(fd) = fd else { return Ok(None) };
+    let file = adopt_fd(fd, &format!("sheep '{sheep}' {stream} log"))?;
+    Ok(Some(tokio::fs::File::from_std(file)))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::os::fd::{IntoRawFd as _, RawFd};
+    use std::path::Path;
+
+    use tokio::io::{AsyncSeekExt as _, AsyncWriteExt as _};
+
+    use super::adopt;
+    use crate::handover::{CarriedFds, CarriedSheep, Handover, VERSION};
+    use crate::privilege::SpawnIdentity;
+    use shep_core::status::ProcStatus;
+
+    /// One carried sheep named `web`, whose descriptors are `fds`.
+    fn carried(fds: CarriedFds) -> CarriedSheep {
+        CarriedSheep {
+            id: 1,
+            name: "web".to_owned(),
+            instance: 0,
+            pid: Some(100),
+            restarts: 0,
+            epoch: 7,
+            status: ProcStatus::Online,
+            last_exit: None,
+            credentials: SpawnIdentity::Resolved(None),
+            fds,
+        }
+    }
+
+    /// A blob naming a real listener bound at `socket`, a real pidfile, and
+    /// `sheep`.
+    ///
+    /// Both are opened here rather than left out because `adopt` refuses a
+    /// blob whose listener or pidfile is not open, so there is no such
+    /// thing as a test blob without them.
+    fn blob_with(socket: &Path, sheep: Vec<CarriedSheep>) -> Handover {
+        let listener = std::os::unix::net::UnixListener::bind(socket).unwrap();
+        let pidfile = tempfile::tempfile().unwrap();
+        Handover {
+            version: VERSION,
+            sheep,
+            listener_fd: listener.into_raw_fd(),
+            pidfile_fd: pidfile.into_raw_fd(),
+            next_id: 9,
+            next_deadline: 5,
+            next_action_stamp: 2,
+        }
+    }
+
+    #[tokio::test]
+    async fn an_adopted_listener_accepts() {
+        let dir = tempfile::tempdir().unwrap();
+        let socket = dir.path().join("shep.sock");
+        let blob = blob_with(&socket, Vec::new());
+
+        let adopted = adopt(&blob).unwrap();
+
+        let listener = adopted.listener;
+        let accept = tokio::spawn(async move { listener.accept().await });
+        let _client = tokio::net::UnixStream::connect(&socket).await.unwrap();
+        accept.await.unwrap().expect("the adopted listener accepts");
+    }
+
+    #[tokio::test]
+    async fn an_adopted_log_handle_still_appends() {
+        // Not merely writable: appending. A handle reopened without
+        // `O_APPEND` passes a naive write test and corrupts a rotation, so
+        // the assertion is that a write at offset 0 still lands at the end.
+        let dir = tempfile::tempdir().unwrap();
+        let socket = dir.path().join("shep.sock");
+        let log = dir.path().join("web-out.log");
+        std::fs::write(&log, b"first\n").unwrap();
+        let handle = std::fs::OpenOptions::new().append(true).open(&log).unwrap();
+        let blob = blob_with(
+            &socket,
+            vec![carried(CarriedFds {
+                out_pipe: None,
+                err_pipe: None,
+                out_log: Some(handle.into_raw_fd()),
+                err_log: None,
+            })],
+        );
+
+        let mut adopted = adopt(&blob).unwrap();
+
+        let mut out = adopted.sheep[0].out_log.take().expect("an adopted log");
+        out.seek(std::io::SeekFrom::Start(0)).await.unwrap();
+        out.write_all(b"second\n").await.unwrap();
+        out.flush().await.unwrap();
+        assert_eq!(
+            std::fs::read_to_string(&log).unwrap(),
+            "first\nsecond\n",
+            "a write at offset 0 overwrote the file, so O_APPEND was lost"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_blob_naming_a_descriptor_that_is_not_open_fails_loudly() {
+        // Better to refuse the whole rehydrate than to supervise a flock
+        // with one sheep's output silently going nowhere: the child does not
+        // lose its output, it blocks on `write()` once the pipe buffer fills.
+        //
+        // fd 4096 is a number this process will never own, the same floor
+        // `sys`'s own refusal tests use.
+        const NEVER_OPEN: RawFd = 4096;
+
+        let dir = tempfile::tempdir().unwrap();
+        let socket = dir.path().join("shep.sock");
+        let blob = blob_with(
+            &socket,
+            vec![carried(CarriedFds {
+                out_pipe: Some(NEVER_OPEN),
+                err_pipe: None,
+                out_log: None,
+                err_log: None,
+            })],
+        );
+
+        let err = adopt(&blob).expect_err("a descriptor that is not open must refuse");
+
+        let text = err.to_string();
+        assert!(
+            text.contains("web"),
+            "the refusal must name the sheep: {text}"
+        );
+        assert!(
+            text.contains("stdout"),
+            "the refusal must name the stream: {text}"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_refused_rehydrate_leaves_the_pidfile_lock_held() {
+        // The pidfile descriptor is adopted last, so a failure anywhere
+        // before it leaves that descriptor open and unowned, which is what
+        // keeps its `flock` held. Closing it would release this home to a
+        // second daemon at the exact moment there is no daemon supervising
+        // it.
+        const NEVER_OPEN: RawFd = 4096;
+
+        let dir = tempfile::tempdir().unwrap();
+        let socket = dir.path().join("shep.sock");
+        let blob = blob_with(
+            &socket,
+            vec![carried(CarriedFds {
+                out_pipe: Some(NEVER_OPEN),
+                err_pipe: None,
+                out_log: None,
+                err_log: None,
+            })],
+        );
+        let pidfile_fd = blob.pidfile_fd;
+
+        adopt(&blob).expect_err("a descriptor that is not open must refuse");
+
+        assert!(
+            nix::fcntl::fcntl(pidfile_fd, nix::fcntl::FcntlArg::F_GETFD).is_ok(),
+            "the pidfile descriptor was closed by a failed rehydrate"
+        );
+    }
+
+    #[tokio::test]
+    async fn an_adopted_pipe_reads_what_was_written_before_the_adoption() {
+        let dir = tempfile::tempdir().unwrap();
+        let socket = dir.path().join("shep.sock");
+        let (reader, mut writer) = std::io::pipe().unwrap();
+        std::io::Write::write_all(&mut writer, b"a line\n").unwrap();
+        drop(writer);
+        let blob = blob_with(
+            &socket,
+            vec![carried(CarriedFds {
+                out_pipe: Some(reader.into_raw_fd()),
+                err_pipe: None,
+                out_log: None,
+                err_log: None,
+            })],
+        );
+
+        let mut adopted = adopt(&blob).unwrap();
+
+        let out = adopted.sheep[0].out_pipe.take().expect("an adopted pipe");
+        let mut lines = tokio::io::AsyncBufReadExt::lines(tokio::io::BufReader::new(out));
+        assert_eq!(lines.next_line().await.unwrap().as_deref(), Some("a line"));
+    }
+
+    #[tokio::test]
+    async fn a_log_file_offered_as_a_pipe_is_refused() {
+        // The read ends are checked to really be pipes, so a blob that
+        // crossed two numbers is refused rather than pumped from a file
+        // that never produces a line.
+        let dir = tempfile::tempdir().unwrap();
+        let socket = dir.path().join("shep.sock");
+        // `into_raw_fd`, because `adopt` takes ownership of whatever the
+        // blob names: leaving a `File` owning the same number would double
+        // close it.
+        let file = tempfile::tempfile().unwrap();
+        let blob = blob_with(
+            &socket,
+            vec![carried(CarriedFds {
+                out_pipe: Some(file.into_raw_fd()),
+                err_pipe: None,
+                out_log: None,
+                err_log: None,
+            })],
+        );
+
+        let err = adopt(&blob).expect_err("a file is not a pipe");
+
+        assert!(err.to_string().contains("web"), "{err}");
+    }
+}

--- a/crates/shep-daemon/src/handover/fds.rs
+++ b/crates/shep-daemon/src/handover/fds.rs
@@ -1,0 +1,84 @@
+//! Clearing `FD_CLOEXEC` on a descriptor the handover carries, and reading
+//! it back.
+//!
+//! Every descriptor in the handover blob passes through [`keep_across_exec`]
+//! exactly once, deliberately, before the daemon `execv`s its successor.
+//! Everything the daemon opens is close-on-exec by default (verified
+//! against pinned `mio`, `tokio` and `std` sources), so a descriptor this
+//! module never touches is closed by the kernel at the exec boundary and
+//! silently dropped from the new image. For a sheep's stdout read end, that
+//! does not lose the sheep's output: the child blocks on `write()` once the
+//! 64KiB pipe buffer fills, and hangs — which reads as an application bug,
+//! not a shep one.
+
+use std::io;
+use std::os::fd::{AsRawFd, BorrowedFd};
+
+use nix::fcntl::{FcntlArg, FdFlag, fcntl};
+
+/// Clear `FD_CLOEXEC` on `fd`, so it survives this process's next
+/// `execve`.
+///
+/// Reads the descriptor's current flags with `F_GETFD`, clears only the
+/// `FD_CLOEXEC` bit, and writes the result back with `F_SETFD`. A bare
+/// `F_SETFD(FdFlag::empty())` would clobber any other flag the descriptor
+/// carries, and would not be idempotent: a second call would re-derive
+/// `empty()` from whatever the first call left rather than from the
+/// descriptor's real flags, so the operation would happen to look
+/// idempotent only because it always writes the same clobbered value.
+///
+/// Do not call this on a descriptor the successor will not adopt: every fd
+/// left `FD_CLOEXEC`-clear leaks into the new process image across the
+/// exec, whether or not the handover blob names it.
+///
+/// # Errors
+///
+/// Returns an error if `fcntl` fails, which on a valid open descriptor
+/// should not happen in practice.
+pub fn keep_across_exec(fd: BorrowedFd<'_>) -> io::Result<()> {
+    let fd = fd.as_raw_fd();
+    let flags = fcntl(fd, FcntlArg::F_GETFD)?;
+    let mut flags = FdFlag::from_bits_truncate(flags);
+    flags.remove(FdFlag::FD_CLOEXEC);
+    fcntl(fd, FcntlArg::F_SETFD(flags))?;
+    Ok(())
+}
+
+/// Whether `fd` currently survives an `execve` (i.e. `FD_CLOEXEC` is
+/// clear).
+///
+/// # Errors
+///
+/// Returns an error if `fcntl` fails, which on a valid open descriptor
+/// should not happen in practice.
+pub fn is_kept(fd: BorrowedFd<'_>) -> io::Result<bool> {
+    let flags = fcntl(fd.as_raw_fd(), FcntlArg::F_GETFD)?;
+    let flags = FdFlag::from_bits_truncate(flags);
+    Ok(!flags.contains(FdFlag::FD_CLOEXEC))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::os::fd::AsFd;
+
+    #[test]
+    fn a_fresh_pipe_is_close_on_exec_and_can_be_kept() {
+        let (r, _w) = std::io::pipe().unwrap();
+        // Establishes the default this whole phase depends on. If this ever
+        // fails, std changed and the fd inventory needs re-auditing.
+        assert!(
+            !super::is_kept(r.as_fd()).unwrap(),
+            "std pipes are CLOEXEC by default"
+        );
+        super::keep_across_exec(r.as_fd()).unwrap();
+        assert!(super::is_kept(r.as_fd()).unwrap());
+    }
+
+    #[test]
+    fn keeping_is_idempotent() {
+        let (r, _w) = std::io::pipe().unwrap();
+        super::keep_across_exec(r.as_fd()).unwrap();
+        super::keep_across_exec(r.as_fd()).unwrap();
+        assert!(super::is_kept(r.as_fd()).unwrap());
+    }
+}

--- a/crates/shep-daemon/src/handover/fds.rs
+++ b/crates/shep-daemon/src/handover/fds.rs
@@ -35,6 +35,11 @@ use nix::fcntl::{FcntlArg, FdFlag, fcntl};
 ///
 /// Returns an error if `fcntl` fails, which on a valid open descriptor
 /// should not happen in practice.
+#[allow(
+    dead_code,
+    reason = "exercised by this module's own tests; production goes through \
+                             `keep_raw_across_exec`, which a blob's numbers are all it has"
+)]
 pub fn keep_across_exec(fd: BorrowedFd<'_>) -> io::Result<()> {
     keep_raw_across_exec(fd.as_raw_fd())
 }
@@ -69,6 +74,7 @@ pub fn keep_raw_across_exec(fd: RawFd) -> io::Result<()> {
 ///
 /// Returns an error if `fcntl` fails, which on a valid open descriptor
 /// should not happen in practice.
+#[allow(dead_code, reason = "read by this module's own tests")]
 pub fn is_kept(fd: BorrowedFd<'_>) -> io::Result<bool> {
     let flags = fcntl(fd.as_raw_fd(), FcntlArg::F_GETFD)?;
     let flags = FdFlag::from_bits_truncate(flags);

--- a/crates/shep-daemon/src/handover/fds.rs
+++ b/crates/shep-daemon/src/handover/fds.rs
@@ -12,7 +12,7 @@
 //! not a shep one.
 
 use std::io;
-use std::os::fd::{AsRawFd, BorrowedFd};
+use std::os::fd::{AsRawFd, BorrowedFd, RawFd};
 
 use nix::fcntl::{FcntlArg, FdFlag, fcntl};
 
@@ -36,7 +36,25 @@ use nix::fcntl::{FcntlArg, FdFlag, fcntl};
 /// Returns an error if `fcntl` fails, which on a valid open descriptor
 /// should not happen in practice.
 pub fn keep_across_exec(fd: BorrowedFd<'_>) -> io::Result<()> {
-    let fd = fd.as_raw_fd();
+    keep_raw_across_exec(fd.as_raw_fd())
+}
+
+/// [`keep_across_exec`], for a descriptor known only by its number.
+///
+/// The handover blob names descriptors as numbers, not as borrows, and the
+/// borrowed form is reached only through `BorrowedFd::borrow_raw`, which is
+/// unsafe and would have to live in `sys.rs` (IR-22/23). `fcntl` on a
+/// number needs neither, so the number is the primitive here and the
+/// borrowed form delegates to it.
+///
+/// The same warning applies: call this only for a descriptor the successor
+/// will adopt.
+///
+/// # Errors
+///
+/// Returns an error if `fcntl` fails, which is what a number naming no open
+/// descriptor looks like.
+pub fn keep_raw_across_exec(fd: RawFd) -> io::Result<()> {
     let flags = fcntl(fd, FcntlArg::F_GETFD)?;
     let mut flags = FdFlag::from_bits_truncate(flags);
     flags.remove(FdFlag::FD_CLOEXEC);

--- a/crates/shep-daemon/src/handover/fds.rs
+++ b/crates/shep-daemon/src/handover/fds.rs
@@ -67,6 +67,30 @@ pub fn keep_raw_across_exec(fd: RawFd) -> io::Result<()> {
     Ok(())
 }
 
+/// Set `FD_CLOEXEC` on `fd` again, undoing a [`keep_raw_across_exec`] whose
+/// exec never happened.
+///
+/// The inverse of that function, bit for bit: reads the current flags,
+/// sets only `FD_CLOEXEC`, writes them back. Nothing else the descriptor
+/// carries is disturbed.
+///
+/// Restoring is the right direction and not merely the symmetric one.
+/// Everything the daemon opens is close-on-exec at creation, per this
+/// module's own preamble, so the flag this puts back is the flag the
+/// descriptor had before the handover cleared it.
+///
+/// # Errors
+///
+/// Returns an error if `fcntl` fails, which on a valid open descriptor
+/// should not happen in practice.
+pub fn close_raw_after_exec(fd: RawFd) -> io::Result<()> {
+    let flags = fcntl(fd, FcntlArg::F_GETFD)?;
+    let mut flags = FdFlag::from_bits_truncate(flags);
+    flags.insert(FdFlag::FD_CLOEXEC);
+    fcntl(fd, FcntlArg::F_SETFD(flags))?;
+    Ok(())
+}
+
 /// Whether `fd` currently survives an `execve` (i.e. `FD_CLOEXEC` is
 /// clear).
 ///

--- a/crates/shep-daemon/src/handover/fds.rs
+++ b/crates/shep-daemon/src/handover/fds.rs
@@ -8,7 +8,7 @@
 //! module never touches is closed by the kernel at the exec boundary and
 //! silently dropped from the new image. For a sheep's stdout read end, that
 //! does not lose the sheep's output: the child blocks on `write()` once the
-//! 64KiB pipe buffer fills, and hangs — which reads as an application bug,
+//! 64KiB pipe buffer fills, and hangs, which reads as an application bug
 //! not a shep one.
 
 use std::io;

--- a/crates/shep-daemon/src/handover/mod.rs
+++ b/crates/shep-daemon/src/handover/mod.rs
@@ -1489,6 +1489,16 @@ mod tests {
             "{stdout}{}",
             String::from_utf8_lossy(&out.stderr)
         );
+        // Checked before the real assertion, because the two failures look
+        // the same from the outside and only one of them is about the
+        // handover. `--exact` against a name that no longer resolves matches
+        // nothing: the child runs zero tests, exits successfully, and prints
+        // no marker, which would otherwise be reported as a descriptor that
+        // did not cross.
+        assert!(
+            stdout.contains("running 1 test"),
+            "the child ran no test, so `{SELFTEST_NAME}` is not where this test lives any more;              `--exact` needs the full path and nothing updates it automatically: {stdout}"
+        );
         // The whole mechanism in one assertion: a pipe written before the
         // exec is readable by the process after it, on the same fd number,
         // proving both that the image changed and that the descriptor

--- a/crates/shep-daemon/src/handover/mod.rs
+++ b/crates/shep-daemon/src/handover/mod.rs
@@ -22,6 +22,7 @@
 pub(crate) mod adopt;
 mod fds;
 pub(crate) mod reap;
+pub(crate) mod uptime;
 
 use core::convert::Infallible;
 use std::ffi::CString;
@@ -277,6 +278,7 @@ const FILE_NAME: &str = "handover.json";
 /// means nothing outside the runtime that read it. The successor re-derives
 /// each sheep's start time from the operating system, which is authoritative
 /// about a pid it did not spawn in a way a carried value could never be.
+/// [`uptime::started_at_of`] is that derivation.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Handover {
     /// The format this blob was written in; see [`VERSION`].

--- a/crates/shep-daemon/src/handover/mod.rs
+++ b/crates/shep-daemon/src/handover/mod.rs
@@ -1,5 +1,6 @@
 //! Whole-flock handover: whether this daemon's flock can be replaced in
-//! place, and (in later tasks) the blob and the exec that carry it.
+//! place, the [`Handover`] blob that describes it, and (in a later task) the
+//! exec that carries it.
 //!
 //! Phase 2a carries only the plainest sheep: no shepherd channel, no stdin,
 //! no dog, one instance, no in-flight reload, and nothing an operator has
@@ -9,18 +10,30 @@
 //! back to the stop-and-start arm that already works. That asymmetry is why
 //! an unclear case refuses rather than guesses.
 
-// Nothing in this crate calls `fitness` yet. Task 8 wires it into
-// `boot.rs`'s SIGHUP arm; until then, an honestly-unreachable gate is
-// better than a stub that pretends to decide something and always answers
-// the same way.
+// Nothing in this crate calls `fitness` or writes a blob yet. Task 8 wires
+// the gate into `boot.rs`'s SIGHUP arm and task 5 writes the blob; until
+// then, an honestly-unreachable gate is better than a stub that pretends to
+// decide something and always answers the same way.
 #![expect(
     dead_code,
-    reason = "task 8 wires fitness into boot.rs's SIGHUP arm; nothing calls it yet"
+    reason = "tasks 5 and 8 wire the blob and the gate into boot.rs; nothing calls them yet"
 )]
 
 mod fds;
 
+use std::fs::{self, OpenOptions};
+use std::io;
+use std::os::fd::RawFd;
+use std::os::unix::fs::OpenOptionsExt;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+use shep_core::paths::ShepPaths;
+use shep_core::protocol::ExitInfo;
+use shep_core::status::ProcStatus;
+
 use crate::entry::ProcessEntry;
+use crate::privilege::SpawnIdentity;
 
 /// Whether a flock can be handed over in place, or must fall back to a
 /// stop-and-start.
@@ -169,16 +182,292 @@ fn refusal(candidate: &Candidate<'_>) -> Option<RefusedReason> {
     None
 }
 
+/// The blob format this daemon writes, and the only one it can read.
+///
+/// A successor is not necessarily the same build as the image that wrote the
+/// blob, which is the entire point of a handover, so the two agree on a
+/// number rather than on a struct layout. [`Handover::load_value`] refuses
+/// anything else outright: an image that cannot understand the blob must
+/// fail loudly so its caller falls back to the stop arm, never adopt a
+/// partial picture of a live flock.
+pub const VERSION: u32 = 1;
+
+/// The file name the blob is written under, inside `$SHEP_HOME/run`.
+const FILE_NAME: &str = "handover.json";
+
+/// Everything the successor needs to keep supervising a flock it did not
+/// spawn.
+///
+/// Written by the outgoing image just before it `execve`s, read once by the
+/// incoming one, and unlinked by that reader (task 6's job, in
+/// `handover::adopt`). It is the whole of what crosses the exec besides the
+/// descriptors themselves, which it names by number.
+///
+/// **No environment values, ever.** A sheep's env can hold secrets, and the
+/// successor re-reads them from config, so nothing here is derived from
+/// `AppConfig::env`. That is asserted by an exact-string test over the
+/// serialized form rather than by a field check, because the risk is a
+/// future field that carries env by accident (IR-41). `Debug` is derived
+/// for the same reason: ids, pids, a name and a handful of descriptor
+/// numbers are all an operator could read out of `ps`.
+///
+/// **`ProcessEntry::started_at` is deliberately absent**, and no serializer
+/// for it would help. It is a `tokio::time::Instant`, which has no epoch and
+/// means nothing outside the runtime that read it. The successor re-derives
+/// each sheep's start time from the operating system, which is authoritative
+/// about a pid it did not spawn in a way a carried value could never be.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Handover {
+    /// The format this blob was written in; see [`VERSION`].
+    version: u32,
+    /// Every sheep the successor is to adopt, in no particular order.
+    sheep: Vec<CarriedSheep>,
+    /// The control listener's descriptor number.
+    listener_fd: RawFd,
+    /// The pidfile lock's descriptor number.
+    ///
+    /// Carried so the successor can hold the descriptor open, not so it can
+    /// re-acquire the lock. `flock` is a property of the open file
+    /// description, so the lock crossed the exec already; releasing it to
+    /// take it again would open a window for a second daemon to win it.
+    pidfile_fd: RawFd,
+    /// The supervisor's next entry id.
+    ///
+    /// The three counters below reset to zero in every constructor, so a
+    /// successor that did not carry them would reissue an id, a watchdog
+    /// stamp or an action stamp that a caller is still holding.
+    next_id: u32,
+    /// The supervisor's next reload-watchdog stamp.
+    next_deadline: u64,
+    /// The supervisor's next action-wait stamp.
+    next_action_stamp: u64,
+}
+
+impl Handover {
+    /// Where the blob lives under `paths`: `$SHEP_HOME/run/handover.json`.
+    #[must_use]
+    pub fn path(paths: &ShepPaths) -> PathBuf {
+        paths.run.join(FILE_NAME)
+    }
+
+    /// Write the blob under `paths`, at mode `0600`, and return where it
+    /// went.
+    ///
+    /// The mode is set at creation rather than with a `chmod` afterwards.
+    /// A `chmod` leaves a window in which the file is world-readable, and it
+    /// names this host's pids and descriptor numbers.
+    ///
+    /// Any leftover blob is removed first, because
+    /// [`OpenOptions::mode`](OpenOptionsExt::mode) is honoured only when the
+    /// open actually creates the file: reopening a stale one would inherit
+    /// whatever mode it already carried.
+    ///
+    /// # Errors
+    ///
+    /// The leftover blob could not be removed, the new one could not be
+    /// created (including because something else created it in between), or
+    /// serializing to it failed.
+    pub fn write(&self, paths: &ShepPaths) -> io::Result<PathBuf> {
+        let path = Self::path(paths);
+        match fs::remove_file(&path) {
+            Ok(()) => {}
+            Err(err) if err.kind() == io::ErrorKind::NotFound => {}
+            Err(err) => return Err(err),
+        }
+        let file = OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .mode(0o600)
+            .open(&path)?;
+        serde_json::to_writer(&file, self).map_err(io::Error::other)?;
+        Ok(path)
+    }
+
+    /// Read the blob at `path`.
+    ///
+    /// Reading does not unlink: the successor does that once it has adopted
+    /// what the blob describes, so a failure here leaves the file for an
+    /// operator to look at.
+    ///
+    /// # Errors
+    ///
+    /// The file could not be read, its bytes are not a handover blob, or it
+    /// names a format version this image does not implement.
+    pub fn read(path: &Path) -> Result<Self, LoadError> {
+        let text = fs::read_to_string(path).map_err(LoadError::Io)?;
+        let value = serde_json::from_str(&text).map_err(LoadError::Malformed)?;
+        Self::load_value(value)
+    }
+
+    /// Check `value`'s format version, then deserialize it.
+    ///
+    /// The version is read off the raw JSON before anything else, so a blob
+    /// from a format this image does not know is refused by number rather
+    /// than by whichever field happens to fail to deserialize first.
+    ///
+    /// # Errors
+    ///
+    /// `value` carries no `version`, carries one other than [`VERSION`], or
+    /// is not a handover blob.
+    pub fn load_value(value: serde_json::Value) -> Result<Self, LoadError> {
+        match value.get("version").and_then(serde_json::Value::as_u64) {
+            Some(found) if found == u64::from(VERSION) => {}
+            Some(found) => return Err(LoadError::UnsupportedVersion { found }),
+            None => return Err(LoadError::MissingVersion),
+        }
+        serde_json::from_value(value).map_err(LoadError::Malformed)
+    }
+}
+
+/// Why a handover blob could not be loaded.
+///
+/// Every variant means the successor must not adopt anything: it has no
+/// picture of the flock, or only part of one, and supervising a flock it
+/// half understands is worse than refusing.
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum LoadError {
+    /// The blob could not be read off disk.
+    Io(io::Error),
+    /// The blob names no format version at all, so it is not one this image
+    /// wrote.
+    MissingVersion,
+    /// The blob names a format version this image does not implement.
+    UnsupportedVersion {
+        /// The version the blob claims.
+        found: u64,
+    },
+    /// The blob names a version this image implements, but its contents do
+    /// not deserialize into one.
+    Malformed(serde_json::Error),
+}
+
+impl core::fmt::Display for LoadError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::Io(err) => write!(f, "the handover blob could not be read: {err}"),
+            Self::MissingVersion => f.write_str("the handover blob names no format version"),
+            Self::UnsupportedVersion { found } => write!(
+                f,
+                "the handover blob is format version {found}, and this shep implements \
+                 version {VERSION}"
+            ),
+            Self::Malformed(err) => write!(f, "the handover blob is not readable: {err}"),
+        }
+    }
+}
+
+impl core::error::Error for LoadError {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
+        match self {
+            Self::Io(err) => Some(err),
+            Self::Malformed(err) => Some(err),
+            Self::MissingVersion | Self::UnsupportedVersion { .. } => None,
+        }
+    }
+}
+
+/// One sheep, as the successor will find it.
+///
+/// Everything here is a fact about an instance that is already running, or
+/// already registered and not running. Nothing is re-derivable from config,
+/// which is why each field is here: config says what an app *is*, and this
+/// says what this instance currently *is doing*.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CarriedSheep {
+    /// The supervisor's entry id, which callers already hold and selectors
+    /// already name.
+    id: u32,
+    /// The sheep's name, which is how an operator names it back.
+    name: String,
+    /// The instance slot within its app.
+    instance: u32,
+    /// The running process, or `None` for an instance that is registered and
+    /// not running.
+    pid: Option<u32>,
+    /// Respawns performed so far, which the restart budget counts against.
+    restarts: u32,
+    /// The supervisor slot's respawn epoch, so a timer armed before the exec
+    /// is still recognised as stale afterwards.
+    epoch: u64,
+    /// The instance's lifecycle status.
+    status: ProcStatus,
+    /// How this instance most recently stopped existing, if it has.
+    last_exit: Option<ExitInfo>,
+    /// The identity this instance's next spawn runs under.
+    ///
+    /// Carried resolved, never re-derived. The value is pinned at the first
+    /// spawn precisely so a later change to the passwd database cannot move
+    /// a running app's identity underneath it; looking the name up again in
+    /// the successor would reintroduce exactly the re-lookup the pinning
+    /// exists to prevent.
+    credentials: SpawnIdentity,
+    /// The descriptor numbers this instance's output travels on.
+    fds: CarriedFds,
+}
+
+impl CarriedSheep {
+    /// Describe `entry` for the successor.
+    ///
+    /// `epoch` and `fds` are arguments rather than reads off `entry`
+    /// because neither lives there: the respawn epoch is on the
+    /// supervisor's private slot, and the descriptor numbers are known only
+    /// to whichever code holds the open descriptors. This is the same split
+    /// [`Candidate`] makes, for the same reason.
+    #[must_use]
+    pub fn from_entry(entry: &ProcessEntry, epoch: u64, fds: CarriedFds) -> Self {
+        Self {
+            id: entry.id,
+            name: entry.spec.config().name.clone(),
+            instance: entry.instance,
+            pid: entry.pid,
+            restarts: entry.restarts,
+            epoch,
+            status: entry.status,
+            last_exit: entry.last_exit,
+            credentials: entry.credentials,
+            fds,
+        }
+    }
+}
+
+/// The four descriptor numbers one sheep's output travels on.
+///
+/// Grouped rather than spelled as four fields on [`CarriedSheep`] for two
+/// reasons: they are all `Option<RawFd>`, so a constructor taking them
+/// positionally would let a caller swap two of them silently, and they share
+/// one fact, which is that a running instance has all four and a registered
+/// one that is not running has none.
+///
+/// `None` is that second case and only that case. A blob naming a
+/// descriptor that is not open in the successor is a failure to refuse, not
+/// a `None` to tolerate: losing a sheep's stdout read end does not lose its
+/// output, it blocks the child on `write()` once the 64KiB pipe buffer
+/// fills, which reads as an application hang rather than as a shep bug.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CarriedFds {
+    /// The read end of the sheep's stdout pipe.
+    pub out_pipe: Option<RawFd>,
+    /// The read end of the sheep's stderr pipe.
+    pub err_pipe: Option<RawFd>,
+    /// The appending handle on the sheep's stdout log file.
+    pub out_log: Option<RawFd>,
+    /// The appending handle on the sheep's stderr log file.
+    pub err_log: Option<RawFd>,
+}
+
 #[cfg(test)]
 mod tests {
     use shep_core::config::AppConfig;
     use shep_core::status::ProcStatus;
     use std::path::PathBuf;
 
+    use std::os::unix::fs::PermissionsExt;
+
     use super::*;
     use crate::entry::{ReloadState, RestartBudget};
     use crate::privilege::SpawnIdentity;
-    use crate::testing::app_with;
+    use crate::testing::{app_with, test_paths};
 
     /// A plain, `Online` entry: no channel, no stdin, not a dog, one
     /// instance, no in-flight reload. Every field a real spawn would set is
@@ -315,6 +604,106 @@ mod tests {
             fitness(&[candidate]),
             Fitness::Refused(RefusedReason::PendingStop { .. })
         ));
+    }
+
+    /// One carried sheep off `entry`, with the descriptor numbers a
+    /// running sheep would have.
+    fn carried(entry: &ProcessEntry) -> CarriedSheep {
+        CarriedSheep::from_entry(
+            entry,
+            7,
+            CarriedFds {
+                out_pipe: Some(11),
+                err_pipe: Some(12),
+                out_log: Some(13),
+                err_log: Some(14),
+            },
+        )
+    }
+
+    fn handover_over(entry: &ProcessEntry) -> Handover {
+        Handover {
+            version: VERSION,
+            sheep: vec![carried(entry)],
+            listener_fd: 3,
+            pidfile_fd: 4,
+            next_id: 9,
+            next_deadline: 5,
+            next_action_stamp: 2,
+        }
+    }
+
+    fn sample_handover() -> Handover {
+        handover_over(&entry_fixture(|_| {}))
+    }
+
+    fn sample_handover_with_secret_env() -> Handover {
+        let entry = entry_fixture(|app| {
+            app.env.insert("TOKEN".to_owned(), "hunter2".to_owned());
+        });
+        // Without this the secret test could pass on a fixture that never
+        // carried a secret in the first place.
+        assert!(
+            entry.spec.config().env.values().any(|v| v == "hunter2"),
+            "the fixture must really carry the secret it is testing for"
+        );
+        handover_over(&entry)
+    }
+
+    #[test]
+    fn a_blob_round_trips() {
+        let h = sample_handover();
+        let back: Handover = serde_json::from_str(&serde_json::to_string(&h).unwrap()).unwrap();
+        assert_eq!(back, h);
+    }
+
+    #[test]
+    fn the_blob_carries_no_environment_values() {
+        // A sheep's env can hold secrets. This is an exact-string assertion
+        // rather than a field check, because the risk is a future field that
+        // serializes env by accident (IR-41).
+        let text = serde_json::to_string(&sample_handover_with_secret_env()).unwrap();
+        assert!(!text.contains("hunter2"), "{text}");
+    }
+
+    #[test]
+    fn a_written_blob_is_readable_only_by_its_owner() {
+        // It names this host's pids and descriptor numbers, and the mode is
+        // set at creation so there is never a window in which it is not.
+        let dir = tempfile::tempdir().unwrap();
+        let paths = test_paths(&dir);
+        std::fs::create_dir_all(&paths.run).unwrap();
+
+        let written = sample_handover().write(&paths).unwrap();
+
+        assert_eq!(written, Handover::path(&paths));
+        let mode = std::fs::metadata(&written).unwrap().permissions().mode();
+        assert_eq!(mode & 0o777, 0o600, "{mode:o}");
+        assert_eq!(Handover::read(&written).unwrap(), sample_handover());
+    }
+
+    #[test]
+    fn a_stale_blob_does_not_lend_its_mode_to_the_next_one() {
+        // `OpenOptions::mode` applies only when the open creates the file,
+        // so a leftover blob left in place would keep whatever mode it had.
+        let dir = tempfile::tempdir().unwrap();
+        let paths = test_paths(&dir);
+        std::fs::create_dir_all(&paths.run).unwrap();
+        let path = Handover::path(&paths);
+        std::fs::write(&path, "stale").unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644)).unwrap();
+
+        sample_handover().write(&paths).unwrap();
+
+        let mode = std::fs::metadata(&path).unwrap().permissions().mode();
+        assert_eq!(mode & 0o777, 0o600, "{mode:o}");
+    }
+
+    #[test]
+    fn a_blob_from_a_future_version_is_refused_not_guessed_at() {
+        let mut v = serde_json::to_value(sample_handover()).unwrap();
+        v["version"] = serde_json::json!(u32::MAX);
+        assert!(Handover::load_value(v).is_err());
     }
 
     #[test]

--- a/crates/shep-daemon/src/handover/mod.rs
+++ b/crates/shep-daemon/src/handover/mod.rs
@@ -144,6 +144,38 @@ pub struct Candidate<'a> {
     pub pending_delete: bool,
 }
 
+/// A [`Candidate`] that owns its entry.
+///
+/// The supervisor cannot lend one. Assembling a snapshot means asking every
+/// log pump for its descriptors, and no `.await` on a pump may happen on the
+/// actor loop (see `Actor::handle_reopen` for the cycle that rules it out),
+/// so the assembly runs on a task of its own and the entries have to travel
+/// there. A borrow cannot.
+///
+/// [`Self::as_candidate`] is how it reaches [`fitness`], which stays a pure
+/// function over borrowed data.
+#[derive(Debug, Clone)]
+pub struct OwnedCandidate {
+    /// The sheep's lifecycle entry, cloned off the supervisor's slot.
+    pub entry: ProcessEntry,
+    /// Whether an operator's command is waiting on this sheep's next exit.
+    pub pending_stop: bool,
+    /// Whether an operator's `delete` targets this sheep.
+    pub pending_delete: bool,
+}
+
+impl OwnedCandidate {
+    /// Borrow this as the [`Candidate`] [`fitness`] takes.
+    #[must_use]
+    pub fn as_candidate(&self) -> Candidate<'_> {
+        Candidate {
+            entry: &self.entry,
+            pending_stop: self.pending_stop,
+            pending_delete: self.pending_delete,
+        }
+    }
+}
+
 /// Decide whether a flock can be handed over in place.
 ///
 /// Whole-flock, not per-sheep: the handover blob describes one process
@@ -273,6 +305,37 @@ pub struct Handover {
 }
 
 impl Handover {
+    /// Describe a flock for the successor.
+    ///
+    /// Every argument comes from a different owner, which is why none of
+    /// them is read in here: `sheep` is assembled from the supervisor's
+    /// slots and its pumps, `fds` from `boot`, and `counters` from the
+    /// actor. Nothing in this crate can see all three.
+    #[must_use]
+    pub fn new(sheep: Vec<CarriedSheep>, fds: DaemonFds, counters: Counters) -> Self {
+        Self {
+            version: VERSION,
+            sheep,
+            listener_fd: fds.listener,
+            pidfile_fd: fds.pidfile,
+            next_id: counters.next_id,
+            next_deadline: counters.next_deadline,
+            next_action_stamp: counters.next_action_stamp,
+        }
+    }
+
+    /// Every sheep this blob carries.
+    #[must_use]
+    pub fn sheep(&self) -> &[CarriedSheep] {
+        &self.sheep
+    }
+
+    /// The entry id the successor is to issue next.
+    #[must_use]
+    pub const fn next_id(&self) -> u32 {
+        self.next_id
+    }
+
     /// Where the blob lives under `paths`: `$SHEP_HOME/run/handover.json`.
     #[must_use]
     pub fn path(paths: &ShepPaths) -> PathBuf {
@@ -287,14 +350,11 @@ impl Handover {
     /// named leaks into the successor's image, which is the mirror of the
     /// failure this module exists to avoid.
     fn named_fds(&self) -> impl Iterator<Item = RawFd> + '_ {
-        [self.listener_fd, self.pidfile_fd]
-            .into_iter()
-            .chain(self.sheep.iter().flat_map(|sheep| {
-                let fds = sheep.fds;
-                [fds.out_pipe, fds.err_pipe, fds.out_log, fds.err_log]
-                    .into_iter()
-                    .flatten()
-            }))
+        [self.listener_fd, self.pidfile_fd].into_iter().chain(
+            self.sheep
+                .iter()
+                .flat_map(|sheep| sheep.fds.all().into_iter().flatten()),
+        )
     }
 
     /// Write the blob under `paths`, at mode `0600`, and return where it
@@ -414,6 +474,37 @@ impl core::error::Error for LoadError {
     }
 }
 
+/// The daemon's own two descriptors, as the party that opened them knows
+/// them.
+///
+/// A pair rather than two arguments because both are a bare `RawFd`: passing
+/// them positionally lets a caller swap them silently, and the swap is not
+/// detectable afterwards — the successor would `flock` its control socket
+/// and listen on its pidfile. This is the same argument [`CarriedFds`] makes
+/// for grouping its four.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DaemonFds {
+    /// The control listener's descriptor number.
+    pub listener: RawFd,
+    /// The pidfile lock's descriptor number.
+    pub pidfile: RawFd,
+}
+
+/// The three supervisor counters a successor must not reissue.
+///
+/// They reset to zero in every constructor, so a successor that did not
+/// carry them would hand out an entry id, a reload-watchdog stamp or an
+/// action stamp that a caller is still holding.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Counters {
+    /// The next entry id.
+    pub next_id: u32,
+    /// The next reload-watchdog stamp.
+    pub next_deadline: u64,
+    /// The next action-wait stamp.
+    pub next_action_stamp: u64,
+}
+
 /// One sheep, as the successor will find it.
 ///
 /// Two halves. [`Self::app`] is what the sheep IS, carried whole so the
@@ -505,6 +596,18 @@ impl CarriedSheep {
             app: entry.spec.config().clone(),
         }
     }
+
+    /// The descriptor numbers this instance's output travels on.
+    #[must_use]
+    pub const fn fds(&self) -> CarriedFds {
+        self.fds
+    }
+
+    /// The supervisor slot's respawn epoch at the moment of the handover.
+    #[must_use]
+    pub const fn epoch(&self) -> u64 {
+        self.epoch
+    }
 }
 
 /// The four descriptor numbers one sheep's output travels on.
@@ -530,6 +633,33 @@ pub struct CarriedFds {
     pub out_log: Option<RawFd>,
     /// The appending handle on the sheep's stderr log file.
     pub err_log: Option<RawFd>,
+}
+
+impl CarriedFds {
+    /// The four numbers, listener-order irrelevant but fixed: stdout's pipe,
+    /// stderr's pipe, stdout's log, stderr's log.
+    ///
+    /// One array rather than four field reads, so a caller that walks all of
+    /// them — clearing `FD_CLOEXEC`, checking each is open — cannot walk
+    /// three by mistake.
+    #[must_use]
+    pub const fn all(&self) -> [Option<RawFd>; 4] {
+        [self.out_pipe, self.err_pipe, self.out_log, self.err_log]
+    }
+
+    /// The no-descriptors case: a sheep that is registered and not running.
+    ///
+    /// Not a failure, and [`fitness`] does not refuse it. A stopped sheep
+    /// has no pump, so it has nothing to carry and nothing to lose.
+    #[must_use]
+    pub const fn none() -> Self {
+        Self {
+            out_pipe: None,
+            err_pipe: None,
+            out_log: None,
+            err_log: None,
+        }
+    }
 }
 
 /// Where this process's binary was when it started, as `argv[0]` resolved

--- a/crates/shep-daemon/src/handover/mod.rs
+++ b/crates/shep-daemon/src/handover/mod.rs
@@ -21,6 +21,7 @@
 
 pub(crate) mod adopt;
 mod fds;
+pub(crate) mod reap;
 
 use core::convert::Infallible;
 use std::ffi::CString;

--- a/crates/shep-daemon/src/handover/mod.rs
+++ b/crates/shep-daemon/src/handover/mod.rs
@@ -34,6 +34,7 @@ use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
 
 use serde::{Deserialize, Serialize};
+use shep_core::config::AppConfig;
 use shep_core::paths::ShepPaths;
 use shep_core::protocol::ExitInfo;
 use shep_core::status::ProcStatus;
@@ -209,13 +210,35 @@ const FILE_NAME: &str = "handover.json";
 /// `handover::adopt`). It is the whole of what crosses the exec besides the
 /// descriptors themselves, which it names by number.
 ///
-/// **No environment values, ever.** A sheep's env can hold secrets, and the
-/// successor re-reads them from config, so nothing here is derived from
-/// `AppConfig::env`. That is asserted by an exact-string test over the
-/// serialized form rather than by a field check, because the risk is a
-/// future field that carries env by accident (IR-41). `Debug` is derived
-/// for the same reason: ids, pids, a name and a handful of descriptor
-/// numbers are all an operator could read out of `ps`.
+/// **It carries each sheep's whole resolved spec, environment included.**
+/// That is deliberate, and an earlier draft of this module said the
+/// opposite, so here is the argument rather than only the conclusion.
+///
+/// The muster roll already persists every sheep's environment in cleartext,
+/// permanently. [`SavedApp::app`](crate::snapshot::SavedApp::app) is a whole
+/// `AppConfig`, `AppConfig::env` is a plain `BTreeMap<String, String>` with
+/// no skip attribute, and `flock.json` is written at `0600`. That type's own
+/// doc even notes that `Debug` redacts env, so the sensitivity was
+/// understood and the value persisted anyway. A blob carrying the same
+/// values, at the same mode, on a file the successor unlinks the moment it
+/// has read it, is strictly less exposure than the file already sitting
+/// there for the life of the flock.
+///
+/// Refusing to carry it bought nothing and cost a great deal. Without a spec
+/// the successor has to rebuild one from the roll and bind carried sheep to
+/// roll apps by name and instance, except the roll records a running COUNT
+/// per app rather than which slots were up, and `muster` starts what it
+/// restores. A second source of truth that can disagree with the blob, to
+/// protect a value that is already on disk.
+///
+/// What protects it is what always did: mode `0600` set at creation rather
+/// than by a later `chmod`, inside a `0700` directory, unlinked by the
+/// successor as soon as it has read it. `Debug` stays derived and stays
+/// safe, because `AppConfig`'s own `Debug` prints `env` as a count rather
+/// than as pairs; an exact-string test pins that (IR-41), and a second one
+/// pins that the serialized form does carry the values, since a successor
+/// that silently lost them would respawn an app under an environment it was
+/// never started with.
 ///
 /// **`ProcessEntry::started_at` is deliberately absent**, and no serializer
 /// for it would help. It is a `tokio::time::Instant`, which has no epoch and
@@ -393,10 +416,10 @@ impl core::error::Error for LoadError {
 
 /// One sheep, as the successor will find it.
 ///
-/// Everything here is a fact about an instance that is already running, or
-/// already registered and not running. Nothing is re-derivable from config,
-/// which is why each field is here: config says what an app *is*, and this
-/// says what this instance currently *is doing*.
+/// Two halves. [`Self::app`] is what the sheep IS, carried whole so the
+/// successor can respawn this exact instance without asking the muster roll
+/// what it was. Every other field is what this instance is currently DOING,
+/// none of which any config could answer.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CarriedSheep {
     /// The supervisor's entry id, which callers already hold and selectors
@@ -428,6 +451,34 @@ pub struct CarriedSheep {
     credentials: SpawnIdentity,
     /// The descriptor numbers this instance's output travels on.
     fds: CarriedFds,
+    /// The resolved config this instance runs under, environment included.
+    ///
+    /// This is the `AppConfig` beneath [`ProcessEntry::spec`]'s
+    /// `ResolvedApp`, not the `ResolvedApp` itself. That type is a proof
+    /// token, obtainable only by passing a config through `normalize`, so
+    /// deriving `Deserialize` for it would mint the token out of arbitrary
+    /// JSON for every consumer of shep-core, which is a far wider change
+    /// than a handover needs. The value here has already been through
+    /// `normalize`, and `normalize` is pure over one of its own outputs: it
+    /// reads no filesystem, and a `~/` it expanded no longer begins with
+    /// `~`. So the successor rebuilds the token by normalizing this again.
+    ///
+    /// The roll persists an app the same way for the same reason, and doing
+    /// it differently here would be a second shape for one job:
+    /// [`SavedApp::app`](crate::snapshot::SavedApp::app) is an `AppConfig`
+    /// and `snapshot.rs` re-normalizes it on restore.
+    ///
+    /// One residual, recorded because it is real and not introduced here. A
+    /// successor whose `normalize` has tightened can refuse a config its
+    /// predecessor accepted, and after the exec there is no stop arm left to
+    /// fall back to. Carrying the resolved token instead would not buy the
+    /// escape it looks like it would: the alternative to carrying a spec at
+    /// all is the roll, which re-normalizes this identical `AppConfig` and
+    /// meets the identical refusal, with a second source of truth on top.
+    ///
+    /// Its serialized shape is part of this blob's version 1 format, as
+    /// [`SpawnIdentity`]'s is.
+    app: AppConfig,
 }
 
 impl CarriedSheep {
@@ -451,6 +502,7 @@ impl CarriedSheep {
             last_exit: entry.last_exit,
             credentials: entry.credentials,
             fds,
+            app: entry.spec.config().clone(),
         }
     }
 }
@@ -768,7 +820,6 @@ fn c_string(bytes: &[u8]) -> io::Result<CString> {
 
 #[cfg(test)]
 mod tests {
-    use shep_core::config::AppConfig;
     use shep_core::status::ProcStatus;
     use std::path::PathBuf;
 
@@ -968,11 +1019,27 @@ mod tests {
     }
 
     #[test]
-    fn the_blob_carries_no_environment_values() {
-        // A sheep's env can hold secrets. This is an exact-string assertion
-        // rather than a field check, because the risk is a future field that
-        // serializes env by accident (IR-41).
+    fn a_blob_round_trips_a_sheeps_environment_intact() {
+        // The successor respawns this sheep from what the blob carries, so
+        // an env value the blob drops is an app that comes back with a
+        // different environment than the one it was started with. Silent,
+        // and visible only as the app misbehaving.
         let text = serde_json::to_string(&sample_handover_with_secret_env()).unwrap();
+        let back: Handover = serde_json::from_str(&text).unwrap();
+        assert_eq!(
+            back.sheep[0].app.env.get("TOKEN").map(String::as_str),
+            Some("hunter2"),
+            "{text}"
+        );
+    }
+
+    #[test]
+    fn debug_redacts_a_carried_sheeps_environment() {
+        // The blob carries env; a log line naming the daemon's own state
+        // must not. An exact-string assertion rather than a field check,
+        // because the risk is a future field printing env by accident
+        // (IR-41).
+        let text = format!("{:?}", sample_handover_with_secret_env());
         assert!(!text.contains("hunter2"), "{text}");
     }
 

--- a/crates/shep-daemon/src/handover/mod.rs
+++ b/crates/shep-daemon/src/handover/mod.rs
@@ -1626,6 +1626,27 @@ mod tests {
             );
         }
 
+        // Drives `keep_and_exec` directly so the clear itself is observable.
+        // Without this the case cannot fail on the regression it exists to
+        // catch: if `named_fds` yielded nothing, no descriptor would be
+        // cleared and none restored, and the before and after assertions
+        // would both still pass over untouched flags.
+        let mut cleared = Vec::new();
+        let written = Handover::path(&paths);
+        let _ = keep_and_exec(&target, &blob, &written, &mut cleared);
+        cleared.sort_unstable();
+        let mut expected = vec![
+            listener.as_raw_fd(),
+            pidfile.as_raw_fd(),
+            out_log.as_raw_fd(),
+        ];
+        expected.sort_unstable();
+        assert_eq!(
+            cleared, expected,
+            "every named descriptor must be cleared, from both of the two \
+             places `named_fds` draws them"
+        );
+
         let err = exec_into(&target, &blob, &paths).unwrap_err();
 
         for file in [&listener, &pidfile, &out_log] {

--- a/crates/shep-daemon/src/handover/mod.rs
+++ b/crates/shep-daemon/src/handover/mod.rs
@@ -10,15 +10,6 @@
 //! back to the stop-and-start arm that already works. That asymmetry is why
 //! an unclear case refuses rather than guesses.
 
-// Nothing in this crate calls `fitness` or writes a blob yet. Task 8 wires
-// the gate into `boot.rs`'s SIGHUP arm and task 5 writes the blob; until
-// then, an honestly-unreachable gate is better than a stub that pretends to
-// decide something and always answers the same way.
-#![expect(
-    dead_code,
-    reason = "tasks 5 and 8 wire the blob and the gate into boot.rs; nothing calls them yet"
-)]
-
 pub(crate) mod adopt;
 mod fds;
 pub(crate) mod reap;
@@ -327,15 +318,39 @@ impl Handover {
     }
 
     /// Every sheep this blob carries.
+    ///
+    /// Read by this crate's own tests and by `adopt`, which reaches the
+    /// field directly from inside the module; `allow` rather than `expect`
+    /// because the expectation would go unfulfilled in a test build.
     #[must_use]
+    #[allow(dead_code, reason = "read by this crate's own tests")]
     pub fn sheep(&self) -> &[CarriedSheep] {
         &self.sheep
     }
 
     /// The entry id the successor is to issue next.
+    ///
+    /// [`Self::counters`] is what a successor restores from; this is the one
+    /// counter a test asserts on its own.
     #[must_use]
+    #[allow(dead_code, reason = "read by this crate's own tests")]
     pub const fn next_id(&self) -> u32 {
         self.next_id
+    }
+
+    /// The three counters the successor restores before installing any
+    /// sheep.
+    ///
+    /// All three together rather than one accessor each: they are restored
+    /// in one act, and a successor that carried two of them would reissue a
+    /// live stamp of the third.
+    #[must_use]
+    pub const fn counters(&self) -> Counters {
+        Counters {
+            next_id: self.next_id,
+            next_deadline: self.next_deadline,
+            next_action_stamp: self.next_action_stamp,
+        }
     }
 
     /// Where the blob lives under `paths`: `$SHEP_HOME/run/handover.json`.
@@ -601,6 +616,7 @@ impl CarriedSheep {
 
     /// The descriptor numbers this instance's output travels on.
     #[must_use]
+    #[allow(dead_code, reason = "read by this crate's own tests")]
     pub const fn fds(&self) -> CarriedFds {
         self.fds
     }

--- a/crates/shep-daemon/src/handover/mod.rs
+++ b/crates/shep-daemon/src/handover/mod.rs
@@ -608,6 +608,71 @@ impl CarriedSheep {
     pub const fn epoch(&self) -> u64 {
         self.epoch
     }
+
+    /// The entry id this instance keeps across the handover.
+    #[must_use]
+    pub const fn id(&self) -> u32 {
+        self.id
+    }
+
+    /// The name an operator reaches this instance by.
+    #[must_use]
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// The instance slot within its app.
+    #[must_use]
+    pub const fn instance(&self) -> u32 {
+        self.instance
+    }
+
+    /// The pid this instance is running under, or `None` for one that is
+    /// registered and not running.
+    ///
+    /// The one question a successor asks before adopting anything: there is
+    /// no process to take over for an instance that has none, and its
+    /// [`Self::fds`] are [`CarriedFds::none`] for the same reason.
+    #[must_use]
+    pub const fn pid(&self) -> Option<u32> {
+        self.pid
+    }
+
+    /// Respawns performed so far, which the restart budget counts against.
+    #[must_use]
+    pub const fn restarts(&self) -> u32 {
+        self.restarts
+    }
+
+    /// The instance's lifecycle status.
+    #[must_use]
+    pub const fn status(&self) -> ProcStatus {
+        self.status
+    }
+
+    /// How this instance most recently stopped existing, if it has.
+    #[must_use]
+    pub const fn last_exit(&self) -> Option<ExitInfo> {
+        self.last_exit
+    }
+
+    /// The identity this instance's next spawn runs under, resolved once by
+    /// the predecessor and never looked up again.
+    #[must_use]
+    pub const fn credentials(&self) -> SpawnIdentity {
+        self.credentials
+    }
+
+    /// The config this instance runs under, as its predecessor normalized it.
+    ///
+    /// Not a [`ResolvedApp`](shep_core::config::ResolvedApp): see the field's
+    /// own doc for why the proof token is rebuilt by re-normalizing this
+    /// rather than carried, and why re-normalizing is a no-op that hands the
+    /// token back.
+    #[must_use]
+    pub const fn app(&self) -> &AppConfig {
+        &self.app
+    }
 }
 
 /// The four descriptor numbers one sheep's output travels on.

--- a/crates/shep-daemon/src/handover/mod.rs
+++ b/crates/shep-daemon/src/handover/mod.rs
@@ -26,6 +26,7 @@ use std::io;
 use std::os::fd::RawFd;
 use std::os::unix::fs::OpenOptionsExt;
 use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
 
 use serde::{Deserialize, Serialize};
 use shep_core::paths::ShepPaths;
@@ -456,6 +457,159 @@ pub struct CarriedFds {
     pub err_log: Option<RawFd>,
 }
 
+/// Where this process's binary was when it started, as `argv[0]` resolved
+/// against the startup directory. Set once by [`record_launch_path`], and
+/// read only by [`exec_target`], whose doc carries the argument for why a
+/// recorded path beats asking the kernel later.
+///
+/// The inner `Option` is the "recorded, and there was nothing usable to
+/// record" case, which must not be confused with "never recorded": both
+/// fall through to the same fallback, but only the second is a bug in
+/// whoever forgot the call.
+static LAUNCH_PATH: OnceLock<Option<PathBuf>> = OnceLock::new();
+
+/// Record how this process was invoked, for a later [`exec_target`].
+///
+/// Call this once, as early in the daemon's life as there is anywhere to
+/// call it from: it reads `argv[0]` and the current directory, and the
+/// second of those is only the startup directory for as long as nothing has
+/// moved it. The first call wins; a later one is ignored, so a test or a
+/// second boot in the same process cannot overwrite the real launch path.
+///
+/// This is process-global state rather than a field on [`RunningDaemon`]
+/// because [`exec_target`] takes no arguments and is called from the exec
+/// path, which holds no daemon context by then.
+///
+/// [`RunningDaemon`]: crate::boot::RunningDaemon
+pub fn record_launch_path() {
+    let _ = LAUNCH_PATH.set(launch_path_from_argv());
+}
+
+/// The binary to `execv` for a handover, and never the running image.
+///
+/// # Why this does not use [`std::env::current_exe`]
+///
+/// Everywhere else in this workspace resolves its own binary that way, and
+/// here it is wrong. `current_exe` answers "which image am I running?",
+/// while a handover needs "which file holds the version an operator just
+/// installed?". Those are the same path only until somebody upgrades, which
+/// is the one moment this function exists for.
+///
+/// On Linux `current_exe` reads `/proc/self/exe`, a symlink to the *inode*
+/// this process was executed from rather than to a path. `cargo install`
+/// and every package manager replace a binary by renaming a new file over
+/// it, which leaves the old inode unlinked and still open, so the readlink
+/// comes back as `"<path> (deleted)"`. Exec'ing that string fails, and
+/// stripping the suffix is a guess about text the kernel does not promise:
+/// a path may legitimately end that way. So a handover using `current_exe`
+/// on Linux cannot upgrade, which is the whole feature.
+///
+/// On macOS the same sequence returns a clean path that holds the NEW
+/// image, so the naive version passes every local test. That is worse than
+/// failing, not better, and it is why this function is written the way it
+/// is. Do not simplify it back.
+///
+/// So: prefer the path this process was launched from, recorded by
+/// [`record_launch_path`] before anything could move the current directory,
+/// and fall back to `current_exe` only when that is unusable. Both arms go
+/// through [`check_target`], because a fallback that skips validation is
+/// the same bug with an extra step.
+///
+/// A bare `argv[0]` with no separator in it (a `PATH` lookup, so `shep
+/// daemon` typed by hand rather than the CLI's own spawn, which passes an
+/// absolute path) is not resolvable from `argv[0]` alone and is left to the
+/// `current_exe` arm.
+///
+/// # Errors
+/// - [`io::ErrorKind::NotFound`] if neither candidate is a file on disk
+///   that is safe to exec. The message names what each one was, and what
+///   was wrong with it. The caller falls back to the stop-and-start arm, which
+///   restarts the flock but does reach the new binary.
+pub fn exec_target() -> io::Result<PathBuf> {
+    let recorded = LAUNCH_PATH.get().cloned().flatten();
+    let current = std::env::current_exe();
+
+    let mut refusals = Vec::new();
+    for candidate in [recorded, current.as_deref().ok().map(Path::to_path_buf)] {
+        let Some(candidate) = candidate else { continue };
+        match check_target(&candidate) {
+            Ok(()) => return Ok(candidate),
+            Err(problem) => refusals.push(format!("{} ({problem})", candidate.display())),
+        }
+    }
+
+    if let Err(e) = &current {
+        refusals.push(format!("this process's own image ({e})"));
+    }
+    if refusals.is_empty() {
+        refusals.push("no candidate at all".to_owned());
+    }
+    Err(io::Error::new(
+        io::ErrorKind::NotFound,
+        format!("no binary to hand over to: {}", refusals.join("; ")),
+    ))
+}
+
+/// Why a candidate path is not safe to `execv`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TargetProblem {
+    /// The path carries Linux's `" (deleted)"` suffix, so it names an
+    /// unlinked inode rather than a file.
+    DeletedInode,
+    /// Nothing is at the path, or it could not be read.
+    Missing,
+    /// Something is at the path, but it is a directory or a device.
+    NotAFile,
+}
+
+impl core::fmt::Display for TargetProblem {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let text = match self {
+            Self::DeletedInode => "names a deleted inode, not a file",
+            Self::Missing => "is not on disk",
+            Self::NotAFile => "is not a file",
+        };
+        f.write_str(text)
+    }
+}
+
+/// Whether `candidate` is a file this daemon may replace itself with.
+///
+/// The `" (deleted)"` check runs first and refuses even a path that really
+/// does exist. A file genuinely named that way is vanishingly rare, a
+/// handover of it merely falls back to the stop arm, and the alternative is
+/// exec'ing an old image while reporting an upgrade.
+fn check_target(candidate: &Path) -> Result<(), TargetProblem> {
+    if candidate.to_string_lossy().contains(" (deleted)") {
+        return Err(TargetProblem::DeletedInode);
+    }
+    match std::fs::metadata(candidate) {
+        Ok(meta) if meta.is_file() => Ok(()),
+        Ok(_) => Err(TargetProblem::NotAFile),
+        Err(_) => Err(TargetProblem::Missing),
+    }
+}
+
+/// This process's `argv[0]`, resolved against the current directory.
+///
+/// `None` when there is no `argv[0]`, when it is empty, or when it holds no
+/// separator and so came from a `PATH` lookup this cannot undo. An absolute
+/// `argv[0]`, which is what `launch_command` gives the daemon it spawns,
+/// passes through the join unchanged.
+fn launch_path_from_argv() -> Option<PathBuf> {
+    let argv0 = PathBuf::from(std::env::args_os().next()?);
+    if argv0.as_os_str().is_empty() {
+        return None;
+    }
+    if argv0.is_absolute() {
+        return Some(argv0);
+    }
+    let has_separator = argv0
+        .parent()
+        .is_some_and(|dir| !dir.as_os_str().is_empty());
+    has_separator.then(|| std::env::current_dir().ok().map(|cwd| cwd.join(&argv0)))?
+}
+
 #[cfg(test)]
 mod tests {
     use shep_core::config::AppConfig;
@@ -718,5 +872,73 @@ mod tests {
             fitness(&[candidate]),
             Fitness::Refused(RefusedReason::PendingDelete { .. })
         ));
+    }
+
+    #[test]
+    fn the_exec_target_exists_and_is_a_file() {
+        let p = exec_target().unwrap();
+        assert!(p.is_file(), "{}", p.display());
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn a_deleted_inode_path_is_never_returned() {
+        // /proc/self/exe resolves to the inode, so a binary replaced by a
+        // `cargo install` rename gives `"<path> (deleted)"`. Exec'ing that
+        // fails, which would make a handover silently unable to upgrade,
+        // which is the whole point of the feature.
+        let p = exec_target().unwrap();
+        assert!(
+            !p.to_string_lossy().contains("(deleted)"),
+            "exec target resolved to a deleted inode: {}",
+            p.display()
+        );
+    }
+
+    #[test]
+    fn a_deleted_inode_candidate_is_refused_on_every_platform() {
+        // The portable half of the test above. The Linux one asserts the
+        // whole resolution never yields such a path, but a macOS run never
+        // compiles it, so the rule it protects would go unexercised here.
+        // This one drives the same check directly.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("shep (deleted)");
+        std::fs::write(&path, "an exec target that really is on disk").unwrap();
+
+        assert_eq!(
+            check_target(&path),
+            Err(TargetProblem::DeletedInode),
+            "existing on disk must not excuse the suffix"
+        );
+    }
+
+    #[test]
+    fn a_candidate_that_is_not_on_disk_is_refused() {
+        let dir = tempfile::tempdir().unwrap();
+        assert_eq!(
+            check_target(&dir.path().join("never-written")),
+            Err(TargetProblem::Missing)
+        );
+    }
+
+    #[test]
+    fn a_directory_is_refused() {
+        let dir = tempfile::tempdir().unwrap();
+        assert_eq!(check_target(dir.path()), Err(TargetProblem::NotAFile));
+    }
+
+    #[test]
+    fn a_real_binary_passes_the_check() {
+        assert_eq!(check_target(&std::env::current_exe().unwrap()), Ok(()));
+    }
+
+    #[test]
+    fn argv0_resolves_against_the_startup_directory() {
+        // The test harness is invoked by an absolute path, so this proves
+        // the argv[0] arm reaches a real file rather than that the join
+        // itself is correct; the join is exercised by `Path::join`'s own
+        // contract that an absolute right-hand side replaces the left.
+        let p = launch_path_from_argv().expect("argv[0] names a path");
+        assert!(p.is_file(), "{}", p.display());
     }
 }

--- a/crates/shep-daemon/src/handover/mod.rs
+++ b/crates/shep-daemon/src/handover/mod.rs
@@ -19,6 +19,7 @@
     reason = "tasks 5 and 8 wire the blob and the gate into boot.rs; nothing calls them yet"
 )]
 
+pub(crate) mod adopt;
 mod fds;
 
 use core::convert::Infallible;

--- a/crates/shep-daemon/src/handover/mod.rs
+++ b/crates/shep-daemon/src/handover/mod.rs
@@ -41,7 +41,7 @@ pub enum Fitness {
 /// `#[non_exhaustive]`, unlike [`crate::boot::Shepherd`]: that enum is
 /// closed by its mechanism (a pidfile lock is either free, held-with-pid or
 /// held-without, and there is no fourth state). This one is closed by
-/// nothing but how much of the handover has shipped — 2b and 2c each widen
+/// nothing but how much of the handover has shipped. 2b and 2c each widen
 /// what phase 2a refuses today into something a later phase carries, so a
 /// match here must keep tolerating a variant this module has not named yet.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -69,7 +69,7 @@ pub enum RefusedReason {
         /// The sheep's name.
         sheep: String,
     },
-    /// The sheep is mid-reload — drainee or replacement — which 2c carries.
+    /// The sheep is mid-reload, drainee or replacement, which 2c carries.
     ReloadInFlight {
         /// The sheep's name.
         sheep: String,
@@ -111,8 +111,8 @@ impl core::fmt::Display for RefusedReason {
 /// Bundles a [`ProcessEntry`] with the two facts that do not live on it: a
 /// pending manual stop and a pending delete both live on the supervisor's
 /// private slot type, not on the entry it wraps, so `fitness` cannot reach
-/// them through `entry` alone. The caller — the supervisor, which owns both
-/// — builds this view; `fitness` stays a pure function over data it is
+/// them through `entry` alone. The caller, the supervisor, which owns both
+/// of them, builds this view; `fitness` stays a pure function over data it is
 /// handed rather than reaching into the registry itself.
 #[derive(Debug, Clone, Copy)]
 pub struct Candidate<'a> {

--- a/crates/shep-daemon/src/handover/mod.rs
+++ b/crates/shep-daemon/src/handover/mod.rs
@@ -18,6 +18,8 @@
     reason = "task 8 wires fitness into boot.rs's SIGHUP arm; nothing calls it yet"
 )]
 
+mod fds;
+
 use crate::entry::ProcessEntry;
 
 /// Whether a flock can be handed over in place, or must fall back to a

--- a/crates/shep-daemon/src/handover/mod.rs
+++ b/crates/shep-daemon/src/handover/mod.rs
@@ -21,9 +21,12 @@
 
 mod fds;
 
+use core::convert::Infallible;
+use std::ffi::CString;
 use std::fs::{self, OpenOptions};
 use std::io;
 use std::os::fd::RawFd;
+use std::os::unix::ffi::{OsStrExt, OsStringExt};
 use std::os::unix::fs::OpenOptionsExt;
 use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
@@ -249,6 +252,24 @@ impl Handover {
     #[must_use]
     pub fn path(paths: &ShepPaths) -> PathBuf {
         paths.run.join(FILE_NAME)
+    }
+
+    /// Every descriptor number this blob names, listener and pidfile
+    /// first.
+    ///
+    /// This is the exact set [`hand_over`] clears `FD_CLOEXEC` on, and
+    /// nothing else may be added to it: a descriptor kept without being
+    /// named leaks into the successor's image, which is the mirror of the
+    /// failure this module exists to avoid.
+    fn named_fds(&self) -> impl Iterator<Item = RawFd> + '_ {
+        [self.listener_fd, self.pidfile_fd]
+            .into_iter()
+            .chain(self.sheep.iter().flat_map(|sheep| {
+                let fds = sheep.fds;
+                [fds.out_pipe, fds.err_pipe, fds.out_log, fds.err_log]
+                    .into_iter()
+                    .flatten()
+            }))
     }
 
     /// Write the blob under `paths`, at mode `0600`, and return where it
@@ -610,6 +631,139 @@ fn launch_path_from_argv() -> Option<PathBuf> {
     has_separator.then(|| std::env::current_dir().ok().map(|cwd| cwd.join(&argv0)))?
 }
 
+/// The environment variable a handover leaves for its successor, holding
+/// the path of the blob it is to adopt.
+///
+/// Its presence is also the successor's only marker that it is one: an
+/// image started any other way has no blob to read and boots normally.
+/// Naming a descriptor-carrying thing in the environment follows the
+/// `SHEP_CHANNEL_FD` precedent this daemon already sets for a sheep's
+/// shepherd channel.
+pub const HANDOVER_ENV: &str = "SHEP_HANDOVER";
+
+/// Replace this process with a fresh copy of the shep binary, handing it
+/// `blob`'s flock.
+///
+/// Returns [`Infallible`] rather than `()` so that a call site reads as
+/// what it is: on success there is no successor statement, because there is
+/// no successor image running this code. Only the error arm returns.
+///
+/// The order is the whole of this function, and getting it wrong loses a
+/// flock:
+///
+/// 1. write the blob, so the successor has something to read before there
+///    is any chance of it existing;
+/// 2. clear `FD_CLOEXEC` on every descriptor the blob names, and only
+///    those, since a descriptor kept without being named leaks into the new
+///    image;
+/// 3. `execv` the binary [`exec_target`] resolves, which is deliberately
+///    not this running image.
+///
+/// If the exec fails, the blob on disk is a lie: it describes a handover
+/// that never happened, and the next boot would adopt a picture of a
+/// process image that does not exist. It is removed before the error is
+/// returned, and the caller falls back to the stop-and-start arm.
+///
+/// The target is resolved before anything is written, so the one failure
+/// that needs no cleanup does not get any.
+///
+/// Nothing this process installed on a signal survives. `execve` resets
+/// every disposition that names a handler back to `SIG_DFL`, so tokio's
+/// `SIGCHLD` handling and this daemon's own installer both go, and the
+/// successor installs them again. That is the design, not a loss to work
+/// around.
+///
+/// # Errors
+///
+/// No binary is safe to exec (see [`exec_target`]), the blob could not be
+/// written, a descriptor it names is not open, or the exec itself failed.
+/// Every one of those returns with no blob left on disk.
+pub fn hand_over(blob: &Handover, paths: &ShepPaths) -> io::Result<Infallible> {
+    exec_into(&exec_target()?, blob, paths)
+}
+
+/// [`hand_over`], against a caller-chosen binary.
+///
+/// Split out so a test can point the exec at something that cannot run and
+/// watch the blob be cleaned up; production has exactly one target and
+/// [`exec_target`] chooses it.
+///
+/// # Errors
+///
+/// As [`hand_over`], minus the target resolution.
+fn exec_into(target: &Path, blob: &Handover, paths: &ShepPaths) -> io::Result<Infallible> {
+    let written = blob.write(paths)?;
+    let failure = match exec_with_blob(target, blob, &written) {
+        Ok(never) => match never {},
+        Err(err) => err,
+    };
+    match fs::remove_file(&written) {
+        Ok(()) | Err(_) => Err(failure),
+    }
+}
+
+/// Clear `FD_CLOEXEC` on what `blob` names, then become `target`.
+///
+/// # Errors
+///
+/// A descriptor the blob names is not open, a path or an environment entry
+/// holds an interior NUL, or the exec failed. On any of them this process
+/// is still itself and `written` is still on disk, which is what
+/// [`exec_into`] cleans up.
+fn exec_with_blob(target: &Path, blob: &Handover, written: &Path) -> io::Result<Infallible> {
+    for fd in blob.named_fds() {
+        fds::keep_raw_across_exec(fd)?;
+    }
+
+    let path = c_string(target.as_os_str().as_bytes())?;
+    let argv = std::env::args_os()
+        .map(|arg| c_string(arg.as_bytes()))
+        .collect::<io::Result<Vec<_>>>()?;
+    let env = successor_env(written)?;
+
+    // `execve` rather than `execv`: `execv` inherits this process's
+    // `environ`, so pointing the successor at the blob would mean
+    // `std::env::set_var`, which is unsafe in edition 2024 and unsound in a
+    // process with as many threads as this one. Handing the environment
+    // over explicitly needs neither.
+    nix::unistd::execve(&path, &argv, &env).map_err(io::Error::from)
+}
+
+/// This process's environment, with [`HANDOVER_ENV`] set to `written`.
+///
+/// Any inherited value of that variable is dropped rather than kept: a
+/// successor that adopts a blob must adopt the one its predecessor just
+/// wrote, and a stale entry from an earlier handover would name a file that
+/// has already been read and unlinked.
+///
+/// # Errors
+///
+/// A name or value holds an interior NUL, which no environment this process
+/// was given can.
+fn successor_env(written: &Path) -> io::Result<Vec<CString>> {
+    let mut env = std::env::vars_os()
+        .filter(|(name, _)| name != HANDOVER_ENV)
+        .map(|(name, value)| {
+            let mut entry = name.into_vec();
+            entry.push(b'=');
+            entry.extend(value.into_vec());
+            c_string(&entry)
+        })
+        .collect::<io::Result<Vec<_>>>()?;
+
+    let mut marker = HANDOVER_ENV.as_bytes().to_vec();
+    marker.push(b'=');
+    marker.extend(written.as_os_str().as_bytes());
+    env.push(c_string(&marker)?);
+    Ok(env)
+}
+
+/// `bytes` as a C string, with an interior NUL reported as an `io::Error`
+/// rather than as a `NulError` nothing else in this module speaks.
+fn c_string(bytes: &[u8]) -> io::Result<CString> {
+    CString::new(bytes).map_err(io::Error::other)
+}
+
 #[cfg(test)]
 mod tests {
     use shep_core::config::AppConfig;
@@ -940,5 +1094,153 @@ mod tests {
         // contract that an absolute right-hand side replaces the left.
         let p = launch_path_from_argv().expect("argv[0] names a path");
         assert!(p.is_file(), "{}", p.display());
+    }
+
+    /// Names the directory the exec self-test's middle stage works in, and
+    /// tells that stage it is not the ordinary run of the test.
+    const SELFTEST_HOME: &str = "SHEP_HANDOVER_SELFTEST";
+
+    /// The full path of the self-test, as libtest's `--exact` wants it.
+    const SELFTEST_NAME: &str =
+        "handover::tests::an_exec_replaces_the_image_and_keeps_a_descriptor";
+
+    /// A blob naming real descriptors: `entry`'s sheep carries `fds`, and
+    /// the listener and pidfile numbers are the caller's own open files.
+    fn handover_with_fds(
+        entry: &ProcessEntry,
+        listener_fd: RawFd,
+        pidfile_fd: RawFd,
+        fds: CarriedFds,
+    ) -> Handover {
+        Handover {
+            version: VERSION,
+            sheep: vec![CarriedSheep::from_entry(entry, 7, fds)],
+            listener_fd,
+            pidfile_fd,
+            next_id: 9,
+            next_deadline: 5,
+            next_action_stamp: 2,
+        }
+    }
+
+    fn selftest_paths(home: &Path) -> ShepPaths {
+        let home = home.display().to_string();
+        let paths = ShepPaths::resolve(
+            &|key| (key == "SHEP_HOME").then(|| home.clone()),
+            Path::new("/nonexistent"),
+        );
+        std::fs::create_dir_all(&paths.run).unwrap();
+        paths
+    }
+
+    #[test]
+    fn an_exec_replaces_the_image_and_keeps_a_descriptor() {
+        // Three stages of the same test binary. The ordinary run is the
+        // parent: it re-runs this one test in a child, which writes into a
+        // pipe and hands over, and the image that `hand_over` execs into
+        // reads that pipe back by number. There is no helper binary to
+        // borrow here, shep-daemon being a library, and a test that stopped
+        // short of a real `execve` would prove none of what this one does.
+        if let Some(blob) = std::env::var_os(HANDOVER_ENV) {
+            successor_stage(Path::new(&blob));
+        }
+        if let Some(home) = std::env::var_os(SELFTEST_HOME) {
+            exec_stage(Path::new(&home));
+        }
+
+        let dir = tempfile::tempdir().unwrap();
+        let out = std::process::Command::new(std::env::current_exe().unwrap())
+            .arg(SELFTEST_NAME)
+            .arg("--exact")
+            .arg("--nocapture")
+            .env(SELFTEST_HOME, dir.path())
+            .env_remove(HANDOVER_ENV)
+            .output()
+            .unwrap();
+
+        let stdout = String::from_utf8_lossy(&out.stdout);
+        assert!(
+            out.status.success(),
+            "{stdout}{}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+        // The whole mechanism in one assertion: a pipe written before the
+        // exec is readable by the process after it, on the same fd number,
+        // proving both that the image changed and that the descriptor
+        // crossed.
+        assert!(stdout.contains("adopted: hello"), "{stdout}");
+    }
+
+    /// The middle stage: fill a pipe, name its read end in a blob, and hand
+    /// over. Returns only if the exec failed, which is a test failure.
+    fn exec_stage(home: &Path) -> ! {
+        use std::io::Write as _;
+        use std::os::fd::AsRawFd as _;
+
+        let paths = selftest_paths(home);
+        let (reader, mut writer) = std::io::pipe().unwrap();
+        writer.write_all(b"hello").unwrap();
+        drop(writer);
+
+        let listener = tempfile::tempfile().unwrap();
+        let pidfile = tempfile::tempfile().unwrap();
+        let blob = handover_with_fds(
+            &entry_fixture(|_| {}),
+            listener.as_raw_fd(),
+            pidfile.as_raw_fd(),
+            CarriedFds {
+                out_pipe: Some(reader.as_raw_fd()),
+                err_pipe: None,
+                out_log: None,
+                err_log: None,
+            },
+        );
+
+        let err = hand_over(&blob, &paths).unwrap_err();
+        panic!("the exec should not have returned: {err}");
+    }
+
+    /// The stage after the exec: read the blob this process was pointed at,
+    /// and read the descriptor it names.
+    fn successor_stage(blob_path: &Path) -> ! {
+        let blob = Handover::read(blob_path).expect("the successor's blob");
+        let fd = blob.sheep[0].fds.out_pipe.expect("a carried stdout pipe");
+        let mut buf = [0_u8; 16];
+        let read = nix::unistd::read(fd, &mut buf).expect("the carried descriptor is open");
+        println!("adopted: {}", String::from_utf8_lossy(&buf[..read]));
+        std::process::exit(0);
+    }
+
+    #[test]
+    fn a_failed_exec_leaves_no_blob_behind() {
+        // A blob that outlives a failed exec describes a handover that never
+        // happened, and the next boot would adopt a picture of a process
+        // image that does not exist.
+        use std::os::fd::AsRawFd as _;
+
+        let dir = tempfile::tempdir().unwrap();
+        let paths = selftest_paths(dir.path());
+        let target = dir.path().join("not-a-binary");
+        std::fs::write(&target, "this will never execute").unwrap();
+
+        let listener = tempfile::tempfile().unwrap();
+        let pidfile = tempfile::tempfile().unwrap();
+        let blob = handover_with_fds(
+            &entry_fixture(|_| {}),
+            listener.as_raw_fd(),
+            pidfile.as_raw_fd(),
+            CarriedFds {
+                out_pipe: None,
+                err_pipe: None,
+                out_log: None,
+                err_log: None,
+            },
+        );
+
+        let err = exec_into(&target, &blob, &paths).unwrap_err();
+        assert!(
+            !Handover::path(&paths).exists(),
+            "a failed exec left a blob behind: {err}"
+        );
     }
 }

--- a/crates/shep-daemon/src/handover/mod.rs
+++ b/crates/shep-daemon/src/handover/mod.rs
@@ -1,0 +1,331 @@
+//! Whole-flock handover: whether this daemon's flock can be replaced in
+//! place, and (in later tasks) the blob and the exec that carry it.
+//!
+//! Phase 2a carries only the plainest sheep: no shepherd channel, no stdin,
+//! no dog, one instance, no in-flight reload, and nothing an operator has
+//! already asked to stop or delete. [`fitness`] is the gate: get it wrong in
+//! the permissive direction and a half-built handover corrupts a live
+//! flock; get it wrong in the strict direction and the caller merely falls
+//! back to the stop-and-start arm that already works. That asymmetry is why
+//! an unclear case refuses rather than guesses.
+
+// Nothing in this crate calls `fitness` yet. Task 8 wires it into
+// `boot.rs`'s SIGHUP arm; until then, an honestly-unreachable gate is
+// better than a stub that pretends to decide something and always answers
+// the same way.
+#![expect(
+    dead_code,
+    reason = "task 8 wires fitness into boot.rs's SIGHUP arm; nothing calls it yet"
+)]
+
+use crate::entry::ProcessEntry;
+
+/// Whether a flock can be handed over in place, or must fall back to a
+/// stop-and-start.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Fitness {
+    /// Every sheep in the flock is carryable by phase 2a.
+    Carryable,
+    /// At least one sheep is not carryable, and why.
+    Refused(RefusedReason),
+}
+
+/// Why a flock cannot be handed over in place, and what happens instead.
+///
+/// Every variant is a feature phase 2a does not yet carry, not an error. The
+/// caller falls back to the stop arm, which is correct behaviour rather
+/// than a degraded one.
+///
+/// `#[non_exhaustive]`, unlike [`crate::boot::Shepherd`]: that enum is
+/// closed by its mechanism (a pidfile lock is either free, held-with-pid or
+/// held-without, and there is no fourth state). This one is closed by
+/// nothing but how much of the handover has shipped — 2b and 2c each widen
+/// what phase 2a refuses today into something a later phase carries, so a
+/// match here must keep tolerating a variant this module has not named yet.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum RefusedReason {
+    /// The sheep holds a shepherd channel: `channel`, `wait_ready` or
+    /// `shutdown_with_message`, whose socketpair 2b carries.
+    Channel {
+        /// The sheep's name.
+        sheep: String,
+    },
+    /// The sheep has `stdin = true`, whose pipe 2b carries.
+    Stdin {
+        /// The sheep's name.
+        sheep: String,
+    },
+    /// The sheep is a dog, which 2b's descriptor inventory does not cover
+    /// yet.
+    Dog {
+        /// The sheep's name.
+        sheep: String,
+    },
+    /// The sheep's app runs more than one instance, which 2b carries.
+    MultiInstance {
+        /// The sheep's name.
+        sheep: String,
+    },
+    /// The sheep is mid-reload — drainee or replacement — which 2c carries.
+    ReloadInFlight {
+        /// The sheep's name.
+        sheep: String,
+    },
+    /// An operator's `stop` is waiting on this sheep's next exit, which 2c
+    /// carries.
+    PendingStop {
+        /// The sheep's name.
+        sheep: String,
+    },
+    /// An operator's `delete` targets this sheep, which 2c carries.
+    PendingDelete {
+        /// The sheep's name.
+        sheep: String,
+    },
+}
+
+impl core::fmt::Display for RefusedReason {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let (sheep, feature) = match self {
+            Self::Channel { sheep } => (sheep, "a shepherd channel"),
+            Self::Stdin { sheep } => (sheep, "stdin"),
+            Self::Dog { sheep } => (sheep, "being a dog"),
+            Self::MultiInstance { sheep } => (sheep, "more than one instance"),
+            Self::ReloadInFlight { sheep } => (sheep, "an in-flight reload"),
+            Self::PendingStop { sheep } => (sheep, "a pending manual stop"),
+            Self::PendingDelete { sheep } => (sheep, "a pending delete"),
+        };
+        write!(
+            f,
+            "sheep '{sheep}' has {feature}, which this daemon cannot yet hand \
+             over; reload falls back to a stop-and-start instead"
+        )
+    }
+}
+
+/// One sheep's carryability-relevant facts.
+///
+/// Bundles a [`ProcessEntry`] with the two facts that do not live on it: a
+/// pending manual stop and a pending delete both live on the supervisor's
+/// private slot type, not on the entry it wraps, so `fitness` cannot reach
+/// them through `entry` alone. The caller — the supervisor, which owns both
+/// — builds this view; `fitness` stays a pure function over data it is
+/// handed rather than reaching into the registry itself.
+#[derive(Debug, Clone, Copy)]
+pub struct Candidate<'a> {
+    /// The sheep's lifecycle entry.
+    pub entry: &'a ProcessEntry,
+    /// Whether an operator's `stop` is waiting on this sheep's next exit.
+    pub pending_stop: bool,
+    /// Whether an operator's `delete` targets this sheep.
+    pub pending_delete: bool,
+}
+
+/// Decide whether a flock can be handed over in place.
+///
+/// Whole-flock, not per-sheep: the handover blob describes one process
+/// image, so a flock is carried whole or refused whole. An empty flock is
+/// carryable.
+#[must_use]
+pub fn fitness(sheep: &[Candidate<'_>]) -> Fitness {
+    for candidate in sheep {
+        if let Some(reason) = refusal(candidate) {
+            return Fitness::Refused(reason);
+        }
+    }
+    Fitness::Carryable
+}
+
+/// Why `candidate` alone refuses the flock, if it does.
+fn refusal(candidate: &Candidate<'_>) -> Option<RefusedReason> {
+    let entry = candidate.entry;
+    let config = entry.spec.config();
+    let name = || config.name.clone();
+
+    if config.channel || config.wait_ready || config.shutdown_with_message {
+        return Some(RefusedReason::Channel { sheep: name() });
+    }
+    if config.stdin {
+        return Some(RefusedReason::Stdin { sheep: name() });
+    }
+    if entry.dog.is_some() {
+        return Some(RefusedReason::Dog { sheep: name() });
+    }
+    if config.instances > 1 {
+        return Some(RefusedReason::MultiInstance { sheep: name() });
+    }
+    if !matches!(entry.reload, crate::entry::ReloadState::None) {
+        return Some(RefusedReason::ReloadInFlight { sheep: name() });
+    }
+    if candidate.pending_delete {
+        return Some(RefusedReason::PendingDelete { sheep: name() });
+    }
+    if candidate.pending_stop {
+        return Some(RefusedReason::PendingStop { sheep: name() });
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use shep_core::config::AppConfig;
+    use shep_core::status::ProcStatus;
+    use std::path::PathBuf;
+
+    use super::*;
+    use crate::entry::{ReloadState, RestartBudget};
+    use crate::privilege::SpawnIdentity;
+    use crate::testing::app_with;
+
+    /// A plain, `Online` entry: no channel, no stdin, not a dog, one
+    /// instance, no in-flight reload. Every field a real spawn would set is
+    /// present so a future field this gate should read cannot be silently
+    /// left at a `Default` that hides a bug.
+    fn entry_fixture(mutate: impl FnOnce(&mut AppConfig)) -> ProcessEntry {
+        let spec = app_with("web", mutate);
+        ProcessEntry {
+            id: 1,
+            spec,
+            instance: 0,
+            status: ProcStatus::Online,
+            pid: Some(100),
+            restarts: 0,
+            started_at: None,
+            budget: RestartBudget::default(),
+            reload: ReloadState::None,
+            credentials: SpawnIdentity::Resolved(None),
+            out_file: PathBuf::from("/tmp/shep-handover-test-out.log"),
+            err_file: PathBuf::from("/tmp/shep-handover-test-err.log"),
+            dog: None,
+            last_exit: None,
+        }
+    }
+
+    fn plain(entry: &ProcessEntry) -> Candidate<'_> {
+        Candidate {
+            entry,
+            pending_stop: false,
+            pending_delete: false,
+        }
+    }
+
+    #[test]
+    fn a_plain_sheep_is_carryable() {
+        let e = entry_fixture(|_| {});
+        assert_eq!(fitness(&[plain(&e)]), Fitness::Carryable);
+    }
+
+    #[test]
+    fn one_unsupported_sheep_refuses_the_whole_flock() {
+        // Not per-sheep. The blob describes one process image, so a flock is
+        // carried whole or not at all.
+        let plain_entry = entry_fixture(|_| {});
+        let channelled = entry_fixture(|app| app.channel = true);
+        assert!(matches!(
+            fitness(&[plain(&plain_entry), plain(&channelled)]),
+            Fitness::Refused(_)
+        ));
+    }
+
+    #[test]
+    fn the_refusal_names_which_sheep_and_why() {
+        // The operator sees this in `shep daemon reload`'s output, so it has
+        // to say what to do about it, not just that it declined.
+        let channelled = entry_fixture(|app| app.channel = true);
+        let Fitness::Refused(r) = fitness(&[plain(&channelled)]) else {
+            panic!("expected a refusal")
+        };
+        let text = r.to_string();
+        assert!(text.contains("shepherd channel"), "{text}");
+    }
+
+    #[test]
+    fn an_empty_flock_is_carryable() {
+        assert_eq!(fitness(&[]), Fitness::Carryable);
+    }
+
+    #[test]
+    fn wait_ready_alone_refuses_as_a_channel() {
+        let e = entry_fixture(|app| app.wait_ready = true);
+        assert!(matches!(
+            fitness(&[plain(&e)]),
+            Fitness::Refused(RefusedReason::Channel { .. })
+        ));
+    }
+
+    #[test]
+    fn shutdown_with_message_alone_refuses_as_a_channel() {
+        let e = entry_fixture(|app| app.shutdown_with_message = true);
+        assert!(matches!(
+            fitness(&[plain(&e)]),
+            Fitness::Refused(RefusedReason::Channel { .. })
+        ));
+    }
+
+    #[test]
+    fn stdin_refuses() {
+        let e = entry_fixture(|app| app.stdin = true);
+        assert!(matches!(
+            fitness(&[plain(&e)]),
+            Fitness::Refused(RefusedReason::Stdin { .. })
+        ));
+    }
+
+    #[test]
+    fn a_dog_refuses() {
+        let mut e = entry_fixture(|_| {});
+        e.dog = Some(shep_core::protocol::DogSource::BuiltIn);
+        assert!(matches!(
+            fitness(&[plain(&e)]),
+            Fitness::Refused(RefusedReason::Dog { .. })
+        ));
+    }
+
+    #[test]
+    fn more_than_one_instance_refuses() {
+        let e = entry_fixture(|app| app.instances = 2);
+        assert!(matches!(
+            fitness(&[plain(&e)]),
+            Fitness::Refused(RefusedReason::MultiInstance { .. })
+        ));
+    }
+
+    #[test]
+    fn an_in_flight_reload_refuses() {
+        let mut e = entry_fixture(|_| {});
+        e.reload = ReloadState::Replacement;
+        assert!(matches!(
+            fitness(&[plain(&e)]),
+            Fitness::Refused(RefusedReason::ReloadInFlight { .. })
+        ));
+    }
+
+    #[test]
+    fn a_pending_manual_stop_refuses() {
+        let e = entry_fixture(|_| {});
+        let candidate = Candidate {
+            entry: &e,
+            pending_stop: true,
+            pending_delete: false,
+        };
+        assert!(matches!(
+            fitness(&[candidate]),
+            Fitness::Refused(RefusedReason::PendingStop { .. })
+        ));
+    }
+
+    #[test]
+    fn a_pending_delete_refuses() {
+        let e = entry_fixture(|_| {});
+        let candidate = Candidate {
+            entry: &e,
+            pending_stop: false,
+            pending_delete: true,
+        };
+        assert!(matches!(
+            fitness(&[candidate]),
+            Fitness::Refused(RefusedReason::PendingDelete { .. })
+        ));
+    }
+}

--- a/crates/shep-daemon/src/handover/mod.rs
+++ b/crates/shep-daemon/src/handover/mod.rs
@@ -944,7 +944,10 @@ pub const HANDOVER_ENV: &str = "SHEP_HANDOVER";
 ///
 /// No binary is safe to exec (see [`exec_target`]), the blob could not be
 /// written, a descriptor it names is not open, or the exec itself failed.
-/// Every one of those returns with no blob left on disk.
+/// Every one of those returns with no blob left on disk, and with
+/// `FD_CLOEXEC` back on every descriptor the attempt cleared it from, so the
+/// caller's fallback to a graceful stop leaves nothing exec-inheritable
+/// behind it.
 pub fn hand_over(blob: &Handover, paths: &ShepPaths) -> io::Result<Infallible> {
     exec_into(&exec_target()?, blob, paths)
 }
@@ -978,8 +981,48 @@ fn exec_into(target: &Path, blob: &Handover, paths: &ShepPaths) -> io::Result<In
 /// is still itself and `written` is still on disk, which is what
 /// [`exec_into`] cleans up.
 fn exec_with_blob(target: &Path, blob: &Handover, written: &Path) -> io::Result<Infallible> {
+    let mut cleared = Vec::new();
+    let failure = match keep_and_exec(target, blob, written, &mut cleared) {
+        Ok(never) => match never {},
+        Err(err) => err,
+    };
+    // Every descriptor put back the way it was found. Without this the
+    // daemon returns to the graceful-stop fallback with the listener, the
+    // pidfile and every carried log descriptor still exec-inheritable, and
+    // the supervisor is still running: a restart or a queued `Start` in the
+    // window before teardown spawns a sheep that inherits them, and a child
+    // holding the pidfile keeps this home claimed after the daemon it
+    // belonged to has gone.
+    //
+    // Failures ignored, one descriptor at a time, because there is nothing
+    // better to do with them: the error being carried out of here is the one
+    // that matters, and a descriptor whose `fcntl` fails now is one that was
+    // already not what the blob said it was.
+    for fd in cleared {
+        let _ = fds::close_raw_after_exec(fd);
+    }
+    Err(failure)
+}
+
+/// [`exec_with_blob`]'s body, recording what it cleared as it goes.
+///
+/// Split out so the caller can restore on every failure path with one piece
+/// of cleanup rather than one per `?`. `cleared` is pushed to only after a
+/// clear succeeds, so it never names a descriptor this process did not
+/// change.
+///
+/// # Errors
+///
+/// As [`exec_with_blob`].
+fn keep_and_exec(
+    target: &Path,
+    blob: &Handover,
+    written: &Path,
+    cleared: &mut Vec<RawFd>,
+) -> io::Result<Infallible> {
     for fd in blob.named_fds() {
         fds::keep_raw_across_exec(fd)?;
+        cleared.push(fd);
     }
 
     let path = c_string(target.as_os_str().as_bytes())?;
@@ -1524,5 +1567,62 @@ mod tests {
             !Handover::path(&paths).exists(),
             "a failed exec left a blob behind: {err}"
         );
+    }
+
+    /// A failed exec puts `FD_CLOEXEC` back on everything it cleared.
+    ///
+    /// The clearing is what makes a descriptor cross an `execve`, and when
+    /// the exec does not happen the daemon returns to the graceful-stop
+    /// fallback with its supervisor still running. A restart or a queued
+    /// `Start` in the window before teardown then spawns a sheep that
+    /// inherits whatever is still exec-inheritable, and a child holding the
+    /// pidfile keeps this home claimed after the daemon that owned it has
+    /// gone.
+    ///
+    /// Asserted on both the daemon's own two descriptors and a carried log
+    /// handle, because `named_fds` yields them from two different places and
+    /// a restore that walked only the first pair would pass on a shorter
+    /// case.
+    #[test]
+    fn a_failed_exec_makes_every_descriptor_close_on_exec_again() {
+        use std::os::fd::{AsFd as _, AsRawFd as _};
+
+        let dir = tempfile::tempdir().unwrap();
+        let paths = selftest_paths(dir.path());
+        let target = dir.path().join("not-a-binary");
+        std::fs::write(&target, "this will never execute").unwrap();
+
+        let listener = tempfile::tempfile().unwrap();
+        let pidfile = tempfile::tempfile().unwrap();
+        let out_log = tempfile::tempfile().unwrap();
+        let blob = handover_with_fds(
+            &entry_fixture(|_| {}),
+            listener.as_raw_fd(),
+            pidfile.as_raw_fd(),
+            CarriedFds {
+                out_pipe: None,
+                err_pipe: None,
+                out_log: Some(out_log.as_raw_fd()),
+                err_log: None,
+            },
+        );
+
+        // The precondition, so the assertion below cannot pass on a
+        // descriptor that was never cleared in the first place.
+        for file in [&listener, &pidfile, &out_log] {
+            assert!(
+                !fds::is_kept(file.as_fd()).unwrap(),
+                "the daemon opens everything close-on-exec, so this starts set"
+            );
+        }
+
+        let err = exec_into(&target, &blob, &paths).unwrap_err();
+
+        for file in [&listener, &pidfile, &out_log] {
+            assert!(
+                !fds::is_kept(file.as_fd()).unwrap(),
+                "a failed exec left a descriptor exec-inheritable: {err}"
+            );
+        }
     }
 }

--- a/crates/shep-daemon/src/handover/reap.rs
+++ b/crates/shep-daemon/src/handover/reap.rs
@@ -1,0 +1,459 @@
+//! Reaping the sheep a successor adopted, one pid at a time and never
+//! wildcard.
+//!
+//! An adopted sheep has no `tokio::process::Child` and there is no way to
+//! build one: tokio produces a `Child` only from `Command::spawn`, and its
+//! public API has no constructor from a bare pid. A successor therefore
+//! cannot await an adopted sheep through tokio at all, so this is a second
+//! reaping mechanism that runs permanently alongside tokio's own, in the
+//! same process.
+//!
+//! # Why every wait here names a pid
+//!
+//! **`waitpid(-1, ..)` is forbidden in this process, and this repository
+//! has already paid to learn it.** tokio reaps its own children by calling
+//! `waitpid` on their exact pids when `SIGCHLD` fires. A blind wildcard
+//! loop in the same process races that and sometimes wins, taking the
+//! status tokio needed; tokio's own wait then answers `ECHILD` and a clean
+//! exit reaches the supervisor as an `io::Error`. The record is in three
+//! places: `crates/shep-cli/src/commands/reap.rs`, which is `shep runtime`'s
+//! PID-1 init and says so in its own module doc; decision 14 in
+//! `docs/decisions.md`; and `crates/shep-cli/tests/init.rs`, where CI
+//! actually hit it. `crates/shep-daemon/src/tokio_runner.rs` is already
+//! written to expect the loss and degrades to `{code: None, signal: None}`,
+//! which means a stolen status is not merely an error, it is an exit code
+//! and a signal number gone for good.
+//!
+//! That init loop's own wildcard wait is correct where it lives, because it
+//! lives in a *separate process* from tokio's reaper. A successor cannot do
+//! that: it is the same process. So the vocabulary here is borrowed from it
+//! and the architecture deliberately is not.
+//!
+//! A targeted wait is safe for exactly the opposite reason. Nothing else in
+//! this process holds a `Child` for an adopted pid, so nothing else will
+//! ever wait on it, and taking its status steals nothing. The pid is still
+//! a child of this process after the `execve`: an exec replaces the image,
+//! not the process, so the parent/child relationships the predecessor had
+//! are the ones the successor has.
+//!
+//! **Zero and negative pids are refused rather than passed through.**
+//! `waitpid(0, ..)` waits on any child in this process group and
+//! `waitpid(-n, ..)` on any child in group `n`. Both are the wildcard this
+//! module exists to refuse, wearing a different number, and a pid that
+//! arrived as a zero would otherwise turn a targeted wait into one silently.
+//!
+//! # How a wakeup arrives
+//!
+//! Each wait arms its own `SIGCHLD` stream through
+//! `tokio::signal::unix::signal`, which multiplexes: every stream
+//! registered for a kind is notified, so arming one here takes nothing away
+//! from the stream tokio's own process driver arms for itself. The stream
+//! is armed BEFORE the first look, so an exit that lands between the look
+//! and the registration still wakes the loop instead of being lost. A pid
+//! that had already exited needs no wakeup at all: the kernel holds the
+//! zombie until somebody waits, so the first look reports the real status.
+
+use std::collections::HashMap;
+use std::io;
+use std::sync::{Mutex, PoisonError};
+
+use nix::errno::Errno;
+use nix::sys::wait::{WaitPidFlag, WaitStatus, waitpid};
+use nix::unistd::Pid;
+use tokio::signal::unix::{SignalKind, signal};
+
+use crate::runner::ExitOutcome;
+
+/// Waits on the pids a successor adopted, targeted and never wildcard.
+///
+/// One reaper serves a whole adopted flock; [`AdoptedReaper::wait`] takes
+/// `&self` so several waits can be in flight at once, one per sheep.
+///
+/// `Debug` is derived: this holds pids and exit statuses, both of which an
+/// operator already reads out of `shep flock`, and no environment value
+/// ever reaches it.
+#[derive(Debug, Default)]
+pub struct AdoptedReaper {
+    /// Statuses already taken from the kernel, by pid.
+    ///
+    /// A status can be collected exactly once, so a second wait on a pid
+    /// already reaped would meet `ECHILD` and lose it. Remembering makes a
+    /// repeated or concurrent wait replay the first answer instead, which
+    /// is the contract `crate::runner::RunningProcess::wait` already states
+    /// for tokio-supervised sheep.
+    observed: Mutex<HashMap<i32, ExitOutcome>>,
+}
+
+impl AdoptedReaper {
+    /// A reaper that has seen nothing yet.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Waits for one adopted pid and reports how it exited.
+    ///
+    /// Returns as soon as the pid has a status, whether it exited before
+    /// this call or long after it. Cancel-safe in the way that matters: a
+    /// dropped wait loses no status, because a status this reaper has taken
+    /// is remembered and replayed to the next caller.
+    ///
+    /// # Errors
+    ///
+    /// - [`io::ErrorKind::InvalidInput`] if `pid` is zero or does not fit
+    ///   in an `i32`. Zero is refused because `waitpid(0, ..)` is a
+    ///   group-wide wait, not a targeted one.
+    /// - [`io::ErrorKind::NotFound`] if the kernel has no such child and
+    ///   this reaper never took its status, which means something else in
+    ///   this process reaped it and the exit is gone.
+    /// - Any other `waitpid` errno, and a failure to arm a `SIGCHLD`
+    ///   stream, reported as-is.
+    pub async fn wait(&self, pid: u32) -> io::Result<ExitOutcome> {
+        let pid = targeted(pid)?;
+        // Armed before the first look: an exit that lands in between still
+        // wakes this loop, where one armed afterwards would sleep through
+        // the only notification it was ever going to get.
+        let mut sigchld = signal(SignalKind::child())?;
+        loop {
+            if let Some(outcome) = self.look(pid)? {
+                return Ok(outcome);
+            }
+            if sigchld.recv().await.is_none() {
+                return Err(io::Error::new(
+                    io::ErrorKind::BrokenPipe,
+                    format!("the SIGCHLD stream closed while waiting for adopted pid {pid}"),
+                ));
+            }
+        }
+    }
+
+    /// One non-blocking look at `pid`, replaying a status already taken.
+    ///
+    /// The lock spans the `waitpid` call deliberately, so two concurrent
+    /// waits on the same pid cannot have one take the status while the
+    /// other is between its own `ECHILD` and this map. Nothing awaits while
+    /// it is held and `WNOHANG` never blocks.
+    fn look(&self, pid: i32) -> io::Result<Option<ExitOutcome>> {
+        let mut observed = self.observed.lock().unwrap_or_else(PoisonError::into_inner);
+        if let Some(outcome) = observed.get(&pid) {
+            return Ok(Some(*outcome));
+        }
+        match wait_once(pid) {
+            Ok(Some(outcome)) => {
+                observed.insert(pid, outcome);
+                Ok(Some(outcome))
+            }
+            Ok(None) => Ok(None),
+            Err(Errno::ECHILD) => Err(io::Error::new(
+                io::ErrorKind::NotFound,
+                format!(
+                    "adopted pid {pid} is not a child of this process, so its exit status is lost"
+                ),
+            )),
+            Err(errno) => Err(io::Error::from_raw_os_error(errno as i32)),
+        }
+    }
+}
+
+/// Checks that `pid` names one process and converts it for `waitpid`.
+///
+/// # Errors
+///
+/// [`io::ErrorKind::InvalidInput`] for zero, which `waitpid` reads as this
+/// process's whole group, and for anything too large to be an `i32`.
+fn targeted(pid: u32) -> io::Result<i32> {
+    let pid = i32::try_from(pid).map_err(|_| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("pid {pid} is too large to wait on"),
+        )
+    })?;
+    if pid == 0 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "pid 0 is a group-wide wait, not an adopted sheep",
+        ));
+    }
+    Ok(pid)
+}
+
+/// One `waitpid(pid, WNOHANG)`, retried past `EINTR`.
+///
+/// `Ok(None)` means the pid is still running. `EINTR` is retried rather
+/// than reported, because reporting it as "still running" would send the
+/// caller back to sleep on a `SIGCHLD` that may already have been the last
+/// one it was going to get.
+fn wait_once(pid: i32) -> Result<Option<ExitOutcome>, Errno> {
+    loop {
+        match waitpid(Pid::from_raw(pid), Some(WaitPidFlag::WNOHANG)) {
+            Ok(status) => return Ok(outcome_of(status)),
+            Err(Errno::EINTR) => continue,
+            Err(errno) => return Err(errno),
+        }
+    }
+}
+
+/// Maps one `waitpid` return into the daemon's own [`ExitOutcome`].
+///
+/// Pure and `cfg`-free, so the one thing that must never blur can be
+/// asserted without a child: a code and a signal are different fields and
+/// stay that way. `crates/shep-cli/src/output/rows.rs`'s `exit_cell`
+/// renders one or the other, so collapsing them makes the EXIT column lie.
+///
+/// `Stopped` and `Continued` need `WUNTRACED`/`WCONTINUED`, which nothing
+/// here passes, so they cannot arrive in practice. They map to "not an
+/// exit" rather than to a panic, so a future flag addition keeps a
+/// supervising daemon alive.
+fn outcome_of(status: WaitStatus) -> Option<ExitOutcome> {
+    match status {
+        WaitStatus::Exited(_, code) => Some(ExitOutcome {
+            code: Some(code),
+            signal: None,
+        }),
+        WaitStatus::Signaled(_, sig, _core_dumped) => Some(ExitOutcome {
+            code: None,
+            signal: Some(sig as i32),
+        }),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    // Every child here is deliberately never `Child::wait()`ed on: that is
+    // the whole shape under test. An adopted sheep reaches a successor as a
+    // bare pid with no handle to wait through, so the reaper is what
+    // collects its status, and a `wait()` added to satisfy this lint would
+    // take the status the assertions are about.
+    #![expect(
+        clippy::zombie_processes,
+        reason = "the reaper collects these statuses; a Child::wait would take them first"
+    )]
+
+    use core::time::Duration;
+    use std::io::Read as _;
+    use std::process::{Command, Stdio};
+
+    use nix::sys::signal::{self, Signal};
+    use nix::unistd::Pid;
+
+    use super::{AdoptedReaper, outcome_of};
+    use crate::runner::ExitOutcome;
+
+    /// A child spawned the way an adopted sheep reaches a successor: by
+    /// `std::process::Command`, so tokio holds no `Child` for it and
+    /// nothing but this module will ever wait on it.
+    fn adopted(script: &str) -> std::process::Child {
+        Command::new("/bin/sh")
+            .args(["-c", script])
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .spawn()
+            .expect("spawn a shell")
+    }
+
+    /// fails if an adopted pid's real exit code does not reach the caller.
+    #[tokio::test]
+    async fn an_adopted_pid_yields_its_real_exit_code() {
+        let child = adopted("exit 7");
+        let reaper = AdoptedReaper::new();
+        let outcome = tokio::time::timeout(Duration::from_secs(10), reaper.wait(child.id()))
+            .await
+            .expect("the reaper answered within the budget")
+            .expect("the adopted pid was reapable");
+        assert_eq!(
+            outcome,
+            ExitOutcome {
+                code: Some(7),
+                signal: None
+            }
+        );
+    }
+
+    /// fails if a signalled adopted pid reports a code instead of a signal.
+    #[tokio::test]
+    async fn an_adopted_pid_killed_by_a_signal_reports_the_signal() {
+        let child = adopted("sleep 30");
+        let pid = child.id();
+        signal::kill(
+            Pid::from_raw(i32::try_from(pid).expect("a pid fits in an i32")),
+            Signal::SIGKILL,
+        )
+        .expect("kill the adopted child");
+        let reaper = AdoptedReaper::new();
+        let outcome = tokio::time::timeout(Duration::from_secs(10), reaper.wait(pid))
+            .await
+            .expect("the reaper answered within the budget")
+            .expect("the adopted pid was reapable");
+        assert_eq!(
+            outcome,
+            ExitOutcome {
+                code: None,
+                signal: Some(9)
+            }
+        );
+    }
+
+    /// fails if the reaper waits for a `SIGCHLD` that already came and
+    /// went. The kernel holds the zombie until somebody waits, so a pid
+    /// that exited before the reaper's first look still has a real status
+    /// to report; an implementation that awaits the signal before looking
+    /// hangs here forever and the timeout turns that into a failure.
+    #[tokio::test]
+    async fn a_pid_that_exited_before_the_first_look_still_yields_its_status() {
+        let mut child = adopted("echo bye; exit 5");
+        let pid = child.id();
+        let mut said = String::new();
+        child
+            .stdout
+            .take()
+            .expect("piped stdout")
+            .read_to_string(&mut said)
+            .expect("read to EOF, which the child's own exit closes");
+        assert_eq!(said.trim(), "bye");
+        // EOF means the child is in its exit path; this gives the kernel
+        // time to finish making it a zombie, so the reaper's first look is
+        // genuinely after the exit rather than racing it.
+        std::thread::sleep(Duration::from_millis(50));
+
+        let reaper = AdoptedReaper::new();
+        let outcome = tokio::time::timeout(Duration::from_secs(10), reaper.wait(pid))
+            .await
+            .expect("the reaper answered within the budget")
+            .expect("the adopted pid was reapable");
+        assert_eq!(
+            outcome,
+            ExitOutcome {
+                code: Some(5),
+                signal: None
+            }
+        );
+    }
+
+    /// fails if the reaper ever waits wildcard. The regression this file
+    /// exists to prevent: a tokio-spawned child's status is pending at the
+    /// moment the reaper looks, and both processes must still report their
+    /// own real exit rather than one of them meeting an `io::Error`.
+    ///
+    /// The steal is made deterministic rather than left to a race. tokio
+    /// does not call `waitpid` for a live `Child` until its `wait()` is
+    /// polled, so a child that exits while nothing is awaiting it leaves
+    /// its status sitting in the kernel; the adopted sheep is meanwhile
+    /// still running, so the `SIGCHLD` that wakes the reaper is that other
+    /// child's. A `waitpid(-1, ..)` in this position takes the pending
+    /// status every time. Confirmed by implementing the wildcard and
+    /// watching this test redden on its own.
+    #[tokio::test]
+    async fn reaping_an_adopted_pid_does_not_disturb_a_tokio_spawned_child() {
+        let reaper = std::sync::Arc::new(AdoptedReaper::new());
+        for round in 0..3 {
+            // Exits only when its stdin closes, so it is alive across the
+            // whole window below.
+            let mut carried = adopted("read line; exit 4");
+            let carried_pid = carried.id();
+            let waiting = {
+                let reaper = std::sync::Arc::clone(&reaper);
+                tokio::spawn(async move { reaper.wait(carried_pid).await })
+            };
+            // Long enough for that wait to arm its SIGCHLD stream and take
+            // its first look before anything else exits.
+            tokio::time::sleep(Duration::from_millis(50)).await;
+
+            let mut supervised = tokio::process::Command::new("/bin/sh")
+                .args(["-c", "exit 3"])
+                .stdout(Stdio::null())
+                .spawn()
+                .expect("spawn a tokio-supervised child");
+            // It exits here, with nothing polling its `wait()`, so its
+            // status is pending when the reaper's wakeup arrives.
+            tokio::time::sleep(Duration::from_millis(200)).await;
+
+            drop(carried.stdin.take());
+            let carried_exit = tokio::time::timeout(Duration::from_secs(10), waiting)
+                .await
+                .expect("the reaper answered within the budget")
+                .expect("the waiting task did not panic")
+                .unwrap_or_else(|error| panic!("round {round}: adopted pid unreapable: {error}"));
+            assert_eq!(
+                carried_exit,
+                ExitOutcome {
+                    code: Some(4),
+                    signal: None
+                },
+                "round {round}: the adopted pid reported somebody else's status"
+            );
+
+            let supervised_exit = tokio::time::timeout(Duration::from_secs(10), supervised.wait())
+                .await
+                .expect("tokio answered within the budget")
+                .unwrap_or_else(|error| {
+                    panic!("round {round}: tokio's own status was stolen: {error}")
+                });
+            assert_eq!(
+                supervised_exit.code(),
+                Some(3),
+                "round {round}: tokio's child reported somebody else's status"
+            );
+        }
+    }
+
+    /// fails if a second wait on an already-reaped pid answers `ECHILD`
+    /// instead of replaying what the first one saw. A supervisor may ask
+    /// twice, and the second answer must not be an error.
+    #[tokio::test]
+    async fn a_second_wait_replays_the_status_the_first_one_saw() {
+        let child = adopted("exit 6");
+        let reaper = AdoptedReaper::new();
+        let first = tokio::time::timeout(Duration::from_secs(10), reaper.wait(child.id()))
+            .await
+            .expect("the reaper answered within the budget")
+            .expect("the adopted pid was reapable");
+        let second = tokio::time::timeout(Duration::from_secs(10), reaper.wait(child.id()))
+            .await
+            .expect("the replay answered within the budget")
+            .expect("the replay is not an error");
+        assert_eq!(first, second);
+    }
+
+    /// fails if pid 0 ever reaches `waitpid`. `waitpid(0, ..)` is not a
+    /// targeted wait at all: it waits on any child in this process group,
+    /// which is the wildcard this module exists to refuse, wearing a
+    /// different number.
+    #[tokio::test]
+    async fn pid_zero_is_refused_rather_than_becoming_a_group_wide_wait() {
+        let reaper = AdoptedReaper::new();
+        let error = reaper.wait(0).await.expect_err("pid 0 is refused");
+        assert_eq!(error.kind(), std::io::ErrorKind::InvalidInput);
+    }
+
+    /// fails if an exit code and a signal are ever collapsed into one
+    /// another. `crates/shep-cli/src/output/rows.rs`'s `exit_cell` renders
+    /// one or the other, so a reaper that mixed them up would make the
+    /// EXIT column lie.
+    #[test]
+    fn a_code_and_a_signal_are_never_collapsed_into_one_another() {
+        assert_eq!(
+            outcome_of(nix::sys::wait::WaitStatus::Exited(Pid::from_raw(7), 3)),
+            Some(ExitOutcome {
+                code: Some(3),
+                signal: None
+            })
+        );
+        assert_eq!(
+            outcome_of(nix::sys::wait::WaitStatus::Signaled(
+                Pid::from_raw(7),
+                Signal::SIGTERM,
+                false
+            )),
+            Some(ExitOutcome {
+                code: None,
+                signal: Some(15)
+            })
+        );
+        assert_eq!(
+            outcome_of(nix::sys::wait::WaitStatus::StillAlive),
+            None,
+            "still alive is not an exit"
+        );
+    }
+}

--- a/crates/shep-daemon/src/handover/uptime.rs
+++ b/crates/shep-daemon/src/handover/uptime.rs
@@ -1,0 +1,270 @@
+//! Re-deriving an adopted sheep's start time from the operating system.
+//!
+//! [`Handover`](super::Handover) carries no `started_at`, and no serializer
+//! for it would help: a [`tokio::time::Instant`] has no epoch and means
+//! nothing outside the runtime that read it. The successor asks the process
+//! table instead, which is authoritative about a pid it did not spawn in a
+//! way a carried value could never be.
+//!
+//! Without this, a sheep that has been up three days reports `0s` in
+//! `shep flock`'s UPTIME column the moment a handover completes. That is
+//! the one column an operator reads to see whether anything moved, so a
+//! zero there says the opposite of what the handover achieved.
+//!
+//! # What the operating system is asked for
+//!
+//! One number: the second the process started, since the Unix epoch. Both
+//! platforms this module compiles for fill it while the process table row is
+//! built, unconditionally, rather than under a [`ProcessRefreshKind`]
+//! branch. macOS reads `pbi_start_tvsec` out of `proc_pidinfo`; Linux takes
+//! field 22 of `/proc/<pid>/stat`, divides by the clock tick and adds the
+//! boot time. `limits::sample`'s `.with_cpu()` tuning, whose whole point is
+//! that a field IS gated on the refresh kind and silently reads zero
+//! without it, therefore does not apply here.
+//!
+//! The answer is a wall-clock second, and the field being filled is a
+//! monotonic [`Instant`], so the conversion goes through an age: how long
+//! ago the process started, subtracted from now. That is the only bridge
+//! between the two clocks, and it is why every step of it saturates.
+
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use sysinfo::{Pid, ProcessRefreshKind, ProcessesToUpdate, System};
+use tokio::time::Instant;
+
+/// The refresh kind [`start_epoch_secs`] asks sysinfo for.
+///
+/// Neither memory nor CPU: the start time is not gated on the refresh kind
+/// on either platform (see this module's doc), so widening it would cost an
+/// adoption the syscalls of the 15-second memory poll for figures nothing
+/// here reads.
+///
+/// `.without_tasks()` for the reason `limits::sample` gives at length. Its
+/// symptom cannot reach this module, which looks up exactly one pid and
+/// reads no total, but on Linux it is still a `readdir` of
+/// `/proc/<pid>/task/` and a row per thread, bought for nothing.
+fn refresh_kind() -> ProcessRefreshKind {
+    ProcessRefreshKind::nothing().without_tasks()
+}
+
+/// This machine's wall clock, in seconds since the Unix epoch.
+///
+/// A clock set before the epoch reads as `0`, which makes every process look
+/// older than the epoch and so gives an age of zero once
+/// [`age_from_epoch`] has saturated. Same answer as every other unusable
+/// clock reading below, reached the same way.
+fn wall_clock_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |since_epoch| since_epoch.as_secs())
+}
+
+/// The second `pid` started at, as the operating system reports it, or
+/// `None` if it will not say.
+///
+/// A [`System`] of this call's own, built here and dropped at the end of it,
+/// rather than the one `SysinfoSampler` retains for the memory poll. The
+/// reason is not the one that makes `identify` do the same thing (a name
+/// read out of a retained table is frozen at the pid's first sighting) but
+/// a plainer one: this runs during a rehydrate, before a supervisor exists,
+/// and there is no retained table to borrow.
+///
+/// Only `pid` is refreshed, never the whole machine. Adoption asks this once
+/// per carried sheep, and a whole-table walk per sheep would make the cost
+/// of a handover quadratic in a quantity (the machine's process count) that
+/// has nothing to do with the flock's size.
+///
+/// A reported `0` is read as unknown rather than as the epoch. It is
+/// sysinfo's initial value for the field, and a process that genuinely
+/// started at midnight on 1 January 1970 is not a case worth preferring
+/// over a field that was never filled.
+fn start_epoch_secs(pid: u32) -> Option<u64> {
+    let pid = Pid::from_u32(pid);
+    let mut system = System::new();
+    system.refresh_processes_specifics(ProcessesToUpdate::Some(&[pid]), true, refresh_kind());
+    let started = system.process(pid)?.start_time();
+    (started != 0).then_some(started)
+}
+
+/// The age of a process that started at `started_secs`, seen from a wall
+/// clock reading `now_secs`, both in seconds since the Unix epoch.
+///
+/// Saturating rather than asserting, and that is a deliberate answer rather
+/// than defensive habit. Neither reading is under this daemon's control: a
+/// wall clock moves backwards whenever NTP steps it, a VM resumes from a
+/// snapshot, or an operator sets the date, and a process started before such
+/// a step then reports a start time in the future. Nothing can recover the
+/// true age from two readings of a clock that lied about one of them, so
+/// there is no repair to attempt and no invariant to assert. Zero is the
+/// honest answer and also the harmless one, since it is what an operator
+/// already sees from a fresh spawn.
+///
+/// The alternatives are both worse than a wrong column. A panic would take a
+/// supervisor down over a clock adjustment, in the one code path whose
+/// entire purpose is that a flock survives; a wrapping subtraction would
+/// report the sheep as having started some hundreds of billions of years
+/// ago, which the UPTIME column would print in full.
+fn age_from_epoch(started_secs: u64, now_secs: u64) -> Duration {
+    Duration::from_secs(now_secs.saturating_sub(started_secs))
+}
+
+/// The `started_at` an adopted sheep running as `pid` should carry.
+///
+/// The process's age comes from the operating system and is subtracted from
+/// this runtime's own clock, so a sheep that has been up three days is
+/// adopted as three days old and `shep flock` reports its real uptime across
+/// the handover.
+///
+/// Never fails, and deliberately: a pid the process table will not describe
+/// falls back to [`Instant::now`], which reports an uptime restarting at the
+/// handover. That is the case where the sheep exited between the
+/// predecessor writing the blob and this image reading it, and one sheep's
+/// uptime column is not worth refusing a whole rehydrate over.
+#[must_use]
+pub(crate) fn started_at_of(pid: u32) -> Instant {
+    let now = Instant::now();
+    let Some(started_secs) = start_epoch_secs(pid) else {
+        return now;
+    };
+    let age = age_from_epoch(started_secs, wall_clock_secs());
+    // Saturating a third time, for the third reason. This runtime's
+    // monotonic clock counts from the machine's boot, so an age larger than
+    // the machine has been up cannot be subtracted from it. That is not
+    // reachable from an honest pair of readings, but it is reachable from a
+    // wall clock that jumped forward since the process started, and the
+    // answer is the same as everywhere above: report zero rather than
+    // panic.
+    now.checked_sub(age).unwrap_or(now)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // fails if the age is read off either reading alone rather than as the
+    // gap between them
+    #[test]
+    fn an_age_is_the_gap_between_the_two_readings() {
+        assert_eq!(age_from_epoch(100, 400), Duration::from_secs(300));
+    }
+
+    // fails if the subtraction is not saturating: a plain `-` panics in a
+    // debug build and wraps to ~584 billion years in a release one, and
+    // either is reachable from a clock that NTP stepped backwards under a
+    // running sheep
+    #[test]
+    fn a_clock_that_moved_backwards_gives_an_age_of_zero() {
+        assert_eq!(age_from_epoch(400, 100), Duration::ZERO);
+    }
+
+    // fails if a process observed in the same second it started reports
+    // anything but zero
+    #[test]
+    fn a_process_that_started_this_second_has_no_age_yet() {
+        assert_eq!(age_from_epoch(1_700_000_000, 1_700_000_000), Duration::ZERO);
+    }
+
+    // fails if a pid nothing is running under is treated as an error rather
+    // than as an unknown start time. Pid 0 is the one number that is never a
+    // process this daemon could adopt on either platform, so it cannot
+    // collide with a real child the way a large made-up pid could.
+    #[test]
+    fn a_pid_the_table_does_not_know_reads_as_unknown() {
+        assert_eq!(start_epoch_secs(0), None);
+    }
+
+    // fails if the refresh kind widens: the start time is filled whatever it
+    // says, so memory or CPU here would buy an adoption the poll's syscalls
+    // for nothing, and `tasks` a `/proc/<pid>/task/` walk on top
+    #[test]
+    fn the_refresh_kind_asks_for_nothing_the_start_time_does_not_need() {
+        let kind = refresh_kind();
+        assert!(!kind.memory(), "the start time is not a memory reading");
+        assert!(!kind.cpu(), "the start time is not a CPU reading");
+        assert!(!kind.tasks(), "nothing here reads a thread");
+    }
+
+    /// Tests that spawn a real process and wait on real elapsed time.
+    ///
+    /// The inner loop skips this module with `--skip ::slow::`; the full
+    /// suite still runs them because nothing here is `#[ignore]`d.
+    mod slow {
+        use std::process::Command;
+
+        use super::*;
+
+        /// How long the child below is left alive before its start time is
+        /// derived.
+        ///
+        /// Whole seconds because the operating system reports whole seconds:
+        /// a sub-second interval could not be distinguished from zero by any
+        /// implementation, correct or not.
+        const ALIVE_FOR: Duration = Duration::from_secs(3);
+
+        /// The lower bound the derived uptime must clear.
+        ///
+        /// One second under [`ALIVE_FOR`], and the missing second is
+        /// truncation rather than slack: both epoch readings round down, so
+        /// their difference can be a full second short of the real interval
+        /// (a child started at `t = 100.0` and read at `t = 102.99` reports
+        /// an age of 2). It can never be more than that short, and every
+        /// other pressure on this number (a loaded runner, a slow spawn, a
+        /// scheduler that oversleeps) makes the real interval LONGER, so
+        /// the bound only gets easier to clear.
+        const AT_LEAST: Duration = Duration::from_secs(2);
+
+        /// The upper bound, generous by design.
+        ///
+        /// Nothing about a correct derivation comes close to it. It is here
+        /// for the arithmetic that inverts: an implementation reading the
+        /// epoch second as the age itself, or wrapping a backwards
+        /// subtraction, lands tens of billions of seconds away rather than
+        /// one or two, and the lower bound alone would call that a pass.
+        const AT_MOST: Duration = Duration::from_secs(3_600);
+
+        // fails if an adopted sheep's `started_at` is stamped at the moment
+        // of the handover instead of derived from the operating system.
+        // That is exactly what this path did before, and it reports a
+        // three-day-old sheep as `0s` in `shep flock`'s UPTIME column the
+        // instant a successor takes over.
+        //
+        // A real child and real elapsed time are the whole case: the claim
+        // is about what the process table says, and there is no seam that
+        // could fake a pid's start time without also faking the thing under
+        // test. That is why this lives in `slow`, and why it needs a quiet
+        // machine no more than any other case here does: the assertion is
+        // a one-sided bound a full second below the interval, not a window.
+        //
+        // A plain `#[test]`, not a `#[tokio::test]`: this crate's tokio
+        // tests run on a paused clock, where `Instant::now()` does not
+        // advance across a real `thread::sleep` and both a correct
+        // derivation and a stamped one would read the same.
+        #[test]
+        fn an_adopted_child_that_has_been_alive_for_seconds_is_that_old() {
+            let mut child = Command::new("/bin/sh")
+                .arg("-c")
+                .arg("sleep 30")
+                .spawn()
+                .expect("/bin/sh is present on every platform this module compiles for");
+            let pid = child.id();
+
+            std::thread::sleep(ALIVE_FOR);
+            let derived = started_at_of(pid);
+            let uptime = Instant::now().saturating_duration_since(derived);
+
+            let _ = child.kill();
+            let _ = child.wait();
+
+            assert!(
+                uptime >= AT_LEAST,
+                "a child alive for {ALIVE_FOR:?} derived an uptime of {uptime:?}; \
+                 a `started_at` stamped at the handover reads as ~0 here"
+            );
+            assert!(
+                uptime <= AT_MOST,
+                "a child alive for {ALIVE_FOR:?} derived an uptime of {uptime:?}, \
+                 which is not an age but an arithmetic error"
+            );
+        }
+    }
+}

--- a/crates/shep-daemon/src/lib.rs
+++ b/crates/shep-daemon/src/lib.rs
@@ -227,6 +227,11 @@ pub use bus::{Bus, SharedEvent, new_bus};
 pub(crate) mod cron;
 pub(crate) mod entry;
 pub(crate) mod extras;
+// Unix-only, and the module's own contents are what make it so: `fcntl`,
+// `execve` and raw descriptor numbers have no Windows equivalent, and
+// `Arm::for_daemon` already returns the stop arm there. Without this gate the
+// crate does not compile for a Windows target at all.
+#[cfg(unix)]
 pub(crate) mod handover;
 pub(crate) mod kill;
 pub(crate) mod watch;

--- a/crates/shep-daemon/src/lib.rs
+++ b/crates/shep-daemon/src/lib.rs
@@ -227,6 +227,7 @@ pub use bus::{Bus, SharedEvent, new_bus};
 pub(crate) mod cron;
 pub(crate) mod entry;
 pub(crate) mod extras;
+pub(crate) mod handover;
 pub(crate) mod kill;
 pub(crate) mod watch;
 

--- a/crates/shep-daemon/src/privilege.rs
+++ b/crates/shep-daemon/src/privilege.rs
@@ -24,6 +24,7 @@
 
 use core::fmt;
 
+use serde::{Deserialize, Serialize};
 use shep_core::config::AppConfig;
 
 /// Resolved unix credentials for a spawned sheep
@@ -33,7 +34,13 @@ use shep_core::config::AppConfig;
 // silently skipped, since the brief named this type alongside two real
 // accessors (`TopicFilter::patterns`, `SnapshotWriter::writes`) that DID get
 // `#[inline]`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+//
+// `Serialize`/`Deserialize` are here for the handover blob (`handover::Handover`),
+// which carries an entry's resolved identity across an `execve` so a restart
+// cannot re-touch the passwd database. Two numeric ids, so the derived
+// representation is the obvious one; see [`SpawnIdentity`]'s note for what
+// changing it would cost.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Credentials {
     /// Numeric user id to run the child as
     pub uid: u32,
@@ -61,7 +68,14 @@ pub struct Credentials {
 /// ordinary numbers an operator can read out of `id`, not secrets, and the
 /// daemon's own logs are more useful for naming which one a refused spawn
 /// wanted.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+///
+/// `Serialize`/`Deserialize` exist for one reader, the handover blob
+/// (`handover::Handover`, crate-internal, hence code font). That blob is
+/// written by one shep image and read by another, possibly newer, one, so
+/// this type's serialized shape is part of the blob's version-1 format:
+/// renaming a variant or retyping a field is a format change and must bump
+/// `handover::VERSION` alongside it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum SpawnIdentity {
     /// `resolve` has never run for this entry (code font, not a link: the
     /// function is crate-internal while this type is not).

--- a/crates/shep-daemon/src/rpc.rs
+++ b/crates/shep-daemon/src/rpc.rs
@@ -522,6 +522,9 @@ async fn run(id: u64, conn: ConnId, request: Request, ctx: &RpcContext) -> Outco
                 daemon_version: None,
             })),
         },
+        Request::HandoverFitness => reply(Ok(Response::HandoverFitness {
+            refusal: handover_refusal(ctx).await,
+        })),
         Request::KillDaemon => Outcome::Shutdown(Reply {
             id,
             result: Ok(Response::ShuttingDown),
@@ -534,6 +537,48 @@ async fn run(id: u64, conn: ConnId, request: Request, ctx: &RpcContext) -> Outco
             daemon_version: None,
         })),
     }
+}
+
+/// Why this shepherd cannot hand its flock to a successor in place, or
+/// `None` when it can.
+///
+/// The sentence is rendered here rather than on the wire as a structured
+/// reason, for the reason [`Response::HandoverFitness`] gives: the set of
+/// things a handover cannot yet carry is exactly the set of things that
+/// phase has not built, and the client does nothing with it but print it.
+///
+/// An engine that has stopped is a refusal too, not an error. The caller
+/// asked whether to signal a shepherd, and one whose actor is gone must be
+/// answered no.
+#[cfg(unix)]
+async fn handover_refusal(ctx: &RpcContext) -> Option<String> {
+    match ctx.supervisor.handover_fitness().await {
+        Ok(crate::handover::Fitness::Carryable) => None,
+        Ok(crate::handover::Fitness::Refused(reason)) => Some(reason.to_string()),
+        Err(err) => Some(format!(
+            "this shepherd could not check whether its flock can be handed over ({err})"
+        )),
+    }
+}
+
+/// Windows has no `execve`, so there is no image for a successor to become
+/// and every flock is refused.
+///
+/// A refusal rather than an unimplemented request, because the two mean
+/// different things to the caller: this one is answered, and the answer is
+/// what sends `shep daemon reload` to the stop-and-start arm that is the
+/// permanent Windows answer (spec H5).
+#[cfg(windows)]
+#[expect(
+    clippy::unused_async,
+    reason = "one signature for both platforms; the unix arm awaits the supervisor"
+)]
+async fn handover_refusal(_ctx: &RpcContext) -> Option<String> {
+    Some(
+        "this shepherd runs on Windows, which has no `execve`, so its flock cannot be handed to \
+         a successor in place"
+            .to_string(),
+    )
 }
 
 /// Fills in each running sheep's live CPU and memory.

--- a/crates/shep-daemon/src/runner.rs
+++ b/crates/shep-daemon/src/runner.rs
@@ -17,6 +17,12 @@
 //! go through that pair, so neither half can drift from the other on what it
 //! is willing to open.
 //!
+//! A few items here are `#[cfg(unix)]`, and that is a design decision rather
+//! than portability work left unfinished. Windows has no `execve`, so a
+//! shepherd there is replaced by stop-and-start and no image ever adopts a
+//! process it did not spawn; the handover surfaces those items exist for have
+//! nothing to be on that platform. Each one says so at its own definition.
+//!
 //! This whole module is public and stays that way: [`ProcessRunner`] is the
 //! bound on [`boot`](crate::boot::boot), which `shep-cli` calls, so a caller
 //! outside this crate has to be able to name it — and naming it drags in every

--- a/crates/shep-daemon/src/runner.rs
+++ b/crates/shep-daemon/src/runner.rs
@@ -164,6 +164,53 @@ pub enum LogCtl {
         /// gone owes no bytes to anything.
         done: oneshot::Sender<Result<(), FlushError>>,
     },
+    /// Write out whatever the pump has buffered, wait for it to reach the
+    /// files, then acknowledge with the four descriptor numbers the pump is
+    /// holding. Sent while assembling a daemon handover.
+    ///
+    /// # Why the flush and the report are one request
+    ///
+    /// A pump that reported its numbers and was then asked separately to
+    /// flush would leave a window in which the blob already claims a
+    /// descriptor is ready to carry while the bytes behind it are still in
+    /// the buffer. Those bytes die with the image at the `execve`, and the
+    /// successor cannot repair them because it never saw them — a gap in a
+    /// sheep's log, which is one of the two things a handover exists to
+    /// avoid. Doing both under one acknowledgement makes the ordering
+    /// structural rather than a rule a caller has to keep.
+    ///
+    /// # Why this variant is unix-only when the rest of the enum is not
+    ///
+    /// It answers with raw descriptor numbers, and Windows has none of
+    /// those, no `execve` to carry them across, and no handover:
+    /// `Arm::for_daemon` returns the stop-and-start arm there. Gating the
+    /// variant rather than the enum keeps [`Self::Reopen`] and
+    /// [`Self::Flush`] portable, which they are.
+    #[cfg(unix)]
+    ReportFds {
+        /// Fires once both handles have nothing buffered and no write left
+        /// in flight, carrying the descriptors the blob is to name.
+        ///
+        /// `CarriedFds::none` is the honest answer for a pump holding
+        /// nothing — a stream that reached EOF has had its read end closed,
+        /// and a log file whose open failed has no handle. It is never an
+        /// error: a number that names nothing is what the successor must not
+        /// be handed.
+        ///
+        /// # When it never fires
+        ///
+        /// Exactly as [`Self::Reopen`]'s: a pump that ends between accepting
+        /// a request and serving it drops this sender. Treat that as the
+        /// same stopped-sheep no-op a failed send means; a pump that is gone
+        /// holds no descriptors.
+        ///
+        /// `CarriedFds` is `shep-daemon`'s own type and is not reachable
+        /// from outside the crate, so an out-of-tree runner can drop this
+        /// sender but cannot answer it. That is the same no-op a pump that
+        /// has ended produces, and a runner with no handover support is
+        /// exactly a runner nothing hands over.
+        done: oneshot::Sender<crate::handover::CarriedFds>,
+    },
 }
 
 /// A [`LogCtl::Reopen`] that could not open one or both of a sheep's log

--- a/crates/shep-daemon/src/runner.rs
+++ b/crates/shep-daemon/src/runner.rs
@@ -98,7 +98,15 @@ pub struct LogLine {
 /// either variant usable as a barrier. A logrotate `postrotate` stanza needs
 /// that of [`Self::Reopen`] before it compresses or deletes the file it
 /// renamed; `shep flush` needs it of [`Self::Flush`] before it truncates.
+/// `#[non_exhaustive]` because this crate is published and this enum just
+/// grew a variant. An out-of-tree `ProcessRunner` matching it exhaustively
+/// would break on that addition, and would break again on the next one.
+/// Marking it now costs those matchers one wildcard arm, once, in a 0.1.x
+/// release where that is expected, instead of every time the handover needs
+/// to ask a pump something new (IR-20, and the same call `BootError` makes a
+/// few modules over).
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum LogCtl {
     /// Drop the current handle and open the path again, then acknowledge.
     /// Sent when an external rotator has renamed the file.

--- a/crates/shep-daemon/src/runner.rs
+++ b/crates/shep-daemon/src/runner.rs
@@ -35,6 +35,15 @@ use shep_core::signals::OperatorSignal;
 use crate::channel::{ChildMessage, ShepherdMessage};
 use crate::privilege::Credentials;
 
+/// Re-exported so [`AdoptSpec`] can name it: the reaper lives in the
+/// crate-private `handover` module, and a public signature may not carry a
+/// type nothing outside the crate can reach.
+///
+/// Unix only, as the whole handover is. Windows has no `execve`, so no image
+/// there ever adopts a process it did not spawn.
+#[cfg(unix)]
+pub use crate::handover::reap::AdoptedReaper;
+
 /// One exit observation
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ExitOutcome {
@@ -822,6 +831,80 @@ pub trait ProcessRunner: Send + Sync + 'static {
         let _ = spec;
         Preflight::Unknown
     }
+
+    /// Rebuilds a proc around a sheep this process inherited rather than
+    /// started.
+    ///
+    /// The successor half of a handover. Every handle in `spec` crossed an
+    /// `execve` with its `FD_CLOEXEC` cleared, so the sheep on the far side
+    /// of them never noticed the shepherd being replaced: same pid, same
+    /// pipes, same open file description on each log. Nothing here spawns,
+    /// signals or reopens anything.
+    ///
+    /// # Errors
+    ///
+    /// - [`RunnerError::AdoptFailed`] if this runner cannot take a process
+    ///   it did not spawn, which is what the default answers, or if the
+    ///   carried handles could not be wired to a pump.
+    ///
+    /// # Default implementation
+    ///
+    /// Refuses. A defaulted method rather than a required one for the reason
+    /// [`Self::preflight`] gives: this is a `pub` trait in a published
+    /// library, and adding a required method to one breaks every out-of-tree
+    /// implementor with no version bump to warn them (IR-20). The refusal is
+    /// also the truthful answer for a runner that never took part in a
+    /// handover, rather than a stub that pretends to adopt.
+    ///
+    /// Unix only. Windows has no `execve` and `Arm::for_daemon` returns the
+    /// stop-and-start arm there, so no Windows image is ever a successor and
+    /// a portable method would be a promise this workspace could not keep.
+    #[cfg(unix)]
+    fn adopt(&self, spec: AdoptSpec) -> Result<(Self::Proc, ProcIo), RunnerError> {
+        let _ = spec;
+        Err(RunnerError::AdoptFailed(
+            "this runner cannot adopt a process it did not spawn".to_string(),
+        ))
+    }
+}
+
+/// One inherited sheep, and everything a runner needs to supervise it again.
+///
+/// Produced by the successor's `handover::adopt` and consumed by
+/// [`ProcessRunner::adopt`]. The four handles are owned, because adopting is
+/// exactly the act of taking ownership of them; `None` on a pair means the
+/// predecessor had no handle to carry, which is what a sheep whose log open
+/// had failed, or one with no live pump, looks like.
+///
+/// `Debug` is derived, and deliberately so (IR-41): descriptor numbers, a
+/// pid and two log paths are all an operator already reads out of
+/// `shep flock`, and no environment value or other secret reaches this type.
+/// The blob it is built from carries the same rule.
+#[cfg(unix)]
+#[derive(Debug)]
+pub struct AdoptSpec {
+    /// The pid the sheep has been running under all along, unchanged by the
+    /// handover.
+    pub pid: u32,
+    /// Where its stdout is logged, kept so a later rotation can reopen it.
+    pub out_file: PathBuf,
+    /// Where its stderr is logged, kept for the same reason.
+    pub err_file: PathBuf,
+    /// The read end of its stdout pipe, still the one the child writes into.
+    pub out_pipe: Option<tokio::net::unix::pipe::Receiver>,
+    /// The read end of its stderr pipe, likewise.
+    pub err_pipe: Option<tokio::net::unix::pipe::Receiver>,
+    /// The appending handle on its stdout log, written through rather than
+    /// reopened so `O_APPEND` survives.
+    pub out_log: Option<tokio::fs::File>,
+    /// The appending handle on its stderr log, likewise.
+    pub err_log: Option<tokio::fs::File>,
+    /// The one reaper this successor waits every adopted pid through.
+    ///
+    /// Shared rather than owned per sheep: a status can be collected once,
+    /// so two reapers racing on one pid would have one take the exit and the
+    /// other meet `ECHILD` with the exit already gone.
+    pub reaper: std::sync::Arc<AdoptedReaper>,
 }
 
 /// What a [`ProcessRunner`] can tell about a [`SpawnSpec`] before anything is
@@ -908,8 +991,8 @@ pub struct SpawnSpec {
 
 /// Error type returned from spawn and process control
 ///
-/// `#[non_exhaustive]`: today's three variants cover spawn, signal delivery
-/// and a stdin write, and a future process-control primitive — a cgroup
+/// `#[non_exhaustive]`: today's variants cover spawn, adoption, signal
+/// delivery and a stdin write, and a future process-control primitive — a cgroup
 /// freeze, or a Windows job-object failure — would need its own variant
 /// rather than stretching one of these to mean something it does not cover,
 /// and shep-daemon is a published library an out-of-tree matcher should not
@@ -924,6 +1007,10 @@ pub enum RunnerError {
     /// A write to a child's stdin failed (carries the OS message, or the
     /// shepherd's own bound when the app was not reading).
     WriteFailed(String),
+    /// A sheep inherited across a handover could not be taken back under
+    /// supervision: this runner does not adopt at all, or the carried
+    /// handles could not be wired to a pump.
+    AdoptFailed(String),
 }
 
 impl fmt::Display for RunnerError {
@@ -932,6 +1019,7 @@ impl fmt::Display for RunnerError {
             Self::SpawnFailed(msg) => write!(f, "process spawn failed: {msg}"),
             Self::SignalFailed(msg) => write!(f, "signal delivery failed: {msg}"),
             Self::WriteFailed(msg) => write!(f, "stdin write failed: {msg}"),
+            Self::AdoptFailed(msg) => write!(f, "process adoption failed: {msg}"),
         }
     }
 }

--- a/crates/shep-daemon/src/snapshot.rs
+++ b/crates/shep-daemon/src/snapshot.rs
@@ -105,6 +105,27 @@ impl FlockRegistry {
         }
     }
 
+    /// Records one app's config directly, for a successor rebuilding this
+    /// registry from a handover blob.
+    ///
+    /// [`Self::record`] takes [`ResolvedApp`]s because every other caller
+    /// has just normalized one. A successor has not: it holds the
+    /// [`AppConfig`] the blob carried, which the supervisor re-normalizes on
+    /// its own way to installing the sheep, and normalizing it a second time
+    /// here would be a second place for the two to disagree.
+    ///
+    /// Load-bearing rather than a convenience. The registry is what the
+    /// muster roll is written from, so a successor that left it empty would
+    /// overwrite a good roll with an empty one within seconds of taking
+    /// over, and a reboot after that would restore nothing.
+    #[cfg(unix)]
+    pub(crate) fn record_config(&self, config: &AppConfig) {
+        self.apps
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .insert(config.name.clone(), config.clone());
+    }
+
     /// Drops every recorded app, so the next [`Self::roll`] describes an
     /// empty flock regardless of what is still live in the supervisor's own
     /// listing.

--- a/crates/shep-daemon/src/supervisor.rs
+++ b/crates/shep-daemon/src/supervisor.rs
@@ -61,12 +61,18 @@ use crate::channel::{ChildMessage, ShepherdMessage};
 use crate::entry::{ProcessEntry, ReloadState, RestartBudget};
 use crate::extras::{Extras, ExtrasRegistry};
 #[cfg(unix)]
+use crate::handover::adopt::AdoptedSheep;
+#[cfg(unix)]
+use crate::handover::reap::AdoptedReaper;
+#[cfg(unix)]
 use crate::handover::{CarriedFds, CarriedSheep, Counters, DaemonFds, Handover, OwnedCandidate};
 use crate::kill::kill_process;
 use crate::privilege::{self, Credentials, PrivilegeError, SpawnIdentity};
 use crate::probes::Prober;
 use crate::probes::os::OsProber;
 use crate::probes::ready::{Readiness, ReadinessSource, await_ready};
+#[cfg(unix)]
+use crate::runner::AdoptSpec;
 use crate::runner::{
     ExitOutcome, FlushError, LogCtl, Preflight, ProcIo, ProcessRunner, ReopenError, RunnerError,
     RunningProcess, SpawnSpec, StdinWrite, check_log_ancestry, open_log_path,
@@ -1531,11 +1537,80 @@ impl<R: ProcessRunner> SupervisorBuilder<R> {
     /// Must be called from within a Tokio runtime context.
     pub(crate) fn spawn(self) -> SupervisorHandle {
         let (tx, rx) = mpsc::channel(MAILBOX_CAPACITY);
-        let actor = Actor {
+        let actor = self.build(tx.clone());
+        tokio::spawn(actor.run(rx));
+        SupervisorHandle { tx }
+    }
+
+    /// Spawns the actor around a flock this image inherited rather than
+    /// started, restoring the predecessor's `counters` first.
+    ///
+    /// Every sheep in `flock` is installed under the id, epoch, status and
+    /// history the blob carried for it, around the descriptors that crossed
+    /// the `execve`. Nothing here spawns, signals or reopens anything: from
+    /// each sheep's own side the shepherd was never away.
+    ///
+    /// # Why the counters are restored before any slot is installed
+    ///
+    /// [`Actor::next_id`], [`Actor::next_deadline`] and
+    /// [`Actor::next_action_stamp`] reset to zero in every constructor, and
+    /// installing first would leave a window in which a fresh sheep could be
+    /// handed an id a caller is still holding. The three assignments below
+    /// therefore come before the loop rather than after it, and that order
+    /// is the whole of the guarantee.
+    ///
+    /// # Errors
+    ///
+    /// - [`AdoptError::Spec`] — a carried config no longer normalizes.
+    /// - [`AdoptError::Runner`] — the runner refused the inherited handles.
+    ///
+    /// Either one leaves a running process unsupervised, so a caller that
+    /// meets one refuses to boot rather than serving a flock it only half
+    /// holds: the predecessor has already `execve`d itself away by this
+    /// point, and there is no image left to hand the flock back to.
+    ///
+    /// # Panics
+    ///
+    /// Panics if called outside a Tokio runtime context, which is where the
+    /// actor task and every adopted sheep's pump have to be spawned.
+    #[cfg(unix)]
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "task 8d calls this from `boot`'s successor arm; nothing outside this \
+                      crate's own tests calls it yet"
+        )
+    )]
+    pub(crate) fn spawn_adopted(
+        self,
+        flock: Vec<AdoptedSheep>,
+        counters: Counters,
+    ) -> Result<SupervisorHandle, AdoptError> {
+        let (tx, rx) = mpsc::channel(MAILBOX_CAPACITY);
+        let mut actor = self.build(tx.clone());
+        // Before the loop below, per this method's own doc.
+        actor.next_id = counters.next_id;
+        actor.next_deadline = counters.next_deadline;
+        actor.next_action_stamp = counters.next_action_stamp;
+        // One reaper for the whole adopted flock: a status can be collected
+        // once, so two reapers racing on one pid would have one take the
+        // exit and the other meet `ECHILD` with the exit already gone.
+        let reaper = Arc::new(AdoptedReaper::new());
+        for sheep in flock {
+            actor.install_adopted(sheep, &reaper)?;
+        }
+        tokio::spawn(actor.run(rx));
+        Ok(SupervisorHandle { tx })
+    }
+
+    /// The actor both spawn paths start from: no sheep, counters at zero.
+    fn build(self, tx: mpsc::Sender<Msg>) -> Actor<R> {
+        Actor {
             runner: self.runner,
             paths: self.paths,
             events: self.events,
-            tx: tx.clone(),
+            tx,
             sheep: HashMap::new(),
             next_id: 0,
             next_deadline: 0,
@@ -1546,9 +1621,66 @@ impl<R: ProcessRunner> SupervisorBuilder<R> {
             registry: ExtrasRegistry::default(),
             reloads: HashMap::new(),
             smits: Smits::new(),
-        };
-        tokio::spawn(actor.run(rx));
-        SupervisorHandle { tx }
+        }
+    }
+}
+
+/// Why a flock this image inherited could not be installed.
+///
+/// Both variants name the sheep, because that is what an operator needs in
+/// order to know which process is now unsupervised.
+#[cfg(unix)]
+#[derive(Debug)]
+pub(crate) enum AdoptError {
+    /// The config the blob carried for this sheep no longer normalizes.
+    ///
+    /// Reachable when a successor's `normalize` has tightened since the
+    /// predecessor accepted the app. Carrying the resolved spec instead
+    /// would not avoid it: the alternative to the blob is the muster roll,
+    /// which re-normalizes the identical config and meets the identical
+    /// refusal.
+    Spec {
+        /// The sheep whose config was refused.
+        sheep: String,
+        /// What `normalize` said about it.
+        source: shep_core::config::NormalizeError,
+    },
+    /// The runner would not take this sheep's inherited handles.
+    ///
+    /// A runner that never took part in a handover refuses by default, and
+    /// a real one refuses a handle it cannot wire to a pump.
+    Runner {
+        /// The sheep whose adoption was refused.
+        sheep: String,
+        /// What the runner said about it.
+        source: RunnerError,
+    },
+}
+
+#[cfg(unix)]
+impl fmt::Display for AdoptError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Spec { sheep, source } => {
+                write!(
+                    f,
+                    "sheep '{sheep}' carried a config that no longer validates: {source}"
+                )
+            }
+            Self::Runner { sheep, source } => {
+                write!(f, "sheep '{sheep}' could not be adopted: {source}")
+            }
+        }
+    }
+}
+
+#[cfg(unix)]
+impl core::error::Error for AdoptError {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
+        match self {
+            Self::Spec { source, .. } => Some(source),
+            Self::Runner { source, .. } => Some(source),
+        }
     }
 }
 
@@ -3265,6 +3397,207 @@ impl<R: ProcessRunner> Actor<R> {
                 Err(format!("{error}; {attempted}"))
             }
         }
+    }
+
+    /// Installs one sheep this image inherited rather than started: the
+    /// sibling to [`Self::spawn_fresh`] that puts a slot around a process
+    /// which is already running.
+    ///
+    /// Everything the blob carried comes back as it was — id, instance,
+    /// status, epoch, restart count, `last_exit` and resolved identity — and
+    /// nothing is derived a second time. Nothing here spawns, signals or
+    /// reopens anything.
+    ///
+    /// # How the spec comes back
+    ///
+    /// By re-normalizing the `AppConfig` the blob carried, exactly as
+    /// `snapshot::restorable` does on a muster. `normalize` is pure over one
+    /// of its own outputs — it reads no filesystem, and a `~/` it expanded no
+    /// longer begins with `~` — so re-normalizing a config that has already
+    /// been through it is a no-op that hands back the `ResolvedApp` proof
+    /// token. That is what removed this task's earlier binding to the muster
+    /// roll, which recorded a running COUNT per app rather than which
+    /// instance was up, and whose restore path starts what it restores.
+    ///
+    /// # What a sheep that is not running installs as
+    ///
+    /// A slot with no pump and no `ctl`, which is the state it was already
+    /// in. A carried sheep with no pid has no process to take over, and its
+    /// [`CarriedFds`] are `CarriedFds::none()` for that same reason; neither
+    /// is a refusal, and the fitness gate does not treat it as one.
+    ///
+    /// # Why nothing is emitted on the bus
+    ///
+    /// A `Start` or an `Online` would announce a transition to a sheep that
+    /// has been running throughout. This is the successor learning what was
+    /// already true.
+    ///
+    /// # Errors
+    ///
+    /// - [`AdoptError::Spec`] — the carried config no longer normalizes.
+    /// - [`AdoptError::Runner`] — the runner refused the inherited handles.
+    #[cfg(unix)]
+    fn install_adopted(
+        &mut self,
+        sheep: AdoptedSheep,
+        reaper: &Arc<AdoptedReaper>,
+    ) -> Result<(), AdoptError> {
+        let AdoptedSheep {
+            carried,
+            out_pipe,
+            err_pipe,
+            out_log,
+            err_log,
+        } = sheep;
+        let app = normalize(carried.app().clone()).map_err(|source| AdoptError::Spec {
+            sheep: carried.name().to_string(),
+            source,
+        })?;
+        // Reused as resolved, never re-resolved, exactly as `respawn` reuses
+        // it: the value was pinned at the predecessor's first spawn so that a
+        // later change to the passwd database could not move a running app's
+        // identity underneath it, and looking the name up again here would
+        // reintroduce the very re-lookup that pinning prevents.
+        let credentials = match carried.credentials() {
+            SpawnIdentity::Resolved(credentials) => credentials,
+            SpawnIdentity::Unresolved => None,
+        };
+        // Assembled for its log paths only, as `register_without_spawning`
+        // does: nothing is spawned here, but the entry has to name the files
+        // this sheep is writing to, and a later rotation reopens them by
+        // path.
+        let spec = assemble(&app, carried.instance(), &self.paths, credentials);
+        let id = carried.id();
+        let status = carried.status();
+        let mut entry = ProcessEntry {
+            id,
+            spec: app.clone(),
+            instance: carried.instance(),
+            status,
+            pid: carried.pid(),
+            restarts: carried.restarts(),
+            // Filled in below for a sheep with a process, and left `None`
+            // here for one without, which is what a registered-and-stopped
+            // slot carries anyway.
+            started_at: None,
+            // The counted window starts again with the successor. The
+            // restart COUNT is carried (losing it would hand a crash-looping
+            // app amnesty it did not earn), while the window it is counted
+            // over is a run of wall-clock this image did not observe.
+            budget: RestartBudget::default(),
+            // Phase 2a's fitness gate refuses to carry a flock with a reload
+            // in flight, so there is no reload state to restore.
+            reload: ReloadState::None,
+            credentials: carried.credentials(),
+            out_file: spec.out_file.clone(),
+            err_file: spec.err_file.clone(),
+            // The gate refuses any flock carrying a dog, so a carried sheep
+            // is never one, and the blob has no field for it to lose.
+            dog: None,
+            last_exit: carried.last_exit(),
+        };
+
+        let Some(pid) = carried.pid() else {
+            // Registered and not running: no pump, no `ctl`, nothing to
+            // adopt. Trying to adopt a process that is not there would be
+            // asking the reaper to wait on a pid this image never had.
+            self.sheep.insert(
+                id,
+                SheepSlot {
+                    entry,
+                    ctl: None,
+                    log_ctl: None,
+                    to_child: None,
+                    signals: None,
+                    to_stdin: None,
+                    manual: None,
+                    pending_delete: false,
+                    epoch: carried.epoch(),
+                    ready_tx: None,
+                    actions: ActionWaits::default(),
+                    ready_failed: false,
+                },
+            );
+            return Ok(());
+        };
+
+        let (proc, io) = self
+            .runner
+            .adopt(AdoptSpec {
+                pid,
+                out_file: spec.out_file.clone(),
+                err_file: spec.err_file.clone(),
+                out_pipe,
+                err_pipe,
+                out_log,
+                err_log,
+                reaper: Arc::clone(reaper),
+            })
+            .map_err(|source| AdoptError::Runner {
+                sheep: carried.name().to_string(),
+                source,
+            })?;
+        // Off the proc rather than off the blob, as both spawn paths take it:
+        // the pid this entry reports has to be the one the runner will
+        // signal, and for an adoption those are the same number by
+        // construction.
+        entry.pid = Some(proc.pid());
+        // Load-bearing, and not merely a nicer uptime: `handle_exited` reads
+        // `started_at` to decide whether an exit is a real one, and an entry
+        // without it takes the duplicate-`Msg::Exited` branch, which resolves
+        // pending replies and returns before `decide_on_exit` is ever
+        // consulted. An adopted sheep installed without it would sit
+        // `Online` forever after its process died.
+        //
+        // The clock restarts at the handover, so this instance's reported
+        // uptime does too. The blob cannot help: `started_at` is a
+        // `tokio::time::Instant`, which has no epoch and means nothing
+        // outside the runtime that read it.
+        entry.started_at = Some(tokio::time::Instant::now());
+        let log_ctl = io.log_ctl.clone();
+        let to_child = io.to_child.clone();
+        let to_stdin = io.to_stdin.clone();
+        let handles = spawn_sheep_task::<R::Proc>(
+            id,
+            proc,
+            io,
+            app.clone(),
+            self.events.clone(),
+            self.tx.clone(),
+        );
+        self.sheep.insert(
+            id,
+            SheepSlot {
+                entry,
+                ctl: Some(handles.ctl),
+                log_ctl: Some(log_ctl),
+                to_child: Some(to_child),
+                signals: Some(handles.signals),
+                to_stdin: Some(to_stdin),
+                // The gate refuses a flock with a manual stop or a pending
+                // delete waiting on an exit, so there is no marker to carry.
+                manual: None,
+                pending_delete: false,
+                epoch: carried.epoch(),
+                // A readiness wait that was still running belonged to the
+                // predecessor's own task, which the exec took with it. An
+                // instance the blob reports as `Online` has already resolved
+                // one; one it reports as `Starting` has not, and stays
+                // `Starting` until it next exits — see this phase's residuals.
+                ready_tx: None,
+                actions: ActionWaits::default(),
+                ready_failed: false,
+            },
+        );
+        // The same arming a spawn gets on its way to `Online`, and for the
+        // same reason: a watch, a schedule or a memory limit this image did
+        // not arm is one the app quietly stops having. Only for an instance
+        // that is already serving — `went_online` makes the argument for why
+        // arming happens at that transition and not at the spawn.
+        if status == ProcStatus::Online {
+            self.arm_extras(id);
+        }
+        Ok(())
     }
 
     /// Respawns an already-registered id in place: reassembles from its
@@ -7804,6 +8137,11 @@ mod tests {
     // a case can order itself against the actor. Imported here rather than
     // beside the module's other `tokio::sync` uses, which do not need it.
     use tokio::sync::watch;
+    // Test-only: the one case that needs a real exit needs the real runner,
+    // because a scripted one would prove the fake rather than the targeted
+    // `waitpid` an adopted pid is reaped by.
+    #[cfg(unix)]
+    use crate::tokio_runner::TokioRunner;
     // Test-only: `RefusesOneSpawn` counts every spawn ATTEMPTED, which is
     // the number `ScriptedRunner`'s own counters cannot report. Aliased
     // because `Ordering` in this module already means `cmp::Ordering` to a
@@ -16915,5 +17253,318 @@ mod tests {
             CarriedFds::none(),
             "a sheep with no pump has no descriptors to carry"
         );
+    }
+
+    /// A runner that takes an inherited sheep without a real process behind
+    /// it, so the install path can be driven under the paused clock.
+    ///
+    /// `wait` never resolves: these cases assert on what an install PUTS in
+    /// the flock, and an exit that arrived on its own would race them. The
+    /// one case that needs a real exit uses [`crate::tokio_runner::TokioRunner`]
+    /// and a real child, because a fake exit would prove the fake rather than
+    /// the reaper.
+    #[cfg(unix)]
+    #[derive(Debug, Default)]
+    struct AdoptingRunner;
+
+    /// The pid [`AdoptingRunner`] gives anything it spawns fresh, which is
+    /// deliberately not a pid any carried sheep in these cases holds.
+    #[cfg(unix)]
+    const STAND_IN_SPAWN_PID: u32 = 7000;
+
+    /// A proc with a pid and no process: it reports what it was built with
+    /// and never exits.
+    #[cfg(unix)]
+    #[derive(Debug)]
+    struct StandInProc {
+        pid: u32,
+    }
+
+    #[cfg(unix)]
+    impl RunningProcess for StandInProc {
+        fn pid(&self) -> u32 {
+            self.pid
+        }
+
+        async fn wait(&mut self) -> ExitOutcome {
+            core::future::pending().await
+        }
+
+        fn signal(&mut self, _sig: crate::runner::StopSignal) -> Result<(), RunnerError> {
+            Ok(())
+        }
+
+        fn kill_tree(&mut self) -> Result<(), RunnerError> {
+            Ok(())
+        }
+    }
+
+    /// Four channels shaped the way an adopted sheep's are: logs and
+    /// shepherd traffic closed, since nothing here writes either.
+    #[cfg(unix)]
+    fn stand_in_io() -> ProcIo {
+        let (_logs_tx, logs) = mpsc::channel(1);
+        let (_from_child_tx, from_child) = mpsc::channel(1);
+        let (to_child, to_child_rx) = mpsc::channel(1);
+        drop(to_child_rx);
+        let (log_ctl, log_ctl_rx) = mpsc::channel(1);
+        drop(log_ctl_rx);
+        let (to_stdin, to_stdin_rx) = mpsc::channel(1);
+        drop(to_stdin_rx);
+        ProcIo {
+            logs,
+            from_child,
+            to_child,
+            log_ctl,
+            to_stdin,
+        }
+    }
+
+    #[cfg(unix)]
+    impl ProcessRunner for AdoptingRunner {
+        type Proc = StandInProc;
+
+        fn spawn(&self, _spec: &SpawnSpec) -> Result<(Self::Proc, ProcIo), RunnerError> {
+            Ok((
+                StandInProc {
+                    pid: STAND_IN_SPAWN_PID,
+                },
+                stand_in_io(),
+            ))
+        }
+
+        fn adopt(
+            &self,
+            spec: crate::runner::AdoptSpec,
+        ) -> Result<(Self::Proc, ProcIo), RunnerError> {
+            Ok((StandInProc { pid: spec.pid }, stand_in_io()))
+        }
+    }
+
+    /// One sheep as a blob describes it, with `mutate` free to give it a
+    /// history no fresh registration could have.
+    #[cfg(unix)]
+    fn carried(
+        name: &str,
+        id: u32,
+        pid: Option<u32>,
+        mutate: impl FnOnce(&mut ProcessEntry),
+    ) -> CarriedSheep {
+        let mut app = AppConfig::minimal(name, "./srv");
+        // Nothing in these cases wants a respawn: the install path is what
+        // is under test, and an automatic restart would spawn a second
+        // process behind the assertions.
+        app.autorestart = false;
+        let mut entry = ProcessEntry {
+            id,
+            spec: normalize(app).unwrap(),
+            instance: 0,
+            status: ProcStatus::Online,
+            pid,
+            restarts: 0,
+            started_at: None,
+            budget: RestartBudget::default(),
+            reload: ReloadState::None,
+            credentials: SpawnIdentity::Resolved(None),
+            out_file: PathBuf::new(),
+            err_file: PathBuf::new(),
+            dog: None,
+            last_exit: None,
+        };
+        mutate(&mut entry);
+        CarriedSheep::from_entry(&entry, 0, CarriedFds::none())
+    }
+
+    /// A carried sheep with no descriptors to rebuild, which is every case
+    /// below that does not open real pipes.
+    #[cfg(unix)]
+    fn without_handles(carried: CarriedSheep) -> crate::handover::adopt::AdoptedSheep {
+        crate::handover::adopt::AdoptedSheep {
+            carried,
+            out_pipe: None,
+            err_pipe: None,
+            out_log: None,
+            err_log: None,
+        }
+    }
+
+    /// Counters as a blob carries them, with `next_id` the one a case cares
+    /// about.
+    #[cfg(unix)]
+    const fn counters(next_id: u32) -> Counters {
+        Counters {
+            next_id,
+            next_deadline: 0,
+            next_action_stamp: 0,
+        }
+    }
+
+    /// Every row of a listing by id, which is the order these cases name
+    /// their sheep in.
+    #[cfg(unix)]
+    fn by_id(mut info: Vec<ProcessInfo>) -> Vec<ProcessInfo> {
+        info.sort_unstable_by_key(|row| row.id);
+        info
+    }
+
+    /// Fails if an installed flock does not come back under the pids and ids
+    /// the blob named.
+    ///
+    /// The blob's whole purpose. A sheep whose pid moved was respawned, and
+    /// this phase exists to not do that.
+    #[cfg(unix)]
+    #[tokio::test(start_paused = true)]
+    async fn an_adopted_flock_keeps_its_pids_and_ids() {
+        let dir = tempfile::tempdir().unwrap();
+        let (events, _rx) = crate::bus::test_bus(64);
+        let sup = SupervisorBuilder::new(AdoptingRunner, test_paths(&dir), events)
+            .spawn_adopted(
+                vec![
+                    without_handles(carried("web", 7, Some(4242), |_| {})),
+                    without_handles(carried("api", 8, Some(4243), |_| {})),
+                ],
+                counters(9),
+            )
+            .expect("a carried flock installs");
+
+        let info = by_id(sup.list().await);
+
+        assert_eq!(
+            info.iter().map(|row| row.id).collect::<Vec<_>>(),
+            vec![7, 8],
+            "the successor reissued ids instead of carrying them"
+        );
+        assert_eq!(
+            info.iter().map(|row| row.pid).collect::<Vec<_>>(),
+            vec![Some(4242), Some(4243)],
+            "a sheep whose pid moved was respawned"
+        );
+    }
+
+    /// Fails if an adopted sheep comes back without the history the blob
+    /// carried for it.
+    ///
+    /// Losing these is silent. RESTARTS resetting to zero hands a
+    /// crash-looping app amnesty it did not earn, and a lost `last_exit`
+    /// answers "why did it stop" with nothing.
+    #[cfg(unix)]
+    #[tokio::test(start_paused = true)]
+    async fn an_adopted_sheep_keeps_its_counters_and_last_exit() {
+        let dir = tempfile::tempdir().unwrap();
+        let (events, _rx) = crate::bus::test_bus(64);
+        let sup = SupervisorBuilder::new(AdoptingRunner, test_paths(&dir), events)
+            .spawn_adopted(
+                vec![without_handles(carried("web", 7, Some(4242), |entry| {
+                    entry.restarts = 4;
+                    entry.last_exit = Some(ExitInfo {
+                        code: Some(2),
+                        signal: None,
+                    });
+                }))],
+                counters(9),
+            )
+            .expect("a carried flock installs");
+
+        let info = sup.list().await;
+
+        assert_eq!(info[0].restarts, 4, "the restart count was reset");
+        assert_eq!(
+            info[0].last_exit,
+            Some(ExitInfo {
+                code: Some(2),
+                signal: None
+            }),
+            "the last exit was lost"
+        );
+    }
+
+    /// Fails if an adopted sheep's exit never reaches the ordinary path.
+    ///
+    /// The one that proves the reaper is actually wired. An adopted sheep
+    /// that exits must reach `handle_exited` and be judged by
+    /// `decide_on_exit` like any other, not sit there `Online` forever.
+    ///
+    /// A real child and the real runner, because a scripted exit would prove
+    /// the fake rather than the targeted `waitpid` an adopted pid needs.
+    /// `/bin/sh` is spawned by `std::process::Command`, so tokio holds no
+    /// `Child` for it and nothing but the reaper will ever wait on it —
+    /// exactly how a sheep reaches a successor.
+    #[cfg(unix)]
+    #[tokio::test]
+    // The child is deliberately never `Child::wait()`ed on: that is the shape
+    // under test. An adopted sheep reaches a successor as a bare pid with no
+    // handle to wait through, and a `wait()` added here would take the status
+    // the supervisor is supposed to collect.
+    #[expect(
+        clippy::zombie_processes,
+        reason = "the adopted flock's reaper collects this status; a Child::wait would take it first"
+    )]
+    async fn an_adopted_sheeps_exit_flows_through_the_ordinary_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let (events, _rx) = crate::bus::test_bus(64);
+        let child = std::process::Command::new("/bin/sh")
+            .args(["-c", "sleep 30"])
+            .spawn()
+            .expect("a test host can spawn a shell");
+        let pid = child.id();
+        let sup = SupervisorBuilder::new(TokioRunner::new(), test_paths(&dir), events)
+            .spawn_adopted(
+                vec![without_handles(carried("web", 7, Some(pid), |_| {}))],
+                counters(9),
+            )
+            .expect("a carried flock installs");
+
+        nix::sys::signal::kill(
+            nix::unistd::Pid::from_raw(i32::try_from(pid).unwrap()),
+            nix::sys::signal::Signal::SIGKILL,
+        )
+        .expect("the adopted child is signalable");
+
+        let info = tokio::time::timeout(Duration::from_secs(20), async {
+            loop {
+                let info = sup.list().await;
+                if info[0].status == ProcStatus::Stopped {
+                    return info;
+                }
+                tokio::time::sleep(Duration::from_millis(20)).await;
+            }
+        })
+        .await
+        .expect("an adopted sheep's exit reaches the actor");
+
+        assert_eq!(
+            info[0].last_exit,
+            Some(ExitInfo {
+                code: None,
+                signal: Some(9)
+            }),
+            "the exit must be recorded, not lost"
+        );
+    }
+
+    /// Fails if a successor hands a fresh sheep an id a caller is still
+    /// holding.
+    ///
+    /// Counters restored BEFORE any slot is installed. A successor that
+    /// starts `next_id` at zero hands a new sheep an id the predecessor
+    /// already gave out.
+    #[cfg(unix)]
+    #[tokio::test(start_paused = true)]
+    async fn the_successor_does_not_reissue_a_live_id() {
+        let dir = tempfile::tempdir().unwrap();
+        let (events, _rx) = crate::bus::test_bus(64);
+        let sup = SupervisorBuilder::new(AdoptingRunner, test_paths(&dir), events)
+            .spawn_adopted(
+                vec![without_handles(carried("web", 7, Some(4242), |_| {}))],
+                counters(9),
+            )
+            .expect("a carried flock installs");
+
+        let fresh = sup
+            .start(vec![normalize(AppConfig::minimal("api", "./srv")).unwrap()])
+            .await
+            .expect("a fresh app starts under a successor");
+
+        assert!(fresh[0].id >= 9, "reissued a live id: {}", fresh[0].id);
     }
 }

--- a/crates/shep-daemon/src/supervisor.rs
+++ b/crates/shep-daemon/src/supervisor.rs
@@ -1588,10 +1588,15 @@ impl<R: ProcessRunner> SupervisorBuilder<R> {
     /// holds: the predecessor has already `execve`d itself away by this
     /// point, and there is no image left to hand the flock back to.
     ///
-    /// # Panics
+    /// Must be called from within a Tokio runtime context, which is where
+    /// the actor task and every adopted sheep's pump have to be spawned.
     ///
-    /// Panics if called outside a Tokio runtime context, which is where the
-    /// actor task and every adopted sheep's pump have to be spawned.
+    /// Stated as a requirement rather than under a `# Panics` heading, which
+    /// is how the sibling [`Self::spawn`] states the identical one. IR-21
+    /// makes a `# Panics` section and `#[track_caller]` one decision, and
+    /// `#[track_caller]` buys nothing here: the panic is raised inside
+    /// `tokio::spawn`, which does not carry the attribute itself, so the
+    /// location reported would be tokio's either way.
     #[cfg(unix)]
     pub(crate) fn spawn_adopted(
         self,

--- a/crates/shep-daemon/src/supervisor.rs
+++ b/crates/shep-daemon/src/supervisor.rs
@@ -3419,6 +3419,14 @@ impl<R: ProcessRunner> Actor<R> {
     /// roll, which recorded a running COUNT per app rather than which
     /// instance was up, and whose restore path starts what it restores.
     ///
+    /// # Where the start time comes from
+    ///
+    /// The operating system, via
+    /// [`handover::uptime`](crate::handover::uptime). It is the one field
+    /// the blob cannot carry, and re-deriving it is what stops a sheep that
+    /// has been up three days reporting `0s` uptime the moment a successor
+    /// takes over.
+    ///
     /// # What a sheep that is not running installs as
     ///
     /// A slot with no pump and no `ctl`, which is the state it was already
@@ -3549,11 +3557,14 @@ impl<R: ProcessRunner> Actor<R> {
         // consulted. An adopted sheep installed without it would sit
         // `Online` forever after its process died.
         //
-        // The clock restarts at the handover, so this instance's reported
-        // uptime does too. The blob cannot help: `started_at` is a
-        // `tokio::time::Instant`, which has no epoch and means nothing
-        // outside the runtime that read it.
-        entry.started_at = Some(tokio::time::Instant::now());
+        // Derived from the operating system rather than stamped here. The
+        // blob cannot carry it: `started_at` is a `tokio::time::Instant`,
+        // which has no epoch and means nothing outside the runtime that
+        // read it. Asking the process table how old the pid is, and
+        // subtracting that from this runtime's clock, is what keeps a sheep
+        // that has been up three days reporting three days in `shep flock`'s
+        // UPTIME column instead of `0s` the moment a successor takes over.
+        entry.started_at = Some(crate::handover::uptime::started_at_of(proc.pid()));
         let log_ctl = io.log_ctl.clone();
         let to_child = io.to_child.clone();
         let to_stdin = io.to_stdin.clone();

--- a/crates/shep-daemon/src/supervisor.rs
+++ b/crates/shep-daemon/src/supervisor.rs
@@ -65,7 +65,10 @@ use crate::handover::adopt::AdoptedSheep;
 #[cfg(unix)]
 use crate::handover::reap::AdoptedReaper;
 #[cfg(unix)]
-use crate::handover::{CarriedFds, CarriedSheep, Counters, DaemonFds, Handover, OwnedCandidate};
+use crate::handover::{
+    Candidate, CarriedFds, CarriedSheep, Counters, DaemonFds, Fitness, Handover, OwnedCandidate,
+    fitness,
+};
 use crate::kill::kill_process;
 use crate::privilege::{self, Credentials, PrivilegeError, SpawnIdentity};
 use crate::probes::Prober;
@@ -482,14 +485,6 @@ pub(crate) enum Command {
     /// [`SheepSlot`], and the descriptor numbers are known only to each
     /// sheep's log pump.
     #[cfg(unix)]
-    #[cfg_attr(
-        not(test),
-        expect(
-            dead_code,
-            reason = "task 8d sends this from `boot`'s handover arm; nothing outside this \
-                      crate's own tests constructs it yet"
-        )
-    )]
     HandoverSnapshot {
         /// The daemon's own two descriptors, which `boot` knows and the
         /// actor does not.
@@ -498,6 +493,18 @@ pub(crate) enum Command {
         /// task of its own, never the actor loop (see
         /// [`Actor::handle_handover_snapshot`]).
         reply: oneshot::Sender<Result<Snapshot, SupervisorError>>,
+    },
+    /// Answers whether this flock could be handed to a successor in place.
+    ///
+    /// The same gate [`Command::HandoverSnapshot`]'s caller applies, asked
+    /// on its own and without the descriptor round trip, because a client
+    /// asks it before anything is signalled (spec H3a) and a question must
+    /// not flush a pump.
+    #[cfg(unix)]
+    HandoverFitness {
+        /// Answers on the actor loop: the gate reads slot state this actor
+        /// already holds and awaits nothing.
+        reply: oneshot::Sender<Result<Fitness, SupervisorError>>,
     },
     /// Puts one named action on the shepherd channel of every sheep matching
     /// `selector` and answers with what each app said back, or with why
@@ -1275,14 +1282,6 @@ impl SupervisorHandle {
     /// - [`SupervisorError::EngineStopped`] — the actor is gone.
     ///
     #[cfg(unix)]
-    #[cfg_attr(
-        not(test),
-        expect(
-            dead_code,
-            reason = "task 8d calls this from `boot`'s handover arm; nothing outside this \
-                      crate's own tests calls it yet"
-        )
-    )]
     pub(crate) async fn handover_snapshot(
         &self,
         fds: DaemonFds,
@@ -1290,6 +1289,26 @@ impl SupervisorHandle {
         let (reply, rx) = oneshot::channel();
         self.tx
             .send(Msg::Command(Command::HandoverSnapshot { fds, reply }))
+            .await
+            .map_err(|_| SupervisorError::EngineStopped)?;
+        rx.await.map_err(|_| SupervisorError::EngineStopped)?
+    }
+
+    /// Whether this shepherd's flock could be handed to a successor in
+    /// place, or the reason it could not.
+    ///
+    /// Read-only, and nothing here begins a handover: the trigger is a
+    /// signal, and this is the question a client asks before sending one
+    /// (spec H3a).
+    ///
+    /// # Errors
+    ///
+    /// - [`SupervisorError::EngineStopped`]: the actor is gone.
+    #[cfg(unix)]
+    pub(crate) async fn handover_fitness(&self) -> Result<Fitness, SupervisorError> {
+        let (reply, rx) = oneshot::channel();
+        self.tx
+            .send(Msg::Command(Command::HandoverFitness { reply }))
             .await
             .map_err(|_| SupervisorError::EngineStopped)?;
         rx.await.map_err(|_| SupervisorError::EngineStopped)?
@@ -1574,14 +1593,6 @@ impl<R: ProcessRunner> SupervisorBuilder<R> {
     /// Panics if called outside a Tokio runtime context, which is where the
     /// actor task and every adopted sheep's pump have to be spawned.
     #[cfg(unix)]
-    #[cfg_attr(
-        not(test),
-        expect(
-            dead_code,
-            reason = "task 8d calls this from `boot`'s successor arm; nothing outside this \
-                      crate's own tests calls it yet"
-        )
-    )]
     pub(crate) fn spawn_adopted(
         self,
         flock: Vec<AdoptedSheep>,
@@ -2635,6 +2646,14 @@ impl<R: ProcessRunner> Actor<R> {
             #[cfg(unix)]
             Command::HandoverSnapshot { fds, reply } => {
                 self.handle_handover_snapshot(fds, reply);
+                false
+            }
+            // Not rejected while `shutting_down` either, for the reason
+            // above: a question registers nothing, spawns nothing and
+            // changes no actor state.
+            #[cfg(unix)]
+            Command::HandoverFitness { reply } => {
+                self.handle_handover_fitness(reply);
                 false
             }
             // Not rejected while `shutting_down` either, for the reason
@@ -5908,6 +5927,37 @@ impl<R: ProcessRunner> Actor<R> {
             },
             reply,
         );
+    }
+
+    /// Answers whether every sheep this actor holds could be carried across
+    /// a handover.
+    ///
+    /// On the actor loop, unlike [`Self::handle_handover_snapshot`], and the
+    /// difference is that this awaits nothing: the gate reads slot state
+    /// already in hand, where a snapshot has to ask every log pump for its
+    /// descriptors.
+    ///
+    /// Visited in id order rather than [`HashMap`] order, so a flock with two
+    /// unsupported sheep names the same one every time it is asked. An
+    /// operator who fixes what the refusal named and asks again should meet
+    /// the next problem, not a coin flip between the two.
+    #[cfg(unix)]
+    fn handle_handover_fitness(&self, reply: oneshot::Sender<Result<Fitness, SupervisorError>>) {
+        let mut slots: Vec<&SheepSlot> = self.sheep.values().collect();
+        slots.sort_unstable_by_key(|slot| slot.entry.id);
+        let candidates: Vec<Candidate<'_>> = slots
+            .iter()
+            .map(|slot| Candidate {
+                entry: &slot.entry,
+                // Any manual command owning this sheep's next exit, exactly
+                // as `handle_handover_snapshot` reads it: the two must answer
+                // the same question, or a flock passes the gate and then
+                // fails it.
+                pending_stop: slot.manual.is_some(),
+                pending_delete: slot.pending_delete,
+            })
+            .collect();
+        let _ = reply.send(Ok(fitness(&candidates)));
     }
 
     /// Resolves `selector` and hands every match to a task that flushes its

--- a/crates/shep-daemon/src/supervisor.rs
+++ b/crates/shep-daemon/src/supervisor.rs
@@ -60,6 +60,8 @@ use crate::bus::{Bus, SharedEvent};
 use crate::channel::{ChildMessage, ShepherdMessage};
 use crate::entry::{ProcessEntry, ReloadState, RestartBudget};
 use crate::extras::{Extras, ExtrasRegistry};
+#[cfg(unix)]
+use crate::handover::{CarriedFds, CarriedSheep, Counters, DaemonFds, Handover, OwnedCandidate};
 use crate::kill::kill_process;
 use crate::privilege::{self, Credentials, PrivilegeError, SpawnIdentity};
 use crate::probes::Prober;
@@ -464,6 +466,32 @@ pub(crate) enum Command {
         /// Answers once every path has been truncated — off a task of its
         /// own, never the actor loop (see [`Actor::handle_flush`]).
         reply: oneshot::Sender<Result<Vec<ProcessInfo>, SupervisorError>>,
+    },
+    /// Describes the whole flock for a daemon handover: what the fitness
+    /// gate needs, and the blob the successor reads.
+    ///
+    /// One command rather than a set of getters because everything it
+    /// answers with is private to the actor — the three counters are its
+    /// own fields, `epoch`, `manual` and `pending_delete` are on
+    /// [`SheepSlot`], and the descriptor numbers are known only to each
+    /// sheep's log pump.
+    #[cfg(unix)]
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "task 8d sends this from `boot`'s handover arm; nothing outside this \
+                      crate's own tests constructs it yet"
+        )
+    )]
+    HandoverSnapshot {
+        /// The daemon's own two descriptors, which `boot` knows and the
+        /// actor does not.
+        fds: DaemonFds,
+        /// Answers once every live pump has flushed and reported — off a
+        /// task of its own, never the actor loop (see
+        /// [`Actor::handle_handover_snapshot`]).
+        reply: oneshot::Sender<Result<Snapshot, SupervisorError>>,
     },
     /// Puts one named action on the shepherd channel of every sheep matching
     /// `selector` and answers with what each app said back, or with why
@@ -1219,6 +1247,43 @@ impl SupervisorHandle {
         let (reply, rx) = oneshot::channel();
         self.tx
             .send(Msg::Command(Command::Reopen { selector, reply }))
+            .await
+            .map_err(|_| SupervisorError::EngineStopped)?;
+        rx.await.map_err(|_| SupervisorError::EngineStopped)?
+    }
+
+    /// Describes the whole flock for a daemon handover: one
+    /// [`OwnedCandidate`] per registered sheep for the fitness gate, and the
+    /// [`Handover`] blob the successor reads.
+    ///
+    /// `fds` are the daemon's own listener and pidfile descriptors, which
+    /// `boot` opened and the actor has never seen.
+    ///
+    /// Answers once every live pump has flushed what it was holding and
+    /// reported its descriptors. A registered sheep that is not running has
+    /// no pump, and carries no descriptors: that is not a refusal, and the
+    /// gate does not treat it as one.
+    ///
+    /// # Errors
+    ///
+    /// - [`SupervisorError::EngineStopped`] — the actor is gone.
+    ///
+    #[cfg(unix)]
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "task 8d calls this from `boot`'s handover arm; nothing outside this \
+                      crate's own tests calls it yet"
+        )
+    )]
+    pub(crate) async fn handover_snapshot(
+        &self,
+        fds: DaemonFds,
+    ) -> Result<Snapshot, SupervisorError> {
+        let (reply, rx) = oneshot::channel();
+        self.tx
+            .send(Msg::Command(Command::HandoverSnapshot { fds, reply }))
             .await
             .map_err(|_| SupervisorError::EngineStopped)?;
         rx.await.map_err(|_| SupervisorError::EngineStopped)?
@@ -2429,6 +2494,15 @@ impl<R: ProcessRunner> Actor<R> {
             }
             Command::Flush { selector, reply } => {
                 self.handle_flush(&selector, reply);
+                false
+            }
+            // Not rejected while `shutting_down` either, and for the same
+            // reason: a snapshot registers nothing, spawns nothing and
+            // changes no actor state. What it does with the answer is the
+            // caller's business.
+            #[cfg(unix)]
+            Command::HandoverSnapshot { fds, reply } => {
+                self.handle_handover_snapshot(fds, reply);
                 false
             }
             // Not rejected while `shutting_down` either, for the reason
@@ -5439,6 +5513,59 @@ impl<R: ProcessRunner> Actor<R> {
         spawn_reopen_task(matched, pumps, reply);
     }
 
+    /// Reads everything a handover needs off the actor and hands it to a
+    /// task that asks each live pump for its descriptors.
+    ///
+    /// Synchronous and `&self` for the reasons [`Self::handle_reopen`] gives
+    /// at length: a descriptor report waits on a pump's flush, and awaiting
+    /// that inside the actor loop closes CRITICAL-2's cycle.
+    ///
+    /// The entries are CLONED rather than borrowed because of that split.
+    /// Nothing the actor lends can outlive the loop, and the assembly
+    /// happens after it — which is the whole reason
+    /// [`OwnedCandidate`](OwnedCandidate) exists next to
+    /// `Candidate`.
+    ///
+    /// Every registered sheep is described, with no selector: a handover
+    /// carries one process image, so the flock is carried whole or refused
+    /// whole.
+    #[cfg(unix)]
+    fn handle_handover_snapshot(
+        &self,
+        fds: DaemonFds,
+        reply: oneshot::Sender<Result<Snapshot, SupervisorError>>,
+    ) {
+        let mut drafts: Vec<HandoverDraft> = self
+            .sheep
+            .values()
+            .map(|slot| HandoverDraft {
+                entry: slot.entry.clone(),
+                // Any manual command owning this sheep's next exit, not just
+                // a `Stop`. A `Restart` or a `Delete` waiting on that exit
+                // is as unsafe to carry, and the gate refuses in the strict
+                // direction by design.
+                pending_stop: slot.manual.is_some(),
+                pending_delete: slot.pending_delete,
+                epoch: slot.epoch,
+                log_ctl: slot.log_ctl.clone(),
+            })
+            .collect();
+        // `HashMap` iteration order is arbitrary, and the blob is written to
+        // a file an operator may read: id order makes two snapshots of an
+        // unchanged flock identical.
+        drafts.sort_unstable_by_key(|draft| draft.entry.id);
+        spawn_handover_task(
+            drafts,
+            fds,
+            Counters {
+                next_id: self.next_id,
+                next_deadline: self.next_deadline,
+                next_action_stamp: self.next_action_stamp,
+            },
+            reply,
+        );
+    }
+
     /// Resolves `selector` and hands every match to a task that flushes its
     /// log pump, truncates its log files and then answers the caller.
     ///
@@ -7117,6 +7244,94 @@ fn spawn_send_line_task(
         rows.sort_unstable_by(|a, b| (a.name.as_str(), a.id).cmp(&(b.name.as_str(), b.id)));
         let _ = reply.send(Ok(rows));
     });
+}
+
+/// What a [`Command::HandoverSnapshot`] answers with: one candidate per
+/// registered sheep for the fitness gate, and the blob a successor reads.
+///
+/// A pair rather than one type because the two go to different places and
+/// only one of them crosses the exec — the candidates decide whether there
+/// is to be an exec at all, and are then done with.
+#[cfg(unix)]
+type Snapshot = (Vec<OwnedCandidate>, Handover);
+
+/// One sheep on its way from the actor to the handover task.
+///
+/// Everything here is read off a [`SheepSlot`] inside the actor loop, since
+/// nothing outside can see any of it, and carried out owned because the
+/// assembly runs on a task of its own.
+#[cfg(unix)]
+#[derive(Debug)]
+struct HandoverDraft {
+    /// The sheep's lifecycle entry, cloned off the slot.
+    entry: ProcessEntry,
+    /// Whether a manual command owns this sheep's next exit.
+    pending_stop: bool,
+    /// Whether a `Delete` targets this sheep.
+    pending_delete: bool,
+    /// The slot's respawn epoch, so a timer armed before the exec is still
+    /// recognised as stale after it.
+    epoch: u64,
+    /// This sheep's log pump, or `None` for a slot whose spawn never
+    /// succeeded.
+    log_ctl: Option<mpsc::Sender<LogCtl>>,
+}
+
+/// Spawns the task that assembles one handover snapshot and answers its
+/// caller.
+///
+/// Every await lives in here, off the actor loop — see
+/// [`Actor::handle_reopen`] for the cycle that rules out doing it inline.
+///
+/// The sheep are visited one after another rather than concurrently, exactly
+/// as [`spawn_reopen_task`] visits them, and the same trade applies: a
+/// stalled pump delays the sheep behind it, and the request's own deadline
+/// is what bounds the caller either way.
+///
+/// Must be called from within a Tokio runtime context.
+#[cfg(unix)]
+fn spawn_handover_task(
+    drafts: Vec<HandoverDraft>,
+    fds: DaemonFds,
+    counters: Counters,
+    reply: oneshot::Sender<Result<Snapshot, SupervisorError>>,
+) {
+    tokio::spawn(async move {
+        let mut candidates = Vec::with_capacity(drafts.len());
+        let mut carried = Vec::with_capacity(drafts.len());
+        for draft in drafts {
+            let fds = match &draft.log_ctl {
+                Some(log_ctl) => report_fds(log_ctl).await,
+                None => CarriedFds::none(),
+            };
+            carried.push(CarriedSheep::from_entry(&draft.entry, draft.epoch, fds));
+            candidates.push(OwnedCandidate {
+                entry: draft.entry,
+                pending_stop: draft.pending_stop,
+                pending_delete: draft.pending_delete,
+            });
+        }
+        let blob = Handover::new(carried, fds, counters);
+        let _ = reply.send(Ok((candidates, blob)));
+    });
+}
+
+/// Asks one sheep's log pump to flush what it is holding and report the four
+/// descriptors it owns, and waits for the answer.
+///
+/// Not reaching a pump at all is [`CarriedFds::none`], not an error, and both
+/// shapes of it mean the same thing that [`reopen_logs`] documents: there is
+/// no pump, so there are no descriptors. A stopped sheep has nothing to
+/// carry and nothing to lose, and the fitness gate does not refuse it.
+///
+/// [`CarriedFds::none`]: CarriedFds::none
+#[cfg(unix)]
+async fn report_fds(log_ctl: &mpsc::Sender<LogCtl>) -> CarriedFds {
+    let (done, ack) = oneshot::channel();
+    if log_ctl.send(LogCtl::ReportFds { done }).await.is_err() {
+        return CarriedFds::none();
+    }
+    ack.await.unwrap_or_else(|_| CarriedFds::none())
 }
 
 /// Spawns the task that carries out one `Reopen` and answers its caller.
@@ -14574,6 +14789,12 @@ mod tests {
                                 message: PUMP_REFUSAL.to_string(),
                             }));
                         }
+                        // This runner exists for the reopen and flush
+                        // refusals; a handover never reaches it.
+                        #[cfg(unix)]
+                        LogCtl::ReportFds { done } => {
+                            let _ = done.send(CarriedFds::none());
+                        }
                     }
                 }
             });
@@ -15124,6 +15345,12 @@ mod tests {
                         }
                         LogCtl::Reopen { done } => {
                             let _ = done.send(Ok(()));
+                        }
+                        // This runner exists for the flush ordering; a
+                        // handover never reaches it.
+                        #[cfg(unix)]
+                        LogCtl::ReportFds { done } => {
+                            let _ = done.send(CarriedFds::none());
                         }
                     }
                 }
@@ -16581,5 +16808,112 @@ mod tests {
                 Ok::<(), proptest::test_runner::TestCaseError>(())
             })?;
         }
+    }
+
+    /// Two descriptors standing in for the daemon's own, so a snapshot taken
+    /// in a test names numbers that are really open rather than plausible
+    /// ones. The daemon supplies its listener and pidfile from `boot`; the
+    /// actor never learns them, which is why they are an argument.
+    #[cfg(unix)]
+    fn daemon_fds(dir: &tempfile::TempDir) -> (DaemonFds, [std::fs::File; 2]) {
+        use std::os::fd::AsRawFd as _;
+
+        let listener = std::fs::File::create(dir.path().join("listener.stand-in")).unwrap();
+        let pidfile = std::fs::File::create(dir.path().join("pidfile.stand-in")).unwrap();
+        let fds = DaemonFds {
+            listener: listener.as_raw_fd(),
+            pidfile: pidfile.as_raw_fd(),
+        };
+        // Returned alongside so the caller holds both files open: a closed
+        // descriptor's number is free to be handed to the next open.
+        (fds, [listener, pidfile])
+    }
+
+    /// Whether `fd` names something open in this process.
+    #[cfg(unix)]
+    fn is_open(fd: std::os::fd::RawFd) -> bool {
+        nix::fcntl::fcntl(fd, nix::fcntl::FcntlArg::F_GETFD).is_ok()
+    }
+
+    /// Fails if a snapshot of a live flock does not name four open
+    /// descriptors for every sheep in it.
+    ///
+    /// The blob is what the successor adopts by number, and a number it
+    /// cannot adopt is not a gap it can repair: losing a sheep's stdout read
+    /// end blocks the child on `write()` once the pipe buffer fills, which
+    /// reads as an application hang rather than as a shep bug.
+    #[cfg(unix)]
+    #[tokio::test(start_paused = true)]
+    async fn a_blob_from_a_live_flock_names_four_open_descriptors_per_sheep() {
+        let (events, _rx) = crate::bus::test_bus(64);
+        let runner =
+            ScriptedRunner::new(vec![ProcScript::never_exits(), ProcScript::never_exits()]);
+        let dir = tempfile::tempdir().unwrap();
+        let (fds, _held) = daemon_fds(&dir);
+        let handle = spawn_supervisor(runner, test_paths(&dir), events);
+        handle
+            .start(vec![
+                normalize(AppConfig::minimal("web", "./srv")).unwrap(),
+                normalize(AppConfig::minimal("api", "./srv")).unwrap(),
+            ])
+            .await
+            .unwrap();
+
+        let (candidates, blob) = handle.handover_snapshot(fds).await.unwrap();
+
+        assert_eq!(candidates.len(), 2, "both sheep must reach the gate");
+        assert_eq!(blob.sheep().len(), 2);
+        for sheep in blob.sheep() {
+            for fd in sheep.fds().all() {
+                let fd = fd.expect("a running sheep has all four descriptors");
+                assert!(is_open(fd), "blob names a closed descriptor: {fd}");
+            }
+        }
+    }
+
+    /// Fails if a snapshot loses the three actor counters or the two slot
+    /// fields nothing outside the actor can see.
+    ///
+    /// These are the reason this is a command rather than a getter, and each
+    /// one is load-bearing on its own: a successor that reissued a live id
+    /// would collide with a caller still holding it, and a manual stop the
+    /// gate never saw is a flock carried while an operator is waiting on its
+    /// exit.
+    ///
+    /// The sheep here has no live pump, which is also the registered-but-not
+    /// -running case: it reports no descriptors, and that is not a refusal.
+    #[cfg(unix)]
+    #[tokio::test(start_paused = true)]
+    async fn the_snapshot_carries_the_actors_counters_and_slot_state() {
+        let dir = tempfile::tempdir().unwrap();
+        let (fds, _held) = daemon_fds(&dir);
+        let (mut actor, _ctl_rx) = actor_with_stopping_drainee(&dir, 4242, 7);
+        actor.sheep.get_mut(&0).unwrap().manual = Some(PendingManual {
+            kind: ManualKind::Stop,
+            origin: CommandOrigin::Operator,
+        });
+
+        let (reply, rx) = oneshot::channel();
+        actor.handle_handover_snapshot(fds, reply);
+        let (candidates, blob) = rx.await.unwrap().unwrap();
+
+        assert!(
+            candidates[0].pending_stop,
+            "a pending stop must reach the gate"
+        );
+        assert!(
+            !candidates[0].pending_delete,
+            "nothing asked for this sheep to be deleted"
+        );
+        assert!(
+            blob.next_id() > 0,
+            "a successor that reissues a live id collides"
+        );
+        assert_eq!(blob.sheep()[0].epoch(), 7, "a stale timer must stay stale");
+        assert_eq!(
+            blob.sheep()[0].fds(),
+            CarriedFds::none(),
+            "a sheep with no pump has no descriptors to carry"
+        );
     }
 }

--- a/crates/shep-daemon/src/sys.rs
+++ b/crates/shep-daemon/src/sys.rs
@@ -30,6 +30,15 @@
 //! narrower, locally-checkable obligation, not a widening of the
 //! exception.
 //!
+//! **The second entry point, [`adopt_handover_fd`], is safe on purpose.**
+//! It is [`adopt_fd`] for a handover's successor, and its whole doc is the
+//! argument for why the ordering obligation is discharged by the situation
+//! rather than by the call site: a descriptor inherited across `execve` is
+//! open before the new image runs at all, so the kernel can never hand its
+//! number to anything this process opens later. That argument holds for
+//! handover descriptors and for nothing else, which is why it is a second,
+//! narrowly documented function rather than a relaxation of [`adopt_fd`].
+//!
 //! **Rejected alternative:** have the parent pass a socket path
 //! (`SHEP_READY_SOCK`) and let the child connect and write. It is entirely
 //! safe and was the first design. Its cost is a second socket in the boot
@@ -87,7 +96,7 @@
 //!     time against a fd the test itself just created — a different,
 //!     lower-stakes situation than production double-adoption, and not
 //!     what this scenario is about.)
-#![allow(unsafe_code)] // IR-24 exception — seven sites total, all in this file (its own definition plus 6 test call sites; `boot.rs` has none — see the essay above and `crate::boot::BootOptions::ready_fd`'s doc).
+#![allow(unsafe_code)] // IR-24 exception: eight sites total, all in this file (`adopt_fd`'s own definition, `adopt_handover_fd`'s block, and 6 test call sites). `boot.rs` has none; see the essay above and `crate::boot::BootOptions::ready_fd`'s doc.
 
 use core::fmt;
 
@@ -147,13 +156,58 @@ pub unsafe fn adopt_fd(fd: RawFd) -> Result<File, SysError> {
     // the intended inherited pipe rather than something this process opened
     // itself in the meantime. `adopt_fd` is the only place in this crate
     // that constructs a `File` from a bare fd. `boot` never calls it — see
-    // this fn's own doc above — and this crate has no other production
-    // caller today either; every in-crate call site is one of this file's
-    // own tests, each adopting a fd it just created and each doing so at
-    // most once per descriptor. The `File` returned here becomes that
-    // number's sole owner; nothing else will read, write, or close it
-    // again.
+    // this fn's own doc above — and its only in-crate caller outside this
+    // file's own tests is `adopt_handover_fd` below, which discharges the
+    // ordering contract from the situation rather than from where it sits.
+    // The `File` returned here becomes that number's sole owner; nothing
+    // else will read, write, or close it again.
     Ok(unsafe { File::from_raw_fd(fd) })
+}
+
+/// Takes ownership of a descriptor a handover blob names, without the
+/// caller having to discharge [`adopt_fd`]'s ordering precondition itself.
+///
+/// This is [`adopt_fd`] for exactly one situation: the process is a
+/// handover's successor, and `fd` is a number its own predecessor wrote
+/// into the blob at `$SHEP_HOME/run/handover.json` moments before it
+/// `execve`d this image. It is safe to call, and the argument for that is
+/// specific to that situation rather than general.
+///
+/// **Why the recycling hazard cannot arise here.** [`adopt_fd`]'s `#
+/// Safety` section exists because `F_GETFD` proves only that a number is
+/// open right now, never who opened it, so a stale number could name
+/// something this process opened for itself. A descriptor genuinely
+/// inherited across `execve` is never in that position: it is already open
+/// the instant the new image starts, and the kernel allocates the lowest
+/// FREE number, so nothing this process opens afterwards can ever be handed
+/// one of them. The ordering obligation `adopt_fd` pushes onto its caller is
+/// discharged by the inheritance itself, not by where the call sits.
+///
+/// **What that leaves.** A blob naming a number that was NOT inherited,
+/// one left over from a handover that never completed or one an operator
+/// edited, could name a descriptor this process opened. The blob is
+/// written mode `0600` inside `$SHEP_HOME/run`, which is `0700`, and it is
+/// removed both when an exec fails and once a successor has read it, so it
+/// is trusted exactly as far as everything else the daemon reads out of its
+/// own home. Do not call this on a descriptor number from anywhere else.
+///
+/// # Errors
+/// - [`SysError::ReservedFd`]: `fd` is below 3 (stdio is owned elsewhere).
+/// - [`SysError::BadFd`]: `fd` names no open descriptor in this process,
+///   which is what a blob naming a descriptor that did not survive the exec
+///   looks like. Refusing is the whole point: a sheep whose stdout read end
+///   is missing does not lose its output, it blocks on `write()` once the
+///   pipe buffer fills.
+pub fn adopt_handover_fd(fd: RawFd) -> Result<File, SysError> {
+    // SAFETY: `fd` was inherited across `execve` from this process's own
+    // predecessor, which cleared `FD_CLOEXEC` on it and named it in the
+    // handover blob. An inherited descriptor is open before this image runs
+    // its first instruction, so its number is never free for anything this
+    // process opens to be given, which is precisely the recycling scenario
+    // (c) that makes `adopt_fd` unsafe. See this function's own doc for the
+    // one residual case (a blob naming a number that was not inherited) and
+    // why the blob is trusted that far.
+    unsafe { adopt_fd(fd) }
 }
 
 /// Errors adopting an inherited descriptor.

--- a/crates/shep-daemon/src/sys.rs
+++ b/crates/shep-daemon/src/sys.rs
@@ -191,6 +191,14 @@ pub unsafe fn adopt_fd(fd: RawFd) -> Result<File, SysError> {
 /// is trusted exactly as far as everything else the daemon reads out of its
 /// own home. Do not call this on a descriptor number from anywhere else.
 ///
+/// **One number, one owner.** The argument above is about a number naming
+/// the wrong object; a blob naming the SAME number twice would instead build
+/// two owners of the right one, and the second drop would close a descriptor
+/// the first owner, or a later open, is still using.
+/// `handover::adopt::adopt` refuses a repeated number before it adopts
+/// anything, so every call that reaches here is the only call for its
+/// number.
+///
 /// # Errors
 /// - [`SysError::ReservedFd`]: `fd` is below 3 (stdio is owned elsewhere).
 /// - [`SysError::BadFd`]: `fd` names no open descriptor in this process,

--- a/crates/shep-daemon/src/tokio_runner.rs
+++ b/crates/shep-daemon/src/tokio_runner.rs
@@ -2198,6 +2198,60 @@ mod tests {
         assert_eq!(distinct.len(), 4, "four descriptors, four numbers: {fds:?}");
     }
 
+    /// Fails if a report still names a stream whose descriptor the pump has
+    /// already let go of.
+    ///
+    /// The `files.pipes.out = None` in the `StreamEnded` arm is the guard
+    /// that keeps a closed descriptor out of a handover blob, and nothing
+    /// else in this file exercises it.
+    /// [`a_pump_reports_the_descriptors_it_holds`] reports while both
+    /// streams are live, so it passes whether or not the clearing exists.
+    ///
+    /// A number is the whole of what the blob carries, and a closed one is
+    /// free for the next `open` in this process to be handed. The successor
+    /// would then adopt whatever that open produced as this sheep's stdout,
+    /// which `adopt`'s kind check catches only when the two happen to be
+    /// different kinds of object.
+    ///
+    /// One stream, not both. `err_pipe` staying at the harness's own number
+    /// is what makes this a case about the ended stream rather than about a
+    /// pump that stopped answering.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn a_report_after_a_stream_ends_names_no_descriptor_for_it() {
+        let mut pump = PumpHarness::start_over_pipes();
+        pump.feed(false, "before-the-eof").await;
+
+        drop(pump.out_writer);
+        let_the_pump_settle().await;
+
+        // Sent through the field rather than through `report_fds`, because
+        // dropping the writer above moves out of the harness and a `&self`
+        // method is no longer reachable. Same request either way.
+        let (done, ack) = oneshot::channel();
+        pump.ctl
+            .send(LogCtl::ReportFds { done })
+            .await
+            .expect("a pump with one live stream still reads its control channel");
+        let fds = timeout(PUMP_DEADLINE, ack)
+            .await
+            .expect("a descriptor report must be acknowledged")
+            .expect("the pump must answer rather than drop the acknowledgement");
+
+        assert_eq!(
+            fds.out_pipe, None,
+            "stdout is at EOF and its descriptor is gone: {fds:?}"
+        );
+        assert_eq!(
+            fds.err_pipe, pump.pipes.err,
+            "stderr is still live and keeps its own number: {fds:?}"
+        );
+        assert!(
+            fds.out_log.is_some() && fds.err_log.is_some(),
+            "both log handles are held whichever stream ended: {fds:?}"
+        );
+    }
+
     /// Fails if a report is answered before what the pump is holding has
     /// reached the file.
     ///

--- a/crates/shep-daemon/src/tokio_runner.rs
+++ b/crates/shep-daemon/src/tokio_runner.rs
@@ -32,7 +32,7 @@ use core::time::Duration;
 use std::fs;
 use std::io;
 #[cfg(unix)]
-use std::os::fd::OwnedFd;
+use std::os::fd::{AsRawFd, OwnedFd, RawFd};
 #[cfg(unix)]
 use std::os::unix::process::ExitStatusExt as _;
 use std::path::{Path, PathBuf};
@@ -868,6 +868,16 @@ impl ProcessRunner for TokioRunner {
 
         let (logs_tx, logs_rx) = mpsc::channel(CHANNEL_CAPACITY);
         let (log_ctl_tx, log_ctl_rx) = mpsc::channel(CHANNEL_CAPACITY);
+        // Read off the handles this spawn is about to give away, and before
+        // the `take`s below move them: this is the only place the numbers a
+        // handover carries are known.
+        #[cfg(unix)]
+        let pipes = PipeFds {
+            out: child.stdout.as_ref().map(AsRawFd::as_raw_fd),
+            err: child.stderr.as_ref().map(AsRawFd::as_raw_fd),
+        };
+        #[cfg(not(unix))]
+        let pipes = PipeFds;
         spawn_log_pump(
             child.stdout.take(),
             child.stderr.take(),
@@ -875,6 +885,7 @@ impl ProcessRunner for TokioRunner {
             spec.err_file.clone(),
             logs_tx,
             log_ctl_rx,
+            pipes,
         );
 
         let (to_stdin_tx, to_stdin_rx) = mpsc::channel(CHANNEL_CAPACITY);
@@ -990,6 +1001,19 @@ impl LogFile<tokio::fs::File> {
             }),
         }
     }
+
+    /// This stream's open log-file descriptor, or `None` when the open
+    /// failed and there is no handle at all.
+    ///
+    /// Read off the live handle rather than remembered, so a
+    /// [`Self::reopen`] that swapped the file cannot leave a stale number
+    /// behind for a handover to carry.
+    #[cfg(unix)]
+    fn raw_fd(&self) -> Option<RawFd> {
+        self.handle
+            .as_ref()
+            .map(|handle| handle.get_ref().as_raw_fd())
+    }
 }
 
 impl<W: AsyncWrite + Unpin> LogFile<W> {
@@ -1046,12 +1070,43 @@ impl<W: AsyncWrite + Unpin> LogFile<W> {
     }
 }
 
+/// The descriptor numbers of a pump's two stream readers.
+///
+/// Told to the pump rather than read off its readers, because the pump is
+/// generic over them and an in-memory stream has no descriptor at all. The
+/// caller holding the real `ChildStdout` is the one place the numbers are
+/// known, and it reads them off the same object it is about to hand over.
+///
+/// Empty on Windows, which has no descriptors to carry and no handover to
+/// carry them: `Arm::for_daemon` returns the stop-and-start arm there.
+#[cfg(unix)]
+#[derive(Debug, Clone, Copy, Default)]
+struct PipeFds {
+    /// The read end of the child's stdout, while the pump still holds it.
+    out: Option<RawFd>,
+    /// The read end of the child's stderr, while the pump still holds it.
+    err: Option<RawFd>,
+}
+
+/// See the unix definition above; there is nothing to carry here.
+#[cfg(not(unix))]
+#[derive(Debug, Clone, Copy, Default)]
+struct PipeFds;
+
 /// Both of a sheep's log files — the pair one [`LogCtl::Reopen`] swaps, and
-/// the pair one [`LogCtl::Flush`] drains.
+/// the pair one [`LogCtl::Flush`] drains — and the two stream descriptors
+/// alongside them, which is the set a handover carries.
 #[derive(Debug)]
 struct LogFiles {
     out: LogFile,
     err: LogFile,
+    /// The stream read ends the pump still holds, cleared per stream as
+    /// each one ends.
+    ///
+    /// Cleared rather than left standing because the reader is dropped at
+    /// the same moment, which closes the descriptor: a number the kernel is
+    /// free to hand to the next `open` must never reach a handover blob.
+    pipes: PipeFds,
 }
 
 impl LogFiles {
@@ -1150,6 +1205,26 @@ impl LogFiles {
                 // not truncate anything on the strength of an answer it never
                 // read.
                 let _ = done.send(result);
+            }
+            // The flush comes FIRST and in the same request, which is the
+            // whole point of the variant — see `LogCtl::ReportFds`. A
+            // failure is logged rather than reported: the answer has no room
+            // for one, and the descriptor is still the one to carry, since
+            // the successor inherits the same handle on the same file and is
+            // the only party left that could write to it.
+            #[cfg(unix)]
+            LogCtl::ReportFds { done } => {
+                for file in [&mut self.out, &mut self.err] {
+                    if let Err(error) = file.flush().await {
+                        tracing::error!(%error, "log flush before a handover report failed");
+                    }
+                }
+                let _ = done.send(crate::handover::CarriedFds {
+                    out_pipe: self.pipes.out,
+                    err_pipe: self.pipes.err,
+                    out_log: self.out.raw_fd(),
+                    err_log: self.err.raw_fd(),
+                });
             }
         }
     }
@@ -1343,6 +1418,7 @@ fn spawn_log_pump<O, E>(
     err_path: PathBuf,
     logs_tx: mpsc::Sender<LogLine>,
     mut ctl_rx: mpsc::Receiver<LogCtl>,
+    pipes: PipeFds,
 ) where
     O: AsyncRead + Unpin + Send + 'static,
     E: AsyncRead + Unpin + Send + 'static,
@@ -1351,6 +1427,7 @@ fn spawn_log_pump<O, E>(
         let mut files = LogFiles {
             out: LogFile::open(out_path).await,
             err: LogFile::open(err_path).await,
+            pipes,
         };
         let mut out_lines = stdout.map(|reader| BufReader::new(reader).lines());
         let mut err_lines = stderr.map(|reader| BufReader::new(reader).lines());
@@ -1364,14 +1441,30 @@ fn spawn_log_pump<O, E>(
                 result = next_line(&mut out_lines) => {
                     match deliver_line(result, false, &mut files, &logs_tx, &mut ctl_rx).await {
                         AfterLine::KeepReading => {}
-                        AfterLine::StreamEnded => out_lines = None,
+                        // Dropping the reader closes the descriptor, so the
+                        // number stops being ours in the same statement it
+                        // stops being readable.
+                        AfterLine::StreamEnded => {
+                            out_lines = None;
+                            #[cfg(unix)]
+                            {
+                                files.pipes.out = None;
+                            }
+                        }
                         AfterLine::LogsClosed => break,
                     }
                 }
                 result = next_line(&mut err_lines) => {
                     match deliver_line(result, true, &mut files, &logs_tx, &mut ctl_rx).await {
                         AfterLine::KeepReading => {}
-                        AfterLine::StreamEnded => err_lines = None,
+                        // As above: the number goes with the reader.
+                        AfterLine::StreamEnded => {
+                            err_lines = None;
+                            #[cfg(unix)]
+                            {
+                                files.pipes.err = None;
+                            }
+                        }
                         AfterLine::LogsClosed => break,
                     }
                 }
@@ -1639,6 +1732,8 @@ mod tests {
     use core::sync::atomic::{AtomicUsize, Ordering};
     use core::task::{Context, Poll};
     use std::collections::BTreeMap;
+    #[cfg(unix)]
+    use std::collections::BTreeSet;
     use std::fs;
     #[cfg(unix)]
     use std::os::unix::fs::PermissionsExt as _;
@@ -1650,6 +1745,8 @@ mod tests {
     use tokio::time::timeout;
 
     use super::*;
+    #[cfg(unix)]
+    use crate::handover::CarriedFds;
 
     // What needs a real OS child lives in `tests/real_runner.rs`; what is
     // reachable with no process at all belongs here (IR-38). The log pump is
@@ -1679,16 +1776,26 @@ mod tests {
     /// same observation.
     const STREAM_BUFFER: usize = 4096;
 
-    /// One pump over two in-memory streams and two real files — everything
+    /// One pump over two streams and two real files — everything
     /// [`spawn_log_pump`] takes, with no child process involved.
-    struct PumpHarness {
+    ///
+    /// Generic over the writing side only so the descriptor cases can swap
+    /// the in-memory pair for a real one: an in-memory pipe has no
+    /// descriptor at all, which is exactly why the pump is TOLD its stream
+    /// numbers rather than reading them off its own readers. Everything
+    /// else about the two harnesses is identical, and every case that is
+    /// about bytes uses the cheaper [`PumpHarness::start`].
+    struct PumpHarness<W = DuplexStream> {
         dir: tempfile::TempDir,
         out_path: PathBuf,
         err_path: PathBuf,
-        out_writer: DuplexStream,
-        err_writer: DuplexStream,
+        out_writer: W,
+        err_writer: W,
         logs: mpsc::Receiver<LogLine>,
         ctl: mpsc::Sender<LogCtl>,
+        /// The stream descriptor numbers this harness handed the pump, which
+        /// is what a descriptor report has to answer with.
+        pipes: PipeFds,
     }
 
     impl PumpHarness {
@@ -1707,6 +1814,7 @@ mod tests {
                 err_path.clone(),
                 logs_tx,
                 ctl_rx,
+                PipeFds::default(),
             );
             Self {
                 dir,
@@ -1716,9 +1824,68 @@ mod tests {
                 err_writer,
                 logs,
                 ctl,
+                pipes: PipeFds::default(),
+            }
+        }
+    }
+
+    /// A pump reading two REAL pipes, for the cases that are about
+    /// descriptor numbers rather than about bytes.
+    ///
+    /// `tokio::net::unix::pipe` is what a child's stdout actually is, so the
+    /// numbers this hands the pump are the same kind of thing a spawn hands
+    /// it, and the test can hold the writing ends open for as long as it
+    /// needs the reading ends to stay valid.
+    #[cfg(unix)]
+    impl PumpHarness<tokio::net::unix::pipe::Sender> {
+        fn start_over_pipes() -> Self {
+            let dir = tempfile::tempdir().unwrap();
+            let out_path = dir.path().join("out.log");
+            let err_path = dir.path().join("err.log");
+            let (out_writer, out_reader) = tokio::net::unix::pipe::pipe().unwrap();
+            let (err_writer, err_reader) = tokio::net::unix::pipe::pipe().unwrap();
+            let pipes = PipeFds {
+                out: Some(out_reader.as_raw_fd()),
+                err: Some(err_reader.as_raw_fd()),
+            };
+            let (logs_tx, logs) = mpsc::channel(CHANNEL_CAPACITY);
+            let (ctl, ctl_rx) = mpsc::channel(CHANNEL_CAPACITY);
+            spawn_log_pump(
+                Some(out_reader),
+                Some(err_reader),
+                out_path.clone(),
+                err_path.clone(),
+                logs_tx,
+                ctl_rx,
+                pipes,
+            );
+            Self {
+                dir,
+                out_path,
+                err_path,
+                out_writer,
+                err_writer,
+                logs,
+                ctl,
+                pipes,
             }
         }
 
+        /// Sends a [`LogCtl::ReportFds`] and waits for the answer.
+        async fn report_fds(&self) -> CarriedFds {
+            let (done, ack) = oneshot::channel();
+            self.ctl
+                .send(LogCtl::ReportFds { done })
+                .await
+                .expect("the pump must still be reading its control channel");
+            timeout(PUMP_DEADLINE, ack)
+                .await
+                .expect("a descriptor report must be acknowledged")
+                .expect("the pump must answer rather than drop the acknowledgement")
+        }
+    }
+
+    impl<W: AsyncWrite + Unpin> PumpHarness<W> {
         /// Writes one line into the chosen stream and waits for the pump to
         /// hand it back on `logs` — which is proof the pump read it and
         /// issued its file write, and orders the two streams against each
@@ -1806,6 +1973,76 @@ mod tests {
             "{}: expected {expected:?}, found {:?}",
             path.display(),
             fs::read_to_string(path)
+        );
+    }
+
+    /// Whether `fd` names something open in this process.
+    ///
+    /// `F_GETFD` is the cheapest question the kernel answers about a
+    /// descriptor, and it is the one `handover::fds` already asks.
+    #[cfg(unix)]
+    fn is_open(fd: RawFd) -> bool {
+        nix::fcntl::fcntl(fd, nix::fcntl::FcntlArg::F_GETFD).is_ok()
+    }
+
+    /// Fails if a descriptor report answers with anything but the four
+    /// numbers the pump is really holding.
+    ///
+    /// The numbers must be the pump's own, not a guess: an fd number is only
+    /// meaningful in the process that owns it, and the whole handover is
+    /// built on carrying exactly these. The two stream numbers are asserted
+    /// against the ones this harness handed over, which is the half a
+    /// looser `is_some()` would let a wrong-but-open descriptor pass.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn a_pump_reports_the_descriptors_it_holds() {
+        let pump = PumpHarness::start_over_pipes();
+        let fds = pump.report_fds().await;
+
+        assert_eq!(fds.out_pipe, pump.pipes.out, "stdout's read end");
+        assert_eq!(fds.err_pipe, pump.pipes.err, "stderr's read end");
+        assert!(
+            fds.out_log.is_some() && fds.err_log.is_some(),
+            "a pump that opened both log files must name both handles: {fds:?}"
+        );
+
+        let named: Vec<RawFd> = fds.all().into_iter().flatten().collect();
+        assert_eq!(named.len(), 4, "a running sheep has all four: {fds:?}");
+        for fd in &named {
+            assert!(
+                is_open(*fd),
+                "the blob would name a closed descriptor: {fd}"
+            );
+        }
+        let distinct: BTreeSet<RawFd> = named.iter().copied().collect();
+        assert_eq!(distinct.len(), 4, "four descriptors, four numbers: {fds:?}");
+    }
+
+    /// Fails if a report is answered before what the pump is holding has
+    /// reached the file.
+    ///
+    /// Written before the report, readable on disk after it, with no
+    /// settling in between — deliberately not [`assert_file_settles`], since
+    /// polling would let [`IDLE_FLUSH`] pass the case that the report itself
+    /// is supposed to have flushed. A blob whose descriptors are ready but
+    /// whose bytes are not is a log gap the successor cannot repair, because
+    /// the bytes died with the image at the exec.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn reporting_flushes_first() {
+        let mut pump = PumpHarness::start_over_pipes();
+        pump.feed(false, "before-the-blob").await;
+        pump.feed(true, "and-on-stderr").await;
+
+        let _ = pump.report_fds().await;
+
+        assert_eq!(
+            fs::read_to_string(&pump.out_path).unwrap(),
+            "before-the-blob\n"
+        );
+        assert_eq!(
+            fs::read_to_string(&pump.err_path).unwrap(),
+            "and-on-stderr\n"
         );
     }
 
@@ -1965,6 +2202,7 @@ mod tests {
         let mut files = LogFiles {
             out: LogFile::open(dir.path().join("out.log")).await,
             err: LogFile::open(dir.path().join("err.log")).await,
+            pipes: PipeFds::default(),
         };
         assert_eq!(
             files.flush_deadline(),

--- a/crates/shep-daemon/src/tokio_runner.rs
+++ b/crates/shep-daemon/src/tokio_runner.rs
@@ -37,6 +37,8 @@ use std::os::fd::{AsRawFd, OwnedFd, RawFd};
 use std::os::unix::process::ExitStatusExt as _;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
+#[cfg(unix)]
+use std::sync::Arc;
 
 #[cfg(unix)]
 use command_fds::{CommandFdExt, FdMapping};
@@ -57,6 +59,8 @@ use tokio::time::{Instant, sleep_until};
 #[cfg(unix)]
 use crate::boot::DIR_MODE;
 use crate::channel::{CHANNEL_VERSION, ChildMessage, ShepherdMessage};
+#[cfg(unix)]
+use crate::runner::{AdoptSpec, AdoptedReaper};
 use crate::runner::{
     ExitOutcome, FlushError, LogCtl, LogLine, Preflight, ProcIo, ProcessRunner, ReopenError,
     RunnerError, RunningProcess, SpawnSpec, StdinWrite, StopSignal, check_log_ancestry,
@@ -131,8 +135,12 @@ pub struct TokioProc {
     /// Captured once at spawn time — `tokio::process::Child::id` reports
     /// `None` after the child has been waited to completion, but callers
     /// (e.g. a kill ladder) may still need the pid after that point.
+    ///
+    /// Also the whole of an adopted sheep's identity: a successor inherits a
+    /// pid and no `Child` at all, which is why this was never read off the
+    /// child in the first place.
     pid: u32,
-    child: Child,
+    proc: Supervised,
     /// The job object this sheep and every process it spawns belong to —
     /// Windows' stand-in for the unix process group `process_group(0)`
     /// establishes, and what [`RunningProcess::kill_tree`] terminates.
@@ -144,19 +152,62 @@ pub struct TokioProc {
     job: crate::sys_windows::Job,
 }
 
+/// Where this proc's exit comes from: tokio, or a targeted `waitpid`.
+///
+/// The two arms are the two ways a sheep can be under this daemon's care.
+/// A spawned one has a `tokio::process::Child` and tokio does the waiting.
+/// An adopted one crossed an `execve` into a successor that has no `Child`
+/// for it and no way to make one, since only `Command::spawn` produces those,
+/// so its exit is collected by [`AdoptedReaper`]'s targeted wait instead.
+///
+/// Only the wait differs. `signal`, `signal_process` and `kill_tree` all
+/// address the pid, which is the same number either way.
+#[derive(Debug)]
+enum Supervised {
+    /// Started by this daemon, and waited by tokio.
+    Spawned(Child),
+    /// Inherited across a handover, and waited by the reaper the successor
+    /// shares between every sheep it adopted.
+    #[cfg(unix)]
+    Adopted(Arc<AdoptedReaper>),
+}
+
 impl RunningProcess for TokioProc {
     fn pid(&self) -> u32 {
         self.pid
     }
 
     async fn wait(&mut self) -> ExitOutcome {
+        let child = match &mut self.proc {
+            Supervised::Spawned(child) => child,
+            // The reaper carries the same cancel-safety contract by its own
+            // route: a status it has taken is remembered and replayed, so a
+            // dropped wait loses nothing and a second one answers the same.
+            // It reports an error where tokio cannot (nothing else in this
+            // process may reap an adopted pid, and something that did has
+            // taken the exit with it), which lands on the same degenerate
+            // outcome the failed-wait arm below returns.
+            #[cfg(unix)]
+            Supervised::Adopted(reaper) => {
+                return match reaper.wait(self.pid).await {
+                    Ok(outcome) => outcome,
+                    Err(error) => {
+                        tracing::error!(pid = self.pid, %error, "adopted process wait failed");
+                        ExitOutcome {
+                            code: None,
+                            signal: None,
+                        }
+                    }
+                };
+            }
+        };
         // tokio::process::Child::wait is documented cancel-safe (repeat
         // calls, or calls after a dropped-mid-flight future, replay the
         // cached result instead of restarting) — RunningProcess::wait's own
         // cancel-safety contract is inherited directly from it, no extra
         // latching needed on our side (contrast the scripted fake, which
         // has to hand-roll that latch itself).
-        match self.child.wait().await {
+        match child.wait().await {
             Ok(status) => ExitOutcome {
                 code: status.code(),
                 // Always `None` on Windows, and that is the truth rather
@@ -275,9 +326,9 @@ impl RunningProcess for TokioProc {
     /// [`Self::kill_tree`].
     #[cfg(windows)]
     fn signal_process(&mut self, sig: OperatorSignal) -> Result<(), RunnerError> {
+        let Supervised::Spawned(child) = &mut self.proc;
         match sig {
-            OperatorSignal::Kill => self
-                .child
+            OperatorSignal::Kill => child
                 .start_kill()
                 .map_err(|error| RunnerError::SignalFailed(error.to_string())),
             other => Err(RunnerError::SignalFailed(format!(
@@ -584,6 +635,75 @@ impl ProcessRunner for TokioRunner {
         what_exec_will_find(spec)
     }
 
+    /// Takes a sheep this image inherited rather than started.
+    ///
+    /// Nothing is spawned, opened or signalled. The carried pipe read ends
+    /// are handed to the same log pump a spawn feeds, the carried
+    /// log handles are written through rather than reopened, and the pid is
+    /// the one the sheep has been running under all along. From the sheep's
+    /// side the shepherd was never away.
+    ///
+    /// The three channels a spawn may wire are all closed here rather than
+    /// left dangling, exactly as a spawn closes the ones its own spec did
+    /// not ask for. Phase 2a's fitness gate refuses to carry any sheep with
+    /// a shepherd channel or a stdin pipe, so a carried sheep has neither,
+    /// and a caller's `is_closed()` says so at once instead of a send
+    /// buffering into a channel nobody drains.
+    #[cfg(unix)]
+    fn adopt(&self, spec: AdoptSpec) -> Result<(Self::Proc, ProcIo), RunnerError> {
+        let AdoptSpec {
+            pid,
+            out_file,
+            err_file,
+            out_pipe,
+            err_pipe,
+            out_log,
+            err_log,
+            reaper,
+        } = spec;
+
+        let (logs_tx, logs_rx) = mpsc::channel(CHANNEL_CAPACITY);
+        let (log_ctl_tx, log_ctl_rx) = mpsc::channel(CHANNEL_CAPACITY);
+        // Read off the readers before they are moved into the pump, as the
+        // spawn path does: these are the numbers the NEXT handover carries,
+        // and a successor that reported its predecessor's would be naming
+        // descriptors this process does not have.
+        let pipes = PipeFds {
+            out: out_pipe.as_ref().map(AsRawFd::as_raw_fd),
+            err: err_pipe.as_ref().map(AsRawFd::as_raw_fd),
+        };
+        spawn_log_pump(
+            out_pipe,
+            err_pipe,
+            carried_sink(out_file, out_log),
+            carried_sink(err_file, err_log),
+            logs_tx,
+            log_ctl_rx,
+            pipes,
+        );
+
+        let (from_child_tx, from_child) = mpsc::channel(CHANNEL_CAPACITY);
+        drop(from_child_tx);
+        let (to_child, to_child_rx) = mpsc::channel(CHANNEL_CAPACITY);
+        drop(to_child_rx);
+        let (to_stdin, to_stdin_rx) = mpsc::channel(CHANNEL_CAPACITY);
+        drop(to_stdin_rx);
+
+        Ok((
+            TokioProc {
+                pid,
+                proc: Supervised::Adopted(reaper),
+            },
+            ProcIo {
+                logs: logs_rx,
+                from_child,
+                to_child,
+                log_ctl: log_ctl_tx,
+                to_stdin,
+            },
+        ))
+    }
+
     fn spawn(&self, spec: &SpawnSpec) -> Result<(Self::Proc, ProcIo), RunnerError> {
         let mut command = Command::new(&spec.program);
         command.args(&spec.args);
@@ -881,8 +1001,8 @@ impl ProcessRunner for TokioRunner {
         spawn_log_pump(
             child.stdout.take(),
             child.stderr.take(),
-            spec.out_file.clone(),
-            spec.err_file.clone(),
+            LogSink::Path(spec.out_file.clone()),
+            LogSink::Path(spec.err_file.clone()),
             logs_tx,
             log_ctl_rx,
             pipes,
@@ -909,12 +1029,28 @@ impl ProcessRunner for TokioRunner {
         Ok((
             TokioProc {
                 pid,
-                child,
+                proc: Supervised::Spawned(child),
                 #[cfg(windows)]
                 job,
             },
             io,
         ))
+    }
+}
+
+/// The sink for one carried stream: its handle when the blob had one, and
+/// its path when it did not.
+///
+/// A sheep whose log open had failed before the handover carries no handle
+/// for that stream, which is a `None` rather than a refusal (see
+/// `handover::adopt`). Opening the path here is the right recovery: it is
+/// what the predecessor's pump would have done at its next reopen, and it
+/// costs the successor nothing when the open fails again.
+#[cfg(unix)]
+fn carried_sink(path: PathBuf, handle: Option<tokio::fs::File>) -> LogSink {
+    match handle {
+        Some(file) => LogSink::Carried(path, file),
+        None => LogSink::Path(path),
     }
 }
 
@@ -938,7 +1074,51 @@ struct LogFile<W = tokio::fs::File> {
     buffered_since: Option<Instant>,
 }
 
+/// Where one stream's log handle comes from when a pump starts.
+///
+/// Two arms because a successor's pump starts differently from a spawn's: it
+/// is handed a handle that is already open on the file, and opening the path
+/// again instead would lose `O_APPEND` and the guarantee that goes with it
+/// (see [`open_append`]). The path travels with the handle either way, so a
+/// later [`LogCtl::Reopen`] behaves identically for both.
+enum LogSink {
+    /// Open this path for appending, which is what every spawn does.
+    Path(PathBuf),
+    /// Write through this already-open appending handle, on this path.
+    #[cfg(unix)]
+    Carried(PathBuf, tokio::fs::File),
+}
+
 impl LogFile<tokio::fs::File> {
+    /// Builds the log file a [`LogSink`] describes.
+    async fn from_sink(sink: LogSink) -> Self {
+        match sink {
+            LogSink::Path(path) => Self::open(path).await,
+            #[cfg(unix)]
+            LogSink::Carried(path, file) => Self::from_file(path, file),
+        }
+    }
+
+    /// Takes an already-open appending handle on `path`, opening nothing.
+    ///
+    /// The successor's half of a handover. `O_APPEND` is a file status flag
+    /// on the open file description, so it crossed the `execve` with the
+    /// descriptor and is still set; reopening `path` here would produce a
+    /// handle that passes a naive write test and then writes at its own
+    /// tracked offset, which is the sparse hole [`open_append`] documents.
+    ///
+    /// Nothing else about the file changes. [`Self::reopen`] still goes back
+    /// through [`open_append`] by path, so a rotation works on a carried
+    /// handle exactly as it does on an opened one.
+    #[cfg(unix)]
+    fn from_file(path: PathBuf, file: tokio::fs::File) -> Self {
+        Self {
+            path,
+            handle: Some(BufWriter::with_capacity(LOG_BUFFER, file)),
+            buffered_since: None,
+        }
+    }
+
     /// Opens `path` for appending, keeping the path for later reopens.
     ///
     /// A failed open is not fatal here — it is already logged, and the pump
@@ -1414,8 +1594,8 @@ where
 fn spawn_log_pump<O, E>(
     stdout: Option<O>,
     stderr: Option<E>,
-    out_path: PathBuf,
-    err_path: PathBuf,
+    out_sink: LogSink,
+    err_sink: LogSink,
     logs_tx: mpsc::Sender<LogLine>,
     mut ctl_rx: mpsc::Receiver<LogCtl>,
     pipes: PipeFds,
@@ -1425,8 +1605,8 @@ fn spawn_log_pump<O, E>(
 {
     tokio::spawn(async move {
         let mut files = LogFiles {
-            out: LogFile::open(out_path).await,
-            err: LogFile::open(err_path).await,
+            out: LogFile::from_sink(out_sink).await,
+            err: LogFile::from_sink(err_sink).await,
             pipes,
         };
         let mut out_lines = stdout.map(|reader| BufReader::new(reader).lines());
@@ -1810,8 +1990,8 @@ mod tests {
             spawn_log_pump(
                 Some(out_reader),
                 Some(err_reader),
-                out_path.clone(),
-                err_path.clone(),
+                LogSink::Path(out_path.clone()),
+                LogSink::Path(err_path.clone()),
                 logs_tx,
                 ctl_rx,
                 PipeFds::default(),
@@ -1853,8 +2033,8 @@ mod tests {
             spawn_log_pump(
                 Some(out_reader),
                 Some(err_reader),
-                out_path.clone(),
-                err_path.clone(),
+                LogSink::Path(out_path.clone()),
+                LogSink::Path(err_path.clone()),
                 logs_tx,
                 ctl_rx,
                 pipes,
@@ -2701,6 +2881,43 @@ mod tests {
         assert!(
             error.message.starts_with(&format!("{}: ", path.display())),
             "the failure must name the file it belongs to: {error}"
+        );
+    }
+
+    /// Fails if a log handle carried across a handover writes anywhere but
+    /// the end of the file.
+    ///
+    /// Not merely "the handle is writable". `O_APPEND` is a file status flag
+    /// on the open file description, so it crosses an exec with the
+    /// descriptor, and a handle that lost it writes at its own tracked
+    /// offset instead: the first line already in the file is overwritten
+    /// here, and after a `copytruncate` rotation the same difference leaves
+    /// a sparse hole the size of everything rotated away. The content
+    /// assertion below is what tells the two apart, which is why it reads
+    /// both lines rather than checking the file is non-empty.
+    ///
+    /// `cfg(unix)` alongside the constructor it drives, and the whole
+    /// handover with it: Windows has no `execve`, so no image there is ever
+    /// handed a log handle it did not open.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn a_log_file_from_an_open_handle_still_appends() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("out.log");
+        fs::write(&path, "first\n").unwrap();
+
+        // Opened exactly as a predecessor's pump had it, and handed over
+        // rather than reopened by path.
+        let handle = open_append(&path).await.unwrap();
+        let mut log = LogFile::from_file(path.clone(), handle);
+
+        log.append("second").await;
+        log.flush().await.expect("the carried handle must be live");
+
+        assert_eq!(
+            fs::read_to_string(&path).unwrap(),
+            "first\nsecond\n",
+            "a carried handle must append, not write at its own offset"
         );
     }
 

--- a/crates/shep-daemon/tests/real_runner.rs
+++ b/crates/shep-daemon/tests/real_runner.rs
@@ -11,13 +11,15 @@
 use std::collections::BTreeMap;
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 use std::time::Duration;
 
 use shep_core::signals::OperatorSignal;
 use shep_daemon::channel::{ChildMessage, ShepherdMessage};
 use shep_daemon::privilege::Credentials;
 use shep_daemon::runner::{
-    ProcIo, ProcessRunner, RunningProcess, SpawnSpec, StdinWrite, StopSignal,
+    AdoptSpec, AdoptedReaper, ProcIo, ProcessRunner, RunningProcess, SpawnSpec, StdinWrite,
+    StopSignal,
 };
 use shep_daemon::tokio_runner::TokioRunner;
 
@@ -960,5 +962,183 @@ async fn a_child_that_did_not_ask_for_stdin_gets_eof_at_once() {
     let outcome = tokio::time::timeout(Duration::from_secs(10), proc.wait())
         .await
         .expect("cat did not exit on EOF within 10s");
+    assert_eq!(outcome.code, Some(0));
+}
+
+// ---------------------------------------------------------------------------
+// Adoption: the seam a successor reaches a still-running sheep through.
+//
+// Every child below is spawned by `std::process::Command`, which is what
+// makes these cases about adoption at all: tokio holds no `Child` for such a
+// process, so its exit can only be collected by the targeted `waitpid` an
+// `AdoptedReaper` runs. A `tokio::process::Command` child would prove
+// nothing, because tokio would be waiting it.
+// ---------------------------------------------------------------------------
+
+/// A child the way an adopted sheep reaches a successor: no `tokio::Child`
+/// anywhere, so nothing but the reaper will ever wait on it.
+fn adopted_child(script: &str) -> std::process::Child {
+    std::process::Command::new("/bin/sh")
+        .args(["-c", script])
+        .stdout(std::process::Stdio::piped())
+        .spawn()
+        .expect("spawn a shell")
+}
+
+/// The plainest adoption: a pid and its two log paths, no carried handles.
+///
+/// Every handle is `None` here, which is the shape a sheep whose log opens
+/// had failed arrives in. The cases that are about handles fill them in.
+fn adopt_spec(dir: &tempfile::TempDir, pid: u32, reaper: &Arc<AdoptedReaper>) -> AdoptSpec {
+    AdoptSpec {
+        pid,
+        out_file: dir.path().join("out.log"),
+        err_file: dir.path().join("err.log"),
+        out_pipe: None,
+        err_pipe: None,
+        out_log: None,
+        err_log: None,
+        reaper: Arc::clone(reaper),
+    }
+}
+
+/// fails if an adopted sheep's real exit never reaches the supervisor.
+///
+/// The whole point of the seam. Task 7 proved the reaper in isolation; this
+/// proves it is reachable through `RunningProcess`, the type the supervisor
+/// actually holds, so an adopted sheep's exit drives autorestart and the
+/// EXIT column exactly as a spawned one's does.
+#[tokio::test]
+#[expect(
+    clippy::zombie_processes,
+    reason = "the reaper collects these statuses; a Child::wait would take them first"
+)]
+async fn an_adopted_proc_reports_its_real_exit() {
+    let dir = tempfile::tempdir().unwrap();
+    let child = adopted_child("exit 3");
+    let pid = child.id();
+    let reaper = Arc::new(AdoptedReaper::new());
+
+    let (mut proc, io) = TokioRunner::new()
+        .adopt(adopt_spec(&dir, pid, &reaper))
+        .expect("the real runner must be able to adopt");
+    assert_eq!(
+        proc.pid(),
+        pid,
+        "an adopted proc keeps the pid it was given"
+    );
+
+    let outcome = tokio::time::timeout(Duration::from_secs(10), proc.wait())
+        .await
+        .expect("the adopted pid must be reaped within the budget");
+    assert_eq!((outcome.code, outcome.signal), (Some(3), None));
+    drop(io);
+}
+
+/// fails if the adopted arm disturbed the path every sheep takes today.
+///
+/// Regression, and the reason it is worth a case of its own: `wait` now
+/// chooses between two sources of an exit, and the spawned one is the choice
+/// every running flock depends on.
+#[tokio::test]
+async fn a_spawned_proc_still_reports_its_real_exit() {
+    let dir = tempfile::tempdir().unwrap();
+    let runner = TokioRunner::new();
+    let (mut proc, io) = runner
+        .spawn(&spec_for(&dir, "/bin/sh", &["-c", "exit 4"]))
+        .unwrap();
+
+    let outcome = tokio::time::timeout(Duration::from_secs(10), proc.wait())
+        .await
+        .expect("a spawned child must be waited within the budget");
+    assert_eq!((outcome.code, outcome.signal), (Some(4), None));
+    drop(io);
+}
+
+/// fails if an adopted sheep killed by a signal reports a code instead.
+///
+/// `output/rows.rs`'s `exit_cell` renders a code and a signal differently,
+/// so collapsing the two makes the EXIT column lie about how a sheep died.
+#[tokio::test]
+#[expect(
+    clippy::zombie_processes,
+    reason = "the reaper collects these statuses; a Child::wait would take them first"
+)]
+async fn an_adopted_proc_reports_a_signal_as_a_signal() {
+    let dir = tempfile::tempdir().unwrap();
+    let child = adopted_child("sleep 30");
+    let pid = child.id();
+    let reaper = Arc::new(AdoptedReaper::new());
+
+    let (mut proc, io) = TokioRunner::new()
+        .adopt(adopt_spec(&dir, pid, &reaper))
+        .expect("the real runner must be able to adopt");
+    // Per-process rather than `kill_tree`, and the difference is about the
+    // fixture rather than about adoption: a real sheep is the leader of its
+    // own group because the predecessor spawned it that way, while a child
+    // spawned here is in the test binary's group, so the group-wide rung
+    // has no group of its own to address. `signal_process` addresses the
+    // pid, which is the number an adopted proc carries and the one thing it
+    // was never going to have to relearn.
+    proc.signal_process(OperatorSignal::Kill)
+        .expect("SIGKILL the adopted sheep");
+
+    let outcome = tokio::time::timeout(Duration::from_secs(10), proc.wait())
+        .await
+        .expect("the adopted pid must be reaped within the budget");
+    assert_eq!((outcome.code, outcome.signal), (None, Some(9)));
+    drop(io);
+}
+
+/// fails if an adopted sheep's output stops reaching its log file.
+///
+/// The other half of the seam, and the one a successor's operator notices
+/// first: the carried pipe read end has to feed the same pump a spawn feeds,
+/// and the carried log handle has to be written through rather than reopened.
+/// The line already in the file is what proves the second half, because a
+/// handle that lost `O_APPEND` would write over it.
+#[tokio::test]
+#[expect(
+    clippy::zombie_processes,
+    reason = "the reaper collects these statuses; a Child::wait would take them first"
+)]
+async fn an_adopted_pump_appends_the_carried_pipes_lines_through_the_carried_handle() {
+    let dir = tempfile::tempdir().unwrap();
+    let out_file = dir.path().join("out.log");
+    fs::write(&out_file, "before-the-handover\n").unwrap();
+
+    let mut child = adopted_child("echo after-the-handover");
+    let pid = child.id();
+    let stdout = child.stdout.take().expect("piped stdout");
+    let carried_pipe = tokio::net::unix::pipe::Receiver::from_file(std::fs::File::from(
+        std::os::fd::OwnedFd::from(stdout),
+    ))
+    .expect("a child's stdout is a readable pipe");
+    let carried_log = tokio::fs::OpenOptions::new()
+        .append(true)
+        .open(&out_file)
+        .await
+        .expect("open the log the predecessor was appending to");
+
+    let reaper = Arc::new(AdoptedReaper::new());
+    let mut spec = adopt_spec(&dir, pid, &reaper);
+    spec.out_file = out_file.clone();
+    spec.out_pipe = Some(carried_pipe);
+    spec.out_log = Some(carried_log);
+
+    let (mut proc, mut io) = TokioRunner::new()
+        .adopt(spec)
+        .expect("the real runner must be able to adopt");
+
+    let line = tokio::time::timeout(Duration::from_secs(10), io.logs.recv())
+        .await
+        .expect("the carried pipe must still be pumped")
+        .expect("the pump must forward the line");
+    assert_eq!(line.line, "after-the-handover");
+    await_file_contents(&out_file, "before-the-handover\nafter-the-handover\n").await;
+
+    let outcome = tokio::time::timeout(Duration::from_secs(10), proc.wait())
+        .await
+        .expect("the adopted pid must be reaped within the budget");
     assert_eq!(outcome.code, Some(0));
 }

--- a/docs/brainstorming/specs/2026-08-29-daemon-handover-design.md
+++ b/docs/brainstorming/specs/2026-08-29-daemon-handover-design.md
@@ -73,53 +73,149 @@ cannot `wait()` on it, so a new daemon can never learn that a sheep exited
 or reap it.
 
 `execve` keeps both. This is how nginx, HAProxy and Envoy do a binary
-upgrade, and shep's case is smaller than any of them: shep never holds an
-app's listening socket, only pipes, child handles and its own control
-socket.
+upgrade.
+
+This spec originally added "and shep's case is smaller than any of them",
+on the grounds that shep never holds an app's listening socket, only pipes,
+child handles and its own control socket. **That was written before the
+surface was measured, and it is too generous.** The listening-socket point
+is true and it is the hardest part of nginx's problem, but H2's measurements
+show shep pays two costs nginx does not: a per-sheep descriptor count that
+reaches 145 for a 20-sheep flock, and a permanent second reaping mechanism,
+because tokio will not hand back a `Child` for a pid it did not spawn.
+Easier in one dimension, not smaller overall.
 
 ### H2. What crosses the exec, and what is rebuilt
 
-Three categories, and getting the boundary right is most of the work.
+**Measured 2026-08-30, and it revised this section twice.** What follows is
+read off the code with citations, not reasoned from the mechanism. Three of
+this spec's original claims were wrong in specifics and are corrected below
+rather than quietly edited, because the corrections are what make the work
+bigger than it first looked.
 
-**Descriptors that must survive.** Rust opens descriptors close-on-exec, so
-every one of these needs `FD_CLOEXEC` cleared deliberately, and every other
-descriptor must keep it. Getting this backwards either leaks descriptors
-into the new image or silently loses a sheep's output.
+#### Descriptors: the count, and the second half nobody planned for
 
-- each sheep's stdout and stderr pipe read ends
-- each sheep's log file write ends
-- the control socket listener, so no client sees a closed socket during
-  the swap
-- the pidfile lock, which is held on a descriptor and survives with it, so
-  the successor keeps proving liveness without a window where a second
-  daemon could win the lock
+Everything is `FD_CLOEXEC` by default, confirmed against pinned sources
+rather than assumed: `mio` sets it on every socket, epoll and kqueue fd, and
+std sets it on every file and pipe.
 
-**A blob describing them.** Written to `$SHEP_HOME/run/handover.json` at
-mode 0600, its path passed in an environment variable, unlinked by the
-successor once read. It carries each sheep's identity, its pid, which
-descriptor numbers belong to it, its restart counters, its epoch and its
-start time. It carries no environment values: a sheep's env may hold
-secrets, and the successor can re-read them from config rather than having
-them transit a file.
+Per sheep or dog: 2 log file handles, 2 pipe read ends, plus 1 for the
+shepherd channel if it asks for one, plus 1 for stdin if `stdin = true`,
+plus 1 more on Linux for tokio's per-child `pidfd`. Daemon-wide: the
+listener, the pidfile lock, the signal self-pipe, the reactor.
 
-**Everything else is rebuilt.** Cron schedules, watchers and debouncers all
-derive from config. The bus, every `mpsc` and every `oneshot` are rebuilt
-empty.
+**20 sheep is 85 descriptors, and 145 in the worst case.** `merge_logs` does
+NOT reduce the count, which is easy to assume and wrong: it changes the path
+stem so instances share a filename, and every instance still opens its own
+handle on that one inode.
+
+**The half this spec originally missed is that clearing the flag is not
+enough. The successor also has to learn each descriptor's NUMBER.** There is
+exactly one piece of prior art in the tree: `command-fds` clears
+`FD_CLOEXEC` deliberately for the shepherd channel, and `SHEP_CHANNEL_FD`
+names the number in the environment. That pattern generalises. Nothing else
+in the tree does it.
+
+**The worst single failure is not lost output.** Lose a sheep's stdout read
+end and the child does not lose its output, it BLOCKS on write once the
+64KiB pipe buffer fills, and hangs. Silent, and it looks like an application
+bug rather than a shep bug. One descriptor on the wrong side is worse than
+everything else on this list combined.
+
+#### Reaping: there is no way back to a `Child`
+
+**`tokio::process::Child` has no constructor from a bare pid.** It is
+produced only by `Command::spawn`. So a sheep that survives the exec cannot
+be awaited through tokio at all, and this spec's original line about reaping
+"becoming SIGCHLD plus `waitpid`" understated it: that is not a smaller
+version of the same thing, it is a second mechanism.
+
+The obvious form of it is banned, and this repo already knows why.
+`crates/shep-cli/src/commands/reap.rs:6` records that a blind
+`waitpid(-1, WNOHANG)` in the same process races tokio's own reaper and
+steals statuses it needed; `docs/decisions.md:1588` records the same as a
+decision, and CI has been bitten by it (`crates/shep-cli/tests/init.rs:325`).
+`tokio_runner.rs:172` is already written to expect the loss: the outcome
+degrades to `{code: None, signal: None}` and the real exit is gone.
+
+What makes it tractable is that tokio only ever reaps TARGETED, with
+`waitpid(pid, WNOHANG)` on pids it owns. So targeted reaping of adopted pids
+is safe precisely because tokio holds no `Child` for them. The successor
+therefore runs two reaping mechanisms side by side, permanently: hand-rolled
+targeted waits for adopted sheep, tokio's own path for anything spawned
+after. A wildcard wait stays forbidden forever.
+
+`execve` also resets every handler to `SIG_DFL`, so tokio's SIGCHLD handler
+does not survive and neither does shep's own signal installer. Both are
+re-armed by the successor, and there is a window.
+
+#### State: bigger than the roll, and two fields that cannot serialize
+
+**Two fields cannot be carried as they stand.** `ProcessEntry.started_at`
+and `limits/stats.rs`'s `Baseline.at` are `tokio::time::Instant`, which has
+no epoch and means nothing outside the runtime that read it. UPTIME and CPU%
+need a different representation, not a better serializer.
+
+**The muster roll is not a foundation for this.** It omits `id`, `instance`,
+`restarts`, `last_exit`, `credentials`, `manual` and `reload`, and it
+collapses a multi-instance app to a bare count, so an app running slots 1
+and 3 restores as 0 and 1 and every `{{instance}}` template and `name:2`
+selector then points somewhere else. Dogs are not in it at all. This spec
+originally said the roll "records what an app IS rather than which pid is
+currently serving it"; accurate, and understated.
+
+**One correctness bug the original design would have shipped.**
+`SheepSlot.manual` records that an exit was operator-requested, and
+`handle_exited` takes it to decide whether an exit is a clean stop or a
+crash. Lose it and a `shep stop` racing a handover has its app RESPAWNED
+despite an explicit stop, because the exit reads as an ordinary crash. The
+same shape applies to `pending_delete`.
+
+Also load-bearing and easy to miss: `credentials` is pinned deliberately so
+a passwd-db change cannot move a running app's identity, so the successor
+must carry the resolved value rather than re-deriving it. The three counters
+(`next_id`, `next_deadline`, `next_action_stamp`) reset to zero in every
+constructor, so a successor that does not carry them can reissue an id a
+caller is still holding.
 
 What is genuinely lost, and why each is acceptable:
 
 | lost | consequence | why it is fine |
 |---|---|---|
-| `tokio::process::Child` handles | reaping becomes SIGCHLD plus `waitpid`, on raw pids | the successor is still the parent, so the kernel still delivers |
-| in-flight RPCs | the client sees the connection drop | clients already retry a dropped connection |
+| in-flight RPCs | the client sees the connection drop | clients already retry, and the accepted socket's protocol state could not be rebuilt anyway |
 | bus subscriptions | subscribers resubscribe | `lookout` already repairs drift on a two-second poll |
 | pending action waiters | a caller awaiting a custom action gets no reply | these already carry a timeout |
+| watch debouncers | changes during the swap are missed | the debounce window lives inside a third-party thread and is not shep's to carry |
+| CPU% baselines | one blank cell for up to 15s | the sampler already renders a missing baseline as absent rather than inventing a number |
 
-The supervisor's live state is channels, `Child` handles and oneshot
-waiters. **None of it is serializable, and none of it should be.** What
-crosses is the small factual core: which pid is which sheep, which
-descriptor carries its output, what its counters were. The machinery around
-that is rebuilt from scratch on the far side.
+#### The blob
+
+Written to `$SHEP_HOME/run/handover.json` at mode 0600, its path passed in
+an environment variable, unlinked by the successor once read. It carries the
+factual core above plus the descriptor numbers. It carries no environment
+values: a sheep's env may hold secrets, and the successor can re-read them
+from config rather than having them transit a file.
+
+### H2a. Staging, and the gate that makes each stage safe to ship
+
+The surface above does not land in one step, and a half-built handover that
+silently mishandles an app is worse than no handover. **Phase 1 already
+built the seam that makes staging safe:** `Arm::for_daemon` chooses between
+a handover and a stop-and-start, and a successor can refuse to hand over
+whatever it cannot yet carry.
+
+So each stage widens what counts as carryable, and everything else falls
+back to the stop arm, which is correct rather than merely tolerable.
+
+- **2a, the spine.** Sheep with nothing but stdout, stderr and log files:
+  no channel, no stdin, no dog, no in-flight reload. Descriptor survival and
+  number transport, the factual core, targeted reaping, rehydrate. Any flock
+  containing anything else takes the stop arm.
+- **2b, the surface.** Shepherd channel, stdin, dogs, multi-instance, and
+  re-arming watch, cron and memory limits.
+- **2c, the hard cases.** A handover mid-reload, `manual` and
+  `pending_delete`, the counters, the reload deadline watchdog, and rollback
+  when a rehydrate fails.
 
 ### H3. The trigger is a signal, never the socket
 

--- a/docs/brainstorming/specs/2026-08-29-daemon-handover-design.md
+++ b/docs/brainstorming/specs/2026-08-29-daemon-handover-design.md
@@ -192,9 +192,34 @@ What is genuinely lost, and why each is acceptable:
 
 Written to `$SHEP_HOME/run/handover.json` at mode 0600, its path passed in
 an environment variable, unlinked by the successor once read. It carries the
-factual core above plus the descriptor numbers. It carries no environment
-values: a sheep's env may hold secrets, and the successor can re-read them
-from config rather than having them transit a file.
+factual core above plus the descriptor numbers, **and each sheep's whole
+resolved spec, environment included.**
+
+This spec originally said the opposite, that the blob carries no environment
+values because a sheep's env may hold secrets. That was reasoning from a
+principle without checking what shep already does, which is the same mistake
+as the crash-loop claim two sections up.
+
+**The muster roll already persists every sheep's environment in cleartext,
+permanently.** `SavedApp.app` is a whole `AppConfig` and `AppConfig.env` is a
+plain `BTreeMap<String, String>` with no skip attribute, written to
+`flock.json` at `0600`. The type's own doc even notes that `Debug` redacts
+env, so the sensitivity was understood and the value persisted anyway. A
+handover blob carrying the same values, at the same mode, on a file the
+successor unlinks the moment it has read it, is strictly less exposure than
+the file already sitting there for the life of the flock.
+
+Refusing to carry it bought nothing, and cost a great deal. Without a spec
+the successor has to rebuild one from the roll and bind carried sheep to
+roll apps by name and instance, except the roll records a running COUNT per
+app rather than which slots were up, and `muster` starts what it restores.
+That is a second source of truth that can disagree with the blob, plus a
+restore-without-spawning path that does not exist, to protect a value that
+is already on disk.
+
+What still protects it is what always did: mode `0600` set at creation
+rather than by a later `chmod`, inside a `0700` directory, unlinked by the
+successor as soon as it is read.
 
 ### H2a. Staging, and the gate that makes each stage safe to ship
 

--- a/docs/brainstorming/specs/2026-08-29-daemon-handover-design.md
+++ b/docs/brainstorming/specs/2026-08-29-daemon-handover-design.md
@@ -251,6 +251,35 @@ version, which is a stronger check than a reply would have been: it proves
 the successor is serving, not merely that the predecessor received
 something.
 
+### H3a. The trigger is a signal; the DECISION is a question over the socket
+
+Found while implementing 2a, and it is a hole in H3 rather than a detail
+under it.
+
+A signal carries no reply. So a daemon that receives SIGHUP, decides it
+cannot carry its flock, and falls back to its own graceful stop leaves the
+CLI polling for a successor that nobody started. The flock goes down the
+kill ladder and stays down. That is worse than either arm.
+
+**So the CLI asks before it signals.** It queries fitness over the control
+socket, and only then chooses: a `Carryable` answer sends SIGHUP, a
+`Refused` answer runs the stop arm and prints the reason.
+
+This does not weaken H3, which says a socket REQUEST cannot be the trigger.
+The trigger is still the signal. What moves to the socket is the decision,
+and it can only ever be needed where the socket already works:
+
+- to pick the handover arm at all, the CLI must know the daemon's version,
+  which requires a successful handshake
+- a handshake that succeeds means the socket is good, so a fitness query
+  works too
+- a handshake that fails means the stop arm regardless, and fitness never
+  comes up
+
+The refusal also has to reach the operator rather than the daemon log. They
+ran `shep daemon reload`; the sentence explaining why their flock restarted
+belongs in front of them.
+
 ### H4. `shep daemon reload` is the one verb
 
 It reports what happened to each sheep rather than announcing that the

--- a/docs/writing-plans/plans/2026-08-30-handover-phase2a.md
+++ b/docs/writing-plans/plans/2026-08-30-handover-phase2a.md
@@ -415,7 +415,7 @@ Rebuild each one from its raw number:
 
 **The pidfile lock needs no rebuilding and must not be re-acquired.** `flock` is a property of the open file description, so it survived the exec with its descriptor. Re-acquiring would mean releasing first, opening a window for a second daemon to win it.
 
-- [ ] **Step 1: Write the failing tests**
+- [x] **Step 1: Write the failing tests**
 
 ```rust
 #[test]
@@ -436,13 +436,47 @@ fn a_blob_naming_a_descriptor_that_is_not_open_fails_loudly() {
 }
 ```
 
-- [ ] **Step 2: Run to verify they fail**
+- [x] **Step 2: Run to verify they fail**
 
-- [ ] **Step 3: Implement**
+Actual: FAIL, unresolved `adopt` and `successor_handover_at` (E0432/E0425 x5).
 
-- [ ] **Step 4: Run to verify they pass**
+- [x] **Step 3: Implement**
 
-- [ ] **Step 5: Task gate, then commit**
+Nothing here opens anything: every object is wrapped around an inherited
+number, which is what preserves `O_APPEND` on the log handles and the `flock`
+on the pidfile without a single reopen.
+
+The one unsafe stays in `sys.rs`, as a second safe entry point
+`adopt_handover_fd` next to the existing `adopt_fd`. `adopt_fd` is an
+`unsafe fn` whose precondition is an ordering claim about the call site, and
+calling it from `handover::adopt` would put an `unsafe` block outside
+`sys.rs` (IR-22/23). The handover situation discharges that precondition
+structurally rather than by ordering: an inherited descriptor is open before
+the successor's first instruction, so the kernel can never hand its number to
+anything this process opens later. That argument is written where the unsafe
+lives.
+
+The pidfile is adopted LAST, so any refusal before it leaves that descriptor
+open and unowned and its lock still held. A successor that cannot rehydrate
+must not release this home to a second daemon on its way out.
+
+`successor_handover` in `boot.rs` reads `SHEP_HANDOVER`, and a blob that is
+missing or of an unknown version is logged at `error` and treated as a fresh
+boot rather than as a panic or a silent fall-through. The predecessor is gone
+by then, so there is no stop arm to take; the case this actually happens in
+is a stale inherited variable with no live flock behind it, and a genuinely
+lost blob is self-limiting because the inherited pidfile lock stops the fresh
+boot at `AlreadyRunning` before it restores anything.
+
+- [x] **Step 4: Run to verify they pass**
+
+Actual: 587 passed, 18 filtered (up from 577: the plan's three, plus three
+over the pidfile ordering, an adopted pipe really reading, and a file offered
+where a pipe was named). The `O_APPEND` test was confirmed non-vacuous by
+handing it a non-appending handle, at which point the write at offset 0
+overwrites the file and it fails.
+
+- [x] **Step 5: Task gate, then commit**
 
 ---
 

--- a/docs/writing-plans/plans/2026-08-30-handover-phase2a.md
+++ b/docs/writing-plans/plans/2026-08-30-handover-phase2a.md
@@ -887,7 +887,7 @@ The pump reads through a `BufReader`, so bytes consumed but not yet a complete l
 
 Four `#[expect(dead_code)]` attributes fire as unfulfilled once their items are called. `handover/mod.rs`'s module-level one gets deleted outright rather than narrowed, and its reason text is already stale.
 
-- [ ] **Step 1: Write the failing tests**
+- [x] **Step 1: Write the failing tests**
 
 ```rust
 #[tokio::test]
@@ -920,13 +920,13 @@ async fn a_reload_against_an_older_daemon_never_sends_the_query() {
 async fn the_control_socket_accepts_throughout() { ... }
 ```
 
-- [ ] **Step 2: Run to verify they fail**
+- [x] **Step 2: Run to verify they fail**
 
-- [ ] **Step 3: Implement**
+- [x] **Step 3: Implement**
 
-- [ ] **Step 4: Run to verify they pass**
+- [x] **Step 4: Run to verify they pass**
 
-- [ ] **Step 5: Full phase gate, then commit**
+- [x] **Step 5: Full phase gate, then commit**
 
 ## Phase gate
 

--- a/docs/writing-plans/plans/2026-08-30-handover-phase2a.md
+++ b/docs/writing-plans/plans/2026-08-30-handover-phase2a.md
@@ -28,7 +28,7 @@ Those are 2b's and 2c's. The fallback is correct behaviour, not a stub.
 - MSRV 1.88, edition 2024. **No new crate dependencies in any task.**
 - The whole phase is `#[cfg(unix)]`. Windows has no `execve`; `Arm::for_daemon` already returns the stop arm there and must keep doing so.
 - Unsafe is permitted ONLY in `crates/shep-daemon/src/sys.rs`, with a per-block `// SAFETY:` comment (IR-22/23). `fcntl`, `execv` and `waitpid` go through `nix`, which is safe-wrapped; if any raw call is unavoidable it lives in `sys.rs` and nowhere else.
-- Every new public item needs a doc comment, a `# Errors` section if it returns `Result`, and a deliberate `Debug` decision. **The handover blob carries no environment values and no secrets**; if a type could ever hold one, redact it with an exact-string test (IR-41).
+- Every new public item needs a doc comment, a `# Errors` section if it returns `Result`, and a deliberate `Debug` decision. **The handover blob does carry each sheep's resolved `AppConfig`, environment included** (see `Handover`'s own doc for why refusing to carry it bought nothing). What protects it is mode `0600` set at creation inside a `0700` directory, an unlink by the successor the moment it has read it, and `AppConfig`'s `Debug` printing `env` as a count rather than as pairs, pinned by an exact-string test (IR-41).
 - `core::error::Error`, never `std::error::Error`.
 - **Invoke the `shep-idiomatic-rust` skill before writing any Rust.** Cite `IR-<n>` in review.
 - **One cargo shape per task.** Daemon-side work uses `cargo test -p shep-daemon --lib --all-features -- --skip ::slow::`. Anything crossing into shep-cli uses `cargo test --workspace --all-features`. Never alternate within a task.

--- a/docs/writing-plans/plans/2026-08-30-handover-phase2a.md
+++ b/docs/writing-plans/plans/2026-08-30-handover-phase2a.md
@@ -778,11 +778,73 @@ fn the_adopted_pidfile_arm_does_not_release_the_lock() {
 
 #### Task 8c: install the adopted flock
 
-Insert slots carrying the blob's ids, epochs, statuses and `last_exit`, without spawning. `spawn_fresh` is the only path that inserts a live slot today.
+**Files:**
+- Modify: `crates/shep-daemon/src/supervisor.rs` (a sibling to `spawn_fresh`)
+- Test: same file
 
-**This is much smaller than it was, because the blob now carries each sheep's `AppConfig`.** The earlier version had to rebuild every spec from the muster roll and bind carried sheep to roll apps by name and instance, against a roll that records a running count rather than which slots were up, with `muster` starting whatever it restored. All of that is gone: the blob is self-sufficient, there is no second source of truth, and no restore-without-spawning path is needed.
+**Interfaces:**
+- Consumes: `Handover` and `CarriedSheep` (Task 3), `ProcessRunner::adopt` and `AdoptSpec` (8b).
 
-Re-normalize each carried `AppConfig` to recover its `ResolvedApp`, exactly as `snapshot.rs:333` already does on a muster.
+`spawn_fresh` is the only path that inserts a `SheepSlot` with a live `ctl`, and it spawns. A successor needs one that installs a slot around a process that is already running.
+
+**Much smaller than it was, because the blob carries each sheep's `AppConfig`.** The earlier design rebuilt every spec from the muster roll and bound carried sheep to roll apps by name and instance, against a roll that records a running count rather than which slots were up, with `muster` starting whatever it restored. All gone. Re-normalize each carried `AppConfig` to recover its `ResolvedApp`, exactly as `snapshot.rs:333` already does on a muster.
+
+**Restore the counters before installing any slot.** `next_id`, `next_deadline` and `next_action_stamp` reset to zero in every constructor, so a successor that installs sheep first and restores counters second can hand a fresh sheep an id a caller is still holding.
+
+- [ ] **Step 1: Write the failing tests**
+
+```rust
+#[tokio::test]
+async fn an_adopted_flock_keeps_its_pids_and_ids() {
+    // The blob's whole purpose. A sheep whose pid moved was respawned, and
+    // this phase exists to not do that.
+    let sup = supervisor_from_blob(blob_with_two_sheep()).await;
+    let info = sup.list().await.unwrap();
+    assert_eq!(pids_of(&info), vec![4242, 4243]);
+    assert_eq!(ids_of(&info), vec![7, 8]);
+}
+
+#[tokio::test]
+async fn an_adopted_sheep_keeps_its_counters_and_last_exit() {
+    // Losing these is silent. RESTARTS resetting to zero hands a
+    // crash-looping app amnesty it did not earn, and a lost last_exit
+    // answers "why did it stop" with nothing.
+    let sup = supervisor_from_blob(blob_with_history()).await;
+    let info = sup.list().await.unwrap();
+    assert_eq!(info[0].restarts, 4);
+    assert_eq!(info[0].last_exit, Some(ExitInfo { code: Some(2), signal: None }));
+}
+
+#[tokio::test]
+async fn an_adopted_sheeps_exit_flows_through_the_ordinary_path() {
+    // The one that proves the reaper is actually wired. An adopted sheep
+    // that exits must reach handle_exited and be judged by decide_on_exit
+    // like any other, not sit there online forever.
+    let sup = supervisor_from_blob(blob_with_one_real_child()).await;
+    kill_the_child();
+    let info = await_status(&sup, ProcStatus::Stopped).await;
+    assert!(info[0].last_exit.is_some(), "the exit must be recorded, not lost");
+}
+
+#[tokio::test]
+async fn the_successor_does_not_reissue_a_live_id() {
+    // Counters restored BEFORE any slot is installed. A successor that
+    // starts next_id at zero hands a new sheep an id a caller still holds.
+    let sup = supervisor_from_blob(blob_whose_next_id_is(9)).await;
+    let fresh = sup.start(&plain_app()).await.unwrap();
+    assert!(fresh.id >= 9, "reissued a live id: {}", fresh.id);
+}
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+- [ ] **Step 3: Implement**
+
+A carried sheep with no descriptors (registered but stopped, `CarriedFds::none()`) installs as a slot with no pump and no `ctl`, which is the state it was already in. Do not try to adopt a process that is not running.
+
+- [ ] **Step 4: Run to verify they pass**
+
+- [ ] **Step 5: Task gate, then commit**
 
 #### Task 8d: the arms, and proving a sheep never noticed
 

--- a/docs/writing-plans/plans/2026-08-30-handover-phase2a.md
+++ b/docs/writing-plans/plans/2026-08-30-handover-phase2a.md
@@ -848,13 +848,85 @@ A carried sheep with no descriptors (registered but stopped, `CarriedFds::none()
 
 #### Task 8d: the arms, and proving a sheep never noticed
 
-The fitness query over the socket (spec H3a), the CLI's arm choice, the SIGHUP handler, and the end-to-end tests.
+**Files:**
+- Modify: `crates/shep-core/src/protocol/request.rs` (a fitness query)
+- Modify: `crates/shep-daemon/src/rpc.rs`, `boot.rs` (answer it; the SIGHUP arm)
+- Modify: `crates/shep-cli/src/commands/daemon.rs` (`Arm::Handover`)
+- Test: an end-to-end integration test
 
-**The two assertions that define success live here**: a sheep's pid is unchanged across a reload, and its log gains no gap.
+**Cross-crate, so the cargo shape is `cargo test --workspace --all-features`.**
 
-Also here: delete the four `#[expect(dead_code)]` attributes, which fire as unfulfilled once their items are called. The module-level one in `handover/mod.rs` gets deleted outright rather than narrowed, and its reason string is already stale (it still names task 5).
+**The two assertions that define success, and the whole phase:**
 
-**One hazard, found while reviewing Task 8's refusal.** The pump reads through a `BufReader`, so bytes consumed but not yet a complete line die with the image, and the successor's fresh reader starts mid-line and emits the remainder as its own line. 8a's flush covers `LogFile`'s buffer, not that one. Under a chatty sheep the no-gap assertion sees a torn line rather than a missing one, so write it to catch both.
+- a sheep's pid is UNCHANGED across a `shep daemon reload`
+- its log gains no gap
+
+A version passing neither is the stop arm phase 1 already shipped.
+
+##### The fitness query, and why `PROTOCOL_VERSION` does not move
+
+Spec H3a: a signal carries no reply, so a daemon that takes SIGHUP, refuses, and falls back to its own graceful stop leaves the CLI polling for a successor nobody started. The CLI therefore asks first, over the socket, and only then chooses an arm.
+
+Adding a `Request` variant would normally bump `PROTOCOL_VERSION`, the way `SelectorSpec::Instance` did, because an older daemon cannot deserialize a variant it has never seen. **It does not need to here, and the reason is an invariant worth a test rather than a comment.**
+
+`daemon reload` is an exempt verb, so it connects to a mismatched daemon deliberately. It learns the daemon's version from the handshake, and a daemon predating the handover takes the stop arm **without the query ever being sent**. So no daemon that cannot parse the variant is ever asked. Pin that with a test: a reload against an older daemon must reach the stop arm and must not send a fitness query.
+
+If that invariant cannot be held, bump the version rather than shipping a query an old daemon meets as a parse error.
+
+##### What SIGHUP does
+
+Phase 1 made it a graceful stop so a stray signal could never drop a flock uncleanly. It now hands over, because the CLI has already asked and only signals a flock it was told is carryable. Keep the graceful stop as the arm taken when a handover cannot proceed.
+
+##### The torn-line hazard
+
+The pump reads through a `BufReader`, so bytes consumed but not yet a complete line die with the image, and the successor's fresh reader starts mid-line and emits the remainder as its own line. 8a's flush covers `LogFile`'s buffer, not that one.
+
+**Write the no-gap assertion to catch a torn line, not only a missing one.** A sheep emitting a numbered sequence across the reload is the cheap version: assert every number appears exactly once, in order, each on its own line.
+
+##### Cleanup that comes due here
+
+Four `#[expect(dead_code)]` attributes fire as unfulfilled once their items are called. `handover/mod.rs`'s module-level one gets deleted outright rather than narrowed, and its reason text is already stale.
+
+- [ ] **Step 1: Write the failing tests**
+
+```rust
+#[tokio::test]
+async fn a_sheep_keeps_its_pid_and_its_log_across_a_handover() {
+    let before = flock_pids().await;
+    let seen_before = read_sequence();
+    reload().await;
+    assert_eq!(flock_pids().await, before, "a moved pid means it was respawned");
+    let seen = read_sequence();
+    assert!(seen.len() > seen_before.len(), "the sheep stopped logging");
+    assert_no_duplicates_or_tears(&seen);
+}
+
+#[tokio::test]
+async fn a_flock_with_a_channel_sheep_takes_the_stop_arm() {
+    // The gate doing its job. Not a handover, and not a failure either.
+    let out = reload_with_channel_sheep().await;
+    assert!(out.contains("shepherd channel"), "{out}");
+    assert_ne!(flock_pids().await, before, "the stop arm does restart");
+}
+
+#[tokio::test]
+async fn a_reload_against_an_older_daemon_never_sends_the_query() {
+    // What keeps PROTOCOL_VERSION where it is.
+    let sent = record_requests(|| reload_against_version("0.1.8")).await;
+    assert!(!sent.iter().any(is_fitness_query), "{sent:?}");
+}
+
+#[tokio::test]
+async fn the_control_socket_accepts_throughout() { ... }
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+- [ ] **Step 3: Implement**
+
+- [ ] **Step 4: Run to verify they pass**
+
+- [ ] **Step 5: Full phase gate, then commit**
 
 ## Phase gate
 

--- a/docs/writing-plans/plans/2026-08-30-handover-phase2a.md
+++ b/docs/writing-plans/plans/2026-08-30-handover-phase2a.md
@@ -573,60 +573,43 @@ child here and is expected with a reason rather than silenced: adding the
 
 ---
 
-### Task 8: wire it together, and prove a sheep never noticed
+### Task 8: SPLIT. This was mis-scoped and is now 8a through 8d
 
-**Files:**
-- Modify: `crates/shep-daemon/src/boot.rs` (the SIGHUP arm), `crates/shep-cli/src/commands/daemon.rs` (`Arm::Handover`)
-- Test: an end-to-end integration test
+**Task 8 as originally written was wrong, and the implementer refused it rather than shipping half a handover.** It read as a wiring task. Five load-bearing mechanisms it depends on do not exist, and building them is roughly 800 to 1500 lines across `supervisor.rs` (16,578 lines), `tokio_runner.rs`, `boot.rs`, `runner.rs`, `transport.rs` and `daemon.rs`, one of which changes a published trait.
 
-`Arm::Handover` is currently unreachable and carries `#[expect(dead_code)]`. Constructing it without removing that attribute is a compile error, which is deliberate; remove it here.
+Verified against the tree: `ProcessRunner` has only `spawn` and `preflight` (`crates/shep-daemon/src/runner.rs:742`), and `LogCtl` can `Reopen` and `Flush` but cannot report a descriptor (`runner.rs:102`).
 
-**Task 6 found two seams this task needs that the plan did not anticipate. Both make Task 8 a cross-crate change, so its cargo shape is `cargo test --workspace --all-features`, not the daemon-only inner loop.**
+What is genuinely missing:
 
-1. **`spawn_log_pump` cannot take an adopted log handle.** It takes `out_path: PathBuf` / `err_path: PathBuf` (`crates/shep-daemon/src/tokio_runner.rs:1339`) and calls `LogFile::open` itself, so there is no seam for a file that is already open. The fix is small because `LogFile` is already generic over its sink with only `path` and `handle`: it needs a constructor taking a `tokio::fs::File` plus the path for later reopens. Do NOT write a parallel pump. `LogFile::reopen` goes back through `open_append` by path, so rotation keeps working on an adopted handle unchanged.
+1. **No way to learn a sheep's descriptor numbers.** The four fds `CarriedFds` names are owned by the log pump task, inside `Lines<BufReader<ChildStdout>>` and `LogFile`. Needs a new `LogCtl` variant that flushes and reports raw fds, plus a supervisor command that fans it out and waits.
+2. **No way to build the blob.** `next_id`, `next_deadline` and `next_action_stamp` are private `Actor` fields with no accessor, and `epoch`, `manual` and `pending_delete` are on the private `SheepSlot`. Both the `Candidate` list and the blob have to be assembled inside the actor.
+3. **An adopted sheep has no `RunningProcess`.** `TokioProc` holds a `tokio::process::Child`, which only `Command::spawn` produces. Task 7's `AdoptedReaper` is built and tested with no route into the supervisor. Needs a defaulted trait method (IR-20), a `TokioProc` that is either spawned or adopted, and an adopted `ProcIo`.
+4. **No way to install an adopted flock.** `spawn_fresh` is the only path that inserts a `SheepSlot` with a live `ctl`. A successor needs one that inserts slots carrying the blob's ids, epochs, statuses and `last_exit`.
+5. **The blob carries no spec, deliberately**, since env is a secret surface and an exact-string test pins it. So the successor recovers each spec from the muster roll and binds carried sheep to roll apps by name and instance. The roll stores `AppConfig` per app with a running COUNT, not per-instance ids, and `muster` starts what it restores. A restore-without-spawning-then-bind path is a design decision still to make.
 
-2. **`shep_core::transport::Listener` cannot be built from an adopted listener.** Its inner `tokio::net::UnixListener` is private and the type offers only `bind(&Path)`. Adoption yields a bare `tokio::net::UnixListener`, so wiring it into the accept loop needs a constructor added in shep-core.
+The three seams Task 6 predicted are all confirmed small. They are also not the expensive part.
 
-Also from Task 6: `PidfileLock` cannot hold the adopted descriptor, because its unix field is `nix::fcntl::Flock<File>` and `nix` has no constructor for an already-locked file that does not lock it again. `Adopted` carries a plain `std::fs::File`, so this task needs a `PidfileLock` variant or enum arm that holds it. **It must not re-lock**: the descriptor crossed the exec with its `flock` intact, and re-acquiring means releasing first, which opens a window for a second daemon.
+**The fallback design changed too. See the spec's new H3a.** A daemon that refuses internally and stops gracefully leaves the CLI polling for a successor nobody started, so fitness is now asked over the socket before the CLI signals.
 
-Three `#[expect(dead_code)]` attributes come due here and will fire as unfulfilled once their items are called: the module-wide one in `handover/mod.rs` (delete it outright rather than narrowing, per Task 5), and the ones on `successor_handover` and `Successor` in `boot.rs`.
+#### Task 8a: report descriptors and build the blob
 
-SIGHUP currently runs a graceful stop (phase 1, Task 3). It now runs the fitness check and either hands over or falls through to that same graceful stop.
+`LogCtl` gains a variant that flushes and reports the four raw fds. A supervisor command fans it out over the flock, waits, and assembles both the `Candidate` list and the `Handover` blob from inside the actor, where the private counters and `SheepSlot` fields are reachable. Ends with a test that a blob built from a live flock names four open descriptors per sheep.
 
-- [ ] **Step 1: Write the failing tests**
+#### Task 8b: the adopt seam on the runner
 
-```rust
-#[tokio::test]
-async fn a_sheep_keeps_its_pid_and_its_log_across_a_handover() {
-    // The two assertions that separate a hot restart from a fast one.
-    // A version that passes neither is the stop arm phase 1 already shipped.
-    let before = flock_pids().await;
-    let log_len_before = read_log_len();
-    reload().await;
-    assert_eq!(flock_pids().await, before, "pids must not move");
-    assert!(read_log_len() >= log_len_before, "the log must not restart");
-    assert_no_gap_in_sequence(read_log());
-}
+`ProcessRunner` gains a defaulted `adopt` (IR-20, so out-of-tree implementors do not break). `TokioProc` becomes spawned-or-adopted, backed by Task 7's `AdoptedReaper` on the adopted arm. `ProcIo` is built from adopted handles. The three small seams land here: `LogFile::from_file`, `Listener`'s constructor in shep-core, and the `PidfileLock` arm that holds an already-locked descriptor without re-locking.
 
-#[tokio::test]
-async fn a_flock_with_a_channel_sheep_takes_the_stop_arm() {
-    // The gate doing its job. Not a handover, and not a failure either.
-    ...
-}
+#### Task 8c: the successor boot path
 
-#[tokio::test]
-async fn the_control_socket_accepts_throughout() { ... }
-```
+Bind carried sheep to muster-roll apps by name and instance, and install adopted slots in the actor without spawning. This is where 5's design decision gets made and written down.
 
-- [ ] **Step 2: Run to verify they fail**
+#### Task 8d: the arms, and proving a sheep never noticed
 
-- [ ] **Step 3: Implement**
+The fitness query over the socket, the CLI's arm choice, the SIGHUP handler, and the end-to-end tests. **The two assertions that define success live here**: a sheep's pid is unchanged across a reload, and its log gains no gap.
 
-- [ ] **Step 4: Run to verify they pass**
+Also here: delete the four `#[expect(dead_code)]` attributes, which fire as unfulfilled once their items are called.
 
-- [ ] **Step 5: Full phase gate, then commit**
-
----
+**One hazard for 8d, found while reviewing 8's refusal.** The pump reads through a `BufReader`, so bytes consumed but not yet a complete line die with the image, and the successor's fresh reader starts mid-line and emits the remainder as its own line. A pre-exec flush handles `LogFile`'s buffer but not that one. Under a chatty sheep the no-gap assertion would catch it as a torn line rather than a missing one.
 
 ## Phase gate
 

--- a/docs/writing-plans/plans/2026-08-30-handover-phase2a.md
+++ b/docs/writing-plans/plans/2026-08-30-handover-phase2a.md
@@ -141,12 +141,12 @@ pub enum RefusedReason {
 
 Everything the daemon holds is close-on-exec by default, verified against pinned `mio`, `tokio`, `std` and `command-fds` sources. `command-fds` is the one place in the tree that already clears the flag deliberately, for the shepherd channel's fd 3; read `command-fds-0.3.3/src/lib.rs` for the shape before writing this.
 
-- [ ] **Step 1: Write the failing tests**
+- [x] **Step 1: Write the failing tests**
 
 ```rust
 #[test]
 fn a_fresh_pipe_is_close_on_exec_and_can_be_kept() {
-    let (r, _w) = nix::unistd::pipe().unwrap();
+    let (r, _w) = std::io::pipe().unwrap();
     // Establishes the default this whole phase depends on. If this ever
     // fails, std changed and the fd inventory needs re-auditing.
     assert!(!is_kept(r.as_fd()).unwrap(), "std pipes are CLOEXEC by default");
@@ -156,22 +156,34 @@ fn a_fresh_pipe_is_close_on_exec_and_can_be_kept() {
 
 #[test]
 fn keeping_is_idempotent() {
-    let (r, _w) = nix::unistd::pipe().unwrap();
+    let (r, _w) = std::io::pipe().unwrap();
     keep_across_exec(r.as_fd()).unwrap();
     keep_across_exec(r.as_fd()).unwrap();
     assert!(is_kept(r.as_fd()).unwrap());
 }
 ```
 
-- [ ] **Step 2: Run to verify they fail**
+`nix::unistd::pipe()`, as originally written above, wraps the raw `pipe(2)`
+syscall and is not close-on-exec by default — only `std::io::pipe()` (stable
+since Rust 1.87, this workspace runs 1.88) matches the "std pipes are
+CLOEXEC by default" assumption the comment states and the phase's descriptor
+inventory depends on. Swapped in both tests before running them.
 
-- [ ] **Step 3: Implement**
+- [x] **Step 2: Run to verify they fail**
+
+Run: `cargo test -p shep-daemon --lib --all-features -- --skip ::slow:: fds::tests`
+Actual: FAIL, unresolved `is_kept`/`keep_across_exec` (E0425 ×6)
+
+- [x] **Step 3: Implement**
 
 Read the existing flags with `F_GETFD`, clear only the `FD_CLOEXEC` bit, write back with `F_SETFD`. **Do not write a bare `0`**: that would clobber any other flag the descriptor carries, and it makes the call non-idempotent in a way the second test above is written to catch.
 
-- [ ] **Step 4: Run to verify they pass**
+- [x] **Step 4: Run to verify they pass**
 
-- [ ] **Step 5: Task gate, then commit**
+Run: `cargo test -p shep-daemon --lib --all-features -- --skip ::slow:: fds::tests`
+Actual: 2 passed
+
+- [x] **Step 5: Task gate, then commit**
 
 ---
 

--- a/docs/writing-plans/plans/2026-08-30-handover-phase2a.md
+++ b/docs/writing-plans/plans/2026-08-30-handover-phase2a.md
@@ -627,7 +627,7 @@ The four descriptors `CarriedFds` names are owned by the log pump task, inside `
 
 **The counters and the per-slot fields are only reachable inside the actor.** `next_id`, `next_deadline` and `next_action_stamp` are private `Actor` fields; `epoch`, `manual` and `pending_delete` are on the private `SheepSlot`. So the command assembles both the `Candidate` list and the `Handover` from in there, rather than exposing accessors.
 
-- [ ] **Step 1: Write the failing tests**
+- [x] **Step 1: Write the failing tests**
 
 ```rust
 #[tokio::test]
@@ -676,19 +676,19 @@ async fn the_snapshot_carries_the_actors_counters_and_slot_state() {
 }
 ```
 
-- [ ] **Step 2: Run to verify they fail**
+- [x] **Step 2: Run to verify they fail**
 
 Run: `cargo test -p shep-daemon --lib --all-features -- --skip ::slow:: handover_snapshot`
 
-- [ ] **Step 3: Implement**
+- [x] **Step 3: Implement**
 
 Add the `LogCtl` variant. Follow `Reopen`'s existing shape for the acknowledgement channel rather than inventing a second one, and give its doc comment the flush-and-report reasoning above.
 
 A sheep with no live pump (registered but stopped) reports `None` for all four. That is the `Option<RawFd>` case `CarriedFds` already models, and Task 1's gate does not refuse it: a stopped sheep has no descriptors to carry and nothing to lose.
 
-- [ ] **Step 4: Run to verify they pass**
+- [x] **Step 4: Run to verify they pass**
 
-- [ ] **Step 5: Task gate, then commit**
+- [x] **Step 5: Task gate, then commit**
 
 #### Task 8b: the adopt seam on the runner
 

--- a/docs/writing-plans/plans/2026-08-30-handover-phase2a.md
+++ b/docs/writing-plans/plans/2026-08-30-handover-phase2a.md
@@ -713,7 +713,7 @@ The three seams Task 6 measured, all confirmed small:
 - a `#[cfg(unix)]` constructor on `shep_core::transport::Listener`, whose inner `tokio::net::UnixListener` is private and which offers only `bind(&Path)`.
 - a `PidfileLock` arm holding an already-locked `std::fs::File`. **It must not re-lock.** The descriptor crossed the exec with its `flock` intact, and re-acquiring means releasing first, which opens a window for a second daemon to win the home.
 
-- [ ] **Step 1: Write the failing tests**
+- [x] **Step 1: Write the failing tests**
 
 ```rust
 #[tokio::test]
@@ -768,13 +768,13 @@ fn the_adopted_pidfile_arm_does_not_release_the_lock() {
 }
 ```
 
-- [ ] **Step 2: Run to verify they fail**
+- [x] **Step 2: Run to verify they fail**
 
-- [ ] **Step 3: Implement**
+- [x] **Step 3: Implement**
 
-- [ ] **Step 4: Run to verify they pass**
+- [x] **Step 4: Run to verify they pass**
 
-- [ ] **Step 5: Task gate, then commit**
+- [x] **Step 5: Task gate, then commit**
 
 #### Task 8c: install the adopted flock
 

--- a/docs/writing-plans/plans/2026-08-30-handover-phase2a.md
+++ b/docs/writing-plans/plans/2026-08-30-handover-phase2a.md
@@ -497,7 +497,7 @@ Targeted waits are safe precisely because tokio holds no `Child` for an adopted 
 
 Read `crates/shep-cli/src/commands/reap.rs` first. It is prior art for the vocabulary and the `nix` usage, but NOT for the architecture: it works by living in a separate process from tokio's reaper, which a successor cannot do.
 
-- [ ] **Step 1: Write the failing tests**
+- [x] **Step 1: Write the failing tests**
 
 ```rust
 #[test]
@@ -517,13 +517,59 @@ fn reaping_an_adopted_pid_does_not_disturb_a_tokio_spawned_child() {
 
 The third test is the one that matters. Give it its own name in CI's serial job if it proves contention-sensitive, following `two_concurrent_boots`.
 
-- [ ] **Step 2: Run to verify they fail**
+Written as four real-child tests plus three that need no child. The plan's
+three, plus: a pid that had already exited before the reaper's first look
+(the kernel holds the zombie, so it must yield the real status rather than
+an error), a second wait replaying the first one's status instead of
+meeting `ECHILD`, pid 0 refused because `waitpid(0, ..)` is a group-wide
+wait wearing a different number, and a pure `outcome_of` case pinning that
+a code and a signal are never collapsed into each other.
 
-- [ ] **Step 3: Implement**
+`waitpid(-1, ..)` also turned out NOT to be catchable by two children
+exiting at the same instant, which is how the regression test was written
+first: in isolation the wildcard passed, because tokio's own driver reaps
+its child before the reaper's wakeup lands, leaving only the adopted pid
+for the wildcard to find. The version that stands rests on a stronger
+property instead. tokio calls `waitpid` for a live `Child` only when its
+`wait()` is polled, so a supervised child that exits with nothing awaiting
+it leaves its status pending in the kernel while the adopted sheep is still
+running, and a wildcard takes that pending status every time.
 
-- [ ] **Step 4: Run to verify they pass**
+- [x] **Step 2: Run to verify they fail**
 
-- [ ] **Step 5: Task gate, then commit**
+Actual: FAIL, unresolved `AdoptedReaper`/`outcome_of` (E0432).
+
+- [x] **Step 3: Implement**
+
+`AdoptedReaper::wait` arms its own `SIGCHLD` stream through
+`tokio::signal::unix::signal`, which multiplexes, so it takes nothing away
+from the stream tokio's process driver arms for itself. Armed BEFORE the
+first look, so an exit landing in between wakes the loop instead of being
+lost; a pid that already exited needs no wakeup, since the first look finds
+the zombie.
+
+The reaper remembers each status it takes. A status can be collected once,
+so a second or concurrent wait on a reaped pid would meet `ECHILD` and lose
+it; the map makes it replay, which is the contract `RunningProcess::wait`
+already states for tokio-supervised sheep. The lock spans the `waitpid`
+call so two concurrent waits cannot interleave a take with a lookup.
+
+No unsafe: `nix::sys::wait` is safe-wrapped and the pid needs no borrow.
+
+- [x] **Step 4: Run to verify they pass**
+
+Actual: 594 passed, 18 filtered (up from 587: the plan's three plus the four
+above). Confirmed non-vacuous by substituting `Pid::from_raw(-1)` for the
+targeted pid, at which point the regression test fails on its own with the
+adopted pid reporting the supervised child's exit code, and three of the
+other real-child tests fail too when the binary runs whole.
+
+- [x] **Step 5: Task gate, then commit**
+
+Actual: fmt 0, clippy 0, `cargo test --workspace --all-features` 0, doc 0,
+windows-gnu cross-check 0. Clippy's `zombie_processes` fires on every test
+child here and is expected with a reason rather than silenced: adding the
+`Child::wait()` it asks for would take the status the assertions are about.
 
 ---
 

--- a/docs/writing-plans/plans/2026-08-30-handover-phase2a.md
+++ b/docs/writing-plans/plans/2026-08-30-handover-phase2a.md
@@ -33,6 +33,13 @@ Those are 2b's and 2c's. The fallback is correct behaviour, not a stub.
 - **Invoke the `shep-idiomatic-rust` skill before writing any Rust.** Cite `IR-<n>` in review.
 - **One cargo shape per task.** Daemon-side work uses `cargo test -p shep-daemon --lib --all-features -- --skip ::slow::`. Anything crossing into shep-cli uses `cargo test --workspace --all-features`. Never alternate within a task.
 - Task gate, once per task, each from its own command with `$?` captured directly and never through a pipe: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`, `cargo test --workspace --all-features`, `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features`.
+- **The Windows cross-check is part of the PER-TASK gate in this phase, not just the phase gate.** Run it with its own target dir so it does not invalidate the host cache:
+
+  ```bash
+  CARGO_TARGET_DIR=/tmp/xcheck-win cargo check --workspace --all-targets --all-features --target x86_64-pc-windows-gnu
+  ```
+
+  This is not the usual convention and it is here for a measured reason. Task 2 added `crates/shep-daemon/src/handover/fds.rs`, which uses `nix` and `std::os::fd`, and wired the module into `lib.rs` with no `#[cfg(unix)]`. That broke the Windows build, and the host-only task gate reported green for a whole task before Task 3 caught it. Every file in this phase is unix-only, so the gate that would notice has to run every time, not at the end.
 - Repo-relative paths only, in code, comments and commit messages. Never an absolute local path. Do not name any person.
 
 ## The failure this phase exists to avoid

--- a/docs/writing-plans/plans/2026-08-30-handover-phase2a.md
+++ b/docs/writing-plans/plans/2026-08-30-handover-phase2a.md
@@ -535,6 +535,16 @@ The third test is the one that matters. Give it its own name in CI's serial job 
 
 `Arm::Handover` is currently unreachable and carries `#[expect(dead_code)]`. Constructing it without removing that attribute is a compile error, which is deliberate; remove it here.
 
+**Task 6 found two seams this task needs that the plan did not anticipate. Both make Task 8 a cross-crate change, so its cargo shape is `cargo test --workspace --all-features`, not the daemon-only inner loop.**
+
+1. **`spawn_log_pump` cannot take an adopted log handle.** It takes `out_path: PathBuf` / `err_path: PathBuf` (`crates/shep-daemon/src/tokio_runner.rs:1339`) and calls `LogFile::open` itself, so there is no seam for a file that is already open. The fix is small because `LogFile` is already generic over its sink with only `path` and `handle`: it needs a constructor taking a `tokio::fs::File` plus the path for later reopens. Do NOT write a parallel pump. `LogFile::reopen` goes back through `open_append` by path, so rotation keeps working on an adopted handle unchanged.
+
+2. **`shep_core::transport::Listener` cannot be built from an adopted listener.** Its inner `tokio::net::UnixListener` is private and the type offers only `bind(&Path)`. Adoption yields a bare `tokio::net::UnixListener`, so wiring it into the accept loop needs a constructor added in shep-core.
+
+Also from Task 6: `PidfileLock` cannot hold the adopted descriptor, because its unix field is `nix::fcntl::Flock<File>` and `nix` has no constructor for an already-locked file that does not lock it again. `Adopted` carries a plain `std::fs::File`, so this task needs a `PidfileLock` variant or enum arm that holds it. **It must not re-lock**: the descriptor crossed the exec with its `flock` intact, and re-acquiring means releasing first, which opens a window for a second daemon.
+
+Three `#[expect(dead_code)]` attributes come due here and will fire as unfulfilled once their items are called: the module-wide one in `handover/mod.rs` (delete it outright rather than narrowing, per Task 5), and the ones on `successor_handover` and `Successor` in `boot.rs`.
+
 SIGHUP currently runs a graceful stop (phase 1, Task 3). It now runs the fitness check and either hands over or falls through to that same graceful stop.
 
 - [ ] **Step 1: Write the failing tests**

--- a/docs/writing-plans/plans/2026-08-30-handover-phase2a.md
+++ b/docs/writing-plans/plans/2026-08-30-handover-phase2a.md
@@ -791,7 +791,7 @@ fn the_adopted_pidfile_arm_does_not_release_the_lock() {
 
 **Restore the counters before installing any slot.** `next_id`, `next_deadline` and `next_action_stamp` reset to zero in every constructor, so a successor that installs sheep first and restores counters second can hand a fresh sheep an id a caller is still holding.
 
-- [ ] **Step 1: Write the failing tests**
+- [x] **Step 1: Write the failing tests**
 
 ```rust
 #[tokio::test]
@@ -836,15 +836,15 @@ async fn the_successor_does_not_reissue_a_live_id() {
 }
 ```
 
-- [ ] **Step 2: Run to verify they fail**
+- [x] **Step 2: Run to verify they fail**
 
-- [ ] **Step 3: Implement**
+- [x] **Step 3: Implement**
 
 A carried sheep with no descriptors (registered but stopped, `CarriedFds::none()`) installs as a slot with no pump and no `ctl`, which is the state it was already in. Do not try to adopt a process that is not running.
 
-- [ ] **Step 4: Run to verify they pass**
+- [x] **Step 4: Run to verify they pass**
 
-- [ ] **Step 5: Task gate, then commit**
+- [x] **Step 5: Task gate, then commit**
 
 #### Task 8d: the arms, and proving a sheep never noticed
 

--- a/docs/writing-plans/plans/2026-08-30-handover-phase2a.md
+++ b/docs/writing-plans/plans/2026-08-30-handover-phase2a.md
@@ -692,9 +692,89 @@ A sheep with no live pump (registered but stopped) reports `None` for all four. 
 
 #### Task 8b: the adopt seam on the runner
 
-`ProcessRunner` gains a defaulted `adopt` (IR-20, so an out-of-tree implementor does not break). `TokioProc` becomes spawned-or-adopted, backed by Task 7's `AdoptedReaper` on the adopted arm, and `ProcIo` is built from adopted handles.
+**Files:**
+- Modify: `crates/shep-daemon/src/runner.rs` (`ProcessRunner`)
+- Modify: `crates/shep-daemon/src/tokio_runner.rs` (`TokioProc`, `LogFile`, the pump)
+- Modify: `crates/shep-core/src/transport.rs` (a constructor)
+- Modify: `crates/shep-daemon/src/boot.rs` (`PidfileLock`)
+- Test: alongside each
 
-The three seams Task 6 measured land here, all confirmed small: `LogFile::from_file` taking an open handle plus its path, a `#[cfg(unix)]` constructor on `shep_core::transport::Listener`, and a `PidfileLock` arm holding an already-locked descriptor. **That arm must not re-lock**, since the descriptor crossed the exec with its `flock` intact and re-acquiring means releasing first.
+**Cross-crate, so the cargo shape is `cargo test --workspace --all-features`.**
+
+An adopted sheep has no `tokio::process::Child` and there is no way to make one. Task 7 built and tested `AdoptedReaper` for exactly this, and it currently has no route into the supervisor. This task is that route.
+
+**`ProcessRunner::adopt` is DEFAULTED (IR-20).** shep-daemon is published, so a required method would break every out-of-tree implementor. The default returns an error saying adoption is unsupported by this runner, which is the truthful answer for a runner that never took part in a handover.
+
+**`TokioProc` becomes spawned-or-adopted.** It already stores `pid: u32` separately from its `Child`, precisely because `Child::id()` returns `None` after a wait, so the pid half needs nothing. What changes is the wait: the spawned arm keeps `child.wait()`, the adopted arm goes through `AdoptedReaper`. `signal` and `kill_tree` address the pid and are untouched.
+
+The three seams Task 6 measured, all confirmed small:
+
+- `LogFile::from_file(path, file)`. `LogFile` is already generic over its sink with only `path` and `handle`, and `reopen` goes back through `open_append` by path, so rotation keeps working on an adopted handle unchanged.
+- a `#[cfg(unix)]` constructor on `shep_core::transport::Listener`, whose inner `tokio::net::UnixListener` is private and which offers only `bind(&Path)`.
+- a `PidfileLock` arm holding an already-locked `std::fs::File`. **It must not re-lock.** The descriptor crossed the exec with its `flock` intact, and re-acquiring means releasing first, which opens a window for a second daemon to win the home.
+
+- [ ] **Step 1: Write the failing tests**
+
+```rust
+#[tokio::test]
+async fn an_adopted_proc_reports_its_real_exit() {
+    // The whole point of the seam. Task 7 proved the reaper; this proves it
+    // is reachable through the type the supervisor actually holds.
+    let mut proc = adopted_proc_for(spawn_exiting_with(3).await);
+    assert_eq!(proc.wait().await.unwrap().code, Some(3));
+}
+
+#[tokio::test]
+async fn a_spawned_proc_still_reports_its_real_exit() {
+    // Regression. The adopted arm must not disturb the path every sheep
+    // takes today.
+    let mut proc = runner.spawn(&spec_exiting_with(4)).unwrap().0;
+    assert_eq!(proc.wait().await.unwrap().code, Some(4));
+}
+
+#[tokio::test]
+async fn an_adopted_proc_reports_a_signal_as_a_signal() {
+    // rows.rs renders code and signal differently, so collapsing them makes
+    // the EXIT column lie.
+    let mut proc = adopted_proc_for(spawn_then_kill().await);
+    let out = proc.wait().await.unwrap();
+    assert_eq!((out.code, out.signal), (None, Some(9)));
+}
+
+#[test]
+fn a_log_file_from_an_open_handle_still_appends() {
+    // Not merely writable. Task 6 caught this exact difference by swapping
+    // .append(true) for .write(true) and watching the file lose its first
+    // line.
+    let f = open_appending(&path);
+    write_line(&path, "first");
+    let mut lf = LogFile::from_file(path.clone(), f.into());
+    lf.write_line("second");
+    assert_eq!(read(&path), "first
+second
+");
+}
+
+#[test]
+fn the_adopted_pidfile_arm_does_not_release_the_lock() {
+    // The failure it prevents: releasing to re-acquire opens a window where
+    // a second daemon wins the home. `flock` conflicts between separate
+    // descriptions even inside one process, which is what makes this
+    // testable at all.
+    let held = PidfileLock::acquire(&paths).unwrap();
+    let adopted = PidfileLock::from_locked(dup_of(&held));
+    assert!(PidfileLock::acquire(&paths).is_err(), "the lock must never be free");
+    drop(adopted);
+}
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+- [ ] **Step 3: Implement**
+
+- [ ] **Step 4: Run to verify they pass**
+
+- [ ] **Step 5: Task gate, then commit**
 
 #### Task 8c: install the adopted flock
 

--- a/docs/writing-plans/plans/2026-08-30-handover-phase2a.md
+++ b/docs/writing-plans/plans/2026-08-30-handover-phase2a.md
@@ -610,25 +610,109 @@ The three seams Task 6 predicted are all confirmed small. They are also not the 
 
 **The fallback design changed too. See the spec's new H3a.** A daemon that refuses internally and stops gracefully leaves the CLI polling for a successor nobody started, so fitness is now asked over the socket before the CLI signals.
 
-#### Task 8a: report descriptors and build the blob
+#### Task 8a: report descriptors, and build the blob from a live flock
 
-`LogCtl` gains a variant that flushes and reports the four raw fds. A supervisor command fans it out over the flock, waits, and assembles both the `Candidate` list and the `Handover` blob from inside the actor, where the private counters and `SheepSlot` fields are reachable. Ends with a test that a blob built from a live flock names four open descriptors per sheep.
+**Files:**
+- Modify: `crates/shep-daemon/src/runner.rs` (`LogCtl`)
+- Modify: `crates/shep-daemon/src/tokio_runner.rs` (the log pump's handler)
+- Modify: `crates/shep-daemon/src/supervisor.rs` (a new actor command)
+- Test: alongside each
+
+**Interfaces:**
+- Produces: a supervisor command returning `Result<(Vec<Candidate>, Handover), _>`, consumed by 8d.
+
+The four descriptors `CarriedFds` names are owned by the log pump task, inside `Lines<BufReader<ChildStdout>>` and `LogFile`. Nothing outside that task can see them, and `LogCtl` today has only `Reopen` and `Flush` (`runner.rs:102`).
+
+**Flush and report in ONE round trip, not two.** A pump that reports its numbers and is then asked separately to flush leaves a window where the buffered bytes are not on disk but the blob already claims the descriptor is ready to carry. The new variant does both and acknowledges once, which is the same shape `Reopen` already uses.
+
+**The counters and the per-slot fields are only reachable inside the actor.** `next_id`, `next_deadline` and `next_action_stamp` are private `Actor` fields; `epoch`, `manual` and `pending_delete` are on the private `SheepSlot`. So the command assembles both the `Candidate` list and the `Handover` from in there, rather than exposing accessors.
+
+- [ ] **Step 1: Write the failing tests**
+
+```rust
+#[tokio::test]
+async fn a_pump_reports_the_descriptors_it_holds() {
+    // The numbers must be the pump's own, not a guess: an fd number is only
+    // meaningful in the process that owns it, and the whole handover is
+    // built on carrying exactly these.
+    let (pump, ctl) = spawn_pump_fixture().await;
+    let fds = ask_for_fds(&ctl).await.unwrap();
+    assert!(fds.out_pipe.is_some() && fds.err_pipe.is_some());
+    assert!(fds.out_log.is_some() && fds.err_log.is_some());
+    assert!(all_distinct(&fds));
+}
+
+#[tokio::test]
+async fn reporting_flushes_first() {
+    // Written before the report, readable on disk after it. A blob whose
+    // descriptors are ready but whose bytes are not is a log gap the
+    // successor cannot repair, because the bytes died with the image.
+    let (pump, ctl) = spawn_pump_fixture().await;
+    write_line(&pump, "before-the-blob").await;
+    let _ = ask_for_fds(&ctl).await.unwrap();
+    assert!(read_log_file().contains("before-the-blob"));
+}
+
+#[tokio::test]
+async fn a_blob_from_a_live_flock_names_four_open_descriptors_per_sheep() {
+    let sup = supervisor_with_two_plain_sheep().await;
+    let (candidates, blob) = sup.handover_snapshot().await.unwrap();
+    assert_eq!(candidates.len(), 2);
+    for s in &blob.sheep {
+        for fd in s.fds.all() {
+            assert!(is_open(fd.unwrap()), "blob names a closed descriptor");
+        }
+    }
+}
+
+#[tokio::test]
+async fn the_snapshot_carries_the_actors_counters_and_slot_state() {
+    // These are the fields nothing outside the actor can see, and the
+    // reason this is a command rather than a getter.
+    let sup = supervisor_with_a_pending_stop().await;
+    let (candidates, blob) = sup.handover_snapshot().await.unwrap();
+    assert!(candidates[0].pending_stop, "a pending stop must reach the gate");
+    assert!(blob.next_id > 0, "a successor that reissues a live id collides");
+}
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `cargo test -p shep-daemon --lib --all-features -- --skip ::slow:: handover_snapshot`
+
+- [ ] **Step 3: Implement**
+
+Add the `LogCtl` variant. Follow `Reopen`'s existing shape for the acknowledgement channel rather than inventing a second one, and give its doc comment the flush-and-report reasoning above.
+
+A sheep with no live pump (registered but stopped) reports `None` for all four. That is the `Option<RawFd>` case `CarriedFds` already models, and Task 1's gate does not refuse it: a stopped sheep has no descriptors to carry and nothing to lose.
+
+- [ ] **Step 4: Run to verify they pass**
+
+- [ ] **Step 5: Task gate, then commit**
 
 #### Task 8b: the adopt seam on the runner
 
-`ProcessRunner` gains a defaulted `adopt` (IR-20, so out-of-tree implementors do not break). `TokioProc` becomes spawned-or-adopted, backed by Task 7's `AdoptedReaper` on the adopted arm. `ProcIo` is built from adopted handles. The three small seams land here: `LogFile::from_file`, `Listener`'s constructor in shep-core, and the `PidfileLock` arm that holds an already-locked descriptor without re-locking.
+`ProcessRunner` gains a defaulted `adopt` (IR-20, so an out-of-tree implementor does not break). `TokioProc` becomes spawned-or-adopted, backed by Task 7's `AdoptedReaper` on the adopted arm, and `ProcIo` is built from adopted handles.
 
-#### Task 8c: the successor boot path
+The three seams Task 6 measured land here, all confirmed small: `LogFile::from_file` taking an open handle plus its path, a `#[cfg(unix)]` constructor on `shep_core::transport::Listener`, and a `PidfileLock` arm holding an already-locked descriptor. **That arm must not re-lock**, since the descriptor crossed the exec with its `flock` intact and re-acquiring means releasing first.
 
-Bind carried sheep to muster-roll apps by name and instance, and install adopted slots in the actor without spawning. This is where 5's design decision gets made and written down.
+#### Task 8c: install the adopted flock
+
+Insert slots carrying the blob's ids, epochs, statuses and `last_exit`, without spawning. `spawn_fresh` is the only path that inserts a live slot today.
+
+**This is much smaller than it was, because the blob now carries each sheep's `AppConfig`.** The earlier version had to rebuild every spec from the muster roll and bind carried sheep to roll apps by name and instance, against a roll that records a running count rather than which slots were up, with `muster` starting whatever it restored. All of that is gone: the blob is self-sufficient, there is no second source of truth, and no restore-without-spawning path is needed.
+
+Re-normalize each carried `AppConfig` to recover its `ResolvedApp`, exactly as `snapshot.rs:333` already does on a muster.
 
 #### Task 8d: the arms, and proving a sheep never noticed
 
-The fitness query over the socket, the CLI's arm choice, the SIGHUP handler, and the end-to-end tests. **The two assertions that define success live here**: a sheep's pid is unchanged across a reload, and its log gains no gap.
+The fitness query over the socket (spec H3a), the CLI's arm choice, the SIGHUP handler, and the end-to-end tests.
 
-Also here: delete the four `#[expect(dead_code)]` attributes, which fire as unfulfilled once their items are called.
+**The two assertions that define success live here**: a sheep's pid is unchanged across a reload, and its log gains no gap.
 
-**One hazard for 8d, found while reviewing 8's refusal.** The pump reads through a `BufReader`, so bytes consumed but not yet a complete line die with the image, and the successor's fresh reader starts mid-line and emits the remainder as its own line. A pre-exec flush handles `LogFile`'s buffer but not that one. Under a chatty sheep the no-gap assertion would catch it as a torn line rather than a missing one.
+Also here: delete the four `#[expect(dead_code)]` attributes, which fire as unfulfilled once their items are called. The module-level one in `handover/mod.rs` gets deleted outright rather than narrowed, and its reason string is already stale (it still names task 5).
+
+**One hazard, found while reviewing Task 8's refusal.** The pump reads through a `BufReader`, so bytes consumed but not yet a complete line die with the image, and the successor's fresh reader starts mid-line and emits the remainder as its own line. 8a's flush covers `LogFile`'s buffer, not that one. Under a chatty sheep the no-gap assertion sees a torn line rather than a missing one, so write it to catch both.
 
 ## Phase gate
 

--- a/docs/writing-plans/plans/2026-08-30-handover-phase2a.md
+++ b/docs/writing-plans/plans/2026-08-30-handover-phase2a.md
@@ -201,11 +201,15 @@ Actual: 2 passed
 - Test: same file
 
 **Interfaces:**
-- Produces: `pub struct Handover { version: u32, sheep: Vec<CarriedSheep>, listener_fd: RawFd, pidfile_fd: RawFd, next_id: u32, next_deadline: u64, next_action_stamp: u64 }` and `CarriedSheep { id, name, instance, pid, restarts, epoch, status, last_exit, credentials, out_pipe_fd, err_pipe_fd, out_log_fd, err_log_fd }`.
+- Produces: `pub struct Handover { version: u32, sheep: Vec<CarriedSheep>, listener_fd: RawFd, pidfile_fd: RawFd, next_id: u32, next_deadline: u64, next_action_stamp: u64 }` and `CarriedSheep { id, name, instance, pid, restarts, epoch, status, last_exit, credentials, fds, app }`.
 
 **`started_at` is deliberately NOT carried.** It is a `tokio::time::Instant` with no epoch, so it cannot be serialized. Re-derive it in the successor from the operating system, which is authoritative and more correct than carrying it: `sysinfo` is already a shep-daemon dependency and exposes a process start time. Read `crates/shep-daemon/src/limits/sample.rs` for how the crate already drives `sysinfo` before adding a second style.
 
-The blob carries **no environment values**. A sheep's env may hold secrets and the successor re-reads them from config.
+The blob carries **each sheep's whole resolved spec, environment included**. This reverses what this task originally specified, and the reversal is the maintainer's, recorded in the design spec's H2. The muster roll already persists every sheep's env in cleartext and permanently -- `SavedApp.app` is a whole `AppConfig`, `AppConfig.env` is a plain `BTreeMap<String, String>` with no skip attribute, and `flock.json` is written at `0600` -- so a blob carrying the same values at the same mode, on a file the successor unlinks the moment it has read it, is strictly less exposure than the file already sitting there for the life of the flock. Refusing to carry it forced the successor to rebuild each spec from the roll and bind carried sheep to roll apps by name and instance, except the roll records a running COUNT per app rather than which slots were up, and `muster` starts what it restores: a second source of truth that can disagree with the blob, to protect a value already on disk.
+
+`CarriedSheep.app` is the `AppConfig` beneath `ProcessEntry.spec`'s `ResolvedApp`, not the `ResolvedApp` itself. That type is a proof token obtainable only through `normalize`, so a `Deserialize` for it would mint the token from arbitrary JSON for every consumer of shep-core. The carried value has already been normalized, and `normalize` is pure over one of its own outputs, so the successor rebuilds the token by normalizing it again -- which is what the roll's own restore path already does at `snapshot.rs:333`.
+
+`VERSION` stays at `1`. No released image has ever written or read a handover blob, so there is no compatibility to preserve, and bumping it inside the branch that introduces the format would only mean version 1 never existed.
 
 - [x] **Step 1: Write the failing tests**
 
@@ -218,11 +222,24 @@ fn a_blob_round_trips() {
 }
 
 #[test]
-fn the_blob_carries_no_environment_values() {
-    // A sheep's env can hold secrets. This is an exact-string assertion
-    // rather than a field check, because the risk is a future field that
-    // serializes env by accident (IR-41).
+fn a_blob_round_trips_a_sheeps_environment_intact() {
+    // A successor that silently lost an env value would respawn the app
+    // under an environment it was never started with.
     let text = serde_json::to_string(&sample_handover_with_secret_env()).unwrap();
+    let back: Handover = serde_json::from_str(&text).unwrap();
+    assert_eq!(
+        back.sheep[0].app.env.get("TOKEN").map(String::as_str),
+        Some("hunter2"),
+        "{text}"
+    );
+}
+
+#[test]
+fn debug_redacts_a_carried_sheeps_environment() {
+    // The blob carries env; a log line naming the daemon's own state must
+    // not. Exact-string rather than a field check, because the risk is a
+    // future field printing env by accident (IR-41).
+    let text = format!("{:?}", sample_handover_with_secret_env());
     assert!(!text.contains("hunter2"), "{text}");
 }
 
@@ -248,7 +265,9 @@ Write with mode `0600` to `$SHEP_HOME/run/handover.json`, and have the successor
 - [x] **Step 4: Run to verify they pass**
 
 Actual: 569 passed, 18 filtered (up from 564: the plan's three, plus two over
-the file's mode that the plan did not ask for).
+the file's mode that the plan did not ask for). Amended after tasks 4 to 7,
+when the spec was carried: 595 passed, 18 filtered, the no-env test replaced
+by the two above.
 
 - [x] **Step 5: Task gate, then commit**
 

--- a/docs/writing-plans/plans/2026-08-30-handover-phase2a.md
+++ b/docs/writing-plans/plans/2026-08-30-handover-phase2a.md
@@ -271,7 +271,7 @@ On Linux it does not. `current_exe()` reads `/proc/self/exe`, which resolves to 
 
 So: prefer a path recorded at boot, and treat `current_exe()` as a fallback whose Linux result must be validated before use.
 
-- [ ] **Step 1: Write the failing tests**
+- [x] **Step 1: Write the failing tests**
 
 ```rust
 #[test]
@@ -298,15 +298,28 @@ fn a_deleted_inode_path_is_never_returned() {
 
 The Linux test cannot fail on a developer's Mac. **CI is the only thing that runs it**, per this repo's own rule that a local gate does not cover Linux. Say so in the commit message.
 
-- [ ] **Step 2: Run to verify they fail**
+- [x] **Step 2: Run to verify they fail**
 
-- [ ] **Step 3: Implement**
+Actual: FAIL, unresolved `exec_target`/`check_target`/`TargetProblem`/
+`launch_path_from_argv` (E0425/E0433 x9).
 
-Record the daemon's own launch path at boot into the `RunningDaemon` context, taken from `argv[0]` resolved against the cwd at startup, and fall back to `current_exe()` only when that is unusable. Reject any candidate whose string contains `" (deleted)"` or which does not exist on disk, and return a clear error rather than exec'ing something wrong.
+- [x] **Step 3: Implement**
 
-- [ ] **Step 4: Run to verify they pass**
+`RunningDaemon` turned out to be the wrong home. `exec_target()` takes no
+arguments and is called from the exec path, which holds no daemon context by
+then, and the struct's fields are private with nothing threading them to
+this module. So the recorded path is a process-global `OnceLock` in this
+module, set by a new `record_launch_path()` that `boot` calls first thing.
 
-- [ ] **Step 5: Task gate, then commit**
+Record the daemon's own launch path at boot, taken from `argv[0]` resolved against the cwd at startup, and fall back to `current_exe()` only when that is unusable. Reject any candidate whose string contains `" (deleted)"` or which does not exist on disk, and return a clear error rather than exec'ing something wrong.
+
+- [x] **Step 4: Run to verify they pass**
+
+Actual: 575 passed, 18 filtered (up from 569: the plan's one portable test,
+plus five over the validation itself and the argv[0] resolution, so the rule
+the Linux-only test protects is exercised on a platform that compiles it).
+
+- [x] **Step 5: Task gate, then commit**
 
 ---
 

--- a/docs/writing-plans/plans/2026-08-30-handover-phase2a.md
+++ b/docs/writing-plans/plans/2026-08-30-handover-phase2a.md
@@ -1,0 +1,505 @@
+# Daemon handover, phase 2a: the spine
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `shep daemon reload` replaces the shepherd in place, keeping simple sheep running on their original pids with no gap in their logs, and falls back to the stop arm for any flock carrying something this phase cannot yet move.
+
+**Architecture:** The daemon `execve`s its own binary path. Descriptors that must live through that have `FD_CLOEXEC` cleared deliberately and their numbers written into a handover blob; the successor reads the blob from an environment variable, adopts the descriptors by number, and rebuilds every Rust-side object around them. Adopted sheep have no `tokio::process::Child`, so they are reaped by a second, strictly targeted `waitpid` path that runs alongside tokio's own.
+
+**Tech Stack:** Rust 2024, MSRV 1.88. `nix` for `fcntl`, `execv` and `waitpid`. `sysinfo`, already in shep-daemon, for process start times. No new dependencies.
+
+**Spec:** [docs/brainstorming/specs/2026-08-29-daemon-handover-design.md](../../brainstorming/specs/2026-08-29-daemon-handover-design.md), sections H1, H2 and H2a.
+
+## What 2a deliberately refuses
+
+A half-built handover that silently mishandles an app is worse than no handover. Phase 1 shipped `Arm::for_daemon`, which already chooses between a handover and a stop-and-start, so this phase adds a fitness check and **falls back to the stop arm** for anything it cannot carry:
+
+- a sheep with a shepherd channel (`channel`, `wait_ready`, or `shutdown_with_message`)
+- a sheep with `stdin = true`
+- any dog
+- an app with `instances > 1`
+- any in-flight reload
+- any pending manual stop or delete
+
+Those are 2b's and 2c's. The fallback is correct behaviour, not a stub.
+
+## Global Constraints
+
+- MSRV 1.88, edition 2024. **No new crate dependencies in any task.**
+- The whole phase is `#[cfg(unix)]`. Windows has no `execve`; `Arm::for_daemon` already returns the stop arm there and must keep doing so.
+- Unsafe is permitted ONLY in `crates/shep-daemon/src/sys.rs`, with a per-block `// SAFETY:` comment (IR-22/23). `fcntl`, `execv` and `waitpid` go through `nix`, which is safe-wrapped; if any raw call is unavoidable it lives in `sys.rs` and nowhere else.
+- Every new public item needs a doc comment, a `# Errors` section if it returns `Result`, and a deliberate `Debug` decision. **The handover blob carries no environment values and no secrets**; if a type could ever hold one, redact it with an exact-string test (IR-41).
+- `core::error::Error`, never `std::error::Error`.
+- **Invoke the `shep-idiomatic-rust` skill before writing any Rust.** Cite `IR-<n>` in review.
+- **One cargo shape per task.** Daemon-side work uses `cargo test -p shep-daemon --lib --all-features -- --skip ::slow::`. Anything crossing into shep-cli uses `cargo test --workspace --all-features`. Never alternate within a task.
+- Task gate, once per task, each from its own command with `$?` captured directly and never through a pipe: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`, `cargo test --workspace --all-features`, `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features`.
+- Repo-relative paths only, in code, comments and commit messages. Never an absolute local path. Do not name any person.
+
+## The failure this phase exists to avoid
+
+Losing a sheep's stdout read end does **not** lose its output. The child blocks on `write()` once the 64KiB pipe buffer fills, and hangs. It reads as an application bug, not a shep bug. Every descriptor decision in this plan is subordinate to that.
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `crates/shep-daemon/src/handover/mod.rs` | new module: the blob type, fitness check, and the exec |
+| `crates/shep-daemon/src/handover/fds.rs` | clearing `FD_CLOEXEC`, and adopting a descriptor by number |
+| `crates/shep-daemon/src/handover/adopt.rs` | rebuilding readers, the listener, and log handles from raw fds |
+| `crates/shep-daemon/src/handover/reap.rs` | targeted reaping for adopted pids |
+| `crates/shep-daemon/src/boot.rs` | successor detection at boot, and the SIGHUP arm |
+| `crates/shep-cli/src/commands/daemon.rs` | `Arm::Handover` becomes constructible |
+
+---
+
+### Task 1: decide whether this flock can be carried
+
+**Files:**
+- Create: `crates/shep-daemon/src/handover/mod.rs`
+- Test: same file
+
+**Interfaces:**
+- Produces: `pub enum Fitness { Carryable, Refused(RefusedReason) }` and `pub fn fitness(sheep: &[&ProcessEntry]) -> Fitness`. Task 8 consumes it.
+
+This gate is what makes every later stage safe to ship. Get it wrong in the permissive direction and a half-built handover corrupts a flock; wrong in the strict direction and it merely falls back to a working stop-and-start.
+
+**Refuse when ANY sheep has**: a shepherd channel, `stdin = true`, a `dog` marker, `instance` implying a multi-instance app, a non-`None` `reload` marker, or a pending manual/delete. Read the real field names off `crates/shep-daemon/src/entry.rs` before writing the match; do not trust these names.
+
+- [ ] **Step 1: Write the failing tests**
+
+```rust
+#[test]
+fn a_plain_sheep_is_carryable() {
+    let e = entry_fixture();          // no channel, no stdin, not a dog, instance 0
+    assert_eq!(fitness(&[&e]), Fitness::Carryable);
+}
+
+#[test]
+fn one_unsupported_sheep_refuses_the_whole_flock() {
+    // Not per-sheep. The blob describes one process image, so a flock is
+    // carried whole or not at all.
+    let plain = entry_fixture();
+    let channelled = entry_with_channel();
+    assert!(matches!(fitness(&[&plain, &channelled]), Fitness::Refused(_)));
+}
+
+#[test]
+fn the_refusal_names_which_sheep_and_why() {
+    // The operator sees this in `shep daemon reload`'s output, so it has to
+    // say what to do about it, not just that it declined.
+    let Fitness::Refused(r) = fitness(&[&entry_with_channel()]) else { panic!() };
+    let text = r.to_string();
+    assert!(text.contains("shepherd channel"), "{text}");
+}
+
+#[test]
+fn an_empty_flock_is_carryable() {
+    assert_eq!(fitness(&[]), Fitness::Carryable);
+}
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `cargo test -p shep-daemon --lib --all-features -- --skip ::slow:: fitness`
+Expected: FAIL, unresolved `fitness`
+
+- [ ] **Step 3: Implement**
+
+`RefusedReason` carries the sheep's name and the feature that blocked it, and its `Display` names the fallback:
+
+```rust
+/// Why a flock cannot be handed over in place, and what happens instead.
+///
+/// Every variant is a feature phase 2a does not yet carry, not an error. The
+/// caller falls back to the stop arm, which is correct behaviour rather than
+/// a degraded one.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum RefusedReason {
+    /// The sheep holds a shepherd channel, whose socketpair 2b carries.
+    Channel { sheep: String },
+    ...
+}
+```
+
+`#[non_exhaustive]` here, unlike `Shepherd` in `boot.rs`: this set genuinely grows as 2b and 2c widen what is carryable, which is the opposite of that enum's closed-by-mechanism argument.
+
+- [ ] **Step 4: Run to verify they pass**
+
+- [ ] **Step 5: Task gate, then commit**
+
+---
+
+### Task 2: clear `FD_CLOEXEC`, and prove it
+
+**Files:**
+- Create: `crates/shep-daemon/src/handover/fds.rs`
+- Test: same file
+
+**Interfaces:**
+- Produces: `pub fn keep_across_exec(fd: BorrowedFd<'_>) -> io::Result<()>` and `pub fn is_kept(fd: BorrowedFd<'_>) -> io::Result<bool>`.
+
+Everything the daemon holds is close-on-exec by default, verified against pinned `mio`, `tokio`, `std` and `command-fds` sources. `command-fds` is the one place in the tree that already clears the flag deliberately, for the shepherd channel's fd 3; read `command-fds-0.3.3/src/lib.rs` for the shape before writing this.
+
+- [ ] **Step 1: Write the failing tests**
+
+```rust
+#[test]
+fn a_fresh_pipe_is_close_on_exec_and_can_be_kept() {
+    let (r, _w) = nix::unistd::pipe().unwrap();
+    // Establishes the default this whole phase depends on. If this ever
+    // fails, std changed and the fd inventory needs re-auditing.
+    assert!(!is_kept(r.as_fd()).unwrap(), "std pipes are CLOEXEC by default");
+    keep_across_exec(r.as_fd()).unwrap();
+    assert!(is_kept(r.as_fd()).unwrap());
+}
+
+#[test]
+fn keeping_is_idempotent() {
+    let (r, _w) = nix::unistd::pipe().unwrap();
+    keep_across_exec(r.as_fd()).unwrap();
+    keep_across_exec(r.as_fd()).unwrap();
+    assert!(is_kept(r.as_fd()).unwrap());
+}
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+- [ ] **Step 3: Implement**
+
+Read the existing flags with `F_GETFD`, clear only the `FD_CLOEXEC` bit, write back with `F_SETFD`. **Do not write a bare `0`**: that would clobber any other flag the descriptor carries, and it makes the call non-idempotent in a way the second test above is written to catch.
+
+- [ ] **Step 4: Run to verify they pass**
+
+- [ ] **Step 5: Task gate, then commit**
+
+---
+
+### Task 3: the handover blob
+
+**Files:**
+- Modify: `crates/shep-daemon/src/handover/mod.rs`
+- Test: same file
+
+**Interfaces:**
+- Produces: `pub struct Handover { version: u32, sheep: Vec<CarriedSheep>, listener_fd: RawFd, pidfile_fd: RawFd, next_id: u32, next_deadline: u64, next_action_stamp: u64 }` and `CarriedSheep { id, name, instance, pid, restarts, epoch, status, last_exit, credentials, out_pipe_fd, err_pipe_fd, out_log_fd, err_log_fd }`.
+
+**`started_at` is deliberately NOT carried.** It is a `tokio::time::Instant` with no epoch, so it cannot be serialized. Re-derive it in the successor from the operating system, which is authoritative and more correct than carrying it: `sysinfo` is already a shep-daemon dependency and exposes a process start time. Read `crates/shep-daemon/src/limits/sample.rs` for how the crate already drives `sysinfo` before adding a second style.
+
+The blob carries **no environment values**. A sheep's env may hold secrets and the successor re-reads them from config.
+
+- [ ] **Step 1: Write the failing tests**
+
+```rust
+#[test]
+fn a_blob_round_trips() {
+    let h = sample_handover();
+    let back: Handover = serde_json::from_str(&serde_json::to_string(&h).unwrap()).unwrap();
+    assert_eq!(back, h);
+}
+
+#[test]
+fn the_blob_carries_no_environment_values() {
+    // A sheep's env can hold secrets. This is an exact-string assertion
+    // rather than a field check, because the risk is a future field that
+    // serializes env by accident (IR-41).
+    let text = serde_json::to_string(&sample_handover_with_secret_env()).unwrap();
+    assert!(!text.contains("hunter2"), "{text}");
+}
+
+#[test]
+fn a_blob_from_a_future_version_is_refused_not_guessed_at() {
+    let mut v = serde_json::to_value(sample_handover()).unwrap();
+    v["version"] = serde_json::json!(u32::MAX);
+    assert!(Handover::load_value(v).is_err());
+}
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+- [ ] **Step 3: Implement**
+
+`version` is checked on load and refused if unrecognised. A successor that cannot understand the blob must fail loudly and let the caller fall back, never adopt a partial picture.
+
+Write with mode `0600` to `$SHEP_HOME/run/handover.json`, and have the successor unlink it after reading. Set the permissions **at creation** (`OpenOptionsExt::mode`), not with a `chmod` afterwards, so there is no window where it is world-readable.
+
+- [ ] **Step 4: Run to verify they pass**
+
+- [ ] **Step 5: Task gate, then commit**
+
+---
+
+### Task 4: resolve the binary to exec, and do not trust `current_exe`
+
+**Files:**
+- Modify: `crates/shep-daemon/src/handover/mod.rs`
+- Test: same file, plus a `#[cfg(target_os = "linux")]` test
+
+**Interfaces:**
+- Produces: `pub fn exec_target() -> io::Result<PathBuf>`.
+
+**This task exists because the obvious implementation silently execs the OLD binary, which defeats the entire feature.** Everything in this tree spawns via `std::env::current_exe()` (`crates/shep-cli/src/launch.rs:85` and others), and that is wrong here.
+
+Measured 2026-08-30 on macOS: a running process whose binary is replaced by `rename` still gets a clean path from `current_exe()`, and that path holds the new image, so the naive version happens to work.
+
+On Linux it does not. `current_exe()` reads `/proc/self/exe`, which resolves to the **inode** the process was executed from. After `cargo install` renames a new file over the path, that symlink still points at the old, now-unlinked inode, and `readlink` returns a path with `" (deleted)"` appended. Exec'ing that string fails, and stripping the suffix is a guess about a string the kernel is not promising.
+
+So: prefer a path recorded at boot, and treat `current_exe()` as a fallback whose Linux result must be validated before use.
+
+- [ ] **Step 1: Write the failing tests**
+
+```rust
+#[test]
+fn the_exec_target_exists_and_is_a_file() {
+    let p = exec_target().unwrap();
+    assert!(p.is_file(), "{}", p.display());
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn a_deleted_inode_path_is_never_returned() {
+    // /proc/self/exe resolves to the inode, so a binary replaced by a
+    // `cargo install` rename gives `"<path> (deleted)"`. Exec'ing that
+    // fails, which would make a handover silently unable to upgrade,
+    // which is the whole point of the feature.
+    let p = exec_target().unwrap();
+    assert!(
+        !p.to_string_lossy().contains("(deleted)"),
+        "exec target resolved to a deleted inode: {}",
+        p.display()
+    );
+}
+```
+
+The Linux test cannot fail on a developer's Mac. **CI is the only thing that runs it**, per this repo's own rule that a local gate does not cover Linux. Say so in the commit message.
+
+- [ ] **Step 2: Run to verify they fail**
+
+- [ ] **Step 3: Implement**
+
+Record the daemon's own launch path at boot into the `RunningDaemon` context, taken from `argv[0]` resolved against the cwd at startup, and fall back to `current_exe()` only when that is unusable. Reject any candidate whose string contains `" (deleted)"` or which does not exist on disk, and return a clear error rather than exec'ing something wrong.
+
+- [ ] **Step 4: Run to verify they pass**
+
+- [ ] **Step 5: Task gate, then commit**
+
+---
+
+### Task 5: the exec
+
+**Files:**
+- Modify: `crates/shep-daemon/src/handover/mod.rs`
+- Test: an integration test that really execs
+
+**Interfaces:**
+- Produces: `pub fn hand_over(blob: &Handover, paths: &ShepPaths) -> io::Result<Infallible>`, which does not return on success.
+
+Order matters and getting it wrong loses a flock: write the blob to disk FIRST, then clear `FD_CLOEXEC` on every descriptor the blob names, then `execv`. If the exec fails, the blob is stale and must be removed before returning the error, or the next boot adopts a picture that never happened.
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+#[test]
+fn an_exec_replaces_the_image_and_keeps_a_descriptor() {
+    // The whole mechanism in one assertion: a pipe written before the exec
+    // is readable by the process after it, on the same fd number, proving
+    // both that the image changed and that the descriptor crossed.
+    let out = std::process::Command::new(helper_bin())
+        .arg("handover-selftest")
+        .output()
+        .unwrap();
+    assert!(out.status.success(), "{}", String::from_utf8_lossy(&out.stderr));
+    assert!(String::from_utf8_lossy(&out.stdout).contains("adopted: hello"));
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+- [ ] **Step 3: Implement**
+
+Use `nix::unistd::execv`. Pass the successor's marker through the environment: the blob's path in `SHEP_HANDOVER`, following the `SHEP_CHANNEL_FD` precedent of naming a descriptor-carrying thing in the environment.
+
+`execve` resets every signal handler to `SIG_DFL`, so nothing that was installed survives. That is expected and the successor re-installs; do not try to preserve handlers.
+
+- [ ] **Step 4: Run to verify it passes**
+
+- [ ] **Step 5: Task gate, then commit**
+
+---
+
+### Task 6: the successor adopts what it was handed
+
+**Files:**
+- Create: `crates/shep-daemon/src/handover/adopt.rs`
+- Modify: `crates/shep-daemon/src/boot.rs`
+- Test: both
+
+**Interfaces:**
+- Consumes: `Handover` (Task 3), `exec_target` (Task 4).
+- Produces: `pub fn adopt(blob: &Handover) -> io::Result<Adopted>`, carrying a rebuilt `UnixListener`, per-sheep async readers, and per-sheep log writers.
+
+At boot, `SHEP_HANDOVER` in the environment means this process is a successor. It reads the blob, unlinks it, and rebuilds every Rust object around descriptors it did not open.
+
+Rebuild each one from its raw number:
+
+- the control listener with `UnixListener::from_std`, after `std::os::unix::net::UnixListener::from_raw_fd`
+- each pipe read end as an async reader
+- each log file as an appending handle. **`O_APPEND` must be preserved.** `tokio_runner.rs:1454` records that dropping it even briefly reintroduces a sparse-hole hazard a `copytruncate` rotator depends on not existing.
+
+**The pidfile lock needs no rebuilding and must not be re-acquired.** `flock` is a property of the open file description, so it survived the exec with its descriptor. Re-acquiring would mean releasing first, opening a window for a second daemon to win it.
+
+- [ ] **Step 1: Write the failing tests**
+
+```rust
+#[test]
+fn an_adopted_listener_accepts() { ... }
+
+#[test]
+fn an_adopted_log_handle_still_appends() {
+    // Not merely writable: appending. A handle reopened without O_APPEND
+    // passes a naive write test and corrupts a rotation.
+    ...
+}
+
+#[test]
+fn a_blob_naming_a_descriptor_that_is_not_open_fails_loudly() {
+    // Better to refuse the whole rehydrate than to supervise a flock with
+    // one sheep's output silently going nowhere.
+    ...
+}
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+- [ ] **Step 3: Implement**
+
+- [ ] **Step 4: Run to verify they pass**
+
+- [ ] **Step 5: Task gate, then commit**
+
+---
+
+### Task 7: reap adopted pids, targeted and never wildcard
+
+**Files:**
+- Create: `crates/shep-daemon/src/handover/reap.rs`
+- Test: same file
+
+**Interfaces:**
+- Produces: `pub struct AdoptedReaper` with `pub async fn wait(&self, pid: u32) -> io::Result<ExitOutcome>`.
+
+An adopted sheep has no `tokio::process::Child`, and there is no way to make one: `Child` is produced only by `Command::spawn`. So this is a second reaping mechanism running permanently alongside tokio's.
+
+**A wildcard `waitpid(-1, ..)` is forbidden, and this repo already learned why.** `crates/shep-cli/src/commands/reap.rs:6` and `docs/decisions.md:1588` both record that it races tokio's own reaper and steals statuses it needed, turning a clean exit into an `io::Error`; CI was bitten by it in `crates/shep-cli/tests/init.rs:325`. `tokio_runner.rs:172` already degrades to `{code: None, signal: None}` when it happens, losing the real exit.
+
+Targeted waits are safe precisely because tokio holds no `Child` for an adopted pid, so nothing else in the process will ever wait on it. Arm a `SIGCHLD` stream, and on each wakeup call `waitpid(Pid::from_raw(pid), WNOHANG)` **for each adopted pid individually**.
+
+Read `crates/shep-cli/src/commands/reap.rs` first. It is prior art for the vocabulary and the `nix` usage, but NOT for the architecture: it works by living in a separate process from tokio's reaper, which a successor cannot do.
+
+- [ ] **Step 1: Write the failing tests**
+
+```rust
+#[test]
+fn an_adopted_pid_yields_its_real_exit_code() { ... }
+
+#[test]
+fn an_adopted_pid_killed_by_a_signal_reports_the_signal() { ... }
+
+#[test]
+fn reaping_an_adopted_pid_does_not_disturb_a_tokio_spawned_child() {
+    // The regression this file exists to prevent. A tokio-spawned child
+    // and an adopted pid exit at the same time; both must report their own
+    // real status, neither an io::Error.
+    ...
+}
+```
+
+The third test is the one that matters. Give it its own name in CI's serial job if it proves contention-sensitive, following `two_concurrent_boots`.
+
+- [ ] **Step 2: Run to verify they fail**
+
+- [ ] **Step 3: Implement**
+
+- [ ] **Step 4: Run to verify they pass**
+
+- [ ] **Step 5: Task gate, then commit**
+
+---
+
+### Task 8: wire it together, and prove a sheep never noticed
+
+**Files:**
+- Modify: `crates/shep-daemon/src/boot.rs` (the SIGHUP arm), `crates/shep-cli/src/commands/daemon.rs` (`Arm::Handover`)
+- Test: an end-to-end integration test
+
+`Arm::Handover` is currently unreachable and carries `#[expect(dead_code)]`. Constructing it without removing that attribute is a compile error, which is deliberate; remove it here.
+
+SIGHUP currently runs a graceful stop (phase 1, Task 3). It now runs the fitness check and either hands over or falls through to that same graceful stop.
+
+- [ ] **Step 1: Write the failing tests**
+
+```rust
+#[tokio::test]
+async fn a_sheep_keeps_its_pid_and_its_log_across_a_handover() {
+    // The two assertions that separate a hot restart from a fast one.
+    // A version that passes neither is the stop arm phase 1 already shipped.
+    let before = flock_pids().await;
+    let log_len_before = read_log_len();
+    reload().await;
+    assert_eq!(flock_pids().await, before, "pids must not move");
+    assert!(read_log_len() >= log_len_before, "the log must not restart");
+    assert_no_gap_in_sequence(read_log());
+}
+
+#[tokio::test]
+async fn a_flock_with_a_channel_sheep_takes_the_stop_arm() {
+    // The gate doing its job. Not a handover, and not a failure either.
+    ...
+}
+
+#[tokio::test]
+async fn the_control_socket_accepts_throughout() { ... }
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+- [ ] **Step 3: Implement**
+
+- [ ] **Step 4: Run to verify they pass**
+
+- [ ] **Step 5: Full phase gate, then commit**
+
+---
+
+## Phase gate
+
+After Task 8, and not per task:
+
+```bash
+cargo test --workspace --all-features -- --test-threads=1
+```
+```bash
+CARGO_TARGET_DIR=/tmp/xcheck-linux cargo check -p shep-daemon --all-targets --all-features --target x86_64-unknown-linux-gnu
+```
+```bash
+CARGO_TARGET_DIR=/tmp/xcheck-win cargo check --workspace --all-targets --all-features --target x86_64-pc-windows-gnu
+```
+
+**Then read the CI result before calling the branch green.** Task 4's `(deleted)` test is Linux-only and a macOS run never compiles it. This is the phase where that matters most: the local gate cannot prove the handover execs the new binary on the platform where it is hardest.
+
+## Empirical acceptance, beyond the suite
+
+Run by hand before the phase is called done, with two real binaries at different versions, as phase 1's acceptance was:
+
+1. start a flock of plain sheep under the old binary, note every pid
+2. replace the binary on disk
+3. `shep daemon reload`
+4. assert every sheep pid is UNCHANGED, the daemon's own version moved, and `shep bleats` shows no gap
+5. repeat with one sheep given `channel = true`, and assert the stop arm was taken instead
+
+## Self-review checklist
+
+- Every descriptor in the spec's H2 inventory is either carried by Task 3's blob or explicitly refused by Task 1's gate. No third category.
+- No task adds a dependency, and unsafe appears only in `sys.rs` if at all.
+- `PROTOCOL_VERSION` and `SCHEMA_VERSION` do not move. This phase changes no wire type and no JSON envelope.
+- Tasks 1, 2, 3 and 4 are independent of one another. Task 5 needs 2, 3 and 4. Task 6 needs 3. Task 7 is independent. Task 8 needs all of them.

--- a/docs/writing-plans/plans/2026-08-30-handover-phase2a.md
+++ b/docs/writing-plans/plans/2026-08-30-handover-phase2a.md
@@ -200,7 +200,7 @@ Actual: 2 passed
 
 The blob carries **no environment values**. A sheep's env may hold secrets and the successor re-reads them from config.
 
-- [ ] **Step 1: Write the failing tests**
+- [x] **Step 1: Write the failing tests**
 
 ```rust
 #[test]
@@ -227,17 +227,23 @@ fn a_blob_from_a_future_version_is_refused_not_guessed_at() {
 }
 ```
 
-- [ ] **Step 2: Run to verify they fail**
+- [x] **Step 2: Run to verify they fail**
 
-- [ ] **Step 3: Implement**
+Run: `cargo test -p shep-daemon --lib --all-features -- --skip ::slow::`
+Actual: FAIL, unresolved `Handover`/`CarriedSheep`/`CarriedFds`/`VERSION` (E0425/E0422/E0433 x10)
+
+- [x] **Step 3: Implement**
 
 `version` is checked on load and refused if unrecognised. A successor that cannot understand the blob must fail loudly and let the caller fall back, never adopt a partial picture.
 
 Write with mode `0600` to `$SHEP_HOME/run/handover.json`, and have the successor unlink it after reading. Set the permissions **at creation** (`OpenOptionsExt::mode`), not with a `chmod` afterwards, so there is no window where it is world-readable.
 
-- [ ] **Step 4: Run to verify they pass**
+- [x] **Step 4: Run to verify they pass**
 
-- [ ] **Step 5: Task gate, then commit**
+Actual: 569 passed, 18 filtered (up from 564: the plan's three, plus two over
+the file's mode that the plan did not ask for).
+
+- [x] **Step 5: Task gate, then commit**
 
 ---
 

--- a/docs/writing-plans/plans/2026-08-30-handover-phase2a.md
+++ b/docs/writing-plans/plans/2026-08-30-handover-phase2a.md
@@ -958,5 +958,5 @@ Run by hand before the phase is called done, with two real binaries at different
 
 - Every descriptor in the spec's H2 inventory is either carried by Task 3's blob or explicitly refused by Task 1's gate. No third category.
 - No task adds a dependency, and unsafe appears only in `sys.rs` if at all.
-- `PROTOCOL_VERSION` and `SCHEMA_VERSION` do not move. This phase changes no wire type and no JSON envelope.
+- `PROTOCOL_VERSION` and `SCHEMA_VERSION` do not move. The phase DOES change a wire type: Task 8d adds a `Request::HandoverFitness` and its `Response`. Neither constant has to move for it, because the variant is additive and an older daemon is never sent it (`Arm::for_daemon` decides the arm from the running version first). No JSON envelope changes at all.
 - Tasks 1, 2, 3 and 4 are independent of one another. Task 5 needs 2, 3 and 4. Task 6 needs 3. Task 7 is independent. Task 8 needs all of them.

--- a/docs/writing-plans/plans/2026-08-30-handover-phase2a.md
+++ b/docs/writing-plans/plans/2026-08-30-handover-phase2a.md
@@ -65,7 +65,7 @@ This gate is what makes every later stage safe to ship. Get it wrong in the perm
 
 **Refuse when ANY sheep has**: a shepherd channel, `stdin = true`, a `dog` marker, `instance` implying a multi-instance app, a non-`None` `reload` marker, or a pending manual/delete. Read the real field names off `crates/shep-daemon/src/entry.rs` before writing the match; do not trust these names.
 
-- [ ] **Step 1: Write the failing tests**
+- [x] **Step 1: Write the failing tests**
 
 ```rust
 #[test]
@@ -98,12 +98,12 @@ fn an_empty_flock_is_carryable() {
 }
 ```
 
-- [ ] **Step 2: Run to verify they fail**
+- [x] **Step 2: Run to verify they fail**
 
 Run: `cargo test -p shep-daemon --lib --all-features -- --skip ::slow:: fitness`
 Expected: FAIL, unresolved `fitness`
 
-- [ ] **Step 3: Implement**
+- [x] **Step 3: Implement**
 
 `RefusedReason` carries the sheep's name and the feature that blocked it, and its `Display` names the fallback:
 
@@ -124,9 +124,9 @@ pub enum RefusedReason {
 
 `#[non_exhaustive]` here, unlike `Shepherd` in `boot.rs`: this set genuinely grows as 2b and 2c widen what is carryable, which is the opposite of that enum's closed-by-mechanism argument.
 
-- [ ] **Step 4: Run to verify they pass**
+- [x] **Step 4: Run to verify they pass**
 
-- [ ] **Step 5: Task gate, then commit**
+- [x] **Step 5: Task gate, then commit**
 
 ---
 

--- a/docs/writing-plans/plans/2026-08-30-handover-phase2a.md
+++ b/docs/writing-plans/plans/2026-08-30-handover-phase2a.md
@@ -334,7 +334,7 @@ the Linux-only test protects is exercised on a platform that compiles it).
 
 Order matters and getting it wrong loses a flock: write the blob to disk FIRST, then clear `FD_CLOEXEC` on every descriptor the blob names, then `execv`. If the exec fails, the blob is stale and must be removed before returning the error, or the next boot adopts a picture that never happened.
 
-- [ ] **Step 1: Write the failing test**
+- [x] **Step 1: Write the failing test**
 
 ```rust
 #[test]
@@ -351,17 +351,46 @@ fn an_exec_replaces_the_image_and_keeps_a_descriptor() {
 }
 ```
 
-- [ ] **Step 2: Run to verify it fails**
+shep-daemon is a library, so there is no helper binary to reach for and the
+plan's `helper_bin()` has nothing to return. The test binary is its own
+helper instead: three stages of the same test, selected by environment. The
+ordinary run re-runs this one test in a child with `--exact` and a marker
+naming a temp `$SHEP_HOME`; that child writes `hello` into a pipe, names the
+read end in a blob, and calls `hand_over`; the image `execve` lands in sees
+`SHEP_HANDOVER`, reads the blob, and reads the same fd number back. A second
+test covers the failed-exec cleanup, which needs a target that cannot run
+and so goes through a private `exec_into` rather than `hand_over`.
 
-- [ ] **Step 3: Implement**
+- [x] **Step 2: Run to verify it fails**
+
+Actual: FAIL, unresolved `HANDOVER_ENV`/`hand_over`/`exec_into` (E0425 x4).
+
+- [x] **Step 3: Implement**
 
 Use `nix::unistd::execv`. Pass the successor's marker through the environment: the blob's path in `SHEP_HANDOVER`, following the `SHEP_CHANNEL_FD` precedent of naming a descriptor-carrying thing in the environment.
 
 `execve` resets every signal handler to `SIG_DFL`, so nothing that was installed survives. That is expected and the successor re-installs; do not try to preserve handlers.
 
-- [ ] **Step 4: Run to verify it passes**
+`nix::unistd::execve`, not `execv`. `execv` inherits this process's
+`environ`, so setting `SHEP_HANDOVER` in it would mean `std::env::set_var`,
+which is unsafe in edition 2024 and unsound in a process with as many
+threads as the daemon; handing the environment over explicitly needs
+neither, and keeps the module free of unsafe (IR-22/23). Descriptors are
+cleared through a new `fds::keep_raw_across_exec`, for the same reason:
+`BorrowedFd::borrow_raw` is unsafe and a number needs no borrow.
 
-- [ ] **Step 5: Task gate, then commit**
+`exec_target()` resolves before the blob is written, so the one failure that
+leaves nothing behind gets no cleanup; blob, then descriptors, then exec is
+exactly as ordered above.
+
+- [x] **Step 4: Run to verify it passes**
+
+Actual: 577 passed, 18 filtered (up from 575: the plan's exec test, plus the
+one over the failed-exec cleanup the ordering argument demands). The exec
+test was also confirmed non-vacuous by removing the `FD_CLOEXEC` loop, at
+which point the successor cannot read the descriptor and it fails.
+
+- [x] **Step 5: Task gate, then commit**
 
 ---
 

--- a/web/src/data/cli-reference.generated.txt
+++ b/web/src/data/cli-reference.generated.txt
@@ -1,5 +1,5 @@
 @@VERSION@@
-shep 0.1.16
+shep 0.1.17
 @@TOPLEVEL@@
 A process manager for your flock
 

--- a/web/src/pages/docs/getting-started.astro
+++ b/web/src/pages/docs/getting-started.astro
@@ -76,9 +76,11 @@ import CodeBlock from "../../components/docs/CodeBlock.astro";
       <div><span class="prompt">$</span> shep daemon reload</div>
     </div>
     <p>
-      The flock keeps running through the reload. The shepherd replaces its
-      own image in place, so every sheep keeps the pid it already had and its
-      log carries on where it was.
+      A flock that can be carried keeps running through the reload. The
+      shepherd replaces its own image in place, so every sheep keeps the pid
+      it already had and its log carries on where it was. One that cannot is
+      stopped and started instead, which moves every pid and starts every log
+      again; the note below says which flocks those are.
     </p>
     <p class="fine">
       Not every flock can be carried yet. A sheep with a shepherd channel,

--- a/web/src/pages/docs/getting-started.astro
+++ b/web/src/pages/docs/getting-started.astro
@@ -75,6 +75,19 @@ import CodeBlock from "../../components/docs/CodeBlock.astro";
       <div><span class="prompt">$</span> cargo install shep-log-rotate<span class="muted"> # and every other dog</span></div>
       <div><span class="prompt">$</span> shep daemon reload</div>
     </div>
+    <p>
+      The flock keeps running through the reload. The shepherd replaces its
+      own image in place, so every sheep keeps the pid it already had and its
+      log carries on where it was.
+    </p>
+    <p class="fine">
+      Not every flock can be carried yet. A sheep with a shepherd channel,
+      <code>stdin = true</code>, more than one instance, a dog, or anything
+      mid-reload sends the reload down the older path instead: the flock is
+      stopped and started, and the reload prints which sheep held it back.
+      The first reload after upgrading to this version always takes that
+      path, because the shepherd being replaced predates the handover.
+    </p>
     <Callout variant="careful">
       Skip <code>shep daemon reload</code> and the new binary answers
       <code>shep --version</code> while the running shepherd is still the


### PR DESCRIPTION
`shep daemon reload` now replaces the shepherd without stopping the flock. A sheep keeps its pid, its descriptors and its place in its own log file, because the daemon `execve`s itself rather than exiting.

Measured end to end against a real flock under an isolated `SHEP_HOME`, not a fixture:

```
before:  sheep=68913  daemon=68892  log_lines=62
$ shep daemon reload
notice[reload]: the shepherd is now 0.1.17 (pid 68892)
after:   sheep=68913  daemon=68892  log_lines=72

sheep pid unchanged:   YES
daemon pid unchanged:  YES
sequence 1..72, breaks: NONE
```

The daemon's own pid survives too, since that is what `execve` means. Uptime read 13s afterwards rather than resetting.

How it works:

- descriptors that must live through the exec have `FD_CLOEXEC` cleared deliberately, and their numbers travel in a blob at `$SHEP_HOME/run/handover.json`, mode 0600 at creation, unlinked by the successor that reads it
- the trigger is SIGHUP, never a socket request, because the case that most needs a reload is the one where the socket refuses the client
- the decision is a socket query, because a signal carries no reply and a daemon that refuses one and then stops gracefully leaves nobody to start a successor
- an adopted sheep has no `tokio::process::Child`, and there is no way to make one, so it is reaped by a second targeted `waitpid` path running alongside tokio's own. A wildcard would steal statuses tokio needs, which this repo already learned once
- anything this phase cannot carry falls back to the stop arm, which is correct rather than tolerated

Still refused, and each is its own later phase: a shepherd channel, `stdin = true`, dogs, multiple instances, an in-flight reload, a pending stop or delete.

Three things found by looking rather than by review:

- **the torn line is real.** With a sheep emitting as fast as the pipe allows, three runs of three broke. After `10917` came `1916`, which is not a suffix of `10918`, so what died was everything the pump's `BufReader` had consumed and not yet emitted. 2b has to carry the reader's buffer. The numbers are in the test's doc comment
- **a successor would have destroyed the muster roll.** Installing the flock did not repopulate `FlockRegistry`, so the snapshot writer would have written an empty roll within seconds and a reboot after that would have restored nothing
- **a SIGHUP handover execs the test harness**, because boot records `argv[0]` and in a test that is the harness. Now behind a `BootOptions::handover` that defaults to false

Two decisions worth a second opinion:

- `HANDOVER_SINCE` is `0.1.18`, with an allowance so a shepherd reporting this binary's own version also takes the handover arm. Without it the arm is unreachable on this branch and the phase's own assertions cannot be tested. The exposure is a dev 0.1.17 meeting an installed 0.1.17, which ends in the stop arm anyway, and the window closes at the next release. The alternative was bumping `PROTOCOL_VERSION` and costing every operator a cold first upgrade
- the blob carries each sheep's whole config, environment included. The muster roll already persists the same values in cleartext at 0600 for the life of the flock, so this is the same exposure on a file that lives for milliseconds. Refusing to carry it would have meant rebuilding every spec from a roll that records a running count rather than which slots were up

`PROTOCOL_VERSION` and `SCHEMA_VERSION` are both unmoved. 2063 tests, and the Windows cross-check ran on every task rather than at the end, which caught two breaks the host-only gate called green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Unix daemon reloads can replace Shepherd in place while preserving running processes, IDs, logs, counters, and control-socket availability.
  * Reloads check compatibility first and explain when they fall back to stop-and-start.
  * Windows continues using stop-and-start reloads.

* **Bug Fixes**
  * Improved reload reliability by preserving log output and service responsiveness during supported handovers.
  * Prevented stale state from being restored during successor startup.

* **Documentation**
  * Added guidance on supported handovers, fallback scenarios, and upgrade-related reload behavior, including the first reload after upgrading.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->