### PR TITLE
chore: release v0.1.18

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2058,7 +2058,7 @@ dependencies = [
 
 [[package]]
 name = "shep"
-version = "0.1.17"
+version = "0.1.18"
 dependencies = [
  "anstyle",
  "assert_cmd",
@@ -2096,11 +2096,11 @@ dependencies = [
 
 [[package]]
 name = "shep-cli"
-version = "0.1.17"
+version = "0.1.18"
 
 [[package]]
 name = "shep-client"
-version = "0.1.17"
+version = "0.1.18"
 dependencies = [
  "futures-util",
  "nix 0.29.0",
@@ -2113,7 +2113,7 @@ dependencies = [
 
 [[package]]
 name = "shep-core"
-version = "0.1.17"
+version = "0.1.18"
 dependencies = [
  "annotate-snippets",
  "anstyle",
@@ -2143,7 +2143,7 @@ dependencies = [
 
 [[package]]
 name = "shep-daemon"
-version = "0.1.17"
+version = "0.1.18"
 dependencies = [
  "bytes",
  "chrono",
@@ -2172,7 +2172,7 @@ dependencies = [
 
 [[package]]
 name = "shep-examples"
-version = "0.1.17"
+version = "0.1.18"
 dependencies = [
  "nix 0.29.0",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.17"
+version = "0.1.18"
 edition = "2024"
 # 1.88 forced by serde-saphyr (let-chains, stabilized 1.88) — a current dep,
 # not a future one. Also the floor for ratatui/sysinfo/rmcp in later phases.
@@ -31,9 +31,9 @@ license = "MIT OR Apache-2.0"
 # the `[package]` table — so this literal is not sourced from
 # `workspace.package.version` above and a release bump has to touch both
 # places by hand. If that drifts, `cargo-release` is the mechanical fix.
-shep-core = { path = "crates/shep-core", version = "0.1.17" }
-shep-daemon = { path = "crates/shep-daemon", version = "0.1.17" }
-shep-client = { path = "crates/shep-client", version = "0.1.17" }
+shep-core = { path = "crates/shep-core", version = "0.1.18" }
+shep-daemon = { path = "crates/shep-daemon", version = "0.1.18" }
+shep-client = { path = "crates/shep-client", version = "0.1.18" }
 serde = { version = "1", default-features = false, features = ["derive"] }
 serde_json = { version = "1", default-features = false, features = ["std"] }
 toml = { version = "0.8", default-features = false, features = ["parse", "display"] }

--- a/crates/shep-cli/CHANGELOG.md
+++ b/crates/shep-cli/CHANGELOG.md
@@ -13,6 +13,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.18] - 2026-08-30
+
+### Added
+
+- Daemon reload takes the handover arm
+
+### Fixed
+
+- The handover drops an in-flight request, by design
+- A successor skips the roll whatever size its flock is
+- Reload drops its probe connection before the stop arm
+- Running_version is read only on unix, so bind it only there
+- Prove the successor is serving before reporting through it
+- Make the descriptor-restore case able to fail
+- Outlive the predecessor before trusting a successor
+- Refuse the handover arm when no witness can be held
+
+
 ## [0.1.17] - 2026-08-30
 
 ### Added

--- a/crates/shep-client/CHANGELOG.md
+++ b/crates/shep-client/CHANGELOG.md
@@ -10,6 +10,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.18] - 2026-08-30
+
+### Added
+
+- Daemon reload takes the handover arm
+
+
 ## [0.1.17] - 2026-08-30
 
 ### Added

--- a/crates/shep-core/CHANGELOG.md
+++ b/crates/shep-core/CHANGELOG.md
@@ -10,6 +10,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.18] - 2026-08-30
+
+### Added
+
+- Give the runner an adopt seam for a carried sheep
+- A fitness query for the daemon handover
+- SIGHUP hands the flock to a successor
+
+
 ## [0.1.17] - 2026-08-30
 
 ### Added

--- a/crates/shep-daemon/CHANGELOG.md
+++ b/crates/shep-daemon/CHANGELOG.md
@@ -10,6 +10,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.18] - 2026-08-30
+
+### Added
+
+- Whole-flock fitness gate for phase 2a
+- Clear FD_CLOEXEC on a descriptor, and prove it
+- Carry a flock's state across the exec in a handover blob
+- Resolve a handover's exec target without current_exe
+- Write the blob, keep the descriptors, exec the successor
+- Adopt a handover's descriptors in the successor
+- Reap adopted pids one at a time, never wildcard
+- Carry each sheep's resolved spec in the handover blob
+- Report a log pump's descriptors and snapshot a flock for handover
+- Give the runner an adopt seam for a carried sheep
+- Install a flock the successor inherited
+- SIGHUP hands the flock to a successor
+
+### Fixed
+
+- Mark LogCtl non_exhaustive, since 8a just grew it
+- Derive an adopted sheep's start time from the OS
+- A successor skips the roll whatever size its flock is
+- Two handover messages that misdescribed their own state
+- A failed handover puts FD_CLOEXEC back
+- Refuse a handover blob that names one descriptor twice
+- Make the descriptor-restore case able to fail
+
+
 ## [0.1.17] - 2026-08-30
 
 ### Added


### PR DESCRIPTION



## 🤖 New release

* `shep-core`: 0.1.17 -> 0.1.18 (✓ API compatible changes)
* `shep-daemon`: 0.1.17 -> 0.1.18 (✓ API compatible changes)
* `shep-client`: 0.1.17 -> 0.1.18 (✓ API compatible changes)
* `shep`: 0.1.17 -> 0.1.18 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `shep-core`

<blockquote>

## [0.1.18] - 2026-08-30

### Added

- Give the runner an adopt seam for a carried sheep
- A fitness query for the daemon handover
- SIGHUP hands the flock to a successor
</blockquote>

## `shep-daemon`

<blockquote>

## [0.1.18] - 2026-08-30

### Added

- Whole-flock fitness gate for phase 2a
- Clear FD_CLOEXEC on a descriptor, and prove it
- Carry a flock's state across the exec in a handover blob
- Resolve a handover's exec target without current_exe
- Write the blob, keep the descriptors, exec the successor
- Adopt a handover's descriptors in the successor
- Reap adopted pids one at a time, never wildcard
- Carry each sheep's resolved spec in the handover blob
- Report a log pump's descriptors and snapshot a flock for handover
- Give the runner an adopt seam for a carried sheep
- Install a flock the successor inherited
- SIGHUP hands the flock to a successor

### Fixed

- Mark LogCtl non_exhaustive, since 8a just grew it
- Derive an adopted sheep's start time from the OS
- A successor skips the roll whatever size its flock is
- Two handover messages that misdescribed their own state
- A failed handover puts FD_CLOEXEC back
- Refuse a handover blob that names one descriptor twice
- Make the descriptor-restore case able to fail
</blockquote>

## `shep-client`

<blockquote>

## [0.1.18] - 2026-08-30

### Added

- Daemon reload takes the handover arm
</blockquote>

## `shep`

<blockquote>

## [0.1.18] - 2026-08-30

### Added

- Daemon reload takes the handover arm

### Fixed

- The handover drops an in-flight request, by design
- A successor skips the roll whatever size its flock is
- Reload drops its probe connection before the stop arm
- Running_version is read only on unix, so bind it only there
- Prove the successor is serving before reporting through it
- Make the descriptor-restore case able to fail
- Outlive the predecessor before trusting a successor
- Refuse the handover arm when no witness can be held
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).