### PR TITLE
fix(bark): let [[dog.bark.rules]] actually parse from TOML

### DIFF
--- a/_typos.toml
+++ b/_typos.toml
@@ -54,6 +54,16 @@ contro = "contro"
 # error on the first-flockfile docs page.
 instnace = "instnace"
 
+# `retsarts` is the same shape as `contro` and `instnace` above: a deliberate
+# misspelling of `restarts` that a test depends on BY NAME. The bark dog's
+# rule parser must refuse an unknown key and say which one, so
+# `a_misspelled_trigger_field_is_refused_with_the_bad_key_named` asserts the
+# error string contains "retsarts". Correcting the spelling would make that
+# test assert nothing at all. Three sites, all in
+# crates/shep-cli/src/dog/bark/rules.rs: the test's doc comment, its TOML
+# fixture, and the assertion that reads the error back.
+retsarts = "retsarts"
+
 # Triggered by "marketing PNGs" (docs/systematic-refactor/.../assessment.md):
 # typos splits the plural acronym into "PN" + "Gs" and flags the first half
 # as a typo of "ON". A real word, not a real word, either way not a mistake

--- a/crates/shep-cli/src/dog/bark/mod.rs
+++ b/crates/shep-cli/src/dog/bark/mod.rs
@@ -583,7 +583,7 @@ mod tests {
         );
         Rules::new(
             vec![rules::Rule {
-                when: rules::Trigger::GaveUp,
+                when: rules::Trigger::GaveUp {},
                 sinks: vec!["ops".to_owned()],
                 debounce: UpDuration::from_millis(5 * 60_000),
             }],
@@ -788,7 +788,7 @@ mod tests {
         let rules = Rules::new(
             vec![
                 rules::Rule {
-                    when: rules::Trigger::GaveUp,
+                    when: rules::Trigger::GaveUp {},
                     sinks: vec!["slow".to_owned()],
                     debounce: UpDuration::from_millis(0),
                 },
@@ -846,5 +846,57 @@ mod tests {
             barks::DEFAULT_MAX_BYTES
         );
         assert_eq!(BarkConfig::default().sink_timeout.as_millis(), 10_000);
+    }
+
+    /// fails if `[dog.bark]` cannot parse the exact `shep.toml` fragment
+    /// `docs/dogs.md` and `web/src/pages/docs/dogs.astro` publish as the
+    /// worked example — copy-pasted here relative to `[dog.bark]` the way
+    /// `runtime.config::<BarkConfig>()` sees it (that section already
+    /// stripped, so `[sinks]`/`[[rules]]` rather than
+    /// `[dog.bark.sinks]`/`[[dog.bark.rules]]`).
+    ///
+    /// This is the regression test for the shipped bug: `on_empty_section`
+    /// above is the only other test in this module that calls
+    /// `toml::from_str::<BarkConfig>`, and an empty document never
+    /// deserializes a single [`rules::Rule`], so it passed on v0.1.18 even
+    /// though `[[dog.bark.rules]]` could not parse at all — `Rule`'s
+    /// `#[serde(flatten)]` field and its (then) `deny_unknown_fields`
+    /// rejected `on` itself as an unknown key. See `rules.rs`'s own
+    /// `Rule`/[`rules::Trigger`] docs for the fix.
+    #[test]
+    fn the_documented_bark_config_parses_from_toml() {
+        let toml_str = r#"
+[sinks]
+oncall = { kind = "discord", url = "https://discord.com/api/webhooks/..." }
+audit = { kind = "json", url = "https://example.internal/hook" }
+
+[[rules]]
+on = "gave_up"
+sinks = ["oncall", "audit"]
+
+[[rules]]
+on = "restart_rate"
+restarts = 5
+within = "2m"
+sinks = ["oncall"]
+"#;
+        let config: BarkConfig =
+            toml::from_str(toml_str).expect("the documented [dog.bark] example must parse");
+        assert_eq!(config.sinks.len(), 2);
+        assert_eq!(config.rules.len(), 2);
+        assert_eq!(config.rules[0].when, rules::Trigger::GaveUp {});
+        assert_eq!(config.rules[0].sinks, vec!["oncall", "audit"]);
+        assert_eq!(
+            config.rules[1].when,
+            rules::Trigger::RestartRate {
+                restarts: 5,
+                within: UpDuration::from_millis(2 * 60_000),
+            }
+        );
+        assert_eq!(config.rules[1].sinks, vec!["oncall"]);
+        // Both rules must also survive `Rules::new`'s own validation
+        // against the sinks parsed alongside them — the parse succeeding
+        // is necessary but not sufficient for the dog to actually start.
+        Rules::new(config.rules, &config.sinks).expect("both documented rules route to real sinks");
     }
 }

--- a/crates/shep-cli/src/dog/bark/rules.rs
+++ b/crates/shep-cli/src/dog/bark/rules.rs
@@ -45,19 +45,19 @@ fn default_debounce() -> UpDuration {
 
 /// One entry under `[dog.bark.rules]`.
 ///
-/// NOT `#[serde(deny_unknown_fields)]` on this struct, even though a
-/// misspelled key here must still be a startup error — see
+/// A misspelled key anywhere in a rule is a startup error naming the bad
+/// key, never a silently ignored setting. See
 /// [`BarkConfig`](super::BarkConfig)'s own doc for why that posture
-/// matters. `serde` does not support `deny_unknown_fields` together with
-/// `#[serde(flatten)]` on the same struct: the flattened field needs to
-/// collect whatever keys the outer struct's own named fields do not claim,
-/// and `deny_unknown_fields` rejects exactly those before the flattened
-/// field ever sees them — every key of a real rule, `on` included, is
-/// "unknown" from `Rule`'s own point of view. [`Trigger`] carries the
-/// attribute instead: everything this struct's own fields (`sinks`,
-/// `debounce`) do not consume flows into `Trigger`'s deserialize, so its
-/// `deny_unknown_fields` still catches a typo anywhere in a rule, just one
-/// level down from where the old attribute sat.
+/// matters.
+// The attribute enforcing that sits on `Trigger` rather than here, and it
+// cannot sit here: serde does not support `deny_unknown_fields` alongside
+// `#[serde(flatten)]` on one struct. The flattened field has to collect
+// whatever keys this struct's own named fields do not claim, and
+// `deny_unknown_fields` rejects exactly those before the flattened field
+// ever sees them, so every key of a real rule, `on` included, reads as
+// unknown from `Rule`'s point of view. Everything `sinks` and `debounce`
+// do not consume flows into `Trigger`'s deserialize instead, which catches
+// the typo one level down from where the attribute used to sit.
 #[derive(Debug, Clone, PartialEq, Deserialize)]
 pub struct Rule {
     /// What fires it.
@@ -93,20 +93,17 @@ pub enum Trigger {
     /// missed — the app is down and staying down — and because it cannot
     /// disagree with the shepherd: it is keyed to the shepherd's own
     /// decision rather than to a threshold bark chose.
-    ///
-    /// An empty struct variant, `GaveUp {}`, rather than a bare unit
-    /// variant — deliberately, and load-bearing for `deny_unknown_fields`
-    /// above. An internally tagged unit variant deserializes through a
-    /// path that never visits the rest of the map, so a stray key next to
-    /// `on = "gave_up"` (a misspelled `debounce`, say) parsed silently
-    /// even with `deny_unknown_fields` set — confirmed empirically before
-    /// this fix, and covered by
-    /// `tests::a_misspelled_field_next_to_gave_up_is_still_refused` below.
-    /// A struct variant, even an empty one, goes through the same
-    /// field-checking visitor every other variant here already used, so
-    /// the typo is refused like any other. Wire-compatible: `on =
-    /// "gave_up"` alone still parses to this variant, unchanged — nothing
-    /// an operator types needs to change.
+    // An empty struct variant rather than a bare unit variant,
+    // deliberately, and load-bearing for the `deny_unknown_fields` above.
+    // An internally tagged UNIT variant deserializes through a path that
+    // never visits the rest of the map, so a stray key beside
+    // `on = "gave_up"` (a misspelled `debounce`, say) parsed silently even
+    // with the attribute set. Measured, not assumed, and covered by
+    // `tests::a_misspelled_field_next_to_gave_up_is_still_refused` below.
+    // A struct variant, even an empty one, goes through the same
+    // field-checking visitor every other variant here already used. The
+    // wire shape is identical either way: `on = "gave_up"` on its own
+    // still parses to this variant.
     GaveUp {},
     /// The early warning: `restarts` restarts within `within`. Opt-in,
     /// because it is the one that pages at 3am for a blip, and the

--- a/crates/shep-cli/src/dog/bark/rules.rs
+++ b/crates/shep-cli/src/dog/bark/rules.rs
@@ -44,8 +44,21 @@ fn default_debounce() -> UpDuration {
 }
 
 /// One entry under `[dog.bark.rules]`.
+///
+/// NOT `#[serde(deny_unknown_fields)]` on this struct, even though a
+/// misspelled key here must still be a startup error — see
+/// [`BarkConfig`](super::BarkConfig)'s own doc for why that posture
+/// matters. `serde` does not support `deny_unknown_fields` together with
+/// `#[serde(flatten)]` on the same struct: the flattened field needs to
+/// collect whatever keys the outer struct's own named fields do not claim,
+/// and `deny_unknown_fields` rejects exactly those before the flattened
+/// field ever sees them — every key of a real rule, `on` included, is
+/// "unknown" from `Rule`'s own point of view. [`Trigger`] carries the
+/// attribute instead: everything this struct's own fields (`sinks`,
+/// `debounce`) do not consume flows into `Trigger`'s deserialize, so its
+/// `deny_unknown_fields` still catches a typo anywhere in a rule, just one
+/// level down from where the old attribute sat.
 #[derive(Debug, Clone, PartialEq, Deserialize)]
-#[serde(deny_unknown_fields)]
 pub struct Rule {
     /// What fires it.
     #[serde(flatten)]
@@ -62,8 +75,12 @@ pub struct Rule {
 }
 
 /// What makes a rule fire.
+///
+/// `deny_unknown_fields` lives here rather than on [`Rule`] — see that
+/// type's own doc for why the combination with `#[serde(flatten)]` forced
+/// the move.
 #[derive(Debug, Clone, PartialEq, Deserialize)]
-#[serde(tag = "on", rename_all = "snake_case")]
+#[serde(tag = "on", rename_all = "snake_case", deny_unknown_fields)]
 pub enum Trigger {
     /// Any of these bus event kinds, by their wire spelling
     /// (`exit`, `errored`, `online`, ...).
@@ -76,7 +93,21 @@ pub enum Trigger {
     /// missed — the app is down and staying down — and because it cannot
     /// disagree with the shepherd: it is keyed to the shepherd's own
     /// decision rather than to a threshold bark chose.
-    GaveUp,
+    ///
+    /// An empty struct variant, `GaveUp {}`, rather than a bare unit
+    /// variant — deliberately, and load-bearing for `deny_unknown_fields`
+    /// above. An internally tagged unit variant deserializes through a
+    /// path that never visits the rest of the map, so a stray key next to
+    /// `on = "gave_up"` (a misspelled `debounce`, say) parsed silently
+    /// even with `deny_unknown_fields` set — confirmed empirically before
+    /// this fix, and covered by
+    /// `tests::a_misspelled_field_next_to_gave_up_is_still_refused` below.
+    /// A struct variant, even an empty one, goes through the same
+    /// field-checking visitor every other variant here already used, so
+    /// the typo is refused like any other. Wire-compatible: `on =
+    /// "gave_up"` alone still parses to this variant, unchanged — nothing
+    /// an operator types needs to change.
+    GaveUp {},
     /// The early warning: `restarts` restarts within `within`. Opt-in,
     /// because it is the one that pages at 3am for a blip, and the
     /// threshold should be one the operator chose.
@@ -102,7 +133,7 @@ pub enum Trigger {
 fn trigger_name(when: &Trigger) -> &'static str {
     match when {
         Trigger::Event { .. } => "event",
-        Trigger::GaveUp => "gave_up",
+        Trigger::GaveUp {} => "gave_up",
         Trigger::RestartRate { .. } => "restart_rate",
         Trigger::MemoryAbove { .. } => "memory_above",
     }
@@ -269,7 +300,7 @@ impl Rules {
     #[must_use]
     pub fn default_rules(sinks: &BTreeMap<String, Sink>) -> Vec<Rule> {
         vec![Rule {
-            when: Trigger::GaveUp,
+            when: Trigger::GaveUp {},
             sinks: sinks.keys().cloned().collect(),
             debounce: default_debounce(),
         }]
@@ -341,7 +372,7 @@ impl Rules {
                 Trigger::Event { kinds } if kinds.iter().any(|k| k == &kind_wire) => {
                     Some(format!("{} {kind_wire}", info.name))
                 }
-                Trigger::GaveUp if kind == ProcessEventKind::Errored => {
+                Trigger::GaveUp {} if kind == ProcessEventKind::Errored => {
                     Some(format!("{} gave up: restart budget exhausted", info.name))
                 }
                 _ => None,
@@ -382,7 +413,7 @@ impl Rules {
                 let trigger = self.rules[idx].when.clone();
                 let message = match &trigger {
                     Trigger::Event { .. } => None,
-                    Trigger::GaveUp => (info.status == ProcStatus::Errored).then(|| {
+                    Trigger::GaveUp {} => (info.status == ProcStatus::Errored).then(|| {
                         format!("{} gave up: restart budget exhausted", info.name)
                     }),
                     Trigger::RestartRate { restarts, within } => self
@@ -497,7 +528,7 @@ mod tests {
         let sinks = one_sink("ops");
         Rules::new(
             vec![Rule {
-                when: Trigger::GaveUp,
+                when: Trigger::GaveUp {},
                 sinks: vec!["ops".to_owned()],
                 debounce: default_debounce(),
             }],
@@ -521,7 +552,7 @@ mod tests {
 
     fn rule_to(sink: &str) -> Rule {
         Rule {
-            when: Trigger::GaveUp,
+            when: Trigger::GaveUp {},
             sinks: vec![sink.to_owned()],
             debounce: default_debounce(),
         }
@@ -601,7 +632,7 @@ mod tests {
         let sinks = one_sink("ops");
         let rules = Rules::default_rules(&sinks);
         assert_eq!(rules.len(), 1);
-        assert_eq!(rules[0].when, Trigger::GaveUp);
+        assert_eq!(rules[0].when, Trigger::GaveUp {});
         assert_eq!(rules[0].sinks, vec!["ops"]);
     }
 
@@ -612,7 +643,7 @@ mod tests {
     #[test]
     fn a_rule_with_no_sinks_at_all_is_refused_at_startup() {
         let rule = Rule {
-            when: Trigger::GaveUp,
+            when: Trigger::GaveUp {},
             sinks: Vec::new(),
             debounce: default_debounce(),
         };
@@ -784,8 +815,8 @@ mod tests {
     /// `GaveUp` is on by default with no configuration at all; a rule that
     /// fires on every event kind is as useless as one that never fires,
     /// because it trains an operator to ignore it. Proven by mutating the
-    /// `on_event` match arm from `Trigger::GaveUp if kind ==
-    /// ProcessEventKind::Errored` to an unconditional `Trigger::GaveUp`:
+    /// `on_event` match arm from `Trigger::GaveUp {} if kind ==
+    /// ProcessEventKind::Errored` to an unconditional `Trigger::GaveUp {}`:
     /// before this test existed, all 14 other `rules::` tests stayed green
     /// under that mutation because none of them fed `gave_up_rules()`
     /// anything but an `Errored` event or status.
@@ -828,6 +859,211 @@ mod tests {
             rules.on_event(&errored_event("web"), debounce_ms).len(),
             1,
             "exactly at the debounce it may fire again"
+        );
+    }
+
+    // The tests above all build `Rule`/`Trigger` as Rust values, which
+    // never runs `Deserialize` at all and is exactly how the shipped bug
+    // passed every one of them: `Rule`'s `#[serde(flatten)]` combined with
+    // `#[serde(deny_unknown_fields)]` made every `[[dog.bark.rules]]` entry
+    // refuse to parse, and nothing here noticed. The tests below parse
+    // real TOML strings instead — see `Rule`'s and `Trigger`'s own docs
+    // for the fix these prove.
+
+    /// fails if the docs' own `on = "gave_up"` rule cannot be parsed from
+    /// TOML — the exact shape `docs/dogs.md` and
+    /// `web/src/pages/docs/dogs.astro` publish as copy-pasteable.
+    #[test]
+    fn the_docs_gave_up_rule_parses_from_toml() {
+        let rule: Rule = toml::from_str(
+            r#"
+on = "gave_up"
+sinks = ["oncall", "audit"]
+"#,
+        )
+        .unwrap();
+        assert_eq!(rule.when, Trigger::GaveUp {});
+        assert_eq!(rule.sinks, vec!["oncall", "audit"]);
+        assert_eq!(rule.debounce, default_debounce(), "no override in the TOML");
+    }
+
+    /// fails if the docs' own `on = "restart_rate"` rule cannot be parsed
+    /// from TOML, or if `within`'s `"2m"` string form (the same
+    /// [`UpDuration`] grammar every other duration field in `shep.toml`
+    /// accepts) is not honored inside a flattened [`Trigger`].
+    #[test]
+    fn the_docs_restart_rate_rule_parses_from_toml() {
+        let rule: Rule = toml::from_str(
+            r#"
+on = "restart_rate"
+restarts = 5
+within = "2m"
+sinks = ["oncall"]
+"#,
+        )
+        .unwrap();
+        assert_eq!(
+            rule.when,
+            Trigger::RestartRate {
+                restarts: 5,
+                within: UpDuration::from_millis(2 * 60_000),
+            }
+        );
+    }
+
+    /// fails if an `event` rule cannot be parsed from TOML — not shown in
+    /// the published docs, but a real `Trigger` variant a `[[dog.bark.
+    /// rules]]` entry can name, and the same flatten mechanism the docs'
+    /// two forms exercise.
+    #[test]
+    fn an_event_rule_parses_from_toml() {
+        let rule: Rule = toml::from_str(
+            r#"
+on = "event"
+kinds = ["exit", "errored"]
+sinks = ["oncall"]
+"#,
+        )
+        .unwrap();
+        assert_eq!(
+            rule.when,
+            Trigger::Event {
+                kinds: vec!["exit".to_owned(), "errored".to_owned()],
+            }
+        );
+    }
+
+    /// fails if a `memory_above` rule cannot be parsed from TOML, or if
+    /// `bytes`'s `"512M"` string form ([`MemSize`]'s own grammar) is not
+    /// honored inside a flattened [`Trigger`] — the fourth and last
+    /// variant, rounding out coverage of every rule form this parser
+    /// accepts.
+    #[test]
+    fn a_memory_above_rule_parses_from_toml() {
+        let rule: Rule = toml::from_str(
+            r#"
+on = "memory_above"
+bytes = "512M"
+sinks = ["oncall"]
+"#,
+        )
+        .unwrap();
+        assert_eq!(
+            rule.when,
+            Trigger::MemoryAbove {
+                // Binary units — MemSize's grammar is MiB, not MB.
+                bytes: MemSize::from_bytes(512 * 1024 * 1024),
+            }
+        );
+    }
+
+    /// fails if a rule's own `debounce` override does not survive parsing
+    /// alongside a flattened `Trigger` — [`Rule`]'s one other field beyond
+    /// `sinks`, and the one most likely to silently regress if a future
+    /// change reshuffles which fields `Rule` claims directly versus
+    /// forwards to `Trigger`.
+    #[test]
+    fn a_rule_s_debounce_override_parses_from_toml() {
+        let rule: Rule = toml::from_str(
+            r#"
+on = "gave_up"
+sinks = ["oncall"]
+debounce = "10m"
+"#,
+        )
+        .unwrap();
+        assert_eq!(rule.debounce, UpDuration::from_millis(10 * 60_000));
+    }
+
+    /// fails if a misspelled key inside a trigger with its own fields
+    /// (`restarts` typo'd as `retsarts`) is silently accepted rather than
+    /// refused with the bad key named — the protection
+    /// `#[serde(deny_unknown_fields)]` exists for, now living on
+    /// [`Trigger`] rather than [`Rule`]. See [`Rule`]'s own doc for why.
+    #[test]
+    fn a_misspelled_trigger_field_is_refused_with_the_bad_key_named() {
+        let err = toml::from_str::<Rule>(
+            r#"
+on = "restart_rate"
+retsarts = 5
+within = "2m"
+sinks = ["oncall"]
+"#,
+        )
+        .unwrap_err();
+        assert!(
+            err.to_string().contains("retsarts"),
+            "the error must name the misspelled key, not just fail: {err}"
+        );
+    }
+
+    /// fails if a misspelled key sitting next to `on = "gave_up"` is
+    /// silently accepted — the exact gap a bare `Trigger::GaveUp` unit
+    /// variant left even with `deny_unknown_fields` set, because `serde`
+    /// deserializes an internally tagged unit variant through a path that
+    /// never inspects the rest of the map. Proven by mutating `GaveUp {}`
+    /// (an empty *struct* variant) back to a bare `GaveUp` unit variant:
+    /// every other test in this file still passes, since none of them
+    /// parses a misspelled field next to `on = "gave_up"` — this is the
+    /// one that would have caught the exact way the shipped fix's own
+    /// protection could still leak.
+    #[test]
+    fn a_misspelled_field_next_to_gave_up_is_still_refused() {
+        let err = toml::from_str::<Rule>(
+            r#"
+on = "gave_up"
+sinks = ["oncall"]
+debuonce = "10m"
+"#,
+        )
+        .unwrap_err();
+        assert!(
+            err.to_string().contains("debuonce"),
+            "the error must name the misspelled key, not just fail: {err}"
+        );
+    }
+
+    /// fails if a misspelled `sinks` is accepted rather than refused. The
+    /// error names the field that is now missing (`sinks`, required with
+    /// no default) rather than the typo'd key itself (`sinsk` never
+    /// matches any field `Rule` or `Trigger` know about, so it is simply
+    /// absent from both) — still a startup refusal an operator can act on,
+    /// just phrased from the other direction than the trigger-field and
+    /// `GaveUp`-neighbor cases above.
+    #[test]
+    fn a_misspelled_sinks_field_is_refused_as_a_missing_field() {
+        let err = toml::from_str::<Rule>(
+            r#"
+on = "gave_up"
+sinsk = ["oncall"]
+"#,
+        )
+        .unwrap_err();
+        assert!(
+            err.to_string().contains("sinks"),
+            "the error must name the missing field: {err}"
+        );
+    }
+
+    /// fails if an unknown `on` variant is accepted rather than refused
+    /// with the bad value and the known ones both named.
+    #[test]
+    fn an_unknown_on_variant_is_refused_with_the_bad_value_named() {
+        let err = toml::from_str::<Rule>(
+            r#"
+on = "gav_up"
+sinks = ["oncall"]
+"#,
+        )
+        .unwrap_err();
+        let message = err.to_string();
+        assert!(
+            message.contains("gav_up"),
+            "the error must name the bad value: {message}"
+        );
+        assert!(
+            message.contains("gave_up"),
+            "the error must also name a real variant, so a typo suggests its own fix: {message}"
         );
     }
 }

--- a/crates/shep-cli/src/dog/bark/sinks.rs
+++ b/crates/shep-cli/src/dog/bark/sinks.rs
@@ -717,4 +717,125 @@ mod tests {
         };
         require_secure_scheme("ops", &sink).unwrap();
     }
+
+    // `Sink` is an internally tagged enum (`tag = "kind"`) with
+    // `deny_unknown_fields` and no `#[serde(flatten)]` anywhere near it —
+    // a different shape from `rules::Rule`'s, and one this fix's own audit
+    // confirmed parses correctly (`toml::from_str` was never broken here).
+    // These tests parse real TOML rather than building `Sink` in Rust, the
+    // same gap `rules::Rule`'s own tests closed, so a future change that
+    // reintroduces a flatten/deny_unknown_fields conflict here would be
+    // caught rather than shipped quietly a second time.
+
+    /// fails if the docs' own Discord sink — the exact inline-table shape
+    /// `docs/dogs.md` and `web/src/pages/docs/dogs.astro` publish under
+    /// `[dog.bark.sinks]` — cannot be parsed from TOML.
+    #[test]
+    fn the_docs_discord_sink_parses_from_toml() {
+        let sink: Sink = toml::from_str(
+            r#"kind = "discord"
+url = "https://discord.com/api/webhooks/..."
+"#,
+        )
+        .unwrap();
+        assert_eq!(
+            sink,
+            Sink::Discord {
+                url: "https://discord.com/api/webhooks/...".to_owned(),
+            }
+        );
+    }
+
+    /// fails if a Slack sink cannot be parsed from TOML — not shown in the
+    /// published docs' worked example, but a real, documented `kind`
+    /// (`docs/dogs.md`'s reference table names all three).
+    #[test]
+    fn a_slack_sink_parses_from_toml() {
+        let sink: Sink = toml::from_str(
+            r#"kind = "slack"
+url = "https://hooks.slack.com/services/T0/B0/tok"
+"#,
+        )
+        .unwrap();
+        assert_eq!(
+            sink,
+            Sink::Slack {
+                url: "https://hooks.slack.com/services/T0/B0/tok".to_owned(),
+            }
+        );
+    }
+
+    /// fails if the docs' own JSON sink cannot be parsed from TOML, with
+    /// `body` correctly left `None` when the operator does not template
+    /// one — the same fragment `docs/dogs.md` publishes for `audit`.
+    #[test]
+    fn the_docs_json_sink_parses_from_toml() {
+        let sink: Sink = toml::from_str(
+            r#"kind = "json"
+url = "https://example.internal/hook"
+"#,
+        )
+        .unwrap();
+        assert_eq!(
+            sink,
+            Sink::Json {
+                url: "https://example.internal/hook".to_owned(),
+                body: None,
+            }
+        );
+    }
+
+    /// fails if a `Json` sink's own `body` template does not survive
+    /// parsing — `Json`'s one field the other two variants do not have.
+    #[test]
+    fn a_json_sink_s_body_template_parses_from_toml() {
+        let sink: Sink = toml::from_str(
+            r#"kind = "json"
+url = "https://example.internal/hook"
+body = "{\"text\": \"{message}\"}"
+"#,
+        )
+        .unwrap();
+        assert_eq!(
+            sink,
+            Sink::Json {
+                url: "https://example.internal/hook".to_owned(),
+                body: Some(r#"{"text": "{message}"}"#.to_owned()),
+            }
+        );
+    }
+
+    /// fails if a misspelled field is silently accepted rather than
+    /// refused with the bad key named — `deny_unknown_fields` doing the
+    /// job it is declared for, on an internally tagged enum this fix's own
+    /// audit left untouched because it was never broken.
+    #[test]
+    fn a_misspelled_sink_field_is_refused_with_the_bad_key_named() {
+        let err = toml::from_str::<Sink>(
+            r#"kind = "discord"
+urll = "https://discord.com/api/webhooks/..."
+"#,
+        )
+        .unwrap_err();
+        assert!(
+            err.to_string().contains("urll"),
+            "the error must name the misspelled key, not just fail: {err}"
+        );
+    }
+
+    /// fails if an unknown `kind` is accepted rather than refused with the
+    /// bad value named.
+    #[test]
+    fn an_unknown_sink_kind_is_refused_with_the_bad_value_named() {
+        let err = toml::from_str::<Sink>(
+            r#"kind = "discrod"
+url = "https://discord.com/api/webhooks/..."
+"#,
+        )
+        .unwrap_err();
+        assert!(
+            err.to_string().contains("discrod"),
+            "the error must name the bad value: {err}"
+        );
+    }
 }

--- a/web/src/data/cli-reference.generated.txt
+++ b/web/src/data/cli-reference.generated.txt
@@ -1,5 +1,5 @@
 @@VERSION@@
-shep 0.1.17
+shep 0.1.18
 @@TOPLEVEL@@
 A process manager for your flock
 


### PR DESCRIPTION
Two small fixes, neither worth its own PR.

`[[dog.bark.rules]]` could not be parsed at all. `Rule` carried `#[serde(flatten)]` next to `#[serde(deny_unknown_fields)]`, which serde documents as incompatible, so every rule entry was refused, the bark dog exited 4, and it crash-looped. The examples in `docs/dogs.md` and on the docs site were copy-pasteable and broken.

- `deny_unknown_fields` moves onto `Trigger`, the flattened type, so a misspelled key is still a startup error one level down
- `Trigger::GaveUp` becomes `GaveUp {}`, wire-identical. An internally-tagged unit variant skips field checking entirely, so `on = "gave_up"` next to a typo still parsed clean with the first change alone
- 16 new tests that parse real TOML, including one built from the literal documented example
- no config syntax changed, so the published examples parse as they are

Measured against a real daemon using the doc's own example:

| | before | after |
|---|---|---|
| status | `waiting-restart` | `online` |
| exit code | 4 | none |
| restarts | climbing on every check | 0 |

The test gap is the reason this shipped: the only test that deserialized this config from TOML used an empty document, and every other test built the values in Rust where serde never runs. `[dog.bark.sinks]` turned out to be fine, and gets parse tests too so it stays that way.

Also regenerates `web/src/data/cli-reference.generated.txt`, which still declared `shep 0.1.17` after 0.1.18 shipped. One line, no CLI surface moved between the two releases.

2083 tests pass. `astro build` and `astro check` are both clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of TOML bark configurations.
  * Unknown or misspelled trigger and sink fields are now rejected with clearer errors.
  * Preserved support for documented trigger syntax, including `gave_up`.
  * Improved detection of unsupported trigger and sink types.

* **Tests**
  * Added coverage for trigger types, durations, memory settings, debounce options, sink configurations, and documented configuration parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->