### PR TITLE
feat(daemon): carry stdin, the shepherd channel and clustered apps across a handover

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,7 @@ is one class of test.
 cargo test -p shep-daemon --lib --all-features -- --skip ::slow::
 ```
 
-**~1.7s, 548 of 566 lib tests as of 2026-08-29** — the exact counts drift
+**~1.9s, 619 of 638 lib tests as of 2026-08-30** — the exact counts drift
 every time a task adds one, so treat them as a shape, not a checksum. Three
 briefs have now shipped a stale figure, and this file carried "437 of 454"
 for long enough to be wrong by fifty. The 18 tests this skips live in a nested `mod slow`

--- a/crates/shep-cli/src/commands/daemon.rs
+++ b/crates/shep-cli/src/commands/daemon.rs
@@ -1600,7 +1600,7 @@ otel = "/usr/local/bin/shep-otel"
             &paths.socket,
             ack_naming("9.9.9"),
             |_| Response::HandoverFitness {
-                refusal: Some("sheep 'chatty' has a shepherd channel".to_string()),
+                refusal: Some("sheep 'clustered' has more than one instance".to_string()),
             },
         )
         .await;
@@ -1622,7 +1622,7 @@ otel = "/usr/local/bin/shep-otel"
             String::from_utf8(out).unwrap(),
             String::from_utf8(err).unwrap()
         );
-        assert!(text.contains("shepherd channel"), "{text}");
+        assert!(text.contains("more than one instance"), "{text}");
         // No shepherd owns this home, so the stop arm it fell back to has
         // nothing to stop -- which is what proves it took that arm at all.
         assert_eq!(code, ExitCode::DaemonUnreachable, "{text}");

--- a/crates/shep-cli/tests/cli_e2e.rs
+++ b/crates/shep-cli/tests/cli_e2e.rs
@@ -7206,13 +7206,16 @@ fn a_sheep_keeps_its_pid_and_its_log_across_a_daemon_reload() {
 /// moved pid is what proves the stop arm was the one taken.
 #[cfg(unix)]
 #[test]
-fn a_flock_with_a_channel_sheep_takes_the_stop_arm() {
+fn a_flock_with_a_multi_instance_sheep_takes_the_stop_arm() {
     let dir = tempfile::tempdir().unwrap();
     let script = write_test_script(&dir);
+    // More than one instance, which is still a sheep no handover carries. It
+    // was a shepherd channel until 2b task 5 carried one; what this case is
+    // about is the gate refusing at all, and the operator being told.
     let flockfile = write_flockfile(
         &dir,
         &format!(
-            "[[app]]\nname = \"chatty\"\nscript = '{}'\nchannel = true\n",
+            "[[app]]\nname = \"clustered\"\nscript = '{}'\ninstances = 2\n",
             script.display()
         ),
     );
@@ -7243,11 +7246,11 @@ fn a_flock_with_a_channel_sheep_takes_the_stop_arm() {
         String::from_utf8_lossy(&reloaded.stderr)
     );
     assert!(
-        text.contains("shepherd channel"),
+        text.contains("more than one instance"),
         "the refusal must name the feature that blocked the handover: {text}"
     );
     assert!(
-        text.contains("chatty"),
+        text.contains("clustered"),
         "and the sheep it blocked on: {text}"
     );
 
@@ -7259,6 +7262,131 @@ fn a_flock_with_a_channel_sheep_takes_the_stop_arm() {
         pid_before,
         "the stop arm restarts the flock, so the pid must move: {after}"
     );
+
+    graceful_kill(dir.path());
+}
+
+/// A `/bin/sh` sheep that signals readiness on fd 3 and answers every
+/// shepherd message with the same reply.
+///
+/// Three features in one script, because they share one socketpair and the
+/// case below is about that socket surviving an `execve`. The `ready` line
+/// is what `wait_ready` holds the sheep at `starting` for; the loop is what
+/// `shep trigger` gets an answer from; and `read -r line <&3` is a plain
+/// blocking read, which is what an app author writes and what a channel that
+/// came back non-blocking would break.
+///
+/// The reply names the action verbatim rather than echoing what it was sent:
+/// extracting a JSON field in POSIX sh would be its own source of failure,
+/// and `ActionWaits` correlates on the action name when the app echoes no
+/// dispatch id.
+#[cfg(unix)]
+fn write_channel_script(dir: &TempDir) -> PathBuf {
+    write_script(
+        dir,
+        "chatty.sh",
+        &format!(
+            "{}{}printf '{{\"kind\":\"ready\"}}\\n' >&3\nwhile read -r line <&3; do\n  \
+             printf '{{\"kind\":\"action-reply\",\"action\":\"ping\",\"body\":\"pong\"}}\\n' \
+             >&3\ndone\n",
+            script_header(),
+            record_pid_line(dir),
+        ),
+    )
+}
+
+/// Runs `shep trigger chatty ping` and returns the one row's outcome.
+///
+/// Its own helper because the case below asks the identical question twice,
+/// once either side of the reload, and the whole point is that the two
+/// answers are the same.
+#[cfg(unix)]
+fn trigger_ping(home: &Path) -> serde_json::Value {
+    let triggered = shep(home)
+        .arg("--format")
+        .arg("json")
+        .arg("trigger")
+        .arg("chatty")
+        .arg("ping")
+        .output()
+        .unwrap();
+    assert_success(&triggered);
+    let envelope: serde_json::Value = serde_json::from_slice(&triggered.stdout)
+        .unwrap_or_else(|e| panic!("trigger stdout was not JSON: {e}"));
+    envelope["data"][0]["outcome"].clone()
+}
+
+/// A sheep's shepherd channel survives `shep daemon reload`, in both
+/// directions and against a real app.
+///
+/// The end-to-end case for what 2b task 5 carries, and the one a pid check
+/// cannot stand in for. A socketpair can survive as a NUMBER and be attached
+/// to the wrong end, or be adopted with only one of its two pumps rebuilt,
+/// and every one of those leaves the flock healthy and the pid unmoved. What
+/// separates them is whether the app still answers.
+///
+/// `wait_ready` is on as well as `channel`, so `online` before the reload is
+/// itself proof that the child's `{"kind":"ready"}` came up the channel, and
+/// the second `trigger` is proof that both directions still work over the
+/// same socket afterwards.
+#[cfg(unix)]
+#[test]
+fn a_channel_sheep_still_answers_a_trigger_across_a_daemon_reload() {
+    let dir = tempfile::tempdir().unwrap();
+    let script = write_channel_script(&dir);
+    let flockfile = write_flockfile(
+        &dir,
+        &format!(
+            "[[app]]\nname = \"chatty\"\nscript = '{}'\nchannel = true\nwait_ready = true\n",
+            script.display()
+        ),
+    );
+    let mut guard = DaemonGuard::default();
+
+    let started = shep(dir.path())
+        .arg("start")
+        .arg(&flockfile)
+        .output()
+        .unwrap();
+    guard.adopt_home(dir.path());
+    assert_success(&started);
+
+    // `online` rather than `starting`, which only the child's own readiness
+    // line over fd 3 can produce.
+    let before = poll_flock(dir.path(), |info| {
+        info["status"] == "online" && !info["pid"].is_null()
+    });
+    let pid_before = before["pid"]
+        .as_u64()
+        .unwrap_or_else(|| panic!("an online sheep reports a pid: {before}"));
+    let answered = trigger_ping(dir.path());
+    assert_eq!(
+        answered["kind"], "replied",
+        "the channel must work before the reload, or this case proves nothing: {answered}"
+    );
+
+    let reloaded = shep(dir.path())
+        .arg("daemon")
+        .arg("reload")
+        .output()
+        .unwrap();
+    assert_success(&reloaded);
+
+    let after = poll_flock(dir.path(), |info| {
+        info["status"] == "online" && !info["pid"].is_null()
+    });
+    assert_eq!(
+        after["pid"].as_u64(),
+        Some(pid_before),
+        "a moved pid means the sheep was respawned, which is the stop arm: {after}"
+    );
+
+    let still = trigger_ping(dir.path());
+    assert_eq!(
+        still["kind"], "replied",
+        "the successor must reach the same fd 3 the child has had all along: {still}"
+    );
+    assert_eq!(still["body"], "pong", "{still}");
 
     graceful_kill(dir.path());
 }

--- a/crates/shep-cli/tests/cli_e2e.rs
+++ b/crates/shep-cli/tests/cli_e2e.rs
@@ -35,6 +35,8 @@
 // over sixty more items.
 #![cfg_attr(windows, allow(dead_code))]
 
+#[cfg(unix)]
+use std::collections::{BTreeMap, HashMap};
 use std::io::Read;
 #[cfg(unix)]
 use std::os::unix::fs::MetadataExt as _;
@@ -7197,26 +7199,98 @@ fn a_sheep_keeps_its_pid_and_its_log_across_a_daemon_reload() {
     graceful_kill(dir.path());
 }
 
-/// A flock carrying something this phase cannot move takes the stop arm, and
-/// the operator is told which sheep and why.
+/// A script that says which slot it is and which process it is, on every
+/// line.
 ///
-/// The gate doing its job, and not a failure: the reload still happens, the
-/// flock still comes back, and the refusal is a sentence in front of the
-/// person who typed the verb rather than a line in the daemon's log. The
-/// moved pid is what proves the stop arm was the one taken.
+/// `$SHEP_INSTANCE` is injected by the daemon at the spawn and is fixed for
+/// the life of the process, so a line naming a slot is the CHILD's own claim
+/// about which instance it is rather than the shepherd's. That is what makes
+/// a slot swap visible: a successor that rehydrated two instances into each
+/// other's rows leaves every pid alive and every log growing, and the only
+/// evidence is that the row for slot 0 names a file whose lines say slot 1.
+#[cfg(unix)]
+fn write_slot_script(dir: &TempDir) -> PathBuf {
+    write_script(
+        dir,
+        "slot.sh",
+        &format!(
+            "{}{}while :; do\n  echo \"slot=$SHEP_INSTANCE pid=$$\"\n  sleep 0.2\ndone\n",
+            script_header(),
+            record_pid_line(dir),
+        ),
+    )
+}
+
+/// Every line of `path` that names a slot, as `(slot, pid)` pairs.
+///
+/// Panics on a line it cannot parse rather than skipping it: a torn line is
+/// the failure these cases are looking for, and silently dropping it would
+/// turn a lost write into a shorter list.
+#[cfg(unix)]
+fn slot_lines(path: &Path) -> Vec<(u32, u32)> {
+    std::fs::read_to_string(path)
+        .unwrap_or_default()
+        .lines()
+        .map(|line| {
+            let (slot, pid) = line
+                .split_once(' ')
+                .unwrap_or_else(|| panic!("a torn line in {}: {line:?}", path.display()));
+            let parse = |field: &str, prefix: &str| {
+                field
+                    .strip_prefix(prefix)
+                    .and_then(|rest| rest.parse::<u32>().ok())
+                    .unwrap_or_else(|| panic!("a torn line in {}: {line:?}", path.display()))
+            };
+            (parse(slot, "slot="), parse(pid, "pid="))
+        })
+        .collect()
+}
+
+/// Waits until `path` holds at least `want` slot lines, or
+/// [`HANDOVER_DEADLINE`] expires, and returns what it held on the last read.
+#[cfg(unix)]
+fn poll_slot_lines(path: &Path, want: usize) -> Vec<(u32, u32)> {
+    let start = Instant::now();
+    loop {
+        let lines = slot_lines(path);
+        if lines.len() >= want || start.elapsed() >= HANDOVER_DEADLINE {
+            return lines;
+        }
+        std::thread::sleep(FLOCK_POLL_INTERVAL);
+    }
+}
+
+/// A clustered app is carried, and every instance comes back in its own
+/// slot.
+///
+/// Two apps, because `merge_logs` is the whole reason multi-instance was the
+/// one to distrust. It points every instance of an app at ONE log file, and
+/// `handover::adopt::refuse_repeated_fds` refuses the entire blob when a
+/// descriptor number appears twice. Sharing one inode does not share a
+/// number, since each instance's pump runs its own `open`, but the failure
+/// that would follow if it did is a permanent refusal of every merged
+/// clustered app, blaming a descriptor rather than the config that produced
+/// it. So both shapes are exercised here rather than only the one with
+/// separate files.
+///
+/// The pid check is not the assertion. Every handover defect measured so far
+/// left the flock healthy and the pids intact, and a slot swap is exactly
+/// that shape: two live processes, both adopted, each answering to the
+/// other's name and writing under the other's `SHEP_INSTANCE`. So each row's
+/// own `out_file` is read back and the lines in it have to agree with the
+/// row about which slot and which pid they came from.
 #[cfg(unix)]
 #[test]
-fn a_flock_with_a_multi_instance_sheep_takes_the_stop_arm() {
+fn a_clustered_flock_keeps_every_pid_and_every_slot_across_a_daemon_reload() {
     let dir = tempfile::tempdir().unwrap();
-    let script = write_test_script(&dir);
-    // More than one instance, which is still a sheep no handover carries. It
-    // was a shepherd channel until 2b task 5 carried one; what this case is
-    // about is the gate refusing at all, and the operator being told.
+    let script = write_slot_script(&dir);
     let flockfile = write_flockfile(
         &dir,
         &format!(
-            "[[app]]\nname = \"clustered\"\nscript = '{}'\ninstances = 2\n",
-            script.display()
+            "[[app]]\nname = \"split\"\nscript = '{}'\ninstances = 2\n\n\
+             [[app]]\nname = \"merged\"\nscript = '{}'\ninstances = 2\nmerge_logs = true\n",
+            script.display(),
+            script.display(),
         ),
     );
     let mut guard = DaemonGuard::default();
@@ -7229,10 +7303,44 @@ fn a_flock_with_a_multi_instance_sheep_takes_the_stop_arm() {
     guard.adopt_home(dir.path());
     assert_success(&started);
 
-    let before = poll_flock(dir.path(), |info| {
-        info["status"] == "online" && !info["pid"].is_null()
+    let before = poll_flock_data(dir.path(), FLOCK_DEADLINE, |data| {
+        data.as_array().is_some_and(|rows| {
+            rows.len() == 4
+                && rows
+                    .iter()
+                    .all(|row| row["status"] == "online" && !row["pid"].is_null())
+        })
     });
-    let pid_before = before["pid"].as_u64();
+    let rows_before = rows_by_slot(&before);
+    assert_eq!(
+        rows_before.len(),
+        4,
+        "two apps at two instances each: {before}"
+    );
+    // The fixture check. `merge_logs` collapsing both instances onto one
+    // path is the premise of half this case, and a version where it had
+    // quietly stopped applying would pass every assertion below for the
+    // wrong reason.
+    assert_eq!(
+        rows_before[&("merged".to_owned(), 0)].1,
+        rows_before[&("merged".to_owned(), 1)].1,
+        "merge_logs must really point both instances at one file"
+    );
+    assert_ne!(
+        rows_before[&("split".to_owned(), 0)].1,
+        rows_before[&("split".to_owned(), 1)].1,
+        "without merge_logs each instance must have its own file"
+    );
+    for ((name, slot), (_, out_file)) in &rows_before {
+        assert!(
+            !poll_slot_lines(out_file, 1).is_empty(),
+            "{name}:{slot} must be logging before the reload"
+        );
+    }
+    let counts_before: HashMap<(String, u32), usize> = rows_before
+        .iter()
+        .map(|(key, (_, out_file))| (key.clone(), slot_lines(out_file).len()))
+        .collect();
 
     let reloaded = shep(dir.path())
         .arg("daemon")
@@ -7245,25 +7353,104 @@ fn a_flock_with_a_multi_instance_sheep_takes_the_stop_arm() {
         String::from_utf8_lossy(&reloaded.stdout),
         String::from_utf8_lossy(&reloaded.stderr)
     );
+    // The exact sentence the gate prints when it refuses -- see
+    // `handover::RefusedReason`'s `Display`, which every feature variant
+    // ends with. A looser probe would pass whether or not the reload was
+    // refused, which is the failure this assertion is here to catch.
     assert!(
-        text.contains("more than one instance"),
-        "the refusal must name the feature that blocked the handover: {text}"
-    );
-    assert!(
-        text.contains("clustered"),
-        "and the sheep it blocked on: {text}"
+        !text.contains("falls back to a stop-and-start"),
+        "a clustered flock is carried now, not refused: {text}"
     );
 
-    let after = poll_flock(dir.path(), |info| {
-        info["status"] == "online" && !info["pid"].is_null()
+    let after = poll_flock_data(dir.path(), FLOCK_DEADLINE, |data| {
+        data.as_array().is_some_and(|rows| {
+            rows.len() == 4
+                && rows
+                    .iter()
+                    .all(|row| row["status"] == "online" && !row["pid"].is_null())
+        })
     });
-    assert_ne!(
-        after["pid"].as_u64(),
-        pid_before,
-        "the stop arm restarts the flock, so the pid must move: {after}"
+    let rows_after = rows_by_slot(&after);
+    assert_eq!(
+        rows_after, rows_before,
+        "every instance keeps its pid and its own log file: {after}"
     );
+
+    // The slot assertion, and the one a pid check cannot make. Each row is
+    // asked for its own file, and every line written into that file AFTER
+    // the reload has to name that row's slot and that row's pid.
+    for ((name, slot), (pid, out_file)) in &rows_after {
+        let want = counts_before[&(name.clone(), *slot)] + 2;
+        let lines = poll_slot_lines(out_file, want);
+        assert!(
+            lines.len() >= want,
+            "{name}:{slot} stopped logging across the handover: {} lines, wanted {want}",
+            lines.len()
+        );
+        let fresh = &lines[counts_before[&(name.clone(), *slot)]..];
+        if *name == "merged" {
+            // One file for both slots, so the row's own lines are the ones
+            // carrying its pid. Both instances have to be present, or a
+            // handle was lost rather than carried.
+            assert!(
+                fresh.iter().any(|(_, line_pid)| line_pid == pid),
+                "merged:{slot} wrote nothing after the reload: {fresh:?}"
+            );
+            for (line_slot, line_pid) in fresh {
+                assert_eq!(
+                    rows_after[&("merged".to_owned(), *line_slot)].0,
+                    *line_pid,
+                    "a merged line's slot and pid disagree with the flock: {fresh:?}"
+                );
+            }
+        } else {
+            for (line_slot, line_pid) in fresh {
+                assert_eq!(
+                    (*line_slot, *line_pid),
+                    (*slot, *pid),
+                    "{name}:{slot}'s own log holds another instance's output: {fresh:?}"
+                );
+            }
+        }
+    }
 
     graceful_kill(dir.path());
+}
+
+/// `shep flock`'s JSON rows as `(name, instance) -> (pid, out_file)`.
+///
+/// Keyed on the pair rather than on the name, because a name now matches as
+/// many rows as the app has instances.
+#[cfg(unix)]
+fn rows_by_slot(data: &serde_json::Value) -> BTreeMap<(String, u32), (u32, PathBuf)> {
+    data.as_array()
+        .unwrap_or_else(|| panic!("flock data is an array: {data}"))
+        .iter()
+        .map(|row| {
+            let name = row["name"]
+                .as_str()
+                .unwrap_or_else(|| panic!("a row names its app: {row}"))
+                .to_owned();
+            let instance = u32::try_from(
+                row["instance"]
+                    .as_u64()
+                    .unwrap_or_else(|| panic!("a row names its slot: {row}")),
+            )
+            .unwrap();
+            let pid = u32::try_from(
+                row["pid"]
+                    .as_u64()
+                    .unwrap_or_else(|| panic!("an online row names its pid: {row}")),
+            )
+            .unwrap();
+            let out_file = PathBuf::from(
+                row["out_file"]
+                    .as_str()
+                    .unwrap_or_else(|| panic!("a row names its out file: {row}")),
+            );
+            ((name, instance), (pid, out_file))
+        })
+        .collect()
 }
 
 /// A `/bin/sh` sheep that signals readiness on fd 3 and answers every

--- a/crates/shep-cli/tests/cli_e2e.rs
+++ b/crates/shep-cli/tests/cli_e2e.rs
@@ -7042,6 +7042,15 @@ const HANDOVER_DEADLINE: Duration = Duration::from_secs(20);
 #[cfg(unix)]
 const HANDOVER_POLL_INTERVAL: Duration = Duration::from_millis(50);
 
+/// How long [`a_sheep_owed_a_restart_still_gets_one_after_a_daemon_reload`]
+/// waits for a re-armed backoff to fire.
+///
+/// Its app's `restart_delay` is 8s and the successor re-arms with that same
+/// figure, so the honest wait is 8s plus a respawn. Four times that is a
+/// loaded runner's margin rather than a second schedule.
+#[cfg(unix)]
+const RESTARTED_DEADLINE: Duration = Duration::from_secs(40);
+
 /// Writes a script that counts from 1 upwards on stdout, one number per
 /// line, forever.
 ///
@@ -7574,6 +7583,671 @@ fn a_channel_sheep_still_answers_a_trigger_across_a_daemon_reload() {
         "the successor must reach the same fd 3 the child has had all along: {still}"
     );
     assert_eq!(still["body"], "pong", "{still}");
+
+    graceful_kill(dir.path());
+}
+
+/// Rows [`a_flock_of_every_carried_kind_survives_a_daemon_reload`] expects:
+/// four single-instance apps and two clustered ones at two instances each.
+#[cfg(unix)]
+const ROWS_IN_THE_MIXED_FLOCK: usize = 8;
+
+/// Writes one line to `sheep`'s stdin and asserts shep accepted it.
+///
+/// `sent` says the bytes reached the pipe, never that the app read them, so
+/// the caller still has to look in the sheep's own log for the echo. This
+/// helper covers only the half that can fail loudly.
+#[cfg(unix)]
+fn whisper(home: &Path, sheep: &str, line: &str) {
+    let sent = shep(home)
+        .arg("whisper")
+        .arg(sheep)
+        .arg(line)
+        .output()
+        .unwrap();
+    assert_success(&sent);
+}
+
+/// Reads `path` until it holds a line equal to `want`, or
+/// [`HANDOVER_DEADLINE`] expires.
+///
+/// Equality rather than `contains`, so a prefix of a longer line cannot
+/// answer for the line itself. Returns rather than panicking, for
+/// [`counting_lines`]' reason: the failure that reaches CI should be the
+/// caller's own assertion naming what it wanted.
+#[cfg(unix)]
+fn await_log_line(path: &Path, want: &str) -> bool {
+    let start = Instant::now();
+    loop {
+        let text = std::fs::read_to_string(path).unwrap_or_default();
+        if text.lines().any(|line| line == want) {
+            return true;
+        }
+        if start.elapsed() >= HANDOVER_DEADLINE {
+            return false;
+        }
+        std::thread::sleep(HANDOVER_POLL_INTERVAL);
+    }
+}
+
+/// A `/bin/sh` sheep that waits for `gate` to appear, deletes it, and then
+/// grows its resident set past [`BALLOON_BYTES`].
+///
+/// [`write_ballooning_script`] with a trigger in front of it, and the
+/// trigger is the whole reason this is a second script rather than that one.
+/// A sheep already over its ceiling before the reload proves nothing about
+/// the successor: the predecessor armed that enforcer. Growing only after
+/// the exec is what makes the breach attributable to an arming the
+/// successor performed.
+///
+/// It deletes the gate as it passes, so the breach happens exactly once. A
+/// restarted instance waits at a gate that is not there, which keeps the
+/// restart count a fact the assertion can pin rather than a race with the
+/// enforcer's next tick.
+#[cfg(unix)]
+fn write_gated_ballooning_script(dir: &TempDir, name: &str, gate: &Path) -> PathBuf {
+    write_script(
+        dir,
+        name,
+        &format!(
+            "{header}{pid}while [ ! -f '{gate}' ]; do\n  sleep 0.1\ndone\nrm -f '{gate}'\n\
+             s=x\nwhile [ ${{#s}} -lt {BALLOON_BYTES} ]; do s=\"$s$s\"; done\n{sleep}",
+            header = script_header(),
+            pid = record_pid_line(dir),
+            gate = gate.display(),
+            sleep = sleep_line(SLOW_SCRIPT_SLEEP_SECS),
+        ),
+    )
+}
+
+/// Every lifecycle extra is armed again by the successor, and each one is
+/// proved by the behaviour rather than by a handle existing.
+///
+/// The spec's H2 stages "re-arming watch, cron and memory limits" into this
+/// phase, and `Actor::install_adopted` does it in one line: `arm_extras` for
+/// an adopted sheep that is already `Online`. What that line covers is not
+/// self-evident, because [`ExtrasRegistry::arm`] fans out to five separate
+/// mechanisms across two scopes -- sampling, the memory limit and the
+/// liveness loop per instance, the cron worker and the filesystem watch per
+/// name -- and a successor that armed four of them would look identical from
+/// the outside to one that armed five.
+///
+/// **Every trigger here fires after the exec, and that ordering is the case.**
+/// A watch armed by the predecessor and a watch armed by the successor are
+/// indistinguishable if the file is written before the reload; the same goes
+/// for a resident set already over its ceiling and a probe already failing.
+/// So the reload happens first, on a flock where nothing has yet been asked
+/// to do anything, and only then does the case write the file, open the
+/// balloon gates and trip the probe.
+///
+/// `control` is what makes the memory restart attributable. It runs the same
+/// ballooning script, grows the same resident set through the same gate, and
+/// differs only in naming no `max_memory`, so a restart caused by the shell
+/// dying under its own allocation would move both counters. It doubles as
+/// the control for the other three: it configures no watch, no schedule and
+/// no probe, and a `restarts` of 0 at the end says nothing in this case
+/// restarts sheep in general.
+///
+/// What a broken implementation this would catch: an `install_adopted` that
+/// never calls `arm_extras` (all four counters stay 0 and nothing in
+/// `shep flock` says why); one that arms the per-instance extras and skips
+/// the name group, or the reverse (two of the four); an `arm_watch` given
+/// the entry before its log paths were assembled, which would leave the
+/// watch ignoring the wrong files; and an enforcer armed against the sheep's
+/// id where its pid belongs, which the pid guard in `handle_extra_restart`
+/// would then drop silently for the rest of the daemon's life.
+#[cfg(unix)]
+#[test]
+fn every_lifecycle_extra_is_re_armed_across_a_daemon_reload() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path();
+    // Its own tempdir, never `$SHEP_HOME`: every fixture script appends its
+    // pid to `<home>/`[`FIXTURE_PIDS`] on each spawn, so a watch rooted at
+    // the home would restart on its own sheep's restart, forever.
+    let watched = tempfile::tempdir().unwrap();
+    let greedy_gate = dir.path().join("greedy.gate");
+    let control_gate = dir.path().join("control.gate");
+    // A file the probe REQUIRES, so the test trips it by DELETING and
+    // heals it by writing. The opposite polarity raced the fixture: a
+    // script that clears its own trigger on the way up does so whenever
+    // the shell is first scheduled, which under a loaded debug build was
+    // half a second after `shep flock` already called the sheep `online`,
+    // and it deleted the file this case had just written.
+    let healthy = dir.path().join("probe.healthy");
+    std::fs::write(&healthy, "ok").unwrap();
+    let sleeper = write_slow_script(&dir);
+    let greedy = write_gated_ballooning_script(&dir, "greedy.sh", &greedy_gate);
+    let control = write_gated_ballooning_script(&dir, "control.sh", &control_gate);
+    let flockfile = write_flockfile(
+        &dir,
+        &format!(
+            "[[app]]\nname = \"watched\"\nscript = '{sleeper}'\ncwd = '{root}'\nwatch = true\n\n\
+             [[app]]\nname = \"scheduled\"\nscript = '{sleeper}'\ncron_restart = \"* * * * *\"\n\n\
+             [[app]]\nname = \"greedy\"\nscript = '{greedy}'\nmax_memory = \"{BREACH_LIMIT}\"\n\n\
+             [[app]]\nname = \"probed\"\nscript = '{sleeper}'\n\
+             liveness_probe = {{ kind = \"exec\", target = \"test -f {healthy}\", \
+             interval = \"1s\", timeout = \"2s\", failure_threshold = 2 }}\n\n\
+             [[app]]\nname = \"control\"\nscript = '{control}'\n",
+            sleeper = sleeper.display(),
+            root = watched.path().display(),
+            greedy = greedy.display(),
+            control = control.display(),
+            healthy = healthy.display(),
+        ),
+    );
+    let mut guard = DaemonGuard::default();
+
+    let boot = shep(home).arg("start").arg(&flockfile).output().unwrap();
+    guard.adopt_home(home);
+    assert_success(&boot);
+
+    let before = poll_flock_data(home, FLOCK_DEADLINE, |data| {
+        data.as_array().is_some_and(|rows| {
+            rows.len() == 5
+                && rows
+                    .iter()
+                    .all(|row| row["status"] == "online" && !row["pid"].is_null())
+        })
+    });
+    let pids_before: BTreeMap<String, u64> = restart_counts(&before)
+        .keys()
+        .map(|name| {
+            (
+                name.clone(),
+                sheep_named(&before, name)["pid"].as_u64().unwrap(),
+            )
+        })
+        .collect();
+    assert_eq!(
+        restart_counts(&before),
+        BTreeMap::from([
+            ("control".to_owned(), 0),
+            ("greedy".to_owned(), 0),
+            ("probed".to_owned(), 0),
+            ("scheduled".to_owned(), 0),
+            ("watched".to_owned(), 0),
+        ]),
+        "precondition: nothing has restarted yet: {before}"
+    );
+
+    let reloaded = shep(home).arg("daemon").arg("reload").output().unwrap();
+    assert_success(&reloaded);
+    let after = poll_flock_data(home, FLOCK_DEADLINE, |data| {
+        data.as_array()
+            .is_some_and(|rows| rows.len() == 5 && rows.iter().all(|row| row["status"] == "online"))
+    });
+    // The handover really happened, which every assertion below depends on:
+    // a stop-and-start would re-arm everything from a fresh spawn and prove
+    // nothing about `install_adopted`.
+    for (name, pid) in &pids_before {
+        assert_eq!(
+            sheep_named(&after, name)["pid"].as_u64(),
+            Some(*pid),
+            "{name} was respawned, so this reload took the stop arm: {after}"
+        );
+    }
+    // The sampling arm, and the cheapest of the five to lose silently.
+    // `StatsState::sample_now` reports only WATCHED roots and
+    // `with_live_stats` fills a row only from a reading it finds, so a
+    // successor that never called `stats.watch` leaves this null for the
+    // life of the daemon while every other column looks right.
+    for name in pids_before.keys() {
+        assert!(
+            !sheep_named(&after, name)["memory_bytes"].is_null(),
+            "{name} is no longer sampled after the handover: {after}"
+        );
+    }
+
+    // Every trigger, fired only now.
+    std::fs::write(watched.path().join("app.txt"), "changed").unwrap();
+    std::fs::write(&greedy_gate, "go").unwrap();
+    std::fs::write(&control_gate, "go").unwrap();
+    std::fs::remove_file(&healthy).unwrap();
+    // One wait for the three fast arms. The memory limit is the slow one of
+    // the three: the enforcer's ticks are phased off daemon boot rather than
+    // off the breach, so the honest worst case is a whole
+    // `MEMORY_POLL_INTERVAL` after the resident set moves.
+    let fired = poll_flock_data(home, BREACH_DEADLINE, |data| {
+        ["watched", "probed", "greedy"]
+            .iter()
+            .all(|name| sheep_named(data, name)["restarts"].as_u64().unwrap_or(0) >= 1)
+    });
+    assert!(
+        sheep_named(&fired, "watched")["restarts"].as_u64().unwrap() >= 1,
+        "a write under the watched tree after the exec must restart the sheep: {fired}"
+    );
+    assert!(
+        sheep_named(&fired, "probed")["restarts"].as_u64().unwrap() >= 1,
+        "a liveness probe failing after the exec must restart the sheep: {fired}"
+    );
+    assert!(
+        sheep_named(&fired, "greedy")["restarts"].as_u64().unwrap() >= 1,
+        "a resident set crossing max_memory after the exec must restart the sheep: {fired}"
+    );
+    // Healed now that the restart is on the books, so the probe stops
+    // failing and `probed` cannot spend its `max_restarts` while the case
+    // waits out the cron minute below.
+    std::fs::write(&healthy, "ok").unwrap();
+
+    // The cron worker, and the slow one. A `* * * * *` pattern armed at an
+    // arbitrary moment is a uniform draw on the minute it lands in, so the
+    // only bound worth stating is a minute plus the restart's round trip.
+    let cronned = poll_flock_data(home, CRON_DEADLINE, |data| {
+        sheep_named(data, "scheduled")["restarts"]
+            .as_u64()
+            .unwrap_or(0)
+            >= 1
+    });
+    assert!(
+        sheep_named(&cronned, "scheduled")["restarts"]
+            .as_u64()
+            .unwrap()
+            >= 1,
+        "a cron occurrence after the exec must restart the sheep: {cronned}"
+    );
+    assert_eq!(
+        sheep_named(&cronned, "control")["restarts"].as_u64(),
+        Some(0),
+        "the control ballooned through the same gate and configures no extra at all; \
+         a restart it shares is this case restarting sheep rather than an extra firing: \
+         {cronned}"
+    );
+
+    // The daemon's own log, which is the only place the observed resident
+    // set and the ceiling it crossed are ever stated. Read rather than
+    // polled: `spawn_extras_reporter` writes the record before it asks for
+    // the restart, so the counter above reaching 1 has already ordered it.
+    let daemon_log = std::fs::read_to_string(home.join("logs").join("shepd.err.log")).unwrap();
+    assert!(
+        daemon_log.contains("exceeded its max_memory"),
+        "the successor's own log must say why the sheep was restarted: {daemon_log:?}"
+    );
+
+    graceful_kill(home);
+}
+
+/// `restarts` per sheep name, for the two observations this case compares.
+#[cfg(unix)]
+fn restart_counts(data: &serde_json::Value) -> BTreeMap<String, u64> {
+    data.as_array()
+        .unwrap_or_else(|| panic!("flock data is an array: {data}"))
+        .iter()
+        .map(|row| {
+            (
+                row["name"].as_str().unwrap().to_owned(),
+                row["restarts"].as_u64().unwrap_or(0),
+            )
+        })
+        .collect()
+}
+
+/// A sheep already owed a respawn when the shepherd is replaced still gets
+/// it.
+///
+/// The strand this pins is silent, permanent and reachable on a released
+/// build. `Actor::schedule_restart` spawns a task that sleeps and then
+/// sends `Msg::RestartDue`, and that task dies with the process image;
+/// `handle_restart_due` is the only thing that moves a sheep off
+/// `WaitingRestart`. A successor that installs the status without re-arming
+/// the timer therefore leaves the sheep down for the rest of its life while
+/// `shep flock` keeps printing `waiting-restart`, which an operator reads as
+/// "coming back".
+///
+/// Not a narrow race either, which is why it earns its own case rather than
+/// a line in the mixed flock above. The default backoff climbs to 15s, so a
+/// crash-looping app spends most of its time in this status -- and upgrading
+/// the shepherd is exactly what an operator does about a crash-looping app.
+///
+/// The precondition is asserted twice, before and immediately after the
+/// reload, and the second one is load-bearing. If the delay elapsed while
+/// `daemon reload` was running, the predecessor would have respawned the
+/// sheep before the exec and the final assertion would pass without proving
+/// anything.
+///
+/// `steady` is what says the reload was a handover at all: it never exits,
+/// so a moved pid means the stop arm ran and restarted the whole flock,
+/// which would bring `flapper` back for a reason this case is not about.
+#[cfg(unix)]
+#[test]
+fn a_sheep_owed_a_restart_still_gets_one_after_a_daemon_reload() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path();
+    let steady = write_slow_script(&dir);
+    let flapper = write_script(
+        &dir,
+        "flapper.sh",
+        &format!("{}{}exit 1\n", script_header(), record_pid_line(&dir)),
+    );
+    let flockfile = write_flockfile(
+        &dir,
+        &format!(
+            // Long enough that a loaded runner cannot let the wait expire
+            // between the observation below and the reload after it, and
+            // short enough that the case then waits it out once.
+            "[[app]]\nname = \"flapper\"\nscript = '{flapper}'\nrestart_delay = \"8s\"\n\n\
+             [[app]]\nname = \"steady\"\nscript = '{steady}'\n",
+            flapper = flapper.display(),
+            steady = steady.display(),
+        ),
+    );
+    let mut guard = DaemonGuard::default();
+
+    let boot = shep(home).arg("start").arg(&flockfile).output().unwrap();
+    guard.adopt_home(home);
+    assert_success(&boot);
+
+    let before = poll_flock_data(home, FLOCK_DEADLINE, |data| {
+        sheep_named(data, "flapper")["status"] == "waiting-restart"
+            && sheep_named(data, "steady")["status"] == "online"
+    });
+    assert_eq!(
+        sheep_named(&before, "flapper")["status"],
+        "waiting-restart",
+        "precondition: the sheep must be owed a respawn when the shepherd is replaced: {before}"
+    );
+    let steady_pid = sheep_named(&before, "steady")["pid"].as_u64().unwrap();
+
+    let reloaded = shep(home).arg("daemon").arg("reload").output().unwrap();
+    assert_success(&reloaded);
+    let text = format!(
+        "{}{}",
+        String::from_utf8_lossy(&reloaded.stdout),
+        String::from_utf8_lossy(&reloaded.stderr)
+    );
+    assert!(
+        !text.contains("falls back to a stop-and-start"),
+        "a sheep in its restart backoff is carried, not refused: {text}"
+    );
+
+    let carried = poll_flock_data(home, FLOCK_DEADLINE, |data| {
+        !sheep_named(data, "steady")["pid"].is_null()
+    });
+    assert_eq!(
+        sheep_named(&carried, "steady")["pid"].as_u64(),
+        Some(steady_pid),
+        "a moved pid means the stop arm ran, which restarts everything: {carried}"
+    );
+    assert_eq!(
+        sheep_named(&carried, "flapper")["status"],
+        "waiting-restart",
+        "the wait must still have been pending at the exec, or this case proves nothing: \
+         {carried}"
+    );
+    assert_eq!(
+        sheep_named(&carried, "flapper")["restarts"].as_u64(),
+        Some(0),
+        "ditto: the predecessor must not have respawned it first: {carried}"
+    );
+
+    let restarted = poll_flock_data(home, RESTARTED_DEADLINE, |data| {
+        sheep_named(data, "flapper")["restarts"]
+            .as_u64()
+            .unwrap_or(0)
+            >= 1
+    });
+    assert!(
+        sheep_named(&restarted, "flapper")["restarts"]
+            .as_u64()
+            .unwrap()
+            >= 1,
+        "the sheep was left waiting for a timer that died with the exec: {restarted}"
+    );
+
+    graceful_kill(home);
+}
+
+/// A `/bin/sh` sheep that echoes every line it is whispered, prefixed.
+///
+/// `stdin = true` is the only thing that gives a sheep a readable fd 0, and
+/// the loop is what makes a whisper observable: the line comes back in the
+/// sheep's own log, from the same process, so a pipe that survived as a
+/// number but was attached to the wrong end delivers nothing.
+///
+/// No trailing `sleep`. The `read` parks the script for as long as the
+/// daemon holds the write end open, which is exactly as long as the sheep is
+/// registered, so this fixture stays alive on the descriptor under test
+/// rather than on a timer.
+#[cfg(unix)]
+fn write_echoing_script(dir: &TempDir) -> PathBuf {
+    write_script(
+        dir,
+        "echoer.sh",
+        &format!(
+            "{}{}while read -r line; do\n  echo \"heard $line\"\n done\n",
+            script_header(),
+            record_pid_line(dir),
+        ),
+    )
+}
+
+/// A `/bin/sh` sheep that writes down whatever the shepherd tells it and
+/// then exits cleanly.
+///
+/// For `shutdown_with_message`, which is the third feature routed through
+/// the channel refusal and the one neither of the other two channel cases
+/// reaches: `wait_ready` is the child writing UP the socket and a `trigger`
+/// is a round trip, while this is the daemon writing down it on the stop
+/// path, with no reply to correlate. The line in the log is the whole of the
+/// evidence, and the clean `exit 0` beside it is what says the message
+/// arrived rather than the kill ladder.
+#[cfg(unix)]
+fn write_farewell_script(dir: &TempDir) -> PathBuf {
+    write_script(
+        dir,
+        "bye.sh",
+        &format!(
+            "{}{}while read -r line <&3; do\n  echo \"told $line\"\n  exit 0\ndone\n",
+            script_header(),
+            record_pid_line(dir),
+        ),
+    )
+}
+
+/// Every kind of sheep phase 2b carries, in one flock, across one reload.
+///
+/// 2a's case widened, and the reason it is one flock rather than five is
+/// that the descriptor rules are whole-flock rules.
+/// `handover::adopt::refuse_repeated_fds` refuses the ENTIRE blob over one
+/// repeated number, and the blob a mixed flock produces is the only place
+/// six kinds of descriptor -- two log files, two pipe read ends, a stdin
+/// pipe and a socketpair, times seven sheep -- are ever numbered together.
+///
+/// Every assertion here is one a pid check cannot make, which is the lesson
+/// of this whole phase: three separate defects have now been found that left
+/// the flock healthy, every pid intact and the suite green.
+///
+/// - `counter` is the log plane. Its sequence is unbroken or it is not.
+/// - `echoer` answers a whisper, so its stdin pipe is still the end the
+///   child reads from and still attached to that child.
+/// - `chatty` reaches `online` only by writing `{"kind":"ready"}` up fd 3,
+///   and answers a `trigger` afterwards with the CHILD's own reply.
+/// - `bye` is told `{"kind":"shutdown"}` down the same kind of socket at the
+///   end, which is the direction a `trigger` alone does not isolate.
+/// - `split` and `merged` are the clustered halves, and each row's own file
+///   has to name that row's slot and that row's pid: a successor that
+///   rehydrated two instances into each other's rows leaves every pid alive
+///   and every log growing.
+#[cfg(unix)]
+#[test]
+fn a_flock_of_every_carried_kind_survives_a_daemon_reload() {
+    let dir = tempfile::tempdir().unwrap();
+    let counter = write_counting_script(&dir);
+    let slot = write_slot_script(&dir);
+    let chatty = write_channel_script(&dir);
+    let echoer = write_echoing_script(&dir);
+    let bye = write_farewell_script(&dir);
+    let flockfile = write_flockfile(
+        &dir,
+        &format!(
+            "[[app]]\nname = \"counter\"\nscript = '{counter}'\n\n\
+             [[app]]\nname = \"echoer\"\nscript = '{echoer}'\nstdin = true\n\n\
+             [[app]]\nname = \"chatty\"\nscript = '{chatty}'\nchannel = true\nwait_ready = true\n\n\
+             [[app]]\nname = \"bye\"\nscript = '{bye}'\nshutdown_with_message = true\n\n\
+             [[app]]\nname = \"split\"\nscript = '{slot}'\ninstances = 2\n\n\
+             [[app]]\nname = \"merged\"\nscript = '{slot}'\ninstances = 2\nmerge_logs = true\n",
+            counter = counter.display(),
+            echoer = echoer.display(),
+            chatty = chatty.display(),
+            bye = bye.display(),
+            slot = slot.display(),
+        ),
+    );
+    let mut guard = DaemonGuard::default();
+
+    let started = shep(dir.path())
+        .arg("start")
+        .arg(&flockfile)
+        .output()
+        .unwrap();
+    guard.adopt_home(dir.path());
+    assert_success(&started);
+
+    // `online` for all seven, which for `chatty` is already an assertion:
+    // `wait_ready` holds it at `starting` until the child writes up fd 3.
+    let before = poll_flock_data(dir.path(), FLOCK_DEADLINE, |data| {
+        data.as_array().is_some_and(|rows| {
+            rows.len() == ROWS_IN_THE_MIXED_FLOCK
+                && rows
+                    .iter()
+                    .all(|row| row["status"] == "online" && !row["pid"].is_null())
+        })
+    });
+    let rows_before = rows_by_slot(&before);
+    assert_eq!(
+        rows_before.len(),
+        ROWS_IN_THE_MIXED_FLOCK,
+        "six apps, two of them clustered: {before}"
+    );
+
+    // Every feature is exercised BEFORE the reload too. A case where the
+    // whisper or the trigger never worked at all would otherwise read as a
+    // handover defect, and the point of this one is to separate those.
+    let out_file = |name: &str| rows_before[&(name.to_owned(), 0)].1.clone();
+    let counter_log = out_file("counter");
+    let echoer_log = out_file("echoer");
+    let bye_log = out_file("bye");
+    let seen_before = counting_lines(&counter_log, 3);
+    assert!(
+        seen_before.len() >= 3,
+        "the counter must be logging before the reload: {seen_before:?}"
+    );
+    whisper(dir.path(), "echoer", "before");
+    assert!(
+        await_log_line(&echoer_log, "heard before"),
+        "the whisper must reach the sheep before the reload, or this case proves nothing: {}",
+        std::fs::read_to_string(&echoer_log).unwrap_or_default()
+    );
+    let answered = trigger_ping(dir.path());
+    assert_eq!(
+        answered["kind"], "replied",
+        "the channel must work before the reload: {answered}"
+    );
+    let counts_before: HashMap<(String, u32), usize> = rows_before
+        .iter()
+        .filter(|((name, _), _)| name == "split" || name == "merged")
+        .map(|(key, (_, out_file))| (key.clone(), slot_lines(out_file).len()))
+        .collect();
+
+    let reloaded = shep(dir.path())
+        .arg("daemon")
+        .arg("reload")
+        .output()
+        .unwrap();
+    assert_success(&reloaded);
+    let text = format!(
+        "{}{}",
+        String::from_utf8_lossy(&reloaded.stdout),
+        String::from_utf8_lossy(&reloaded.stderr)
+    );
+    // The exact sentence every feature variant of `handover::RefusedReason`
+    // ends with. Without this the case would pass on a stop-and-start, which
+    // restarts the flock and satisfies "everything still works".
+    assert!(
+        !text.contains("falls back to a stop-and-start"),
+        "every kind in this flock is carried now, not refused: {text}"
+    );
+
+    let after = poll_flock_data(dir.path(), FLOCK_DEADLINE, |data| {
+        data.as_array().is_some_and(|rows| {
+            rows.len() == ROWS_IN_THE_MIXED_FLOCK
+                && rows
+                    .iter()
+                    .all(|row| row["status"] == "online" && !row["pid"].is_null())
+        })
+    });
+    let rows_after = rows_by_slot(&after);
+    assert_eq!(
+        rows_after, rows_before,
+        "every sheep keeps its pid and its own log file: {after}"
+    );
+
+    // The log plane, on a plain sheep.
+    let seen = counting_lines(&counter_log, seen_before.len() + 3);
+    assert!(
+        seen.len() > seen_before.len(),
+        "the counter stopped logging across the handover: {seen:?}"
+    );
+    assert_unbroken_sequence(&seen, "the counter's log across a handover");
+
+    // stdin, which nothing else in this file covers. A fresh line, so a
+    // stale `heard before` in the file cannot answer for it.
+    whisper(dir.path(), "echoer", "after");
+    assert!(
+        await_log_line(&echoer_log, "heard after"),
+        "the carried stdin pipe must still reach the same child: {}",
+        std::fs::read_to_string(&echoer_log).unwrap_or_default()
+    );
+
+    // The channel, both directions, against the child that has had fd 3
+    // since before the exec.
+    let still = trigger_ping(dir.path());
+    assert_eq!(
+        still["kind"], "replied",
+        "the successor must reach the same fd 3 the child has had all along: {still}"
+    );
+    assert_eq!(still["body"], "pong", "{still}");
+
+    // The clustered halves. Each row is asked for its own file, and every
+    // line written into it after the reload has to agree with the row.
+    for ((name, slot), (pid, out_file)) in &rows_after {
+        if name != "split" && name != "merged" {
+            continue;
+        }
+        let before = counts_before[&(name.clone(), *slot)];
+        let want = before + 2;
+        let lines = poll_slot_lines(out_file, want);
+        assert!(
+            lines.len() >= want,
+            "{name}:{slot} stopped logging across the handover: {} lines, wanted {want}",
+            lines.len()
+        );
+        for (line_slot, line_pid) in &lines[before..] {
+            assert_eq!(
+                rows_after[&(name.clone(), *line_slot)].0,
+                *line_pid,
+                "a {name} line's slot and pid disagree with the flock: {lines:?}"
+            );
+            if name == "split" {
+                assert_eq!(
+                    (*line_slot, *line_pid),
+                    (*slot, *pid),
+                    "{name}:{slot}'s own log holds another instance's output: {lines:?}"
+                );
+            }
+        }
+    }
+
+    // `shutdown_with_message`, last because it ends its sheep. The message
+    // goes down the carried socket, the child writes it to its own log and
+    // exits 0, so a `stopped` row with `told` in the file is the write
+    // direction working on the stop path four assertions after the exec.
+    let stopped = shep(dir.path()).arg("stop").arg("bye").output().unwrap();
+    assert_success(&stopped);
+    assert!(
+        await_log_line(&bye_log, "told {\"kind\":\"shutdown\"}"),
+        "the stop message must reach the child down the carried channel: {}",
+        std::fs::read_to_string(&bye_log).unwrap_or_default()
+    );
 
     graceful_kill(dir.path());
 }

--- a/crates/shep-daemon/src/boot.rs
+++ b/crates/shep-daemon/src/boot.rs
@@ -1995,11 +1995,45 @@ pub(crate) struct HandoverSeam {
 /// a graceful stop.
 #[cfg(unix)]
 async fn hand_over_now(seam: &HandoverSeam) -> Result<core::convert::Infallible, String> {
-    let (candidates, blob) = seam
+    let (candidates, blob, parked) = seam
         .supervisor
         .handover_snapshot(seam.fds)
         .await
         .map_err(|err| format!("the supervisor could not describe its flock: {err}"))?;
+    let refusal = match hand_over_carrying(&candidates, &blob, seam) {
+        Ok(never) => match never {},
+        Err(refusal) => refusal,
+    };
+    // Taking the snapshot stopped every pump it reached, and this process
+    // is the one that owes them a resume: there is no successor image to do
+    // it, and nothing else in the daemon ever sends one. The caller falls
+    // back to a graceful stop, which is a stretch of seconds during which
+    // the flock is being told to exit and is writing exactly the lines an
+    // operator will reach for. A refusal that changes nothing else must not
+    // silently cost them.
+    //
+    // Here rather than inside `exec_into`'s own error path, which restores
+    // `FD_CLOEXEC` on the same failure: the gate below refuses BEFORE
+    // anything is exec'd, so a resume that lived with the descriptors would
+    // miss the abort that happens most often. This is where every way out
+    // meets.
+    parked.resume().await;
+    Err(refusal)
+}
+
+/// [`hand_over_now`]'s body, split out so a single resume can cover every
+/// way it refuses.
+///
+/// # Errors
+///
+/// The flock cannot be carried, or the exec itself failed. Both leave this
+/// process still itself, with no blob on disk.
+#[cfg(unix)]
+fn hand_over_carrying(
+    candidates: &[crate::handover::OwnedCandidate],
+    blob: &crate::handover::Handover,
+    seam: &HandoverSeam,
+) -> Result<core::convert::Infallible, String> {
     let borrowed: Vec<crate::handover::Candidate<'_>> = candidates
         .iter()
         .map(crate::handover::OwnedCandidate::as_candidate)
@@ -2007,7 +2041,7 @@ async fn hand_over_now(seam: &HandoverSeam) -> Result<core::convert::Infallible,
     if let crate::handover::Fitness::Refused(reason) = crate::handover::fitness(&borrowed) {
         return Err(reason.to_string());
     }
-    crate::handover::hand_over(&blob, &seam.paths).map_err(|err| err.to_string())
+    crate::handover::hand_over(blob, &seam.paths).map_err(|err| err.to_string())
 }
 
 /// Error type returned from this module's boot steps
@@ -3452,6 +3486,99 @@ mod tests {
         // Bounded, like the sibling above. The lock this case now holds is
         // held across this await, so a teardown that hung would stop every
         // other signal test in the module rather than failing this one.
+        tokio::time::timeout(Duration::from_secs(5), daemon.run())
+            .await
+            .unwrap()
+            .unwrap();
+    }
+
+    /// The sharp edge of parking a pump: a handover that reports and then
+    /// refuses has to leave every pump reading again.
+    ///
+    /// Taking the snapshot stops each pump where it stands, which is what
+    /// makes the report still true at the exec. There is no exec here, and
+    /// nothing else in the daemon ever sends a resume, so a missing one is
+    /// not a slow log or a lost line: it is a flock that logs nothing more,
+    /// through the graceful stop this refusal falls back to and for as long
+    /// as the daemon lives after it, having reported no failure beyond the
+    /// refusal itself.
+    ///
+    /// Two sheep, because the resume has to reach every pump that was
+    /// reported to rather than the one the refusal named.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn an_abandoned_handover_starts_every_pump_reading_again() {
+        // As the sibling above: a successful `boot()` installs real signal
+        // listeners for this test's whole duration.
+        let _guard = SIGNAL_TEST_LOCK.lock().await;
+        let dir = tempfile::tempdir().unwrap();
+        let paths = test_paths(&dir);
+        init_dirs(&paths).unwrap();
+        let runner = Arc::new(ScriptedRunner::new(vec![ProcScript::never_exits(); 2]));
+        let daemon = boot(
+            SharedRunner(Arc::clone(&runner)),
+            paths.clone(),
+            BootOptions::default(),
+        )
+        .await
+        .unwrap();
+        let ctx = daemon.context();
+        let plain = AppConfig::minimal("quiet", "./srv");
+        // The refusal: a shepherd channel is a sheep 2a cannot carry, and
+        // the gate reads it after every pump has already been reported to.
+        let mut talkative = AppConfig::minimal("chatty", "./srv");
+        talkative.channel = true;
+        ctx.supervisor
+            .start(vec![
+                normalize(plain).unwrap(),
+                normalize(talkative).unwrap(),
+            ])
+            .await
+            .unwrap();
+        for sheep in 0..2 {
+            assert!(
+                runner.log_ctl_live(sheep),
+                "sheep {sheep} must have a live log pump before the report, or this case                  proves nothing"
+            );
+        }
+
+        let seam = HandoverSeam {
+            supervisor: ctx.supervisor.clone(),
+            fds: crate::handover::DaemonFds {
+                listener: -1,
+                pidfile: -1,
+            },
+            paths: paths.clone(),
+        };
+        let refusal = hand_over_now(&seam)
+            .await
+            .expect_err("a flock with a shepherd channel cannot be carried");
+        assert!(
+            refusal.contains("shepherd channel"),
+            "the gate must refuse before anything is exec'd: {refusal}"
+        );
+
+        // Polled rather than read once: a resume carries no acknowledgement
+        // (see `LogCtl::Resume`), so a send that has returned has been
+        // queued rather than served. Bounded, so a pump that is never told
+        // fails here instead of hanging.
+        let both_resumed = async {
+            while runner.resumes(0) == 0 || runner.resumes(1) == 0 {
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        };
+        tokio::time::timeout(Duration::from_secs(10), both_resumed)
+            .await
+            .expect("every pump a refused handover reported to must be reading again");
+        for sheep in 0..2 {
+            assert_eq!(
+                runner.resumes(sheep),
+                1,
+                "sheep {sheep} must be resumed once rather than repeatedly"
+            );
+        }
+
+        ctx.shutdown();
         tokio::time::timeout(Duration::from_secs(5), daemon.run())
             .await
             .unwrap()

--- a/crates/shep-daemon/src/boot.rs
+++ b/crates/shep-daemon/src/boot.rs
@@ -3585,6 +3585,91 @@ mod tests {
             .unwrap();
     }
 
+    /// The second refusal path, and the one nothing else covers: a snapshot
+    /// abandoned because a pump went quiet still owes a resume to every pump
+    /// that DID answer.
+    ///
+    /// Its sibling above proves the resume for a refusal the gate reads off
+    /// a sheep's config. A missed deadline is a different way in, and it
+    /// arrives with one pump already parked and one that never was. Miss it
+    /// and a handover abandoned on a wedged pump leaves the REST of the
+    /// flock parked, which is a silent logging stop for the life of the
+    /// daemon and strictly worse than the stall this deadline exists to end.
+    ///
+    /// No `boot()` and no signal here, unlike its sibling: this is about
+    /// what `hand_over_now` does with a snapshot, and building the
+    /// supervisor directly is what lets the clock be paused, so the deadline
+    /// costs the suite nothing to wait out.
+    #[cfg(unix)]
+    #[tokio::test(start_paused = true)]
+    async fn a_handover_abandoned_on_a_wedged_pump_resumes_the_pumps_that_parked() {
+        let dir = tempfile::tempdir().unwrap();
+        let paths = test_paths(&dir);
+        init_dirs(&paths).unwrap();
+        let (events, _rx) = crate::bus::test_bus(64);
+        let runner = Arc::new(
+            ScriptedRunner::new(vec![ProcScript::never_exits(); 2])
+                .with_a_pump_that_never_reports(&["wedged"]),
+        );
+        let supervisor = crate::supervisor::spawn_supervisor(
+            SharedRunner(Arc::clone(&runner)),
+            paths.clone(),
+            events,
+        );
+        supervisor
+            .start(vec![
+                normalize(AppConfig::minimal("answering", "./srv")).unwrap(),
+                normalize(AppConfig::minimal("wedged", "./srv")).unwrap(),
+            ])
+            .await
+            .unwrap();
+
+        // Deliberately invalid, as its sibling above explains: if the gate
+        // ever stopped refusing, `hand_over` would meet `EBADF` and return
+        // rather than exec this test binary into a re-run of the whole
+        // suite. The assertion on the message is what tells those apart.
+        let seam = HandoverSeam {
+            supervisor: supervisor.clone(),
+            fds: crate::handover::DaemonFds {
+                listener: -1,
+                pidfile: -1,
+            },
+            paths: paths.clone(),
+        };
+        let refusal = hand_over_now(&seam)
+            .await
+            .expect_err("a flock with a pump that never reported cannot be carried");
+        assert!(
+            refusal.contains("did not report its descriptors in time"),
+            "the refusal must say the pump went quiet, not something else: {refusal}"
+        );
+        assert!(
+            refusal.contains("wedged"),
+            "the refusal must name the sheep whose pump went quiet: {refusal}"
+        );
+
+        let answering = runner.spawn_index_of("answering").expect("started above");
+        let wedged = runner.spawn_index_of("wedged").expect("started above");
+        // Polled rather than read once: a resume carries no acknowledgement
+        // (see `LogCtl::Resume`), so a send that has returned has been
+        // queued rather than served. Instant under the paused clock, and
+        // bounded so a pump that is never told fails here instead of
+        // hanging.
+        let delivered = async {
+            while runner.resumes(answering) == 0 {
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        };
+        tokio::time::timeout(Duration::from_secs(10), delivered)
+            .await
+            .expect("the pump that answered was parked, and a refusal owes it a resume");
+        assert_eq!(
+            runner.resumes(wedged),
+            0,
+            "a pump that never answered never parked, so nothing may resume it"
+        );
+    }
+
     #[tokio::test]
     async fn a_repeat_sigterm_is_observed_not_swallowed() {
         // Pins Decision 3 (2026-08-08): each shutdown-signal listener

--- a/crates/shep-daemon/src/boot.rs
+++ b/crates/shep-daemon/src/boot.rs
@@ -3452,15 +3452,18 @@ mod tests {
         let paths = test_paths(&dir);
         init_dirs(&paths).unwrap();
         let daemon = boot(
-            ScriptedRunner::new(vec![ProcScript::never_exits()]),
+            ScriptedRunner::new(vec![ProcScript::never_exits(); 2]),
             paths.clone(),
             BootOptions::default(),
         )
         .await
         .unwrap();
         let ctx = daemon.context();
-        let mut app = AppConfig::minimal("chatty", "./srv");
-        app.channel = true;
+        // Two instances: a sheep the gate still refuses. It was a shepherd
+        // channel until 2b task 5 carried one, and the case is about the
+        // gate firing at all rather than about which feature fires it.
+        let mut app = AppConfig::minimal("clustered", "./srv");
+        app.instances = 2;
         ctx.supervisor
             .start(vec![normalize(app).unwrap()])
             .await
@@ -3476,9 +3479,9 @@ mod tests {
         };
         let refusal = hand_over_now(&seam)
             .await
-            .expect_err("a flock with a shepherd channel cannot be carried");
+            .expect_err("a flock with more than one instance cannot be carried");
         assert!(
-            refusal.contains("shepherd channel"),
+            refusal.contains("more than one instance"),
             "the gate must refuse before anything is exec'd: {refusal}"
         );
 
@@ -3514,7 +3517,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let paths = test_paths(&dir);
         init_dirs(&paths).unwrap();
-        let runner = Arc::new(ScriptedRunner::new(vec![ProcScript::never_exits(); 2]));
+        let runner = Arc::new(ScriptedRunner::new(vec![ProcScript::never_exits(); 3]));
         let daemon = boot(
             SharedRunner(Arc::clone(&runner)),
             paths.clone(),
@@ -3524,18 +3527,20 @@ mod tests {
         .unwrap();
         let ctx = daemon.context();
         let plain = AppConfig::minimal("quiet", "./srv");
-        // The refusal: a shepherd channel is a sheep 2a cannot carry, and
-        // the gate reads it after every pump has already been reported to.
-        let mut talkative = AppConfig::minimal("chatty", "./srv");
-        talkative.channel = true;
+        // The refusal: more than one instance is a sheep this daemon still
+        // cannot carry, and the gate reads it after every pump has already
+        // been reported to. It was a shepherd channel until 2b task 5
+        // carried one; what the case needs is any refusal at all.
+        let mut clustered = AppConfig::minimal("clustered", "./srv");
+        clustered.instances = 2;
         ctx.supervisor
             .start(vec![
                 normalize(plain).unwrap(),
-                normalize(talkative).unwrap(),
+                normalize(clustered).unwrap(),
             ])
             .await
             .unwrap();
-        for sheep in 0..2 {
+        for sheep in 0..3 {
             assert!(
                 runner.log_ctl_live(sheep),
                 "sheep {sheep} must have a live log pump before the report, or this case                  proves nothing"
@@ -3552,9 +3557,9 @@ mod tests {
         };
         let refusal = hand_over_now(&seam)
             .await
-            .expect_err("a flock with a shepherd channel cannot be carried");
+            .expect_err("a flock with more than one instance cannot be carried");
         assert!(
-            refusal.contains("shepherd channel"),
+            refusal.contains("more than one instance"),
             "the gate must refuse before anything is exec'd: {refusal}"
         );
 
@@ -3562,15 +3567,15 @@ mod tests {
         // (see `LogCtl::Resume`), so a send that has returned has been
         // queued rather than served. Bounded, so a pump that is never told
         // fails here instead of hanging.
-        let both_resumed = async {
-            while runner.resumes(0) == 0 || runner.resumes(1) == 0 {
+        let all_resumed = async {
+            while (0..3).any(|sheep| runner.resumes(sheep) == 0) {
                 tokio::time::sleep(Duration::from_millis(10)).await;
             }
         };
-        tokio::time::timeout(Duration::from_secs(10), both_resumed)
+        tokio::time::timeout(Duration::from_secs(10), all_resumed)
             .await
             .expect("every pump a refused handover reported to must be reading again");
-        for sheep in 0..2 {
+        for sheep in 0..3 {
             assert_eq!(
                 runner.resumes(sheep),
                 1,

--- a/crates/shep-daemon/src/boot.rs
+++ b/crates/shep-daemon/src/boot.rs
@@ -3451,23 +3451,25 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let paths = test_paths(&dir);
         init_dirs(&paths).unwrap();
+        // A dog: the sheep the gate still refuses. This was a shepherd
+        // channel until 2b task 5 carried one and two instances until task
+        // 6 carried those, and the case is about the gate firing at all
+        // rather than about which feature fires it. Task 7 carries dogs, so
+        // it moves again.
         let daemon = boot(
-            ScriptedRunner::new(vec![ProcScript::never_exits(); 2]),
+            ScriptedRunner::new(vec![ProcScript::never_exits()]),
             paths.clone(),
-            BootOptions::default(),
+            BootOptions {
+                dogs: vec![DogSpec {
+                    name: "metrics".to_string(),
+                    source: DogSource::BuiltIn,
+                }],
+                ..BootOptions::default()
+            },
         )
         .await
         .unwrap();
         let ctx = daemon.context();
-        // Two instances: a sheep the gate still refuses. It was a shepherd
-        // channel until 2b task 5 carried one, and the case is about the
-        // gate firing at all rather than about which feature fires it.
-        let mut app = AppConfig::minimal("clustered", "./srv");
-        app.instances = 2;
-        ctx.supervisor
-            .start(vec![normalize(app).unwrap()])
-            .await
-            .unwrap();
 
         let seam = HandoverSeam {
             supervisor: ctx.supervisor.clone(),
@@ -3479,9 +3481,9 @@ mod tests {
         };
         let refusal = hand_over_now(&seam)
             .await
-            .expect_err("a flock with more than one instance cannot be carried");
+            .expect_err("a flock with a dog in it cannot be carried");
         assert!(
-            refusal.contains("more than one instance"),
+            refusal.contains("being a dog"),
             "the gate must refuse before anything is exec'd: {refusal}"
         );
 
@@ -3518,25 +3520,32 @@ mod tests {
         let paths = test_paths(&dir);
         init_dirs(&paths).unwrap();
         let runner = Arc::new(ScriptedRunner::new(vec![ProcScript::never_exits(); 3]));
+        // The refusal: a dog is a sheep this daemon still cannot carry, and
+        // the gate reads it AFTER every pump has already been reported to,
+        // which is what makes the resume owed. It was a shepherd channel
+        // until 2b task 5 carried one and two instances until task 6
+        // carried those; what the case needs is any refusal at all.
+        //
+        // Spawned by `boot` rather than by the `start` below, so the dog is
+        // script 0 and the two sheep are 1 and 2.
         let daemon = boot(
             SharedRunner(Arc::clone(&runner)),
             paths.clone(),
-            BootOptions::default(),
+            BootOptions {
+                dogs: vec![DogSpec {
+                    name: "metrics".to_string(),
+                    source: DogSource::BuiltIn,
+                }],
+                ..BootOptions::default()
+            },
         )
         .await
         .unwrap();
         let ctx = daemon.context();
-        let plain = AppConfig::minimal("quiet", "./srv");
-        // The refusal: more than one instance is a sheep this daemon still
-        // cannot carry, and the gate reads it after every pump has already
-        // been reported to. It was a shepherd channel until 2b task 5
-        // carried one; what the case needs is any refusal at all.
-        let mut clustered = AppConfig::minimal("clustered", "./srv");
-        clustered.instances = 2;
         ctx.supervisor
             .start(vec![
-                normalize(plain).unwrap(),
-                normalize(clustered).unwrap(),
+                normalize(AppConfig::minimal("quiet", "./srv")).unwrap(),
+                normalize(AppConfig::minimal("chatty", "./srv")).unwrap(),
             ])
             .await
             .unwrap();
@@ -3557,9 +3566,9 @@ mod tests {
         };
         let refusal = hand_over_now(&seam)
             .await
-            .expect_err("a flock with more than one instance cannot be carried");
+            .expect_err("a flock with a dog in it cannot be carried");
         assert!(
-            refusal.contains("more than one instance"),
+            refusal.contains("being a dog"),
             "the gate must refuse before anything is exec'd: {refusal}"
         );
 

--- a/crates/shep-daemon/src/fake.rs
+++ b/crates/shep-daemon/src/fake.rs
@@ -359,6 +359,16 @@ impl RunningProcess for FakeProc {
 struct SpawnedProc {
     state: Arc<ProcState>,
     io: Option<FakeIo>,
+    /// The sheep name this spawn carried, copied off [`SpawnSpec::name`] and
+    /// read back via [`ScriptedRunner::spawn_index_of`].
+    ///
+    /// Every other accessor here is indexed by spawn ORDER, which a test
+    /// that starts several apps at once cannot predict without asserting on
+    /// the very ordering it is trying to be independent of. This is how a
+    /// case that picked one app by name (see
+    /// [`ScriptedRunner::with_a_pump_that_never_reports`]) then reads that
+    /// app's counters back.
+    name: String,
     /// `false` once this spawn's log-control task has ended — read back via
     /// [`ScriptedRunner::log_ctl_live`].
     log_ctl_live: Arc<AtomicBool>,
@@ -419,6 +429,22 @@ pub struct ScriptedRunner {
     /// otherwise unreachable from a unit test, and a test written against
     /// the default cannot fail no matter what that pass does.
     refuse: Mutex<Vec<String>>,
+    /// Sheep names whose log-control task accepts a [`LogCtl::ReportFds`]
+    /// and never answers it, by name for the same reason as its two
+    /// siblings above: a case needs ONE named app of several to go silent
+    /// while its neighbours answer, and script order cannot say that.
+    ///
+    /// Models the pump a handover has no other way to meet: one wedged on a
+    /// filesystem that has stopped completing writes, where the request is
+    /// delivered and it is the acknowledgement that never comes. The
+    /// counterpart of [`ProcScript::never_reports_its_exit`] for the
+    /// handover path.
+    ///
+    /// Only this one variant goes unanswered. The task stays live and still
+    /// serves [`LogCtl::Resume`], which is what lets a case tell "this pump
+    /// was never parked" apart from "this pump is gone".
+    #[cfg(unix)]
+    deaf_pump: Mutex<Vec<String>>,
     /// State + IO for every spawn, indexed by spawn order, behind ONE lock.
     /// Two separate `Mutex`es here (one for state, one for IO) would let
     /// concurrent spawns interleave their critical sections and desync a
@@ -442,7 +468,37 @@ impl ScriptedRunner {
             spawned: Mutex::new(Vec::new()),
             refuse: Mutex::new(Vec::new()),
             fail_spawn: Mutex::new(Vec::new()),
+            #[cfg(unix)]
+            deaf_pump: Mutex::new(Vec::new()),
         }
+    }
+
+    /// Makes these sheep's pumps accept a [`LogCtl::ReportFds`] and never
+    /// answer it.
+    ///
+    /// For reaching the handover's own deadline, which nothing else in this
+    /// fake can arm: every other pump here answers instantly, so a snapshot
+    /// taken over them can never be the one that waits.
+    #[cfg(unix)]
+    #[must_use]
+    pub fn with_a_pump_that_never_reports(self, names: &[&str]) -> Self {
+        *self.deaf_pump.lock().unwrap() = names.iter().map(|n| (*n).to_string()).collect();
+        self
+    }
+
+    /// The spawn index the sheep named `name` was given, or `None` if this
+    /// runner never spawned it.
+    ///
+    /// Every counter here is indexed by spawn order, and a test that starts
+    /// several apps in one call would otherwise have to assume which order
+    /// the supervisor spawned them in to read one app's counter back.
+    #[must_use]
+    pub fn spawn_index_of(&self, name: &str) -> Option<usize> {
+        self.spawned
+            .lock()
+            .unwrap()
+            .iter()
+            .position(|p| p.name == name)
     }
 
     /// Makes `spawn` fail for these sheep, without consuming a script.
@@ -805,12 +861,20 @@ impl ProcessRunner for ScriptedRunner {
         let resume_count = Arc::clone(&resumes);
         let lamb_holds_the_pipe = script.lamb_holds_the_pipe;
         let logs_for_pump = logs_tx.clone();
+        #[cfg(unix)]
+        let deaf = self.deaf_pump.lock().unwrap().contains(&spec.name);
         tokio::spawn(async move {
             #[cfg(unix)]
             let mut reportable_fds: Option<(
                 [std::fs::File; 4],
                 crate::handover::CarriedFds,
             )> = None;
+            // Every unanswered report, kept alive rather than dropped — see
+            // the `ReportFds` arm below for why the two differ.
+            #[cfg(unix)]
+            let mut held_reports: Vec<
+                tokio::sync::oneshot::Sender<crate::handover::CarriedFds>,
+            > = Vec::new();
             loop {
                 tokio::select! {
                     ctl = log_ctl_rx.recv() => match ctl {
@@ -843,10 +907,22 @@ impl ProcessRunner for ScriptedRunner {
                         // that never ask for a handover opens nothing. That
                         // the numbers are the PUMP's own is
                         // `tokio_runner`'s tier, against a real pipe.
+                        //
+                        // A pump named to
+                        // `ScriptedRunner::with_a_pump_that_never_reports`
+                        // keeps `done` instead, and holds it for the rest of
+                        // this task's life: dropping it would answer the
+                        // request with a closed channel, which is what a
+                        // pump that has ENDED looks like and is a different
+                        // case entirely.
                         #[cfg(unix)]
                         Some(LogCtl::ReportFds { done }) => {
-                            let fds = reportable_fds.get_or_insert_with(open_reportable_fds);
-                            let _ = done.send(fds.1);
+                            if deaf {
+                                held_reports.push(done);
+                            } else {
+                                let fds = reportable_fds.get_or_insert_with(open_reportable_fds);
+                                let _ = done.send(fds.1);
+                            }
                         }
                         // Counted rather than acted on: the fake reads no
                         // streams, so it has none to start reading again.
@@ -967,6 +1043,7 @@ impl ProcessRunner for ScriptedRunner {
                 from_child_tx: fake_from_child_tx,
                 to_child_rx: fake_to_child_rx,
             }),
+            name: spec.name.clone(),
             log_ctl_live,
             reopens,
             flushes,

--- a/crates/shep-daemon/src/fake.rs
+++ b/crates/shep-daemon/src/fake.rs
@@ -735,29 +735,31 @@ impl ScriptedRunner {
 ///
 /// `/dev/null` because the fake never writes anything to them: what a caller
 /// asserts about a handover blob is that the numbers in it name something
-/// open, not what is on the far side. Five rather than four so a fake sheep
-/// stands in for one with a stdin pipe too, which is the widest shape a blob
-/// carries and so the one that catches a caller walking only part of it.
+/// open, not what is on the far side. Six rather than four so a fake sheep
+/// stands in for one with a stdin pipe and a shepherd channel too, which is
+/// the widest shape a blob carries and so the one that catches a caller
+/// walking only part of it.
 ///
 /// # Panics
 ///
-/// If `/dev/null` cannot be opened five times, which on any unix a test
+/// If `/dev/null` cannot be opened six times, which on any unix a test
 /// suite runs on means the process is out of descriptors.
 #[cfg(unix)]
 #[track_caller]
-fn open_reportable_fds() -> ([std::fs::File; 5], crate::handover::CarriedFds) {
+fn open_reportable_fds() -> ([std::fs::File; 6], crate::handover::CarriedFds) {
     use std::os::fd::AsRawFd as _;
 
     let files = core::array::from_fn(|_| {
         std::fs::File::open("/dev/null").expect("a test host must be able to open /dev/null")
     });
-    let files: [std::fs::File; 5] = files;
+    let files: [std::fs::File; 6] = files;
     let fds = crate::handover::CarriedFds {
         out_pipe: Some(files[0].as_raw_fd()),
         err_pipe: Some(files[1].as_raw_fd()),
         out_log: Some(files[2].as_raw_fd()),
         err_log: Some(files[3].as_raw_fd()),
         stdin: Some(files[4].as_raw_fd()),
+        channel: Some(files[5].as_raw_fd()),
     };
     (files, fds)
 }
@@ -869,7 +871,7 @@ impl ProcessRunner for ScriptedRunner {
         tokio::spawn(async move {
             #[cfg(unix)]
             let mut reportable_fds: Option<(
-                [std::fs::File; 5],
+                [std::fs::File; 6],
                 crate::handover::CarriedFds,
             )> = None;
             // Every unanswered report, kept alive rather than dropped — see
@@ -904,7 +906,7 @@ impl ProcessRunner for ScriptedRunner {
                         // The fake writes no files, so it holds no
                         // descriptors of its own. A caller assembling a
                         // handover still asserts that the numbers it gets
-                        // are really open, so five `/dev/null` handles stand
+                        // are really open, so six `/dev/null` handles stand
                         // in — opened on the first request and held for the
                         // rest of this task's life, so a suite full of tests
                         // that never ask for a handover opens nothing. That

--- a/crates/shep-daemon/src/fake.rs
+++ b/crates/shep-daemon/src/fake.rs
@@ -730,31 +730,34 @@ impl ScriptedRunner {
     }
 }
 
-/// Four real, distinct, open descriptors for a fake pump to report, and the
+/// Five real, distinct, open descriptors for a fake pump to report, and the
 /// handles that keep them open.
 ///
 /// `/dev/null` because the fake never writes anything to them: what a caller
 /// asserts about a handover blob is that the numbers in it name something
-/// open, not what is on the far side.
+/// open, not what is on the far side. Five rather than four so a fake sheep
+/// stands in for one with a stdin pipe too, which is the widest shape a blob
+/// carries and so the one that catches a caller walking only part of it.
 ///
 /// # Panics
 ///
-/// If `/dev/null` cannot be opened four times, which on any unix a test
+/// If `/dev/null` cannot be opened five times, which on any unix a test
 /// suite runs on means the process is out of descriptors.
 #[cfg(unix)]
 #[track_caller]
-fn open_reportable_fds() -> ([std::fs::File; 4], crate::handover::CarriedFds) {
+fn open_reportable_fds() -> ([std::fs::File; 5], crate::handover::CarriedFds) {
     use std::os::fd::AsRawFd as _;
 
     let files = core::array::from_fn(|_| {
         std::fs::File::open("/dev/null").expect("a test host must be able to open /dev/null")
     });
-    let files: [std::fs::File; 4] = files;
+    let files: [std::fs::File; 5] = files;
     let fds = crate::handover::CarriedFds {
         out_pipe: Some(files[0].as_raw_fd()),
         err_pipe: Some(files[1].as_raw_fd()),
         out_log: Some(files[2].as_raw_fd()),
         err_log: Some(files[3].as_raw_fd()),
+        stdin: Some(files[4].as_raw_fd()),
     };
     (files, fds)
 }
@@ -866,7 +869,7 @@ impl ProcessRunner for ScriptedRunner {
         tokio::spawn(async move {
             #[cfg(unix)]
             let mut reportable_fds: Option<(
-                [std::fs::File; 4],
+                [std::fs::File; 5],
                 crate::handover::CarriedFds,
             )> = None;
             // Every unanswered report, kept alive rather than dropped — see
@@ -901,7 +904,7 @@ impl ProcessRunner for ScriptedRunner {
                         // The fake writes no files, so it holds no
                         // descriptors of its own. A caller assembling a
                         // handover still asserts that the numbers it gets
-                        // are really open, so four `/dev/null` handles stand
+                        // are really open, so five `/dev/null` handles stand
                         // in — opened on the first request and held for the
                         // rest of this task's life, so a suite full of tests
                         // that never ask for a handover opens nothing. That

--- a/crates/shep-daemon/src/fake.rs
+++ b/crates/shep-daemon/src/fake.rs
@@ -368,6 +368,10 @@ struct SpawnedProc {
     /// How many [`LogCtl::Flush`] requests it has answered — read back via
     /// [`ScriptedRunner::flushes`].
     flushes: Arc<AtomicU32>,
+    /// How many [`LogCtl::Resume`] requests it has been sent — read back via
+    /// [`ScriptedRunner::resumes`].
+    #[cfg(unix)]
+    resumes: Arc<AtomicU32>,
     /// Every line written to this spawn's stdin, in write order — read back
     /// via [`ScriptedRunner::stdin_lines`].
     stdin_lines: Arc<Mutex<Vec<String>>>,
@@ -612,6 +616,26 @@ impl ScriptedRunner {
             .load(Ordering::SeqCst)
     }
 
+    /// How many [`LogCtl::Resume`] requests the proc spawned at
+    /// `spawn_index` has been sent.
+    ///
+    /// The counter an abandoned handover is asserted against: a report
+    /// parks a real pump, so a handover that reported and then refused owes
+    /// one of these to every pump it reported to, or that sheep's log stops
+    /// for the life of the daemon.
+    ///
+    /// # Panics
+    ///
+    /// If `spawn_index` is out of range.
+    #[cfg(unix)]
+    #[must_use]
+    #[track_caller]
+    pub fn resumes(&self, spawn_index: usize) -> u32 {
+        self.spawned.lock().unwrap()[spawn_index]
+            .resumes
+            .load(Ordering::SeqCst)
+    }
+
     /// Every line the daemon has written to the stdin of the proc spawned at
     /// `spawn_index`, in write order.
     ///
@@ -775,6 +799,10 @@ impl ProcessRunner for ScriptedRunner {
         let reopen_count = Arc::clone(&reopens);
         let flushes = Arc::new(AtomicU32::new(0));
         let flush_count = Arc::clone(&flushes);
+        #[cfg(unix)]
+        let resumes = Arc::new(AtomicU32::new(0));
+        #[cfg(unix)]
+        let resume_count = Arc::clone(&resumes);
         let lamb_holds_the_pipe = script.lamb_holds_the_pipe;
         let logs_for_pump = logs_tx.clone();
         tokio::spawn(async move {
@@ -819,6 +847,15 @@ impl ProcessRunner for ScriptedRunner {
                         Some(LogCtl::ReportFds { done }) => {
                             let fds = reportable_fds.get_or_insert_with(open_reportable_fds);
                             let _ = done.send(fds.1);
+                        }
+                        // Counted rather than acted on: the fake reads no
+                        // streams, so it has none to start reading again.
+                        // What a caller asserts here is that an abandoned
+                        // handover sent one at all, which is the half that
+                        // lives above the pump.
+                        #[cfg(unix)]
+                        Some(LogCtl::Resume) => {
+                            resume_count.fetch_add(1, Ordering::SeqCst);
                         }
                         None => break, // nothing holds ProcIo::log_ctl
                     },
@@ -933,6 +970,8 @@ impl ProcessRunner for ScriptedRunner {
             log_ctl_live,
             reopens,
             flushes,
+            #[cfg(unix)]
+            resumes,
             stdin_lines,
             credentials: spec.credentials,
         });

--- a/crates/shep-daemon/src/handover/adopt.rs
+++ b/crates/shep-daemon/src/handover/adopt.rs
@@ -69,12 +69,12 @@ pub struct Adopted {
     pub pidfile: File,
 }
 
-/// One sheep's output plumbing, rebuilt.
+/// One sheep's output plumbing, rebuilt, and its input plumbing with it.
 ///
-/// `None` on all four means an instance that is registered and not running,
-/// which is the only reason a blob names no descriptor for it. A descriptor
-/// that is named and missing is a refusal, not a `None`; see this module's
-/// own docs.
+/// `None` on all of the first four means an instance that is registered and
+/// not running, which is the only reason a blob names no descriptor for
+/// them. A descriptor that is named and missing is a refusal, not a `None`;
+/// see this module's own docs.
 #[derive(Debug)]
 pub struct AdoptedSheep {
     /// What the blob said about this sheep.
@@ -87,6 +87,11 @@ pub struct AdoptedSheep {
     pub out_log: Option<tokio::fs::File>,
     /// The appending handle on its stderr log file.
     pub err_log: Option<tokio::fs::File>,
+    /// The write end of its stdin pipe, for a sheep whose app asked for one.
+    ///
+    /// The only handle here the daemon writes to rather than reads from,
+    /// and `None` for the commoner sheep that has `/dev/null` on fd 0.
+    pub stdin_pipe: Option<pipe::Sender>,
 }
 
 /// Rebuild everything `blob` describes, around descriptors this process
@@ -99,8 +104,8 @@ pub struct AdoptedSheep {
 ///
 /// The blob names one descriptor number twice, or any descriptor it names is
 /// not open in this process, is not the kind of object it was named as (a
-/// read end that is not a pipe), or could not be registered with the
-/// runtime. The error names the sheep and the stream, because that is what
+/// read end that is not a pipe, a stdin end that is not writable), or could
+/// not be registered with the runtime. The error names the sheep and the stream, because that is what
 /// an operator needs in order to know which process is now unsupervised.
 ///
 /// There is no partial success and no fallback. By the time this runs the
@@ -212,13 +217,14 @@ fn adopt_listener(fd: RawFd) -> io::Result<tokio::net::UnixListener> {
     tokio::net::UnixListener::from_std(listener)
 }
 
-/// Rebuild one sheep's four handles.
+/// Rebuild one sheep's five handles.
 fn adopt_sheep(carried: &CarriedSheep) -> io::Result<AdoptedSheep> {
     let CarriedFds {
         out_pipe,
         err_pipe,
         out_log,
         err_log,
+        stdin,
     } = carried.fds;
     let name = &carried.name;
     Ok(AdoptedSheep {
@@ -226,6 +232,7 @@ fn adopt_sheep(carried: &CarriedSheep) -> io::Result<AdoptedSheep> {
         err_pipe: adopt_pipe(err_pipe, name, "stderr")?,
         out_log: adopt_log(out_log, name, "stdout")?,
         err_log: adopt_log(err_log, name, "stderr")?,
+        stdin_pipe: adopt_stdin(stdin, name)?,
         carried: carried.clone(),
     })
 }
@@ -243,6 +250,29 @@ fn adopt_pipe(fd: Option<RawFd>, sheep: &str, stream: &str) -> io::Result<Option
         io::Error::new(
             error.kind(),
             format!("sheep '{sheep}' {stream} pipe is not a readable pipe: {error}"),
+        )
+    })
+}
+
+/// Rebuild one stdin write end as an async writer, if the blob named one.
+///
+/// The mirror of [`adopt_pipe`], and the check is what makes it worth its
+/// own function: `pipe::Sender::from_file` refuses a descriptor that is not
+/// a pipe OR is not open for writing, so a blob that named the end the child
+/// reads from is refused here rather than adopted into a `shep whisper` that
+/// can never land.
+///
+/// Nothing is opened and nothing is reopened, exactly as everywhere else in
+/// this module: the child's fd 0 is the other end of this same pipe and has
+/// been throughout, so a successor that recreated the pair would be writing
+/// to a pipe the app is not reading.
+fn adopt_stdin(fd: Option<RawFd>, sheep: &str) -> io::Result<Option<pipe::Sender>> {
+    let Some(fd) = fd else { return Ok(None) };
+    let file = adopt_fd(fd, &format!("sheep '{sheep}' stdin pipe"))?;
+    pipe::Sender::from_file(file).map(Some).map_err(|error| {
+        io::Error::new(
+            error.kind(),
+            format!("sheep '{sheep}' stdin is not a writable pipe: {error}"),
         )
     })
 }
@@ -350,6 +380,7 @@ mod tests {
                 err_pipe: None,
                 out_log: None,
                 err_log: None,
+                stdin: None,
             })],
         );
         blob.sheep[0].fds.out_log = Some(blob.listener_fd);
@@ -380,6 +411,7 @@ mod tests {
                 err_pipe: None,
                 out_log: Some(handle.into_raw_fd()),
                 err_log: None,
+                stdin: None,
             })],
         );
 
@@ -415,6 +447,7 @@ mod tests {
                 err_pipe: None,
                 out_log: None,
                 err_log: None,
+                stdin: None,
             })],
         );
 
@@ -449,6 +482,7 @@ mod tests {
                 err_pipe: None,
                 out_log: None,
                 err_log: None,
+                stdin: None,
             })],
         );
         let pidfile_fd = blob.pidfile_fd;
@@ -475,6 +509,7 @@ mod tests {
                 err_pipe: None,
                 out_log: None,
                 err_log: None,
+                stdin: None,
             })],
         );
 
@@ -489,6 +524,81 @@ mod tests {
             .expect("the adopted pipe must produce the line written before it")
             .unwrap();
         assert_eq!(line.as_deref(), Some("a line"));
+    }
+
+    /// fails if a carried stdin write end does not reach the end the child
+    /// reads.
+    ///
+    /// The direction is the whole case. Every other descriptor a sheep
+    /// carries is one the daemon reads from; this is the one it writes to,
+    /// and a blob that named the wrong end of the pair would still adopt,
+    /// still be a pipe, and still never reach the app.
+    #[tokio::test]
+    async fn an_adopted_stdin_pipe_writes_to_the_end_the_child_reads() {
+        let dir = tempfile::tempdir().unwrap();
+        let socket = dir.path().join("shep.sock");
+        // The child's fd 0 stays here, exactly as it does across a real
+        // exec: the daemon carries only the write end.
+        let (mut child_end, daemon_end) = std::io::pipe().unwrap();
+        let blob = blob_with(
+            &socket,
+            vec![carried(CarriedFds {
+                out_pipe: None,
+                err_pipe: None,
+                out_log: None,
+                err_log: None,
+                stdin: Some(daemon_end.into_raw_fd()),
+            })],
+        );
+
+        let mut adopted = adopt(&blob).unwrap();
+
+        let mut stdin = adopted.sheep[0]
+            .stdin_pipe
+            .take()
+            .expect("an adopted stdin pipe");
+        stdin.write_all(b"whisper\n").await.unwrap();
+        stdin.flush().await.unwrap();
+        // A blocking read of bytes already written, so there is nothing to
+        // wait for and nothing to time out.
+        let mut buf = [0_u8; 8];
+        std::io::Read::read_exact(&mut child_end, &mut buf).expect("the child end must read");
+        assert_eq!(&buf, b"whisper\n");
+    }
+
+    /// fails if the stdin number is adopted without checking which end of
+    /// the pipe it is.
+    ///
+    /// A read end passes `is_pipe` and would be adopted as a writer, so
+    /// every `shep whisper` after the handover would fail on a descriptor
+    /// the successor was told was fine.
+    #[tokio::test]
+    async fn a_pipe_read_end_offered_as_stdin_is_refused() {
+        let dir = tempfile::tempdir().unwrap();
+        let socket = dir.path().join("shep.sock");
+        let (reader, _writer) = std::io::pipe().unwrap();
+        let blob = blob_with(
+            &socket,
+            vec![carried(CarriedFds {
+                out_pipe: None,
+                err_pipe: None,
+                out_log: None,
+                err_log: None,
+                stdin: Some(reader.into_raw_fd()),
+            })],
+        );
+
+        let err = adopt(&blob).expect_err("a read end is not something to write to");
+
+        let text = err.to_string();
+        assert!(
+            text.contains("web"),
+            "the refusal must name the sheep: {text}"
+        );
+        assert!(
+            text.contains("stdin"),
+            "the refusal must name what could not be adopted: {text}"
+        );
     }
 
     #[tokio::test]
@@ -509,6 +619,7 @@ mod tests {
                 err_pipe: None,
                 out_log: None,
                 err_log: None,
+                stdin: None,
             })],
         );
 

--- a/crates/shep-daemon/src/handover/adopt.rs
+++ b/crates/shep-daemon/src/handover/adopt.rs
@@ -92,6 +92,14 @@ pub struct AdoptedSheep {
     /// The only handle here the daemon writes to rather than reads from,
     /// and `None` for the commoner sheep that has `/dev/null` on fd 0.
     pub stdin_pipe: Option<pipe::Sender>,
+    /// The daemon's end of its shepherd-channel socketpair, whose other end
+    /// is the child's fd 3.
+    ///
+    /// The only handle here that goes both ways: the successor splits it
+    /// into the same reader and writer a spawn wires, over one open file
+    /// description. `None` for a sheep whose app asked for no channel, one
+    /// that is not running, and one whose child has already closed fd 3.
+    pub channel: Option<tokio::net::UnixStream>,
 }
 
 /// Rebuild everything `blob` describes, around descriptors this process
@@ -217,7 +225,7 @@ fn adopt_listener(fd: RawFd) -> io::Result<tokio::net::UnixListener> {
     tokio::net::UnixListener::from_std(listener)
 }
 
-/// Rebuild one sheep's five handles.
+/// Rebuild one sheep's six handles.
 fn adopt_sheep(carried: &CarriedSheep) -> io::Result<AdoptedSheep> {
     let CarriedFds {
         out_pipe,
@@ -225,6 +233,7 @@ fn adopt_sheep(carried: &CarriedSheep) -> io::Result<AdoptedSheep> {
         out_log,
         err_log,
         stdin,
+        channel,
     } = carried.fds;
     let name = &carried.name;
     Ok(AdoptedSheep {
@@ -233,8 +242,48 @@ fn adopt_sheep(carried: &CarriedSheep) -> io::Result<AdoptedSheep> {
         out_log: adopt_log(out_log, name, "stdout")?,
         err_log: adopt_log(err_log, name, "stderr")?,
         stdin_pipe: adopt_stdin(stdin, name)?,
+        channel: adopt_channel(channel, name)?,
         carried: carried.clone(),
     })
+}
+
+/// Rebuild one shepherd channel's daemon end as an async socket, if the
+/// blob named one.
+///
+/// # Why the kind check is `peer_addr` and not a `from_file`
+///
+/// [`adopt_pipe`] and [`adopt_stdin`] get theirs for free, because
+/// `pipe::Receiver::from_file` and `pipe::Sender::from_file` each refuse a
+/// descriptor that is not a pipe of the right direction. There is no
+/// equivalent for a socket: `std::os::unix::net::UnixStream::from(OwnedFd)`
+/// is infallible and checks nothing, so a number that had been closed and
+/// handed to the next `open` would be adopted as a socket and written to as
+/// one. `getpeername` is what refuses that, and it refuses both ways a
+/// wrong number can be wrong: `ENOTSOCK` for anything that is not a socket
+/// at all, and `ENOTCONN` for a socket that is listening rather than
+/// connected, which is what this daemon's own control listener is.
+///
+/// Non-blocking is set here rather than assumed, for the reason
+/// [`adopt_listener`] gives: it is a file status flag and does cross the
+/// exec, but `tokio::net::UnixStream::from_std` refuses a blocking socket
+/// rather than fixing one, and one `fcntl` is cheaper than depending on an
+/// inherited flag.
+///
+/// Nothing is opened and nothing is paired again. The child's fd 3 is the
+/// other end of this same socketpair and has been throughout, so a
+/// successor that made a new pair would be talking to itself.
+fn adopt_channel(fd: Option<RawFd>, sheep: &str) -> io::Result<Option<tokio::net::UnixStream>> {
+    let Some(fd) = fd else { return Ok(None) };
+    let file = adopt_fd(fd, &format!("sheep '{sheep}' shepherd channel"))?;
+    let socket = std::os::unix::net::UnixStream::from(OwnedFd::from(file));
+    socket.peer_addr().map_err(|error| {
+        io::Error::new(
+            error.kind(),
+            format!("sheep '{sheep}' shepherd channel is not a connected socket: {error}"),
+        )
+    })?;
+    socket.set_nonblocking(true)?;
+    tokio::net::UnixStream::from_std(socket).map(Some)
 }
 
 /// Rebuild one pipe read end as an async reader, if the blob named one.
@@ -381,6 +430,7 @@ mod tests {
                 out_log: None,
                 err_log: None,
                 stdin: None,
+                channel: None,
             })],
         );
         blob.sheep[0].fds.out_log = Some(blob.listener_fd);
@@ -412,6 +462,7 @@ mod tests {
                 out_log: Some(handle.into_raw_fd()),
                 err_log: None,
                 stdin: None,
+                channel: None,
             })],
         );
 
@@ -448,6 +499,7 @@ mod tests {
                 out_log: None,
                 err_log: None,
                 stdin: None,
+                channel: None,
             })],
         );
 
@@ -483,6 +535,7 @@ mod tests {
                 out_log: None,
                 err_log: None,
                 stdin: None,
+                channel: None,
             })],
         );
         let pidfile_fd = blob.pidfile_fd;
@@ -510,6 +563,7 @@ mod tests {
                 out_log: None,
                 err_log: None,
                 stdin: None,
+                channel: None,
             })],
         );
 
@@ -548,6 +602,7 @@ mod tests {
                 out_log: None,
                 err_log: None,
                 stdin: Some(daemon_end.into_raw_fd()),
+                channel: None,
             })],
         );
 
@@ -585,6 +640,7 @@ mod tests {
                 out_log: None,
                 err_log: None,
                 stdin: Some(reader.into_raw_fd()),
+                channel: None,
             })],
         );
 
@@ -620,11 +676,147 @@ mod tests {
                 out_log: None,
                 err_log: None,
                 stdin: None,
+                channel: None,
             })],
         );
 
         let err = adopt(&blob).expect_err("a file is not a pipe");
 
         assert!(err.to_string().contains("web"), "{err}");
+    }
+
+    /// fails if an adopted shepherd channel does not still reach the same
+    /// child on the same socket, in both directions.
+    ///
+    /// Both directions in one case rather than two, because the failure
+    /// this exists to catch is one number naming the wrong end of the pair,
+    /// and a case that only wrote would pass on a socket the child cannot
+    /// answer. `child_end` here is what an app holds on fd 3.
+    #[tokio::test]
+    async fn an_adopted_channel_carries_both_directions() {
+        use tokio::io::AsyncBufReadExt as _;
+
+        let dir = tempfile::tempdir().unwrap();
+        let socket = dir.path().join("shep.sock");
+        let (daemon_end, child_end) = std::os::unix::net::UnixStream::pair().unwrap();
+        child_end.set_nonblocking(true).unwrap();
+        let child_end = tokio::net::UnixStream::from_std(child_end).unwrap();
+        let blob = blob_with(
+            &socket,
+            vec![carried(CarriedFds {
+                out_pipe: None,
+                err_pipe: None,
+                out_log: None,
+                err_log: None,
+                stdin: None,
+                channel: Some(daemon_end.into_raw_fd()),
+            })],
+        );
+
+        let mut adopted = adopt(&blob).unwrap();
+        let channel = adopted.sheep[0]
+            .channel
+            .take()
+            .expect("an adopted shepherd channel");
+        let (read_half, mut write_half) = tokio::io::split(channel);
+
+        // Shepherd to child, which is what `shutdown_with_message` and a
+        // `shep trigger` both ride.
+        let (child_read, mut child_write) = tokio::io::split(child_end);
+        let mut child = tokio::io::BufReader::new(child_read);
+        write_half
+            .write_all(b"{\"kind\":\"shutdown\"}\n")
+            .await
+            .unwrap();
+        let mut line = String::new();
+        child
+            .read_line(&mut line)
+            .await
+            .expect("the child end must read");
+        assert_eq!(line, "{\"kind\":\"shutdown\"}\n");
+
+        // Child to shepherd, which is what `{"kind":"ready"}` and every
+        // action reply ride.
+        child_write
+            .write_all(b"{\"kind\":\"ready\"}\n")
+            .await
+            .unwrap();
+        let mut back = String::new();
+        tokio::io::BufReader::new(read_half)
+            .read_line(&mut back)
+            .await
+            .expect("the daemon end must read");
+        assert_eq!(back, "{\"kind\":\"ready\"}\n");
+    }
+
+    /// fails if a channel number is adopted without checking that it still
+    /// names a connected socket.
+    ///
+    /// `UnixStream::from(OwnedFd)` is infallible and checks nothing, unlike
+    /// the two `from_file` constructors the pipes go through, so a number
+    /// that had been closed and handed to the next `open` would be adopted
+    /// as a socket and written to as one. A plain file is the cheapest
+    /// stand-in for that.
+    #[tokio::test]
+    async fn a_file_offered_as_a_shepherd_channel_is_refused() {
+        let dir = tempfile::tempdir().unwrap();
+        let socket = dir.path().join("shep.sock");
+        let file = tempfile::tempfile().unwrap();
+        let blob = blob_with(
+            &socket,
+            vec![carried(CarriedFds {
+                out_pipe: None,
+                err_pipe: None,
+                out_log: None,
+                err_log: None,
+                stdin: None,
+                channel: Some(file.into_raw_fd()),
+            })],
+        );
+
+        let err = adopt(&blob).expect_err("a file is not a connected socket");
+
+        let text = err.to_string();
+        assert!(
+            text.contains("web"),
+            "the refusal must name the sheep: {text}"
+        );
+        assert!(
+            text.contains("shepherd channel"),
+            "the refusal must name what could not be adopted: {text}"
+        );
+    }
+
+    /// fails if a LISTENING socket offered as a channel is adopted.
+    ///
+    /// The one number in a blob that really is a socket and really is not a
+    /// channel is this daemon's own control listener, so this is the wrong
+    /// number the kind check most plausibly meets. `getpeername` answers
+    /// `ENOTCONN` for it, which a check that only asked "is it a socket"
+    /// would miss.
+    #[tokio::test]
+    async fn a_listening_socket_offered_as_a_shepherd_channel_is_refused() {
+        let dir = tempfile::tempdir().unwrap();
+        let socket = dir.path().join("shep.sock");
+        let other = dir.path().join("other.sock");
+        let listening = std::os::unix::net::UnixListener::bind(&other).unwrap();
+        let blob = blob_with(
+            &socket,
+            vec![carried(CarriedFds {
+                out_pipe: None,
+                err_pipe: None,
+                out_log: None,
+                err_log: None,
+                stdin: None,
+                channel: Some(listening.into_raw_fd()),
+            })],
+        );
+
+        let err = adopt(&blob).expect_err("a listener is not a connected socket");
+
+        assert!(
+            err.to_string().contains("shepherd channel"),
+            "the refusal must name what could not be adopted: {err}"
+        );
     }
 }

--- a/crates/shep-daemon/src/handover/adopt.rs
+++ b/crates/shep-daemon/src/handover/adopt.rs
@@ -351,11 +351,19 @@ mod tests {
 
     /// One carried sheep named `web`, whose descriptors are `fds`.
     fn carried(fds: CarriedFds) -> CarriedSheep {
+        carried_slot(0, fds)
+    }
+
+    /// [`carried`], for a named instance slot of `web`.
+    ///
+    /// The id and the pid move with the slot, so two of these describe two
+    /// real instances of one app rather than the same one twice.
+    fn carried_slot(instance: u32, fds: CarriedFds) -> CarriedSheep {
         CarriedSheep {
-            id: 1,
+            id: instance + 1,
             name: "web".to_owned(),
-            instance: 0,
-            pid: Some(100),
+            instance,
+            pid: Some(u32::from(100 + u16::try_from(instance).unwrap())),
             restarts: 0,
             epoch: 7,
             status: ProcStatus::Online,
@@ -476,6 +484,109 @@ mod tests {
             std::fs::read_to_string(&log).unwrap(),
             "first\nsecond\n",
             "a write at offset 0 overwrote the file, so O_APPEND was lost"
+        );
+    }
+
+    /// Fails if `merge_logs` makes a two-instance app unadoptable, or if
+    /// the two handles it carries stop being independent across the exec.
+    ///
+    /// The hazard this closes is [`refuse_repeated_fds`], which refuses the
+    /// WHOLE blob when any descriptor number appears twice. `merge_logs`
+    /// points every instance of an app at one path, and if that were one
+    /// open file description shared between them then every merged
+    /// clustered app would be refused forever, with a message blaming a
+    /// descriptor rather than the config that produced it.
+    ///
+    /// It is not one description. Each instance's pump runs its own
+    /// `open_append` on the path (`tokio_runner`'s `LogFile::open`), so one
+    /// inode is reached through two descriptions with two numbers, and
+    /// `O_APPEND` is what keeps their writes from overwriting each other.
+    /// The two numbers are what this asserts on, and the interleaved file
+    /// afterwards is what proves they were really independent rather than
+    /// merely distinct.
+    #[tokio::test]
+    async fn two_instances_sharing_one_log_file_are_both_adopted() {
+        let dir = tempfile::tempdir().unwrap();
+        let socket = dir.path().join("shep.sock");
+        // One path for both slots, which is exactly what `merge_logs` does:
+        // `assemble` drops the `-<instance>` suffix and every instance of
+        // the name lands here.
+        let merged = dir.path().join("web-out.log");
+        let zero = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&merged)
+            .unwrap();
+        let one = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&merged)
+            .unwrap();
+        let (zero_fd, one_fd) = (zero.into_raw_fd(), one.into_raw_fd());
+        assert_ne!(
+            zero_fd, one_fd,
+            "two `open`s on one path must yield two numbers, or the premise \
+             of this whole case is wrong"
+        );
+        let blob = blob_with(
+            &socket,
+            vec![
+                carried_slot(
+                    0,
+                    CarriedFds {
+                        out_pipe: None,
+                        err_pipe: None,
+                        out_log: Some(zero_fd),
+                        err_log: None,
+                        stdin: None,
+                        channel: None,
+                    },
+                ),
+                carried_slot(
+                    1,
+                    CarriedFds {
+                        out_pipe: None,
+                        err_pipe: None,
+                        out_log: Some(one_fd),
+                        err_log: None,
+                        stdin: None,
+                        channel: None,
+                    },
+                ),
+            ],
+        );
+
+        let mut adopted = adopt(&blob).expect("a merged-log clustered app must be adoptable");
+
+        assert_eq!(adopted.sheep.len(), 2, "one adopted sheep per instance");
+        let mut zero = adopted.sheep[0].out_log.take().expect("slot 0's log");
+        let mut one = adopted.sheep[1].out_log.take().expect("slot 1's log");
+        // Alternated, so a second handle that had silently become the first
+        // one's alias shows up as lost or overwritten text rather than as
+        // two clean halves.
+        //
+        // Flushed after every line, and that is not tidiness. A
+        // `tokio::fs::File` buffers and hands the real `write(2)` to the
+        // blocking pool, so two handles written in sequence with one flush
+        // at the end reach the file in whichever order that pool finished:
+        // measured, this case failed once in twelve runs on
+        // `zero-1/one-1/one-2/zero-2`. The flush is what makes each write
+        // land before the next begins, which is what an ordered assertion
+        // needs to be an assertion about `O_APPEND` rather than about a
+        // thread pool.
+        for line in ["zero-1\n", "one-1\n", "zero-2\n", "one-2\n"] {
+            let handle = if line.starts_with("zero") {
+                &mut zero
+            } else {
+                &mut one
+            };
+            handle.write_all(line.as_bytes()).await.unwrap();
+            handle.flush().await.unwrap();
+        }
+        assert_eq!(
+            std::fs::read_to_string(&merged).unwrap(),
+            "zero-1\none-1\nzero-2\none-2\n",
+            "both instances append into the one file, in the order written"
         );
     }
 

--- a/crates/shep-daemon/src/handover/mod.rs
+++ b/crates/shep-daemon/src/handover/mod.rs
@@ -2,9 +2,10 @@
 //! place, the [`Handover`] blob that describes it, and (in a later task) the
 //! exec that carries it.
 //!
-//! Phase 2a carries only the plainest sheep: no shepherd channel, no dog,
-//! one instance, no in-flight reload, and nothing an operator has
-//! already asked to stop or delete. [`fitness`] is the gate: get it wrong in
+//! Four things are still not carried: a dog, more than one instance, an
+//! in-flight reload, and anything an operator has already asked to stop or
+//! delete. A sheep's stdout, stderr, log files, stdin pipe and shepherd
+//! channel all cross the exec. [`fitness`] is the gate: get it wrong in
 //! the permissive direction and a half-built handover corrupts a live
 //! flock; get it wrong in the strict direction and the caller merely falls
 //! back to the stop-and-start arm that already works. That asymmetry is why
@@ -74,12 +75,6 @@ pub enum RefusedReason {
         /// The sheep's name.
         sheep: String,
     },
-    /// The sheep holds a shepherd channel: `channel`, `wait_ready` or
-    /// `shutdown_with_message`, whose socketpair 2b carries.
-    Channel {
-        /// The sheep's name.
-        sheep: String,
-    },
     /// The sheep is a dog, which 2b's descriptor inventory does not cover
     /// yet.
     Dog {
@@ -123,7 +118,6 @@ impl core::fmt::Display for RefusedReason {
                      time; reload falls back to a stop-and-start instead"
                 );
             }
-            Self::Channel { sheep } => (sheep, "a shepherd channel"),
             Self::Dog { sheep } => (sheep, "being a dog"),
             Self::MultiInstance { sheep } => (sheep, "more than one instance"),
             Self::ReloadInFlight { sheep } => (sheep, "an in-flight reload"),
@@ -224,9 +218,6 @@ fn refusal(candidate: &Candidate<'_>) -> Option<RefusedReason> {
 
     if candidate.pump_unresponsive {
         return Some(RefusedReason::PumpUnresponsive { sheep: name() });
-    }
-    if config.channel || config.wait_ready || config.shutdown_with_message {
-        return Some(RefusedReason::Channel { sheep: name() });
     }
     if entry.dog.is_some() {
         return Some(RefusedReason::Dog { sheep: name() });
@@ -726,10 +717,11 @@ impl CarriedSheep {
     }
 }
 
-/// The descriptor numbers one sheep's output travels on, and the one its
-/// input travels back through.
+/// The descriptor numbers one sheep's output travels on, the one its input
+/// travels back through, and the one that carries both directions of its
+/// shepherd channel.
 ///
-/// Grouped rather than spelled as five fields on [`CarriedSheep`] for two
+/// Grouped rather than spelled as six fields on [`CarriedSheep`] for two
 /// reasons: they are all `Option<RawFd>`, so a constructor taking them
 /// positionally would let a caller swap two of them silently, and four of
 /// them share one fact, which is that a running instance has all four and a
@@ -742,10 +734,10 @@ impl CarriedSheep {
 /// pipe buffer fills, which reads as an application hang rather than as a
 /// shep bug.
 ///
-/// [`Self::stdin`] is the exception on both counts, and it is the only
-/// field here whose direction is the other way round: it is a WRITE end the
-/// daemon holds, and it is present only for a running sheep whose app asked
-/// for one.
+/// [`Self::stdin`] and [`Self::channel`] are the exceptions on both counts.
+/// Each is present only for a running sheep whose app asked for it, and
+/// neither is a read end the daemon drains one way: stdin is a WRITE end,
+/// and the channel is one socket the daemon reads and writes at once.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CarriedFds {
     /// The read end of the sheep's stdout pipe.
@@ -782,23 +774,45 @@ pub struct CarriedFds {
     /// `a_blob_written_before_stdin_was_carried_still_loads`, which loads a
     /// blob with the key removed.
     pub stdin: Option<RawFd>,
+    /// The daemon's end of the sheep's shepherd-channel socketpair, whose
+    /// other end is the child's fd 3.
+    ///
+    /// One number for both directions, unlike every other field here: a
+    /// socketpair is one descriptor that is read and written at the same
+    /// time, so `spawn_channel_pumps` splits it into two tasks over one
+    /// open file description rather than into two descriptors.
+    ///
+    /// `None` for a sheep whose app set none of `channel`, `wait_ready` or
+    /// `shutdown_with_message` (`assemble` folds all three into one flag),
+    /// for a sheep that is not running, and for one whose child has closed
+    /// its fd 3 and left the daemon's writer nothing to write to. The last
+    /// of those is why the snapshot masks this field rather than reporting
+    /// whatever number a pump last saw: see `SheepSlot::open_channel`.
+    ///
+    /// An absent field loads as `None` for the reason [`Self::stdin`] gives
+    /// at length, and [`VERSION`] is unmoved for the same reason. A
+    /// predecessor from before this field existed refused to carry a sheep
+    /// with a channel at all, so `None` is what its blobs truthfully mean.
+    pub channel: Option<RawFd>,
 }
 
 impl CarriedFds {
-    /// The five numbers, listener-order irrelevant but fixed: stdout's pipe,
-    /// stderr's pipe, stdout's log, stderr's log, stdin's pipe.
+    /// The six numbers, listener-order irrelevant but fixed: stdout's pipe,
+    /// stderr's pipe, stdout's log, stderr's log, stdin's pipe, the
+    /// shepherd channel.
     ///
-    /// One array rather than five field reads, so a caller that walks all of
+    /// One array rather than six field reads, so a caller that walks all of
     /// them — clearing `FD_CLOEXEC`, checking each is open — cannot walk
-    /// four by mistake.
+    /// five by mistake.
     #[must_use]
-    pub const fn all(&self) -> [Option<RawFd>; 5] {
+    pub const fn all(&self) -> [Option<RawFd>; 6] {
         [
             self.out_pipe,
             self.err_pipe,
             self.out_log,
             self.err_log,
             self.stdin,
+            self.channel,
         ]
     }
 
@@ -814,6 +828,7 @@ impl CarriedFds {
             out_log: None,
             err_log: None,
             stdin: None,
+            channel: None,
         }
     }
 }
@@ -1203,9 +1218,9 @@ mod tests {
         // Not per-sheep. The blob describes one process image, so a flock is
         // carried whole or not at all.
         let plain_entry = entry_fixture(|_| {});
-        let channelled = entry_fixture(|app| app.channel = true);
+        let clustered = entry_fixture(|app| app.instances = 2);
         assert!(matches!(
-            fitness(&[plain(&plain_entry), plain(&channelled)]),
+            fitness(&[plain(&plain_entry), plain(&clustered)]),
             Fitness::Refused(_)
         ));
     }
@@ -1214,12 +1229,12 @@ mod tests {
     fn the_refusal_names_which_sheep_and_why() {
         // The operator sees this in `shep daemon reload`'s output, so it has
         // to say what to do about it, not just that it declined.
-        let channelled = entry_fixture(|app| app.channel = true);
-        let Fitness::Refused(r) = fitness(&[plain(&channelled)]) else {
+        let clustered = entry_fixture(|app| app.instances = 2);
+        let Fitness::Refused(r) = fitness(&[plain(&clustered)]) else {
             panic!("expected a refusal")
         };
         let text = r.to_string();
-        assert!(text.contains("shepherd channel"), "{text}");
+        assert!(text.contains("more than one instance"), "{text}");
     }
 
     /// A wedged pump refuses, and says so as a fault rather than as a
@@ -1256,22 +1271,42 @@ mod tests {
         assert_eq!(fitness(&[]), Fitness::Carryable);
     }
 
+    /// fails if the gate still refuses a sheep that asked for a shepherd
+    /// channel by its own name.
+    ///
+    /// One socketpair, carried by number in [`CarriedFds::channel`]. What
+    /// the successor rebuilds on it is the same pair of pumps a spawn
+    /// wires, so the child's fd 3 is the fd 3 it has had all along.
     #[test]
-    fn wait_ready_alone_refuses_as_a_channel() {
-        let e = entry_fixture(|app| app.wait_ready = true);
-        assert!(matches!(
-            fitness(&[plain(&e)]),
-            Fitness::Refused(RefusedReason::Channel { .. })
-        ));
+    fn a_sheep_with_a_channel_is_carried() {
+        let e = entry_fixture(|app| app.channel = true);
+        assert_eq!(fitness(&[plain(&e)]), Fitness::Carryable);
     }
 
+    /// fails if the gate still refuses a sheep gated on `{"kind":"ready"}`.
+    ///
+    /// Its own case rather than a variant of the one above, because
+    /// `wait_ready` reaches machinery `channel` alone does not: the sheep
+    /// may be `Starting` at the exec, and a successor that adopts it with
+    /// nothing waiting leaves it `Starting` outside any timeout. See
+    /// `Actor::install_adopted`, which re-arms the wait.
     #[test]
-    fn shutdown_with_message_alone_refuses_as_a_channel() {
+    fn wait_ready_alone_is_carried() {
+        let e = entry_fixture(|app| app.wait_ready = true);
+        assert_eq!(fitness(&[plain(&e)]), Fitness::Carryable);
+    }
+
+    /// fails if the gate still refuses a sheep that is told before it is
+    /// killed.
+    ///
+    /// Its own case for the same reason: `shutdown_with_message` is the one
+    /// of the three whose channel traffic runs the other way, from the
+    /// shepherd to the child, so it is the writer half of the rebuilt pair
+    /// that has to work.
+    #[test]
+    fn shutdown_with_message_alone_is_carried() {
         let e = entry_fixture(|app| app.shutdown_with_message = true);
-        assert!(matches!(
-            fitness(&[plain(&e)]),
-            Fitness::Refused(RefusedReason::Channel { .. })
-        ));
+        assert_eq!(fitness(&[plain(&e)]), Fitness::Carryable);
     }
 
     /// fails if the gate still refuses a sheep whose app asked for a stdin
@@ -1341,6 +1376,7 @@ mod tests {
                 out_log: Some(13),
                 err_log: Some(14),
                 stdin: Some(15),
+                channel: Some(16),
             },
         )
     }
@@ -1474,7 +1510,38 @@ mod tests {
         assert_eq!(
             loaded.sheep[0].fds.out_pipe,
             sample_handover().sheep[0].fds.out_pipe,
-            "the other four are unchanged by the one that was absent"
+            "the other five are unchanged by the one that was absent"
+        );
+    }
+
+    /// fails if a blob written before this daemon carried a shepherd
+    /// channel stops loading.
+    ///
+    /// The same argument the case above makes for stdin, and it has to be
+    /// made again rather than assumed: `channel` is a second `Option` field
+    /// added after [`VERSION`] was fixed at 1, and a reader that refused an
+    /// absent one would leave a successor unable to boot after its
+    /// predecessor had exec'd itself away. A predecessor from before this
+    /// field existed refused to carry a channelled sheep at all, so `None`
+    /// is not a guess: it is what that blob means.
+    #[test]
+    fn a_blob_written_before_the_channel_was_carried_still_loads() {
+        let mut value = serde_json::to_value(sample_handover()).unwrap();
+        let fds = value["sheep"][0]["fds"]
+            .as_object_mut()
+            .expect("a carried sheep names its descriptors");
+        assert!(
+            fds.remove("channel").is_some(),
+            "the field this case removes must be there to remove"
+        );
+
+        let loaded = Handover::load_value(value).expect("an older blob must still load");
+
+        assert_eq!(loaded.sheep[0].fds.channel, None);
+        assert_eq!(
+            loaded.sheep[0].fds.stdin,
+            sample_handover().sheep[0].fds.stdin,
+            "the other five are unchanged by the one that was absent"
         );
     }
 
@@ -1669,6 +1736,7 @@ mod tests {
                 out_log: None,
                 err_log: None,
                 stdin: None,
+                channel: None,
             },
         );
 
@@ -1711,6 +1779,7 @@ mod tests {
                 out_log: None,
                 err_log: None,
                 stdin: None,
+                channel: None,
             },
         );
 
@@ -1747,10 +1816,11 @@ mod tests {
         let listener = tempfile::tempfile().unwrap();
         let pidfile = tempfile::tempfile().unwrap();
         let out_log = tempfile::tempfile().unwrap();
-        // The stdin write end rides along, because it is the newest of the
-        // five and the one a `named_fds` that still yielded four would
-        // silently leave close-on-exec.
+        // The stdin write end and the channel's daemon end ride along,
+        // because they are the two newest and are what a `named_fds` that
+        // still yielded four, or five, would silently leave close-on-exec.
         let (_child_end, stdin) = std::io::pipe().unwrap();
+        let (channel, _child_channel) = std::os::unix::net::UnixStream::pair().unwrap();
         let blob = handover_with_fds(
             &entry_fixture(|_| {}),
             listener.as_raw_fd(),
@@ -1761,6 +1831,7 @@ mod tests {
                 out_log: Some(out_log.as_raw_fd()),
                 err_log: None,
                 stdin: Some(stdin.as_raw_fd()),
+                channel: Some(channel.as_raw_fd()),
             },
         );
 
@@ -1771,6 +1842,7 @@ mod tests {
             pidfile.as_fd(),
             out_log.as_fd(),
             stdin.as_fd(),
+            channel.as_fd(),
         ] {
             assert!(
                 !fds::is_kept(fd).unwrap(),
@@ -1792,6 +1864,7 @@ mod tests {
             pidfile.as_raw_fd(),
             out_log.as_raw_fd(),
             stdin.as_raw_fd(),
+            channel.as_raw_fd(),
         ];
         expected.sort_unstable();
         assert_eq!(
@@ -1807,6 +1880,7 @@ mod tests {
             pidfile.as_fd(),
             out_log.as_fd(),
             stdin.as_fd(),
+            channel.as_fd(),
         ] {
             assert!(
                 !fds::is_kept(fd).unwrap(),

--- a/crates/shep-daemon/src/handover/mod.rs
+++ b/crates/shep-daemon/src/handover/mod.rs
@@ -2,14 +2,16 @@
 //! place, the [`Handover`] blob that describes it, and (in a later task) the
 //! exec that carries it.
 //!
-//! Four things are still not carried: a dog, more than one instance, an
-//! in-flight reload, and anything an operator has already asked to stop or
-//! delete. A sheep's stdout, stderr, log files, stdin pipe and shepherd
-//! channel all cross the exec. [`fitness`] is the gate: get it wrong in
-//! the permissive direction and a half-built handover corrupts a live
-//! flock; get it wrong in the strict direction and the caller merely falls
-//! back to the stop-and-start arm that already works. That asymmetry is why
-//! an unclear case refuses rather than guesses.
+//! Three things are still not carried: a dog, an in-flight reload, and
+//! anything an operator has already asked to stop or delete. A sheep's
+//! stdout, stderr, log files, stdin pipe and shepherd channel all cross the
+//! exec, and every one of those is per SHEEP rather than per app, so an app
+//! running several instances crosses as several sets and needs nothing of
+//! its own. [`fitness`] is the gate: get it wrong in the permissive
+//! direction and a half-built handover corrupts a live flock; get it wrong
+//! in the strict direction and the caller merely falls back to the
+//! stop-and-start arm that already works. That asymmetry is why an unclear
+//! case refuses rather than guesses.
 
 pub(crate) mod adopt;
 mod fds;
@@ -47,8 +49,8 @@ pub enum Fitness {
 
 /// Why a flock cannot be handed over in place, and what happens instead.
 ///
-/// Almost every variant is a feature phase 2a does not yet carry rather than
-/// an error, and the caller falls back to the stop arm, which is correct
+/// Almost every variant is a feature this daemon does not yet carry rather
+/// than an error, and the caller falls back to the stop arm, which is correct
 /// behaviour rather than a degraded one. [`Self::PumpUnresponsive`] is the
 /// exception and is a fault: it says a sheep's log pump did not answer in
 /// time, so nothing here knows which descriptors that sheep holds. The
@@ -57,9 +59,10 @@ pub enum Fitness {
 /// `#[non_exhaustive]`, unlike [`crate::boot::Shepherd`]: that enum is
 /// closed by its mechanism (a pidfile lock is either free, held-with-pid or
 /// held-without, and there is no fourth state). This one is closed by
-/// nothing but how much of the handover has shipped. 2b and 2c each widen
-/// what phase 2a refuses today into something a later phase carries, so a
-/// match here must keep tolerating a variant this module has not named yet.
+/// nothing but how much of the handover has shipped. Every phase so far has
+/// turned one of these into something the daemon carries, and 2c still has
+/// three to go, so a match here must keep tolerating a variant this module
+/// has not named yet.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum RefusedReason {
@@ -68,21 +71,15 @@ pub enum RefusedReason {
     ///
     /// First in this enum and first in [`refusal`]'s order, because it is
     /// the only variant that is not a statement about the sheep's config: a
-    /// sheep can be both wedged and multi-instance, and the wedge is the
-    /// fact an operator needs, since it will still be true after every
-    /// feature below has shipped.
+    /// sheep can be both wedged and a dog, and the wedge is the fact an
+    /// operator needs, since it will still be true after every feature
+    /// below has shipped.
     PumpUnresponsive {
         /// The sheep's name.
         sheep: String,
     },
-    /// The sheep is a dog, which 2b's descriptor inventory does not cover
-    /// yet.
+    /// The sheep is a dog, whose descriptor inventory is not covered yet.
     Dog {
-        /// The sheep's name.
-        sheep: String,
-    },
-    /// The sheep's app runs more than one instance, which 2b carries.
-    MultiInstance {
         /// The sheep's name.
         sheep: String,
     },
@@ -119,7 +116,6 @@ impl core::fmt::Display for RefusedReason {
                 );
             }
             Self::Dog { sheep } => (sheep, "being a dog"),
-            Self::MultiInstance { sheep } => (sheep, "more than one instance"),
             Self::ReloadInFlight { sheep } => (sheep, "an in-flight reload"),
             Self::PendingStop { sheep } => (sheep, "a pending manual stop"),
             Self::PendingDelete { sheep } => (sheep, "a pending delete"),
@@ -221,9 +217,6 @@ fn refusal(candidate: &Candidate<'_>) -> Option<RefusedReason> {
     }
     if entry.dog.is_some() {
         return Some(RefusedReason::Dog { sheep: name() });
-    }
-    if config.instances > 1 {
-        return Some(RefusedReason::MultiInstance { sheep: name() });
     }
     if !matches!(entry.reload, crate::entry::ReloadState::None) {
         return Some(RefusedReason::ReloadInFlight { sheep: name() });
@@ -1218,9 +1211,10 @@ mod tests {
         // Not per-sheep. The blob describes one process image, so a flock is
         // carried whole or not at all.
         let plain_entry = entry_fixture(|_| {});
-        let clustered = entry_fixture(|app| app.instances = 2);
+        let mut unsupported = entry_fixture(|_| {});
+        unsupported.dog = Some(shep_core::protocol::DogSource::BuiltIn);
         assert!(matches!(
-            fitness(&[plain(&plain_entry), plain(&clustered)]),
+            fitness(&[plain(&plain_entry), plain(&unsupported)]),
             Fitness::Refused(_)
         ));
     }
@@ -1229,12 +1223,14 @@ mod tests {
     fn the_refusal_names_which_sheep_and_why() {
         // The operator sees this in `shep daemon reload`'s output, so it has
         // to say what to do about it, not just that it declined.
-        let clustered = entry_fixture(|app| app.instances = 2);
-        let Fitness::Refused(r) = fitness(&[plain(&clustered)]) else {
+        let mut unsupported = entry_fixture(|_| {});
+        unsupported.dog = Some(shep_core::protocol::DogSource::BuiltIn);
+        let Fitness::Refused(r) = fitness(&[plain(&unsupported)]) else {
             panic!("expected a refusal")
         };
         let text = r.to_string();
-        assert!(text.contains("more than one instance"), "{text}");
+        assert!(text.contains("being a dog"), "{text}");
+        assert!(text.contains("web"), "{text}");
     }
 
     /// A wedged pump refuses, and says so as a fault rather than as a
@@ -1330,13 +1326,93 @@ mod tests {
         ));
     }
 
+    /// fails if the gate still refuses an app running more than one
+    /// instance.
+    ///
+    /// Nothing about the descriptor inventory changes: a slot IS a sheep
+    /// here, with its own supervisor slot, its own log pump and its own set
+    /// of descriptors, so a two-instance app is two entries the gate reads
+    /// one at a time exactly as it reads two apps.
+    ///
+    /// Both slots, not one. The gate is whole-flock, so refusing either of
+    /// them would refuse the app, and a version that only stopped looking
+    /// at `instances` on slot 0 would pass a one-candidate case.
     #[test]
-    fn more_than_one_instance_refuses() {
-        let e = entry_fixture(|app| app.instances = 2);
-        assert!(matches!(
-            fitness(&[plain(&e)]),
-            Fitness::Refused(RefusedReason::MultiInstance { .. })
-        ));
+    fn an_app_with_more_than_one_instance_is_carried() {
+        let mut zero = entry_fixture(|app| app.instances = 2);
+        let mut one = entry_fixture(|app| app.instances = 2);
+        one.id = 2;
+        one.instance = 1;
+        one.pid = Some(101);
+        assert_eq!(fitness(&[plain(&zero), plain(&one)]), Fitness::Carryable);
+        // Order is not the fact being tested, but a gate that read only the
+        // first candidate would pass the assertion above too.
+        zero.instance = 1;
+        one.instance = 0;
+        assert_eq!(fitness(&[plain(&one), plain(&zero)]), Fitness::Carryable);
+    }
+
+    /// fails if a blob folds two instances of one app together, or lets one
+    /// slot's descriptors reach the other's row.
+    ///
+    /// The defect this exists for leaves a flock that looks entirely
+    /// healthy: two live pids, both adopted, both `Online`, and each one
+    /// writing into the other's log file under the other's
+    /// `SHEP_INSTANCE`. Nothing a pid check can see. What stops it is that
+    /// [`CarriedSheep::instance`] is carried per row rather than re-derived
+    /// from a count, and this pins that.
+    #[test]
+    fn each_instance_carries_its_own_slot_and_descriptors() {
+        let mut zero = entry_fixture(|app| app.instances = 2);
+        zero.instance = 0;
+        let mut one = entry_fixture(|app| app.instances = 2);
+        one.id = 2;
+        one.instance = 1;
+        one.pid = Some(101);
+
+        let blob = Handover::new(
+            vec![
+                CarriedSheep::from_entry(&zero, 7, fds_at(11)),
+                CarriedSheep::from_entry(&one, 8, fds_at(21)),
+            ],
+            DaemonFds {
+                listener: 3,
+                pidfile: 4,
+            },
+            Counters {
+                next_id: 9,
+                next_deadline: 5,
+                next_action_stamp: 2,
+            },
+        );
+        let back: Handover = serde_json::from_str(&serde_json::to_string(&blob).unwrap()).unwrap();
+
+        let carried = back.sheep();
+        assert_eq!(carried.len(), 2, "one row per instance, never per app");
+        // Bound by slot rather than by position, so a blob that reordered
+        // the rows still has to put each pid with its own slot.
+        let slot_zero = carried
+            .iter()
+            .find(|sheep| sheep.instance() == 0)
+            .expect("slot 0 must be carried");
+        let slot_one = carried
+            .iter()
+            .find(|sheep| sheep.instance() == 1)
+            .expect("slot 1 must be carried");
+        assert_eq!(slot_zero.id(), 1);
+        assert_eq!(slot_zero.pid(), Some(100));
+        assert_eq!(slot_zero.epoch(), 7);
+        assert_eq!(slot_zero.fds(), fds_at(11));
+        assert_eq!(slot_one.id(), 2);
+        assert_eq!(slot_one.pid(), Some(101));
+        assert_eq!(slot_one.epoch(), 8);
+        assert_eq!(slot_one.fds(), fds_at(21));
+        assert_eq!(
+            slot_zero.name(),
+            slot_one.name(),
+            "both slots are the same app, which is what makes the slot the \
+             only thing telling them apart"
+        );
     }
 
     #[test]
@@ -1364,21 +1440,27 @@ mod tests {
         ));
     }
 
+    /// The six descriptor numbers a running sheep would have, counting up
+    /// from `base`.
+    ///
+    /// Takes a base so two instances of one app can be given two disjoint
+    /// sets, which is what a merged-log app really has: one inode, two
+    /// `open`s, two numbers.
+    const fn fds_at(base: RawFd) -> CarriedFds {
+        CarriedFds {
+            out_pipe: Some(base),
+            err_pipe: Some(base + 1),
+            out_log: Some(base + 2),
+            err_log: Some(base + 3),
+            stdin: Some(base + 4),
+            channel: Some(base + 5),
+        }
+    }
+
     /// One carried sheep off `entry`, with the descriptor numbers a
     /// running sheep would have.
     fn carried(entry: &ProcessEntry) -> CarriedSheep {
-        CarriedSheep::from_entry(
-            entry,
-            7,
-            CarriedFds {
-                out_pipe: Some(11),
-                err_pipe: Some(12),
-                out_log: Some(13),
-                err_log: Some(14),
-                stdin: Some(15),
-                channel: Some(16),
-            },
-        )
+        CarriedSheep::from_entry(entry, 7, fds_at(11))
     }
 
     fn handover_over(entry: &ProcessEntry) -> Handover {

--- a/crates/shep-daemon/src/handover/mod.rs
+++ b/crates/shep-daemon/src/handover/mod.rs
@@ -46,9 +46,12 @@ pub enum Fitness {
 
 /// Why a flock cannot be handed over in place, and what happens instead.
 ///
-/// Every variant is a feature phase 2a does not yet carry, not an error. The
-/// caller falls back to the stop arm, which is correct behaviour rather
-/// than a degraded one.
+/// Almost every variant is a feature phase 2a does not yet carry rather than
+/// an error, and the caller falls back to the stop arm, which is correct
+/// behaviour rather than a degraded one. [`Self::PumpUnresponsive`] is the
+/// exception and is a fault: it says a sheep's log pump did not answer in
+/// time, so nothing here knows which descriptors that sheep holds. The
+/// answer is still to refuse and stop, which is why it lives with the rest.
 ///
 /// `#[non_exhaustive]`, unlike [`crate::boot::Shepherd`]: that enum is
 /// closed by its mechanism (a pidfile lock is either free, held-with-pid or
@@ -59,6 +62,18 @@ pub enum Fitness {
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum RefusedReason {
+    /// The sheep's log pump did not report its descriptors before the
+    /// snapshot's deadline, so nothing knows which four numbers it holds.
+    ///
+    /// First in this enum and first in [`refusal`]'s order, because it is
+    /// the only variant that is not a statement about the sheep's config: a
+    /// sheep can be both wedged and multi-instance, and the wedge is the
+    /// fact an operator needs, since it will still be true after every
+    /// feature below has shipped.
+    PumpUnresponsive {
+        /// The sheep's name.
+        sheep: String,
+    },
     /// The sheep holds a shepherd channel: `channel`, `wait_ready` or
     /// `shutdown_with_message`, whose socketpair 2b carries.
     Channel {
@@ -102,6 +117,17 @@ pub enum RefusedReason {
 impl core::fmt::Display for RefusedReason {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let (sheep, feature) = match self {
+            // Its own sentence rather than a `feature` for the one below:
+            // "has a wedged log pump, which this daemon cannot yet hand
+            // over" would read as a gap a later phase closes, and this one
+            // will still be a fault when every other variant has gone.
+            Self::PumpUnresponsive { sheep } => {
+                return write!(
+                    f,
+                    "sheep '{sheep}' has a log pump that did not report its descriptors in \
+                     time; reload falls back to a stop-and-start instead"
+                );
+            }
             Self::Channel { sheep } => (sheep, "a shepherd channel"),
             Self::Stdin { sheep } => (sheep, "stdin"),
             Self::Dog { sheep } => (sheep, "being a dog"),
@@ -134,6 +160,15 @@ pub struct Candidate<'a> {
     pub pending_stop: bool,
     /// Whether an operator's `delete` targets this sheep.
     pub pending_delete: bool,
+    /// Whether this sheep's log pump was asked for its descriptors and did
+    /// not answer in time.
+    ///
+    /// A third answer rather than a `CarriedFds::none()`, and the
+    /// distinction is the whole point: `none()` is what a STOPPED sheep
+    /// reports, and a wedged live pump collapsed into it would be carried
+    /// with its four descriptors silently dropped. So it reaches the gate
+    /// here, on the candidate, instead of being folded into the blob.
+    pub pump_unresponsive: bool,
 }
 
 /// A [`Candidate`] that owns its entry.
@@ -154,6 +189,9 @@ pub struct OwnedCandidate {
     pub pending_stop: bool,
     /// Whether an operator's `delete` targets this sheep.
     pub pending_delete: bool,
+    /// Whether this sheep's log pump missed the snapshot's deadline; see
+    /// [`Candidate::pump_unresponsive`].
+    pub pump_unresponsive: bool,
 }
 
 impl OwnedCandidate {
@@ -164,6 +202,7 @@ impl OwnedCandidate {
             entry: &self.entry,
             pending_stop: self.pending_stop,
             pending_delete: self.pending_delete,
+            pump_unresponsive: self.pump_unresponsive,
         }
     }
 }
@@ -189,6 +228,9 @@ fn refusal(candidate: &Candidate<'_>) -> Option<RefusedReason> {
     let config = entry.spec.config();
     let name = || config.name.clone();
 
+    if candidate.pump_unresponsive {
+        return Some(RefusedReason::PumpUnresponsive { sheep: name() });
+    }
     if config.channel || config.wait_ready || config.shutdown_with_message {
         return Some(RefusedReason::Channel { sheep: name() });
     }
@@ -1115,6 +1157,7 @@ mod tests {
             entry,
             pending_stop: false,
             pending_delete: false,
+            pump_unresponsive: false,
         }
     }
 
@@ -1146,6 +1189,35 @@ mod tests {
         };
         let text = r.to_string();
         assert!(text.contains("shepherd channel"), "{text}");
+    }
+
+    /// A wedged pump refuses, and says so as a fault rather than as a
+    /// feature this daemon has not shipped yet.
+    ///
+    /// The wording matters more than it looks: every other refusal here is
+    /// "wait for a later version", and an operator who reads that about a
+    /// stuck filesystem will wait for something that is never coming.
+    #[test]
+    fn a_pump_that_did_not_report_in_time_refuses_as_a_fault_not_a_feature() {
+        let e = entry_fixture(|_| {});
+        let candidate = Candidate {
+            entry: &e,
+            pending_stop: false,
+            pending_delete: false,
+            pump_unresponsive: true,
+        };
+        let Fitness::Refused(r) = fitness(&[candidate]) else {
+            panic!("a sheep whose descriptors are unknown cannot be carried")
+        };
+        let text = r.to_string();
+        assert!(
+            text.contains("did not report its descriptors in time"),
+            "{text}"
+        );
+        assert!(
+            !text.contains("cannot yet"),
+            "a wedged pump is not a feature a later phase ships: {text}"
+        );
     }
 
     #[test]
@@ -1216,6 +1288,7 @@ mod tests {
             entry: &e,
             pending_stop: true,
             pending_delete: false,
+            pump_unresponsive: false,
         };
         assert!(matches!(
             fitness(&[candidate]),
@@ -1346,6 +1419,7 @@ mod tests {
             entry: &e,
             pending_stop: false,
             pending_delete: true,
+            pump_unresponsive: false,
         };
         assert!(matches!(
             fitness(&[candidate]),

--- a/crates/shep-daemon/src/handover/mod.rs
+++ b/crates/shep-daemon/src/handover/mod.rs
@@ -2,8 +2,8 @@
 //! place, the [`Handover`] blob that describes it, and (in a later task) the
 //! exec that carries it.
 //!
-//! Phase 2a carries only the plainest sheep: no shepherd channel, no stdin,
-//! no dog, one instance, no in-flight reload, and nothing an operator has
+//! Phase 2a carries only the plainest sheep: no shepherd channel, no dog,
+//! one instance, no in-flight reload, and nothing an operator has
 //! already asked to stop or delete. [`fitness`] is the gate: get it wrong in
 //! the permissive direction and a half-built handover corrupts a live
 //! flock; get it wrong in the strict direction and the caller merely falls
@@ -63,7 +63,7 @@ pub enum Fitness {
 #[non_exhaustive]
 pub enum RefusedReason {
     /// The sheep's log pump did not report its descriptors before the
-    /// snapshot's deadline, so nothing knows which four numbers it holds.
+    /// snapshot's deadline, so nothing knows which descriptors it holds.
     ///
     /// First in this enum and first in [`refusal`]'s order, because it is
     /// the only variant that is not a statement about the sheep's config: a
@@ -77,11 +77,6 @@ pub enum RefusedReason {
     /// The sheep holds a shepherd channel: `channel`, `wait_ready` or
     /// `shutdown_with_message`, whose socketpair 2b carries.
     Channel {
-        /// The sheep's name.
-        sheep: String,
-    },
-    /// The sheep has `stdin = true`, whose pipe 2b carries.
-    Stdin {
         /// The sheep's name.
         sheep: String,
     },
@@ -129,7 +124,6 @@ impl core::fmt::Display for RefusedReason {
                 );
             }
             Self::Channel { sheep } => (sheep, "a shepherd channel"),
-            Self::Stdin { sheep } => (sheep, "stdin"),
             Self::Dog { sheep } => (sheep, "being a dog"),
             Self::MultiInstance { sheep } => (sheep, "more than one instance"),
             Self::ReloadInFlight { sheep } => (sheep, "an in-flight reload"),
@@ -166,7 +160,7 @@ pub struct Candidate<'a> {
     /// A third answer rather than a `CarriedFds::none()`, and the
     /// distinction is the whole point: `none()` is what a STOPPED sheep
     /// reports, and a wedged live pump collapsed into it would be carried
-    /// with its four descriptors silently dropped. So it reaches the gate
+    /// with its descriptors silently dropped. So it reaches the gate
     /// here, on the candidate, instead of being folded into the blob.
     pub pump_unresponsive: bool,
 }
@@ -233,9 +227,6 @@ fn refusal(candidate: &Candidate<'_>) -> Option<RefusedReason> {
     }
     if config.channel || config.wait_ready || config.shutdown_with_message {
         return Some(RefusedReason::Channel { sheep: name() });
-    }
-    if config.stdin {
-        return Some(RefusedReason::Stdin { sheep: name() });
     }
     if entry.dog.is_some() {
         return Some(RefusedReason::Dog { sheep: name() });
@@ -540,7 +531,7 @@ impl core::error::Error for LoadError {
 /// them positionally lets a caller swap them silently, and the swap is not
 /// detectable afterwards — the successor would `flock` its control socket
 /// and listen on its pidfile. This is the same argument [`CarriedFds`] makes
-/// for grouping its four.
+/// for grouping its own.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct DaemonFds {
     /// The control listener's descriptor number.
@@ -735,19 +726,26 @@ impl CarriedSheep {
     }
 }
 
-/// The four descriptor numbers one sheep's output travels on.
+/// The descriptor numbers one sheep's output travels on, and the one its
+/// input travels back through.
 ///
-/// Grouped rather than spelled as four fields on [`CarriedSheep`] for two
+/// Grouped rather than spelled as five fields on [`CarriedSheep`] for two
 /// reasons: they are all `Option<RawFd>`, so a constructor taking them
-/// positionally would let a caller swap two of them silently, and they share
-/// one fact, which is that a running instance has all four and a registered
-/// one that is not running has none.
+/// positionally would let a caller swap two of them silently, and four of
+/// them share one fact, which is that a running instance has all four and a
+/// registered one that is not running has none.
 ///
-/// `None` is that second case and only that case. A blob naming a
-/// descriptor that is not open in the successor is a failure to refuse, not
-/// a `None` to tolerate: losing a sheep's stdout read end does not lose its
-/// output, it blocks the child on `write()` once the 64KiB pipe buffer
-/// fills, which reads as an application hang rather than as a shep bug.
+/// `None` on those four is that second case and only that case. A blob
+/// naming a descriptor that is not open in the successor is a failure to
+/// refuse, not a `None` to tolerate: losing a sheep's stdout read end does
+/// not lose its output, it blocks the child on `write()` once the 64KiB
+/// pipe buffer fills, which reads as an application hang rather than as a
+/// shep bug.
+///
+/// [`Self::stdin`] is the exception on both counts, and it is the only
+/// field here whose direction is the other way round: it is a WRITE end the
+/// daemon holds, and it is present only for a running sheep whose app asked
+/// for one.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CarriedFds {
     /// The read end of the sheep's stdout pipe.
@@ -758,18 +756,50 @@ pub struct CarriedFds {
     pub out_log: Option<RawFd>,
     /// The appending handle on the sheep's stderr log file.
     pub err_log: Option<RawFd>,
+    /// The write end of the sheep's stdin pipe, which `shep whisper` writes
+    /// a line into.
+    ///
+    /// `None` for a sheep whose app did not set `stdin = true`, which has
+    /// `/dev/null` on fd 0 and nothing for the daemon to hold, as well as
+    /// for a sheep that is not running.
+    ///
+    /// # Why an absent field is `None` rather than a refusal to load
+    ///
+    /// The predecessor in a handover is by definition a different build,
+    /// and one from before this field existed refused to carry a sheep with
+    /// a stdin pipe at all. So its blobs describe sheep that genuinely had
+    /// no such descriptor, which is what `None` says. Parsing them as an
+    /// error instead would leave the successor refusing to boot after the
+    /// predecessor had already exec'd itself away, and a whole flock
+    /// unsupervised is a steep price for one added field. [`VERSION`] is
+    /// unmoved for the same reason: nothing an older reader must understand
+    /// has changed.
+    ///
+    /// Serde's derive already lets an `Option` field be absent, so there is
+    /// no `#[serde(default)]` here: adding one changes nothing, and a
+    /// reader would reasonably take it as meaning that without it the field
+    /// is required. What holds the behaviour still is
+    /// `a_blob_written_before_stdin_was_carried_still_loads`, which loads a
+    /// blob with the key removed.
+    pub stdin: Option<RawFd>,
 }
 
 impl CarriedFds {
-    /// The four numbers, listener-order irrelevant but fixed: stdout's pipe,
-    /// stderr's pipe, stdout's log, stderr's log.
+    /// The five numbers, listener-order irrelevant but fixed: stdout's pipe,
+    /// stderr's pipe, stdout's log, stderr's log, stdin's pipe.
     ///
-    /// One array rather than four field reads, so a caller that walks all of
+    /// One array rather than five field reads, so a caller that walks all of
     /// them — clearing `FD_CLOEXEC`, checking each is open — cannot walk
-    /// three by mistake.
+    /// four by mistake.
     #[must_use]
-    pub const fn all(&self) -> [Option<RawFd>; 4] {
-        [self.out_pipe, self.err_pipe, self.out_log, self.err_log]
+    pub const fn all(&self) -> [Option<RawFd>; 5] {
+        [
+            self.out_pipe,
+            self.err_pipe,
+            self.out_log,
+            self.err_log,
+            self.stdin,
+        ]
     }
 
     /// The no-descriptors case: a sheep that is registered and not running.
@@ -783,6 +813,7 @@ impl CarriedFds {
             err_pipe: None,
             out_log: None,
             err_log: None,
+            stdin: None,
         }
     }
 }
@@ -1128,8 +1159,8 @@ mod tests {
     use crate::privilege::SpawnIdentity;
     use crate::testing::{app_with, test_paths};
 
-    /// A plain, `Online` entry: no channel, no stdin, not a dog, one
-    /// instance, no in-flight reload. Every field a real spawn would set is
+    /// A plain, `Online` entry: no channel, not a dog, one instance, no
+    /// in-flight reload. Every field a real spawn would set is
     /// present so a future field this gate should read cannot be silently
     /// left at a `Default` that hides a bug.
     fn entry_fixture(mutate: impl FnOnce(&mut AppConfig)) -> ProcessEntry {
@@ -1243,13 +1274,15 @@ mod tests {
         ));
     }
 
+    /// fails if the gate still refuses a sheep whose app asked for a stdin
+    /// pipe.
+    ///
+    /// The write end is one more descriptor through the machinery that
+    /// already carries four, and [`CarriedFds::stdin`] is where it travels.
     #[test]
-    fn stdin_refuses() {
+    fn a_sheep_with_stdin_is_carried() {
         let e = entry_fixture(|app| app.stdin = true);
-        assert!(matches!(
-            fitness(&[plain(&e)]),
-            Fitness::Refused(RefusedReason::Stdin { .. })
-        ));
+        assert_eq!(fitness(&[plain(&e)]), Fitness::Carryable);
     }
 
     #[test]
@@ -1307,6 +1340,7 @@ mod tests {
                 err_pipe: Some(12),
                 out_log: Some(13),
                 err_log: Some(14),
+                stdin: Some(15),
             },
         )
     }
@@ -1410,6 +1444,38 @@ mod tests {
         let mut v = serde_json::to_value(sample_handover()).unwrap();
         v["version"] = serde_json::json!(u32::MAX);
         assert!(Handover::load_value(v).is_err());
+    }
+
+    /// fails if a blob written before this daemon carried stdin stops
+    /// loading.
+    ///
+    /// The predecessor in a handover is by definition a different build,
+    /// and one old enough not to know about [`CarriedFds::stdin`] refused
+    /// to carry a sheep that had one. So an absent field is not a gap to
+    /// guess at: it says this sheep had no stdin pipe, which is what
+    /// `None` means. Making it a hard parse failure instead would leave the
+    /// successor refusing to boot after the predecessor had already exec'd
+    /// itself away, which is a whole flock unsupervised for one added
+    /// field.
+    #[test]
+    fn a_blob_written_before_stdin_was_carried_still_loads() {
+        let mut value = serde_json::to_value(sample_handover()).unwrap();
+        let fds = value["sheep"][0]["fds"]
+            .as_object_mut()
+            .expect("a carried sheep names its descriptors");
+        assert!(
+            fds.remove("stdin").is_some(),
+            "the field this case removes must be there to remove"
+        );
+
+        let loaded = Handover::load_value(value).expect("an older blob must still load");
+
+        assert_eq!(loaded.sheep[0].fds.stdin, None);
+        assert_eq!(
+            loaded.sheep[0].fds.out_pipe,
+            sample_handover().sheep[0].fds.out_pipe,
+            "the other four are unchanged by the one that was absent"
+        );
     }
 
     #[test]
@@ -1602,6 +1668,7 @@ mod tests {
                 err_pipe: None,
                 out_log: None,
                 err_log: None,
+                stdin: None,
             },
         );
 
@@ -1643,6 +1710,7 @@ mod tests {
                 err_pipe: None,
                 out_log: None,
                 err_log: None,
+                stdin: None,
             },
         );
 
@@ -1679,6 +1747,10 @@ mod tests {
         let listener = tempfile::tempfile().unwrap();
         let pidfile = tempfile::tempfile().unwrap();
         let out_log = tempfile::tempfile().unwrap();
+        // The stdin write end rides along, because it is the newest of the
+        // five and the one a `named_fds` that still yielded four would
+        // silently leave close-on-exec.
+        let (_child_end, stdin) = std::io::pipe().unwrap();
         let blob = handover_with_fds(
             &entry_fixture(|_| {}),
             listener.as_raw_fd(),
@@ -1688,14 +1760,20 @@ mod tests {
                 err_pipe: None,
                 out_log: Some(out_log.as_raw_fd()),
                 err_log: None,
+                stdin: Some(stdin.as_raw_fd()),
             },
         );
 
         // The precondition, so the assertion below cannot pass on a
         // descriptor that was never cleared in the first place.
-        for file in [&listener, &pidfile, &out_log] {
+        for fd in [
+            listener.as_fd(),
+            pidfile.as_fd(),
+            out_log.as_fd(),
+            stdin.as_fd(),
+        ] {
             assert!(
-                !fds::is_kept(file.as_fd()).unwrap(),
+                !fds::is_kept(fd).unwrap(),
                 "the daemon opens everything close-on-exec, so this starts set"
             );
         }
@@ -1713,6 +1791,7 @@ mod tests {
             listener.as_raw_fd(),
             pidfile.as_raw_fd(),
             out_log.as_raw_fd(),
+            stdin.as_raw_fd(),
         ];
         expected.sort_unstable();
         assert_eq!(
@@ -1723,9 +1802,14 @@ mod tests {
 
         let err = exec_into(&target, &blob, &paths).unwrap_err();
 
-        for file in [&listener, &pidfile, &out_log] {
+        for fd in [
+            listener.as_fd(),
+            pidfile.as_fd(),
+            out_log.as_fd(),
+            stdin.as_fd(),
+        ] {
             assert!(
-                !fds::is_kept(file.as_fd()).unwrap(),
+                !fds::is_kept(fd).unwrap(),
                 "a failed exec left a descriptor exec-inheritable: {err}"
             );
         }

--- a/crates/shep-daemon/src/runner.rs
+++ b/crates/shep-daemon/src/runner.rs
@@ -944,6 +944,15 @@ pub struct AdoptSpec {
     /// sheep, which has `/dev/null` on fd 0, and an adoption puts a stdin
     /// pump back only when there is an end for it to write to.
     pub stdin_pipe: Option<tokio::net::unix::pipe::Sender>,
+    /// The daemon's end of its shepherd-channel socketpair, still the one
+    /// whose other end is the child's fd 3.
+    ///
+    /// The one handle here that goes both ways, so an adoption puts BOTH
+    /// pumps back on it: an app that writes `{"kind":"ready"}` or an action
+    /// reply is read again, and a `shep trigger` or a
+    /// `shutdown_with_message` reaches it again. `None` for a sheep whose
+    /// app asked for no channel, and for one whose child has closed fd 3.
+    pub channel: Option<tokio::net::UnixStream>,
     /// The one reaper this successor waits every adopted pid through.
     ///
     /// Shared rather than owned per sheep: a status can be collected once,

--- a/crates/shep-daemon/src/runner.rs
+++ b/crates/shep-daemon/src/runner.rs
@@ -188,8 +188,8 @@ pub enum LogCtl {
         done: oneshot::Sender<Result<(), FlushError>>,
     },
     /// Write out whatever the pump has buffered, wait for it to reach the
-    /// files, then acknowledge with the four descriptor numbers the pump is
-    /// holding. Sent while assembling a daemon handover.
+    /// files, then acknowledge with the descriptor numbers a blob is to
+    /// name for this sheep. Sent while assembling a daemon handover.
     ///
     /// # Why the flush and the report are one request
     ///
@@ -909,7 +909,7 @@ pub trait ProcessRunner: Send + Sync + 'static {
 /// One inherited sheep, and everything a runner needs to supervise it again.
 ///
 /// Produced by the successor's `handover::adopt` and consumed by
-/// [`ProcessRunner::adopt`]. The four handles are owned, because adopting is
+/// [`ProcessRunner::adopt`]. The handles are owned, because adopting is
 /// exactly the act of taking ownership of them; `None` on a pair means the
 /// predecessor had no handle to carry, which is what a sheep whose log open
 /// had failed, or one with no live pump, looks like.
@@ -937,6 +937,13 @@ pub struct AdoptSpec {
     pub out_log: Option<tokio::fs::File>,
     /// The appending handle on its stderr log, likewise.
     pub err_log: Option<tokio::fs::File>,
+    /// The write end of its stdin pipe, still the one the child reads from,
+    /// for a sheep whose app asked for one.
+    ///
+    /// The one handle here the daemon writes to. `None` is the commoner
+    /// sheep, which has `/dev/null` on fd 0, and an adoption puts a stdin
+    /// pump back only when there is an end for it to write to.
+    pub stdin_pipe: Option<tokio::net::unix::pipe::Sender>,
     /// The one reaper this successor waits every adopted pid through.
     ///
     /// Shared rather than owned per sheep: a status can be collected once,

--- a/crates/shep-daemon/src/runner.rs
+++ b/crates/shep-daemon/src/runner.rs
@@ -234,6 +234,38 @@ pub enum LogCtl {
         /// exactly a runner nothing hands over.
         done: oneshot::Sender<crate::handover::CarriedFds>,
     },
+    /// Read the sheep's streams again after a [`Self::ReportFds`] that no
+    /// exec followed. Sent when a handover is abandoned.
+    ///
+    /// A report parks the pump, because a snapshot only stays true while
+    /// nothing moves behind it. The exec is what normally ends that park,
+    /// and it ends it by replacing the whole image. Every other way out of
+    /// a handover leaves this daemon running with a pump that has stopped
+    /// reading, and it stays stopped for the rest of that daemon's life. So
+    /// an abandoned handover owes every pump it reported one of these.
+    ///
+    /// Today that life is short: both aborts fall back to a graceful stop,
+    /// so what a missing resume costs is every line the flock writes while
+    /// it is being stopped, which is the stretch an operator asking why
+    /// reads first. It is not bounded by that, though, and should not be
+    /// reasoned about as if it were: anything that ever abandons a handover
+    /// without also stopping makes the same omission permanent.
+    ///
+    /// # Why there is no acknowledgement
+    ///
+    /// Nobody is ordered against it. The caller is on its way to a graceful
+    /// stop or back to normal service, and neither reads the pump's files
+    /// or its descriptors, which is what [`Self::Flush`] and
+    /// [`Self::Reopen`] have callers waiting on. Sending one to a pump that
+    /// was never parked is a no-op, so this is safe to send widely rather
+    /// than exactly.
+    ///
+    /// # Why this variant is unix-only when the rest of the enum is not
+    ///
+    /// As [`Self::ReportFds`]: there is no handover to abandon on a
+    /// platform with no `execve`, so there is no park to end.
+    #[cfg(unix)]
+    Resume,
 }
 
 /// A [`LogCtl::Reopen`] that could not open one or both of a sheep's log

--- a/crates/shep-daemon/src/supervisor.rs
+++ b/crates/shep-daemon/src/supervisor.rs
@@ -7902,6 +7902,23 @@ enum PumpReport {
 /// the refusal has to name WHICH sheep went quiet. A flock of wedged pumps
 /// therefore costs N times this before the caller falls back, which is the
 /// price of that name.
+///
+/// **N is one config line now.** Since 2b carried multi-instance apps, an
+/// `instances = 10` is ten sheep with ten pumps, where reaching ten used to
+/// take ten app stanzas. Nothing about the cost changed, but the way to
+/// arrive at it got much shorter, so the arithmetic is worth having
+/// written down: `shep daemon reload` gives the successor
+/// `admin::KILL_TEARDOWN_WAIT` (10s) to answer, so six wedged pumps is
+/// where this sweep outlasts the client that asked. Past that the client
+/// reports a failed handover and musters against the PREDECESSOR, which is
+/// still serving and which then refuses and stops gracefully seconds later.
+///
+/// That is a fault path, not a slow one: a pump misses this deadline only
+/// on a filesystem that has stopped completing writes, and a healthy
+/// ten-instance app reports in microseconds. It is left as it is rather
+/// than fixed here because the fix is a different shape (visit the pumps
+/// concurrently, which still knows which one went quiet) and belongs with
+/// whoever decides what the client should do when the sweep outlasts it.
 #[cfg(unix)]
 const REPORT_DEADLINE: Duration = Duration::from_secs(2);
 

--- a/crates/shep-daemon/src/supervisor.rs
+++ b/crates/shep-daemon/src/supervisor.rs
@@ -3480,6 +3480,7 @@ impl<R: ProcessRunner> Actor<R> {
             err_pipe,
             out_log,
             err_log,
+            stdin_pipe,
         } = sheep;
         let app = normalize(carried.app().clone()).map_err(|source| AdoptError::Spec {
             sheep: carried.name().to_string(),
@@ -3563,6 +3564,7 @@ impl<R: ProcessRunner> Actor<R> {
                 err_pipe,
                 out_log,
                 err_log,
+                stdin_pipe,
                 reaper: Arc::clone(reaper),
             })
             .map_err(|source| AdoptError::Runner {
@@ -17380,8 +17382,8 @@ mod tests {
         nix::fcntl::fcntl(fd, nix::fcntl::FcntlArg::F_GETFD).is_ok()
     }
 
-    /// Fails if a snapshot of a live flock does not name four open
-    /// descriptors for every sheep in it.
+    /// Fails if a snapshot of a live flock does not name an open
+    /// descriptor for everything the fake pump reports.
     ///
     /// The blob is what the successor adopts by number, and a number it
     /// cannot adopt is not a gap it can repair: losing a sheep's stdout read
@@ -17389,7 +17391,7 @@ mod tests {
     /// reads as an application hang rather than as a shep bug.
     #[cfg(unix)]
     #[tokio::test(start_paused = true)]
-    async fn a_blob_from_a_live_flock_names_four_open_descriptors_per_sheep() {
+    async fn a_blob_from_a_live_flock_names_open_descriptors_per_sheep() {
         let (events, _rx) = crate::bus::test_bus(64);
         let runner =
             ScriptedRunner::new(vec![ProcScript::never_exits(), ProcScript::never_exits()]);
@@ -17410,7 +17412,7 @@ mod tests {
         assert_eq!(blob.sheep().len(), 2);
         for sheep in blob.sheep() {
             for fd in sheep.fds().all() {
-                let fd = fd.expect("a running sheep has all four descriptors");
+                let fd = fd.expect("the fake reports every descriptor a blob can carry");
                 assert!(is_open(fd), "blob names a closed descriptor: {fd}");
             }
         }
@@ -17426,7 +17428,7 @@ mod tests {
     /// The refusal has to name the sheep, and it has to be its own reason
     /// rather than an empty `CarriedFds`: `none()` is what a STOPPED sheep
     /// reports, so collapsing a wedged live pump into it would pass the gate
-    /// and carry that sheep with its four descriptors dropped.
+    /// and carry that sheep with its descriptors dropped.
     ///
     /// Two sheep, one of each kind, so a gate that refused every flock with
     /// a pump in it would pass here for the wrong reason.
@@ -17713,6 +17715,7 @@ mod tests {
             err_pipe: None,
             out_log: None,
             err_log: None,
+            stdin_pipe: None,
         }
     }
 

--- a/crates/shep-daemon/src/supervisor.rs
+++ b/crates/shep-daemon/src/supervisor.rs
@@ -7783,10 +7783,29 @@ struct HandoverDraft {
 /// Every await lives in here, off the actor loop — see
 /// [`Actor::handle_reopen`] for the cycle that rules out doing it inline.
 ///
-/// The sheep are visited one after another rather than concurrently, exactly
-/// as [`spawn_reopen_task`] visits them, and the same trade applies: a
-/// stalled pump delays the sheep behind it, and the request's own deadline
-/// is what bounds the caller either way.
+/// The sheep are visited CONCURRENTLY, with `join_all` rather than a `for`
+/// loop, exactly as [`spawn_send_line_task`] visits its waits and for the
+/// same reason: a bound meant to sit under a fixed caller deadline stops
+/// doing that the moment several of them are added up serially.
+/// [`spawn_reopen_task`] is the one sibling that stays a `for` loop, and the
+/// difference is which deadline is fixed. A reopen's caller carries `rpc`'s
+/// own per-request budget, which scales with what is asked of it; a
+/// reload's client-side wait is `shep-cli`'s `admin::KILL_TEARDOWN_WAIT`, a
+/// constant the daemon cannot see and does not get to lengthen. Serially, N
+/// wedged pumps cost N times [`REPORT_DEADLINE`], and past six that already
+/// outlasts the client (see `REPORT_DEADLINE`'s own doc): the client gives
+/// up, falls back to a predecessor that is still serving, musters against
+/// it, and exits 0 while the sweep is still running behind it. `join_all`
+/// bounds the whole sweep at one [`REPORT_DEADLINE`] regardless of N, which
+/// is what the fixed deadline on the other end actually needs.
+///
+/// `join_all` returns its results in the order its input futures were
+/// given, not completion order, so the sorted-by-id order `drafts` arrives
+/// in (see [`Actor::handle_handover_snapshot`]) survives into `candidates`
+/// and `carried` untouched: no re-sort is needed or performed here. Each
+/// future closes over its own `draft`, so which pump answered late is still
+/// attached to that sheep's own [`OwnedCandidate::pump_unresponsive`];
+/// racing the reports does not blur which one refused the gate.
 ///
 /// Must be called from within a Tokio runtime context.
 #[cfg(unix)]
@@ -7797,10 +7816,7 @@ fn spawn_handover_task(
     reply: oneshot::Sender<Result<Snapshot, SupervisorError>>,
 ) {
     tokio::spawn(async move {
-        let mut candidates = Vec::with_capacity(drafts.len());
-        let mut carried = Vec::with_capacity(drafts.len());
-        let mut parked = ParkedPumps::default();
-        for draft in drafts {
+        let visited = futures_util::future::join_all(drafts.into_iter().map(|draft| async move {
             // The three answers go to three different places, which is why
             // `report_fds` distinguishes them at all:
             //
@@ -7815,16 +7831,13 @@ fn spawn_handover_task(
             //   descriptors. For a wedged pump that is a value nothing ever
             //   reads: the gate refuses on the candidate, so this blob is
             //   dropped rather than written.
-            let (mut fds, pump_unresponsive) = match &draft.log_ctl {
+            let (mut fds, pump_unresponsive, parked_pump) = match &draft.log_ctl {
                 Some(log_ctl) => match report_fds(log_ctl).await {
-                    PumpReport::Parked(fds) => {
-                        parked.0.push(log_ctl.clone());
-                        (fds, false)
-                    }
-                    PumpReport::Gone => (CarriedFds::none(), false),
-                    PumpReport::Unresponsive => (CarriedFds::none(), true),
+                    PumpReport::Parked(fds) => (fds, false, Some(log_ctl.clone())),
+                    PumpReport::Gone => (CarriedFds::none(), false, None),
+                    PumpReport::Unresponsive => (CarriedFds::none(), true, None),
                 },
-                None => (CarriedFds::none(), false),
+                None => (CarriedFds::none(), false, None),
             };
             // The one number the pump can report and be wrong about. See
             // `HandoverDraft::channel_open` for why the pump cannot know,
@@ -7835,13 +7848,30 @@ fn spawn_handover_task(
             if !draft.channel_open {
                 fds.channel = None;
             }
-            carried.push(CarriedSheep::from_entry(&draft.entry, draft.epoch, fds));
-            candidates.push(OwnedCandidate {
+            let carried = CarriedSheep::from_entry(&draft.entry, draft.epoch, fds);
+            let candidate = OwnedCandidate {
                 entry: draft.entry,
                 pending_stop: draft.pending_stop,
                 pending_delete: draft.pending_delete,
                 pump_unresponsive,
-            });
+            };
+            (candidate, carried, parked_pump)
+        }))
+        .await;
+
+        // `join_all` hands `visited` back in `drafts`' own order (id-sorted,
+        // per `Actor::handle_handover_snapshot`), not completion order, so
+        // this loop reproduces the serial version's ordering without a sort
+        // of its own.
+        let mut candidates = Vec::with_capacity(visited.len());
+        let mut carried = Vec::with_capacity(visited.len());
+        let mut parked = ParkedPumps::default();
+        for (candidate, sheep, parked_pump) in visited {
+            candidates.push(candidate);
+            carried.push(sheep);
+            if let Some(log_ctl) = parked_pump {
+                parked.0.push(log_ctl);
+            }
         }
         let blob = Handover::new(carried, fds, counters);
         let _ = reply.send(Ok((candidates, blob, parked)));
@@ -7875,9 +7905,9 @@ enum PumpReport {
     Gone,
     /// The pump did not answer inside [`REPORT_DEADLINE`].
     ///
-    /// It never parked, so it is still reading its sheep's streams while
-    /// every pump before it in the sweep is frozen, and it must NOT be
-    /// resumed: a resume would wake something that was never asleep.
+    /// It never parked, so it is still reading its sheep's streams, and it
+    /// must NOT be resumed: a resume would wake something that was never
+    /// asleep.
     Unresponsive,
 }
 
@@ -7898,27 +7928,28 @@ enum PumpReport {
 /// this file: a bounded wait on an acknowledgement from a pump-tier task
 /// whose failure mode is a peer that has stopped consuming.
 ///
-/// Per pump, not per sweep, because the pumps are visited one at a time and
-/// the refusal has to name WHICH sheep went quiet. A flock of wedged pumps
-/// therefore costs N times this before the caller falls back, which is the
-/// price of that name.
+/// Per pump, but paid ONCE, not per sweep: [`spawn_handover_task`] visits
+/// every pump concurrently, exactly as [`spawn_send_line_task`] does for
+/// `STDIN_WRITE_TIMEOUT`, so a whole flock of wedged pumps still costs one
+/// [`REPORT_DEADLINE`] rather than N of them, and the refusal still names
+/// WHICH sheep went quiet. Concurrency does not cost that name, because
+/// each pump's report carries its own sheep with it regardless of how the
+/// others answer.
 ///
-/// **N is one config line now.** Since 2b carried multi-instance apps, an
-/// `instances = 10` is ten sheep with ten pumps, where reaching ten used to
-/// take ten app stanzas. Nothing about the cost changed, but the way to
-/// arrive at it got much shorter, so the arithmetic is worth having
-/// written down: `shep daemon reload` gives the successor
-/// `admin::KILL_TEARDOWN_WAIT` (10s) to answer, so six wedged pumps is
-/// where this sweep outlasts the client that asked. Past that the client
-/// reports a failed handover and musters against the PREDECESSOR, which is
-/// still serving and which then refuses and stops gracefully seconds later.
-///
-/// That is a fault path, not a slow one: a pump misses this deadline only
-/// on a filesystem that has stopped completing writes, and a healthy
-/// ten-instance app reports in microseconds. It is left as it is rather
-/// than fixed here because the fix is a different shape (visit the pumps
-/// concurrently, which still knows which one went quiet) and belongs with
-/// whoever decides what the client should do when the sweep outlasts it.
+/// **This bound used to scale with N, and does not any more; the arithmetic
+/// is worth keeping written down because reaching a large N got much
+/// shorter.** Since 2b carried multi-instance apps, an `instances = 10` is
+/// ten sheep with ten pumps, where reaching ten used to take ten app
+/// stanzas. Visited one after another, that sweep would have cost up to ten
+/// times this deadline; `shep daemon reload` only gives the successor
+/// `admin::KILL_TEARDOWN_WAIT` (10s) to answer, so six wedged pumps was
+/// already enough to outlast the client that asked. Past that the client
+/// used to report a failed handover and muster against the PREDECESSOR,
+/// which was still serving and would then refuse and stop gracefully
+/// seconds later, leaving an operator with an exit code of 0 and no flock.
+/// `join_all` closes that: the sweep's worst case is now one
+/// [`REPORT_DEADLINE`] regardless of N, comfortably inside
+/// `KILL_TEARDOWN_WAIT` for any flock size this daemon is likely to carry.
 #[cfg(unix)]
 const REPORT_DEADLINE: Duration = Duration::from_secs(2);
 
@@ -17677,6 +17708,84 @@ mod tests {
             runner.resumes(wedged),
             0,
             "a pump that never answered never parked, so nothing may resume it"
+        );
+    }
+
+    /// Fails if the sweep costs `REPORT_DEADLINE * N` instead of
+    /// `REPORT_DEADLINE` once.
+    ///
+    /// This is the defect task 6 measured but did not fix: a `for` loop over
+    /// the pumps makes a flock of wedged pumps cost N times
+    /// [`REPORT_DEADLINE`] before the caller's own fallback can even start.
+    /// Six is the number [`REPORT_DEADLINE`]'s own doc names as where that
+    /// sweep first outlasts `shep-cli`'s `admin::KILL_TEARDOWN_WAIT` (10s):
+    /// past it, the client gives up first, falls back to a predecessor that
+    /// is still serving, musters against it, and exits 0 seconds before the
+    /// sweep this daemon is still running actually finishes and the gate
+    /// refuses for real. `instances = 6` reaches that count in one stanza.
+    ///
+    /// Asserted against `Instant`, like
+    /// `a_flock_of_wedged_sheep_is_bounded_once_and_not_once_each`: under the
+    /// paused clock the auto-advance is exact, so a serial sweep reliably
+    /// reads six [`REPORT_DEADLINE`]s (12s) and a concurrent one reliably
+    /// reads about one (2s). The bound below sits well inside that gap.
+    #[cfg(unix)]
+    #[tokio::test(start_paused = true)]
+    async fn a_sweep_of_six_wedged_pumps_costs_one_deadline_not_six() {
+        const WEDGED: usize = 6;
+        let names: Vec<String> = (0..WEDGED).map(|i| format!("wedged{i}")).collect();
+        let name_refs: Vec<&str> = names.iter().map(String::as_str).collect();
+
+        let (events, _rx) = crate::bus::test_bus(64);
+        let runner = ScriptedRunner::new(vec![ProcScript::never_exits(); WEDGED])
+            .with_a_pump_that_never_reports(&name_refs);
+        let dir = tempfile::tempdir().unwrap();
+        let (fds, _held) = daemon_fds(&dir);
+        let handle = spawn_supervisor(runner, test_paths(&dir), events);
+        handle
+            .start(
+                names
+                    .iter()
+                    .map(|name| normalize(AppConfig::minimal(name, "./srv")).unwrap())
+                    .collect(),
+            )
+            .await
+            .unwrap();
+
+        let started_at = tokio::time::Instant::now();
+        let (candidates, blob, _parked) =
+            tokio::time::timeout(Duration::from_secs(3600), handle.handover_snapshot(fds))
+                .await
+                .expect("a snapshot over six wedged pumps must answer rather than hang")
+                .unwrap();
+        let elapsed = started_at.elapsed();
+
+        assert!(
+            elapsed < REPORT_DEADLINE * 2,
+            "six wedged pumps swept concurrently should cost about one \
+             REPORT_DEADLINE, not six; took {elapsed:?}"
+        );
+
+        assert_eq!(candidates.len(), WEDGED);
+        for candidate in &candidates {
+            assert!(
+                candidate.pump_unresponsive,
+                "{} must still be reported unresponsive; racing the reports \
+                 must not blur which pump answered",
+                candidate.entry.spec.config().name
+            );
+        }
+        // `join_all` returns in the order its input futures were given, and
+        // `handle_handover_snapshot` sorted `drafts` by id before spawning
+        // this task, so both outputs stay id-ordered across the concurrent
+        // sweep with no re-sort in `spawn_handover_task` itself.
+        assert!(
+            candidates.windows(2).all(|w| w[0].entry.id < w[1].entry.id),
+            "candidates must stay in id order across a concurrent sweep"
+        );
+        assert!(
+            blob.sheep().windows(2).all(|w| w[0].id() < w[1].id()),
+            "the blob must stay in id order too: it is a file an operator may read"
         );
     }
 

--- a/crates/shep-daemon/src/supervisor.rs
+++ b/crates/shep-daemon/src/supervisor.rs
@@ -3552,6 +3552,33 @@ impl<R: ProcessRunner> Actor<R> {
                     ready_failed: false,
                 },
             );
+            // A sheep the blob reports as `WaitingRestart` is owed a respawn,
+            // and the timer that owed it was a `tokio::spawn` of the
+            // predecessor's that the exec took with it. Nothing else raises
+            // `Msg::RestartDue`, so without a fresh one the sheep sits
+            // `WaitingRestart` for the rest of this daemon's life: down,
+            // never coming back, and reporting a status an operator reads as
+            // about to. Same shape as the `Starting` strand the readiness
+            // re-arm above closes, and the same reason for closing it here.
+            //
+            // Not a narrow race, either. The default backoff climbs to 15s,
+            // so a crash-looping app spends most of its time in this status,
+            // and upgrading the shepherd is exactly what an operator does
+            // about a crash-looping app.
+            //
+            // Re-armed rather than carried, for the reason the readiness wait
+            // is: what elapsed is a `tokio::time::Instant` from a runtime
+            // that no longer exists. The delay is the one an app in its FIRST
+            // unstable exit would get, which is what the fresh
+            // `RestartBudget` above already says this image believes: an
+            // explicit `restart_delay` is honoured in full (an operator's
+            // pacing is never shortened by a reload), an exponential-backoff
+            // app gets its initial step, and one that opted out of both
+            // restarts at once.
+            if status == ProcStatus::WaitingRestart {
+                let delay = crate::backoff::restart_delay(app.config(), 1);
+                self.schedule_restart(id, carried.epoch(), delay);
+            }
             return Ok(());
         };
 
@@ -18204,5 +18231,51 @@ mod tests {
             .expect("a fresh app starts under a successor");
 
         assert!(fresh[0].id >= 9, "reissued a live id: {}", fresh[0].id);
+    }
+
+    /// Fails if an adopted sheep owed a respawn never gets one.
+    ///
+    /// The strand this closes is silent and permanent. `schedule_restart`
+    /// spawns a task that sleeps and then sends `Msg::RestartDue`, and that
+    /// task dies with the process image; `handle_restart_due` is the only
+    /// thing that moves a sheep off [`ProcStatus::WaitingRestart`]. So a
+    /// successor that installs the status without re-arming the timer leaves
+    /// the sheep down for the rest of its life while `shep flock` prints a
+    /// status an operator reads as "coming back".
+    ///
+    /// The pid is the assertion, not the status: [`STAND_IN_SPAWN_PID`] is
+    /// what [`AdoptingRunner`] hands anything it spawns fresh, and it is
+    /// deliberately not a pid any carried sheep here holds, so a row
+    /// reporting it can only have been respawned by the re-armed timer.
+    #[cfg(unix)]
+    #[tokio::test(start_paused = true)]
+    async fn an_adopted_sheep_owed_a_restart_still_gets_one() {
+        let dir = tempfile::tempdir().unwrap();
+        let (events, _rx) = crate::bus::test_bus(64);
+        let sup = SupervisorBuilder::new(AdoptingRunner, test_paths(&dir), events)
+            .spawn_adopted(
+                vec![without_handles(carried("web", 7, None, |entry| {
+                    entry.status = ProcStatus::WaitingRestart;
+                }))],
+                counters(9),
+            )
+            .expect("a carried flock installs");
+
+        // Virtual, and instant: the paused clock advances itself once every
+        // task is idle, so this waits out the re-armed backoff without
+        // costing the suite a millisecond.
+        tokio::time::sleep(Duration::from_secs(5)).await;
+
+        let info = sup.list().await;
+        assert_eq!(
+            info[0].status,
+            ProcStatus::Online,
+            "a sheep owed a respawn was left waiting for a timer that died with the exec: {info:?}"
+        );
+        assert_eq!(
+            info[0].pid,
+            Some(STAND_IN_SPAWN_PID),
+            "the restart must be a real respawn, not a status edit: {info:?}"
+        );
     }
 }

--- a/crates/shep-daemon/src/supervisor.rs
+++ b/crates/shep-daemon/src/supervisor.rs
@@ -3481,6 +3481,7 @@ impl<R: ProcessRunner> Actor<R> {
             out_log,
             err_log,
             stdin_pipe,
+            channel,
         } = sheep;
         let app = normalize(carried.app().clone()).map_err(|source| AdoptError::Spec {
             sheep: carried.name().to_string(),
@@ -3565,6 +3566,7 @@ impl<R: ProcessRunner> Actor<R> {
                 out_log,
                 err_log,
                 stdin_pipe,
+                channel,
                 reaper: Arc::clone(reaper),
             })
             .map_err(|source| AdoptError::Runner {
@@ -3591,6 +3593,48 @@ impl<R: ProcessRunner> Actor<R> {
         // that has been up three days reporting three days in `shep flock`'s
         // UPTIME column instead of `0s` the moment a successor takes over.
         entry.started_at = Some(crate::handover::uptime::started_at_of(proc.pid()));
+        // A sheep the blob reports as `Starting` is one whose readiness has
+        // not resolved, and the wait that was going to resolve it was a task
+        // of the predecessor's that the exec took with it. Without a fresh
+        // one it stays `Starting` for the rest of this daemon's life:
+        // `handle_exited` is the only other thing that moves it off, so the
+        // sheep sits outside `listen_timeout` and outside every status an
+        // operator acts on.
+        //
+        // Re-armed rather than carried, because there is nothing to carry.
+        // The deadline is a `tokio::time::Instant` in a runtime that no
+        // longer exists, exactly as `started_at` is, and a probe's next
+        // attempt is a future rather than a value. So the successor starts
+        // the app's own `listen_timeout` again.
+        //
+        // What that costs is bounded and it is worth naming, because the
+        // race is not closeable from here. The blob is a snapshot taken on
+        // the actor loop, and a `{"kind":"ready"}` that arrives between it
+        // and the exec flips the predecessor's slot without reaching the
+        // blob, so the successor waits for a signal that has already been
+        // sent and will not come again. That wait ends at `listen_timeout`
+        // and `handle_ready_result` puts the sheep `Online` anyway, with a
+        // warning, so the worst case is one `listen_timeout` of `Starting`
+        // on a sheep that was already serving. The alternative is refusing
+        // to carry a `Starting` sheep at all, which restarts a whole flock
+        // over one app in its first three seconds.
+        //
+        // `manually` is `false` and cannot be anything else: it belongs to
+        // the spawn that armed the original wait, which is not this image's
+        // to know. It reaches only the `Online` event's own flag.
+        let ready_tx = (status == ProcStatus::Starting).then(|| {
+            let source = ReadinessSource::of(app.config())
+                .expect("ResolvedApp already passed ProbeTarget::parse in normalize");
+            spawn_readiness_task(
+                id,
+                carried.epoch(),
+                false,
+                source,
+                app.config().listen_timeout.as_duration(),
+                spec_prober(&spec),
+                self.tx.clone(),
+            )
+        });
         let log_ctl = io.log_ctl.clone();
         let to_child = io.to_child.clone();
         let to_stdin = io.to_stdin.clone();
@@ -3616,12 +3660,11 @@ impl<R: ProcessRunner> Actor<R> {
                 manual: None,
                 pending_delete: false,
                 epoch: carried.epoch(),
-                // A readiness wait that was still running belonged to the
-                // predecessor's own task, which the exec took with it. An
-                // instance the blob reports as `Online` has already resolved
-                // one; one it reports as `Starting` has not, and stays
-                // `Starting` until it next exits — see this phase's residuals.
-                ready_tx: None,
+                // Armed above for an instance the blob reports as
+                // `Starting`, and `None` for one it reports as `Online`,
+                // which has already resolved its readiness and has nothing
+                // left to wait for.
+                ready_tx,
                 actions: ActionWaits::default(),
                 ready_failed: false,
             },
@@ -5918,6 +5961,7 @@ impl<R: ProcessRunner> Actor<R> {
                 pending_delete: slot.pending_delete,
                 epoch: slot.epoch,
                 log_ctl: slot.log_ctl.clone(),
+                channel_open: slot.open_channel().is_some(),
             })
             .collect();
         // `HashMap` iteration order is arbitrary, and the blob is written to
@@ -7718,6 +7762,19 @@ struct HandoverDraft {
     /// This sheep's log pump, or `None` for a slot whose spawn never
     /// succeeded.
     log_ctl: Option<mpsc::Sender<LogCtl>>,
+    /// Whether this sheep's shepherd channel is still one the daemon can
+    /// write to.
+    ///
+    /// Read here rather than taken from the pump's report, and the two are
+    /// not the same claim. The pump reports the number it was told at the
+    /// spawn and has no way to learn that the channel died: the writer task
+    /// ends on a write that fails, which is what a child that has closed its
+    /// fd 3 produces, and the socketpair's last reference goes with it. The
+    /// number then names whatever the kernel has since handed to the next
+    /// `open`. [`SheepSlot::open_channel`] is the fact that actually decides
+    /// delivery, and it is only reachable from the actor loop, which is
+    /// where this is read.
+    channel_open: bool,
 }
 
 /// Spawns the task that assembles one handover snapshot and answers its
@@ -7758,7 +7815,7 @@ fn spawn_handover_task(
             //   descriptors. For a wedged pump that is a value nothing ever
             //   reads: the gate refuses on the candidate, so this blob is
             //   dropped rather than written.
-            let (fds, pump_unresponsive) = match &draft.log_ctl {
+            let (mut fds, pump_unresponsive) = match &draft.log_ctl {
                 Some(log_ctl) => match report_fds(log_ctl).await {
                     PumpReport::Parked(fds) => {
                         parked.0.push(log_ctl.clone());
@@ -7769,6 +7826,15 @@ fn spawn_handover_task(
                 },
                 None => (CarriedFds::none(), false),
             };
+            // The one number the pump can report and be wrong about. See
+            // `HandoverDraft::channel_open` for why the pump cannot know,
+            // and `PipeFds::channel` for what it costs to carry a number
+            // the kernel has already reissued: `UnixStream::from(OwnedFd)`
+            // checks nothing, so the successor would write a shepherd
+            // message into whatever that descriptor is now.
+            if !draft.channel_open {
+                fds.channel = None;
+            }
             carried.push(CarriedSheep::from_entry(&draft.entry, draft.epoch, fds));
             candidates.push(OwnedCandidate {
                 entry: draft.entry,
@@ -17389,6 +17455,12 @@ mod tests {
     /// cannot adopt is not a gap it can repair: losing a sheep's stdout read
     /// end blocks the child on `write()` once the pipe buffer fills, which
     /// reads as an application hang rather than as a shep bug.
+    ///
+    /// One of the two sheep has a shepherd channel and the other does not,
+    /// which is the case below's subject and this one's precondition: the
+    /// channel is the one number a snapshot may drop, so a case with only
+    /// channelled sheep in it could not tell "every number is open" from
+    /// "every number is present".
     #[cfg(unix)]
     #[tokio::test(start_paused = true)]
     async fn a_blob_from_a_live_flock_names_open_descriptors_per_sheep() {
@@ -17398,10 +17470,12 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let (fds, _held) = daemon_fds(&dir);
         let handle = spawn_supervisor(runner, test_paths(&dir), events);
+        let mut talkative = AppConfig::minimal("api", "./srv");
+        talkative.channel = true;
         handle
             .start(vec![
                 normalize(AppConfig::minimal("web", "./srv")).unwrap(),
-                normalize(AppConfig::minimal("api", "./srv")).unwrap(),
+                normalize(talkative).unwrap(),
             ])
             .await
             .unwrap();
@@ -17411,11 +17485,61 @@ mod tests {
         assert_eq!(candidates.len(), 2, "both sheep must reach the gate");
         assert_eq!(blob.sheep().len(), 2);
         for sheep in blob.sheep() {
-            for fd in sheep.fds().all() {
-                let fd = fd.expect("the fake reports every descriptor a blob can carry");
+            for fd in sheep.fds().all().into_iter().flatten() {
                 assert!(is_open(fd), "blob names a closed descriptor: {fd}");
             }
         }
+    }
+
+    /// Fails if a snapshot names a shepherd-channel descriptor for a sheep
+    /// that has no shepherd channel.
+    ///
+    /// The pump reports the number it was told at the spawn and has no way
+    /// to learn that the channel is gone: the writer task ends on a write
+    /// that fails, which is what a child that has closed its fd 3 produces,
+    /// and the socketpair's last reference goes with it. So the number can
+    /// name whatever the kernel has since handed to the next `open`, and
+    /// `UnixStream::from(OwnedFd)` checks nothing — the successor would
+    /// write a shepherd message into a log file. `SheepSlot::open_channel`
+    /// is the fact that decides delivery, and the snapshot masks the field
+    /// with it.
+    ///
+    /// The fake reports a number for every field unconditionally, which is
+    /// what makes this case able to fail: without the mask it would see one.
+    #[cfg(unix)]
+    #[tokio::test(start_paused = true)]
+    async fn a_snapshot_names_no_channel_for_a_sheep_that_has_none() {
+        let (events, _rx) = crate::bus::test_bus(64);
+        let runner =
+            ScriptedRunner::new(vec![ProcScript::never_exits(), ProcScript::never_exits()]);
+        let dir = tempfile::tempdir().unwrap();
+        let (fds, _held) = daemon_fds(&dir);
+        let handle = spawn_supervisor(runner, test_paths(&dir), events);
+        let mut talkative = AppConfig::minimal("api", "./srv");
+        talkative.channel = true;
+        handle
+            .start(vec![
+                normalize(AppConfig::minimal("web", "./srv")).unwrap(),
+                normalize(talkative).unwrap(),
+            ])
+            .await
+            .unwrap();
+
+        let (_candidates, blob, _parked) = handle.handover_snapshot(fds).await.unwrap();
+
+        let named: Vec<(&str, bool)> = blob
+            .sheep()
+            .iter()
+            .map(|sheep| (sheep.name(), sheep.fds().channel.is_some()))
+            .collect();
+        assert!(
+            named.contains(&("web", false)),
+            "a sheep with no channel must carry no channel descriptor: {named:?}"
+        );
+        assert!(
+            named.contains(&("api", true)),
+            "a sheep with a live channel must carry its descriptor: {named:?}"
+        );
     }
 
     /// Fails if a wedged log pump hangs the snapshot instead of refusing it.
@@ -17671,6 +17795,62 @@ mod tests {
         }
     }
 
+    /// fails if a sheep adopted mid-readiness is left `Starting` forever.
+    ///
+    /// The wait that was going to resolve it belonged to a task of the
+    /// predecessor's, and the `execve` took that with it. Nothing else in
+    /// the daemon moves a sheep off `Starting` except its own exit, so a
+    /// successor that adopts one without re-arming leaves it there for the
+    /// rest of that daemon's life: outside `listen_timeout`, outside every
+    /// status an operator acts on, and with none of `arm_extras`'s watch,
+    /// cron or memory limits, which fire at the `Online` transition.
+    ///
+    /// The readiness here is `wait_ready`, the case 2b task 5 opened the
+    /// gate to: its signal comes over the shepherd channel, so a sheep can
+    /// still be waiting for one at the moment of the exec. The assertion is
+    /// deliberately the TIMEOUT arm rather than the signal arm, since
+    /// nothing here writes `{"kind":"ready"}` — `handle_ready_result` puts a
+    /// timed-out sheep `Online` anyway rather than erroring, so reaching
+    /// `Online` at all is proof a wait was armed. Without one the clock can
+    /// advance as far as it likes and nothing happens.
+    #[cfg(unix)]
+    #[tokio::test(start_paused = true)]
+    async fn an_adopted_sheep_that_was_still_starting_reaches_online() {
+        let dir = tempfile::tempdir().unwrap();
+        let (events, _rx) = crate::bus::test_bus(64);
+        let sup = SupervisorBuilder::new(AdoptingRunner, test_paths(&dir), events)
+            .spawn_adopted(
+                vec![without_handles(carried("web", 7, Some(4242), |entry| {
+                    let mut app = AppConfig::minimal("web", "./srv");
+                    app.autorestart = false;
+                    app.wait_ready = true;
+                    entry.spec = normalize(app).unwrap();
+                    entry.status = ProcStatus::Starting;
+                }))],
+                counters(9),
+            )
+            .expect("a carried flock installs");
+
+        assert_eq!(
+            sup.list().await[0].status,
+            ProcStatus::Starting,
+            "the blob said this sheep was still starting, so the successor must agree"
+        );
+
+        // Polled rather than advanced by a fixed amount: the wait runs on a
+        // task, so its result reaches the actor a message later than the
+        // deadline. Bounded well past the app's own 3s `listen_timeout`, so
+        // a sheep that is never armed fails here rather than hanging.
+        let goes_online = async {
+            while sup.list().await[0].status != ProcStatus::Online {
+                tokio::time::sleep(Duration::from_millis(50)).await;
+            }
+        };
+        tokio::time::timeout(Duration::from_secs(30), goes_online)
+            .await
+            .expect("an adopted sheep left `Starting` must still have a readiness wait over it");
+    }
+
     /// One sheep as a blob describes it, with `mutate` free to give it a
     /// history no fresh registration could have.
     #[cfg(unix)]
@@ -17716,6 +17896,7 @@ mod tests {
             out_log: None,
             err_log: None,
             stdin_pipe: None,
+            channel: None,
         }
     }
 

--- a/crates/shep-daemon/src/supervisor.rs
+++ b/crates/shep-daemon/src/supervisor.rs
@@ -7648,11 +7648,43 @@ fn spawn_send_line_task(
 /// What a [`Command::HandoverSnapshot`] answers with: one candidate per
 /// registered sheep for the fitness gate, and the blob a successor reads.
 ///
-/// A pair rather than one type because the two go to different places and
-/// only one of them crosses the exec — the candidates decide whether there
-/// is to be an exec at all, and are then done with.
+/// Three types rather than one because they go to three different places
+/// and only one of them crosses the exec: the candidates decide whether
+/// there is to be an exec at all and are then done with, and the parked
+/// pumps matter only if there is not.
 #[cfg(unix)]
-type Snapshot = (Vec<OwnedCandidate>, Handover);
+type Snapshot = (Vec<OwnedCandidate>, Handover, ParkedPumps);
+
+/// The log pumps a snapshot stopped, so a handover that is then abandoned
+/// can start them reading again.
+///
+/// Taking the snapshot parks every pump it reaches, because a report is
+/// only true while nothing moves behind it (see `LogFiles::reading`). The
+/// exec is what normally ends that park, by replacing the whole image.
+/// Every other way out leaves this daemon running with pumps that have
+/// stopped reading, and nothing else ever starts one again. See
+/// [`LogCtl::Resume`] for what that costs.
+///
+/// The party that parked them hands them back, rather than the abort path
+/// re-reading the actor's slots: the flock can have changed by then, and
+/// what is owed a resume is what was reported, not what is registered now.
+#[cfg(unix)]
+#[derive(Debug, Default)]
+pub(crate) struct ParkedPumps(Vec<mpsc::Sender<LogCtl>>);
+
+#[cfg(unix)]
+impl ParkedPumps {
+    /// Lets every pump this snapshot parked read its sheep's streams again.
+    ///
+    /// A send that fails is a pump that has ended since the report, which
+    /// is nothing to repair: the sheep it belonged to is no longer being
+    /// read by anything either way.
+    pub(crate) async fn resume(&self) {
+        for pump in &self.0 {
+            let _ = pump.send(LogCtl::Resume).await;
+        }
+    }
+}
 
 /// One sheep on its way from the actor to the handover task.
 ///
@@ -7698,9 +7730,18 @@ fn spawn_handover_task(
     tokio::spawn(async move {
         let mut candidates = Vec::with_capacity(drafts.len());
         let mut carried = Vec::with_capacity(drafts.len());
+        let mut parked = ParkedPumps::default();
         for draft in drafts {
             let fds = match &draft.log_ctl {
-                Some(log_ctl) => report_fds(log_ctl).await,
+                Some(log_ctl) => {
+                    let fds = report_fds(log_ctl).await;
+                    // Recorded whatever the answer was. A pump that could
+                    // not be reached is a failed send that resumes nothing,
+                    // and one that answered `none` has still been asked to
+                    // park.
+                    parked.0.push(log_ctl.clone());
+                    fds
+                }
                 None => CarriedFds::none(),
             };
             carried.push(CarriedSheep::from_entry(&draft.entry, draft.epoch, fds));
@@ -7711,12 +7752,13 @@ fn spawn_handover_task(
             });
         }
         let blob = Handover::new(carried, fds, counters);
-        let _ = reply.send(Ok((candidates, blob)));
+        let _ = reply.send(Ok((candidates, blob, parked)));
     });
 }
 
-/// Asks one sheep's log pump to flush what it is holding and report the four
-/// descriptors it owns, and waits for the answer.
+/// Asks one sheep's log pump to write out everything it is holding, report
+/// the four descriptors it owns, and stop reading until the exec; and waits
+/// for the answer.
 ///
 /// Not reaching a pump at all is [`CarriedFds::none`], not an error, and both
 /// shapes of it mean the same thing that [`reopen_logs`] documents: there is
@@ -15199,6 +15241,11 @@ mod tests {
                         LogCtl::ReportFds { done } => {
                             let _ = done.send(CarriedFds::none());
                         }
+                        // Nothing to start reading again: this runner reads
+                        // no streams, and never reported anything to park
+                        // for.
+                        #[cfg(unix)]
+                        LogCtl::Resume => {}
                     }
                 }
             });
@@ -15756,6 +15803,11 @@ mod tests {
                         LogCtl::ReportFds { done } => {
                             let _ = done.send(CarriedFds::none());
                         }
+                        // Nothing to start reading again: this runner reads
+                        // no streams, and never reported anything to park
+                        // for.
+                        #[cfg(unix)]
+                        LogCtl::Resume => {}
                     }
                 }
             });
@@ -17263,7 +17315,7 @@ mod tests {
             .await
             .unwrap();
 
-        let (candidates, blob) = handle.handover_snapshot(fds).await.unwrap();
+        let (candidates, blob, _parked) = handle.handover_snapshot(fds).await.unwrap();
 
         assert_eq!(candidates.len(), 2, "both sheep must reach the gate");
         assert_eq!(blob.sheep().len(), 2);
@@ -17299,7 +17351,7 @@ mod tests {
 
         let (reply, rx) = oneshot::channel();
         actor.handle_handover_snapshot(fds, reply);
-        let (candidates, blob) = rx.await.unwrap().unwrap();
+        let (candidates, blob, _parked) = rx.await.unwrap().unwrap();
 
         assert!(
             candidates[0].pending_stop,

--- a/crates/shep-daemon/src/supervisor.rs
+++ b/crates/shep-daemon/src/supervisor.rs
@@ -5960,6 +5960,13 @@ impl<R: ProcessRunner> Actor<R> {
                 // fails it.
                 pending_stop: slot.manual.is_some(),
                 pending_delete: slot.pending_delete,
+                // Always `false` here, and it has to be: this gate awaits
+                // nothing, so it cannot ask a pump anything, and a pump that
+                // is wedged right now may well have answered by the time a
+                // SIGHUP arrives. The snapshot's own gate is the one that
+                // knows (see `spawn_handover_task`), which is why that one
+                // is load-bearing and this one is a courtesy to the client.
+                pump_unresponsive: false,
             })
             .collect();
         let _ = reply.send(Ok(fitness(&candidates)));
@@ -7658,8 +7665,11 @@ type Snapshot = (Vec<OwnedCandidate>, Handover, ParkedPumps);
 /// The log pumps a snapshot stopped, so a handover that is then abandoned
 /// can start them reading again.
 ///
-/// Taking the snapshot parks every pump it reaches, because a report is
-/// only true while nothing moves behind it (see `LogFiles::reading`). The
+/// Taking the snapshot parks every pump that ANSWERS it, because a report
+/// is only true while nothing moves behind it (see `LogFiles::reading`). A
+/// pump that missed [`REPORT_DEADLINE`] is deliberately not in here: it
+/// never parked, so a resume would wake something that was never asleep.
+/// The
 /// exec is what normally ends that park, by replacing the whole image.
 /// Every other way out leaves this daemon running with pumps that have
 /// stopped reading, and nothing else ever starts one again. See
@@ -7732,23 +7742,37 @@ fn spawn_handover_task(
         let mut carried = Vec::with_capacity(drafts.len());
         let mut parked = ParkedPumps::default();
         for draft in drafts {
-            let fds = match &draft.log_ctl {
-                Some(log_ctl) => {
-                    let fds = report_fds(log_ctl).await;
-                    // Recorded whatever the answer was. A pump that could
-                    // not be reached is a failed send that resumes nothing,
-                    // and one that answered `none` has still been asked to
-                    // park.
-                    parked.0.push(log_ctl.clone());
-                    fds
-                }
-                None => CarriedFds::none(),
+            // The three answers go to three different places, which is why
+            // `report_fds` distinguishes them at all:
+            //
+            // - only a pump that ANSWERED parked, so only that one is owed a
+            //   resume. A wedged pump never stopped reading, and one that is
+            //   gone is reading nothing.
+            // - only a wedged pump refuses the flock. It is the one case
+            //   where a live sheep's descriptors are unknown, and the gate
+            //   below is the only thing standing between that and a
+            //   successor adopting a sheep with no stdout.
+            // - the blob gets `none()` for both of the answers without
+            //   descriptors. For a wedged pump that is a value nothing ever
+            //   reads: the gate refuses on the candidate, so this blob is
+            //   dropped rather than written.
+            let (fds, pump_unresponsive) = match &draft.log_ctl {
+                Some(log_ctl) => match report_fds(log_ctl).await {
+                    PumpReport::Parked(fds) => {
+                        parked.0.push(log_ctl.clone());
+                        (fds, false)
+                    }
+                    PumpReport::Gone => (CarriedFds::none(), false),
+                    PumpReport::Unresponsive => (CarriedFds::none(), true),
+                },
+                None => (CarriedFds::none(), false),
             };
             carried.push(CarriedSheep::from_entry(&draft.entry, draft.epoch, fds));
             candidates.push(OwnedCandidate {
                 entry: draft.entry,
                 pending_stop: draft.pending_stop,
                 pending_delete: draft.pending_delete,
+                pump_unresponsive,
             });
         }
         let blob = Handover::new(carried, fds, counters);
@@ -7756,23 +7780,88 @@ fn spawn_handover_task(
     });
 }
 
-/// Asks one sheep's log pump to write out everything it is holding, report
-/// the four descriptors it owns, and stop reading until the exec; and waits
-/// for the answer.
+/// What one log pump answered a snapshot's [`LogCtl::ReportFds`] with.
 ///
-/// Not reaching a pump at all is [`CarriedFds::none`], not an error, and both
-/// shapes of it mean the same thing that [`reopen_logs`] documents: there is
-/// no pump, so there are no descriptors. A stopped sheep has nothing to
-/// carry and nothing to lose, and the fitness gate does not refuse it.
+/// Three answers rather than two, and the third is the point. A pump that
+/// cannot be reached and a pump that is wedged both have no descriptors to
+/// give, but they mean opposite things: the first is a sheep that has
+/// stopped and has nothing to lose, and the second is a live sheep whose
+/// four descriptors this daemon simply does not know. Folding the second
+/// into [`CarriedFds::none`] would carry it, silently dropping its stdout,
+/// stderr and both log handles.
 ///
 /// [`CarriedFds::none`]: CarriedFds::none
 #[cfg(unix)]
-async fn report_fds(log_ctl: &mpsc::Sender<LogCtl>) -> CarriedFds {
+#[derive(Debug)]
+enum PumpReport {
+    /// The pump answered, and has stopped reading its streams until the
+    /// exec. It is owed a [`LogCtl::Resume`] if the handover is abandoned.
+    Parked(CarriedFds),
+    /// There is no pump on the other end any more: the send found a closed
+    /// mailbox, or the answer channel dropped unanswered. Either way the
+    /// task is over, so it is reading nothing and is owed nothing.
+    ///
+    /// Not a refusal. A registered sheep that is not running reaches the
+    /// gate exactly like this, and carrying it is correct: there is nothing
+    /// to carry.
+    Gone,
+    /// The pump did not answer inside [`REPORT_DEADLINE`].
+    ///
+    /// It never parked, so it is still reading its sheep's streams while
+    /// every pump before it in the sweep is frozen, and it must NOT be
+    /// resumed: a resume would wake something that was never asleep.
+    Unresponsive,
+}
+
+/// How long a snapshot waits for ONE log pump to report its descriptors.
+///
+/// The work it bounds is small and known (IR-26): the pump drains at most
+/// one bufferful per stream into that stream's log file and flushes both, so
+/// this covers a handful of `write(2)`s of at most 8 KiB each. That is
+/// microseconds on a healthy filesystem and single-digit milliseconds on a
+/// busy one, which puts two seconds three orders of magnitude clear of the
+/// work. The margin is deliberate and the asymmetry is why: firing early
+/// costs the WHOLE flock its handover, while firing late costs a few seconds
+/// before the same fallback. So this fires only for a pump that is genuinely
+/// stuck, on a filesystem that has stopped completing writes, rather than
+/// for one that is merely slow.
+///
+/// Two seconds also matches [`STDIN_WRITE_TIMEOUT`], the closest sibling in
+/// this file: a bounded wait on an acknowledgement from a pump-tier task
+/// whose failure mode is a peer that has stopped consuming.
+///
+/// Per pump, not per sweep, because the pumps are visited one at a time and
+/// the refusal has to name WHICH sheep went quiet. A flock of wedged pumps
+/// therefore costs N times this before the caller falls back, which is the
+/// price of that name.
+#[cfg(unix)]
+const REPORT_DEADLINE: Duration = Duration::from_secs(2);
+
+/// Asks one sheep's log pump to write out everything it is holding, report
+/// the four descriptors it owns, and stop reading until the exec; and waits
+/// up to [`REPORT_DEADLINE`] for the answer.
+///
+/// Not reaching a pump at all is [`PumpReport::Gone`], not an error, and
+/// both shapes of it mean the same thing that [`reopen_logs`] documents:
+/// there is no pump, so there are no descriptors. A stopped sheep has
+/// nothing to carry and nothing to lose, and the fitness gate does not
+/// refuse it.
+///
+/// The deadline covers the send as well as the answer. A pump that has
+/// stopped serving its mailbox fills it and blocks the send instead, which
+/// is the same stall arriving one step earlier.
+#[cfg(unix)]
+async fn report_fds(log_ctl: &mpsc::Sender<LogCtl>) -> PumpReport {
     let (done, ack) = oneshot::channel();
-    if log_ctl.send(LogCtl::ReportFds { done }).await.is_err() {
-        return CarriedFds::none();
-    }
-    ack.await.unwrap_or_else(|_| CarriedFds::none())
+    let answer = async {
+        if log_ctl.send(LogCtl::ReportFds { done }).await.is_err() {
+            return PumpReport::Gone;
+        }
+        ack.await.map_or(PumpReport::Gone, PumpReport::Parked)
+    };
+    tokio::time::timeout(REPORT_DEADLINE, answer)
+        .await
+        .unwrap_or(PumpReport::Unresponsive)
 }
 
 /// Spawns the task that carries out one `Reopen` and answers its caller.
@@ -17325,6 +17414,127 @@ mod tests {
                 assert!(is_open(fd), "blob names a closed descriptor: {fd}");
             }
         }
+    }
+
+    /// Fails if a wedged log pump hangs the snapshot instead of refusing it.
+    ///
+    /// A pump that never answers has no deadline above it but this one: the
+    /// SIGHUP path awaits the snapshot before it can fall back, so the same
+    /// stall takes out the handover AND the graceful stop it would have
+    /// fallen back to, and the daemon has no way out at all.
+    ///
+    /// The refusal has to name the sheep, and it has to be its own reason
+    /// rather than an empty `CarriedFds`: `none()` is what a STOPPED sheep
+    /// reports, so collapsing a wedged live pump into it would pass the gate
+    /// and carry that sheep with its four descriptors dropped.
+    ///
+    /// Two sheep, one of each kind, so a gate that refused every flock with
+    /// a pump in it would pass here for the wrong reason.
+    #[cfg(unix)]
+    #[tokio::test(start_paused = true)]
+    async fn a_pump_that_never_reports_refuses_the_snapshot_instead_of_hanging() {
+        let (events, _rx) = crate::bus::test_bus(64);
+        let runner = ScriptedRunner::new(vec![ProcScript::never_exits(); 2])
+            .with_a_pump_that_never_reports(&["wedged"]);
+        let dir = tempfile::tempdir().unwrap();
+        let (fds, _held) = daemon_fds(&dir);
+        let handle = spawn_supervisor(runner, test_paths(&dir), events);
+        handle
+            .start(vec![
+                normalize(AppConfig::minimal("answering", "./srv")).unwrap(),
+                normalize(AppConfig::minimal("wedged", "./srv")).unwrap(),
+            ])
+            .await
+            .unwrap();
+
+        // Far longer than the deadline under test, and never actually
+        // waited: the clock is paused, so it advances only once every task
+        // is blocked. What it buys is a FAILURE rather than a hung suite if
+        // the snapshot has no deadline of its own.
+        let snapshot =
+            tokio::time::timeout(Duration::from_secs(3600), handle.handover_snapshot(fds))
+                .await
+                .expect("a snapshot over a wedged pump must answer rather than hang")
+                .unwrap();
+        let (candidates, _blob, _parked) = snapshot;
+
+        let borrowed: Vec<crate::handover::Candidate<'_>> = candidates
+            .iter()
+            .map(crate::handover::OwnedCandidate::as_candidate)
+            .collect();
+        assert_eq!(
+            crate::handover::fitness(&borrowed),
+            crate::handover::Fitness::Refused(crate::handover::RefusedReason::PumpUnresponsive {
+                sheep: "wedged".to_string(),
+            }),
+            "the gate must refuse, and must name the sheep whose pump went quiet"
+        );
+        for candidate in &candidates {
+            assert_eq!(
+                candidate.pump_unresponsive,
+                candidate.entry.spec.config().name == "wedged",
+                "exactly the wedged sheep is unresponsive, not its neighbour"
+            );
+        }
+    }
+
+    /// Fails if the snapshot puts a pump it never heard from into the set it
+    /// owes a resume to.
+    ///
+    /// A report parks the pump that answers it, and only that one: a pump
+    /// that missed the deadline is still reading its streams. Resuming it
+    /// would wake something that was never asleep, and the counter it lands
+    /// on is the one an abandoned handover is audited by, so a spurious
+    /// resume reads as a repaired pump forever after.
+    ///
+    /// Asserted by sending the resumes rather than by counting the set, so
+    /// this is a claim about which pump is told rather than about how many
+    /// senders are held.
+    #[cfg(unix)]
+    #[tokio::test(start_paused = true)]
+    async fn a_pump_that_missed_the_deadline_is_not_in_the_parked_set() {
+        let (events, _rx) = crate::bus::test_bus(64);
+        let runner = Arc::new(
+            ScriptedRunner::new(vec![ProcScript::never_exits(); 2])
+                .with_a_pump_that_never_reports(&["wedged"]),
+        );
+        let dir = tempfile::tempdir().unwrap();
+        let (fds, _held) = daemon_fds(&dir);
+        let handle = spawn_supervisor(SharedRunner(Arc::clone(&runner)), test_paths(&dir), events);
+        handle
+            .start(vec![
+                normalize(AppConfig::minimal("answering", "./srv")).unwrap(),
+                normalize(AppConfig::minimal("wedged", "./srv")).unwrap(),
+            ])
+            .await
+            .unwrap();
+
+        let (_candidates, _blob, parked) =
+            tokio::time::timeout(Duration::from_secs(3600), handle.handover_snapshot(fds))
+                .await
+                .expect("a snapshot over a wedged pump must answer rather than hang")
+                .unwrap();
+        parked.resume().await;
+
+        // By name, because spawn order is the supervisor's business and
+        // every counter here is indexed by it.
+        let answering = runner.spawn_index_of("answering").expect("started above");
+        let wedged = runner.spawn_index_of("wedged").expect("started above");
+        // A resume carries no acknowledgement, so a send that has returned
+        // has only been queued. Bounded, and instant under the paused clock.
+        let delivered = async {
+            while runner.resumes(answering) == 0 {
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        };
+        tokio::time::timeout(Duration::from_secs(10), delivered)
+            .await
+            .expect("the pump that answered was parked, and is owed a resume");
+        assert_eq!(
+            runner.resumes(wedged),
+            0,
+            "a pump that never answered never parked, so nothing may resume it"
+        );
     }
 
     /// Fails if a snapshot loses the three actor counters or the two slot

--- a/crates/shep-daemon/src/tokio_runner.rs
+++ b/crates/shep-daemon/src/tokio_runner.rs
@@ -656,12 +656,17 @@ impl ProcessRunner for TokioRunner {
     /// the one the sheep has been running under all along. From the sheep's
     /// side the shepherd was never away.
     ///
-    /// The three channels a spawn may wire are all closed here rather than
-    /// left dangling, exactly as a spawn closes the ones its own spec did
-    /// not ask for. Phase 2a's fitness gate refuses to carry any sheep with
-    /// a shepherd channel or a stdin pipe, so a carried sheep has neither,
-    /// and a caller's `is_closed()` says so at once instead of a send
-    /// buffering into a channel nobody drains.
+    /// The shepherd channel's two are closed here rather than left
+    /// dangling, exactly as a spawn closes the ones its own spec did not ask
+    /// for: the fitness gate refuses to carry a sheep with a shepherd
+    /// channel, so a carried sheep has none, and a caller's `is_closed()`
+    /// says so at once instead of a send buffering into a channel nobody
+    /// drains.
+    ///
+    /// Stdin is the one a handover does carry. A sheep whose blob named a
+    /// write end gets a stdin pump on it again, so `shep whisper` reaches
+    /// the same fd 0 the child has had open all along; one that named none
+    /// is closed like the two above.
     #[cfg(unix)]
     fn adopt(&self, spec: AdoptSpec) -> Result<(Self::Proc, ProcIo), RunnerError> {
         let AdoptSpec {
@@ -672,18 +677,20 @@ impl ProcessRunner for TokioRunner {
             err_pipe,
             out_log,
             err_log,
+            stdin_pipe,
             reaper,
         } = spec;
 
         let (logs_tx, logs_rx) = mpsc::channel(CHANNEL_CAPACITY);
         let (log_ctl_tx, log_ctl_rx) = mpsc::channel(CHANNEL_CAPACITY);
-        // Read off the readers before they are moved into the pump, as the
-        // spawn path does: these are the numbers the NEXT handover carries,
-        // and a successor that reported its predecessor's would be naming
-        // descriptors this process does not have.
+        // Read off the handles before they are moved into their pumps, as
+        // the spawn path does: these are the numbers the NEXT handover
+        // carries, and a successor that reported its predecessor's would be
+        // naming descriptors this process does not have.
         let pipes = PipeFds {
             out: out_pipe.as_ref().map(AsRawFd::as_raw_fd),
             err: err_pipe.as_ref().map(AsRawFd::as_raw_fd),
+            stdin: stdin_pipe.as_ref().map(AsRawFd::as_raw_fd),
         };
         spawn_log_pump(
             out_pipe,
@@ -700,7 +707,11 @@ impl ProcessRunner for TokioRunner {
         let (to_child, to_child_rx) = mpsc::channel(CHANNEL_CAPACITY);
         drop(to_child_rx);
         let (to_stdin, to_stdin_rx) = mpsc::channel(CHANNEL_CAPACITY);
-        drop(to_stdin_rx);
+        if let Some(stdin_pipe) = stdin_pipe {
+            spawn_stdin_pump(Some(stdin_pipe), to_stdin_rx);
+        } else {
+            drop(to_stdin_rx);
+        }
 
         Ok((
             TokioProc {
@@ -1008,6 +1019,10 @@ impl ProcessRunner for TokioRunner {
         let pipes = PipeFds {
             out: child.stdout.as_ref().map(AsRawFd::as_raw_fd),
             err: child.stderr.as_ref().map(AsRawFd::as_raw_fd),
+            // Before the `take` below hands it to the stdin pump, which is
+            // the same reason the two above are read here: after it, there
+            // is nothing left on `child` to read a number off.
+            stdin: child.stdin.as_ref().map(AsRawFd::as_raw_fd),
         };
         #[cfg(not(unix))]
         let pipes = PipeFds;
@@ -1263,7 +1278,7 @@ impl<W: AsyncWrite + Unpin> LogFile<W> {
     }
 }
 
-/// The descriptor numbers of a pump's two stream readers.
+/// The descriptor numbers a handover carries for one sheep's pipes.
 ///
 /// Told to the pump rather than read off its readers, because the pump is
 /// generic over them and an in-memory stream has no descriptor at all. The
@@ -1279,6 +1294,27 @@ struct PipeFds {
     out: Option<RawFd>,
     /// The read end of the child's stderr, while the pump still holds it.
     err: Option<RawFd>,
+    /// The write end of the child's stdin, held by the stdin pump rather
+    /// than by this one.
+    ///
+    /// # Why the log pump reports a number it does not own
+    ///
+    /// It is the only party a snapshot asks. `LogCtl::ReportFds` is the one
+    /// request the supervisor sends per sheep, and a second seam for one
+    /// number would be a second thing to keep in step with the first.
+    ///
+    /// What makes that sound is who pins the descriptor. The stdin pump
+    /// ends when the last `to_stdin` sender drops, and the supervisor's own
+    /// slot holds one for as long as the sheep is registered, so the write
+    /// end cannot be closed and its number handed to the next `open`
+    /// between the report and the exec. That is the same guarantee parking
+    /// buys for [`Self::out`] and [`Self::err`], reached by ownership
+    /// instead: a pump that never stops reading needs to be parked, and a
+    /// pump that only ever writes what an operator hands it does not.
+    ///
+    /// Unlike those two, it is never cleared as a stream ends. It has no
+    /// EOF to reach, and the pump that could observe one is not this pump.
+    stdin: Option<RawFd>,
 }
 
 /// See the unix definition above; there is nothing to carry here.
@@ -1293,8 +1329,8 @@ struct PipeFds;
 struct LogFiles {
     out: LogFile,
     err: LogFile,
-    /// The stream read ends the pump still holds, cleared per stream as
-    /// each one ends.
+    /// The descriptors a blob names for this sheep, with the two stream
+    /// read ends cleared per stream as each one ends.
     ///
     /// Cleared rather than left standing because the reader is dropped at
     /// the same moment, which closes the descriptor: a number the kernel is
@@ -1506,6 +1542,7 @@ impl LogFiles {
                     err_pipe: self.pipes.err,
                     out_log: self.out.raw_fd(),
                     err_log: self.err.raw_fd(),
+                    stdin: self.pipes.stdin,
                 });
             }
             // No acknowledgement to send, and nothing to undo but the flag:
@@ -2259,6 +2296,7 @@ mod tests {
             let pipes = PipeFds {
                 out: Some(out_reader.as_raw_fd()),
                 err: Some(err_reader.as_raw_fd()),
+                stdin: None,
             };
             let (logs_tx, logs) = mpsc::channel(CHANNEL_CAPACITY);
             let (ctl, ctl_rx) = mpsc::channel(CHANNEL_CAPACITY);
@@ -2685,6 +2723,7 @@ mod tests {
         let pipes = PipeFds {
             out: Some(reader.as_raw_fd()),
             err: None,
+            stdin: None,
         };
         spawn_log_pump(
             Some(reader),
@@ -3647,6 +3686,234 @@ mod tests {
                 .expect("its sender must outlive the write")
                 .is_ok()
         );
+    }
+
+    /// fails if a descriptor report leaves out the sheep's stdin write end.
+    ///
+    /// The number belongs to the stdin pump rather than to this one, which
+    /// is why the log pump is TOLD it exactly as it is told its two reader
+    /// numbers. A report that dropped it would hand the successor a sheep
+    /// whose `shep whisper` writes into a descriptor the exec closed.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn a_report_names_the_stdin_write_end_it_was_told_about() {
+        let dir = tempfile::tempdir().unwrap();
+        // Held for the length of the case, as the stdin pump holds it in
+        // production: a number whose owner has dropped it is a number the
+        // next `open` may be handed.
+        let (_child_end, daemon_end) = std::io::pipe().unwrap();
+        // One live stream, so the pump has something to be reading. A pump
+        // handed no streams at all ends before it can answer anything.
+        let (_out_writer, out_reader) = tokio::io::duplex(STREAM_BUFFER);
+        let (logs_tx, _logs) = mpsc::channel(CHANNEL_CAPACITY);
+        let (ctl, ctl_rx) = mpsc::channel(CHANNEL_CAPACITY);
+        let pipes = PipeFds {
+            out: None,
+            err: None,
+            stdin: Some(daemon_end.as_raw_fd()),
+        };
+        spawn_log_pump(
+            Some(out_reader),
+            None::<DuplexStream>,
+            LogSink::Path(dir.path().join("out.log")),
+            LogSink::Path(dir.path().join("err.log")),
+            logs_tx,
+            ctl_rx,
+            pipes,
+        );
+
+        let (done, ack) = oneshot::channel();
+        ctl.send(LogCtl::ReportFds { done }).await.unwrap();
+        let fds = timeout(PUMP_DEADLINE, ack)
+            .await
+            .expect("a descriptor report must be acknowledged")
+            .expect("the pump must answer rather than drop the acknowledgement");
+
+        assert_eq!(fds.stdin, Some(daemon_end.as_raw_fd()));
+    }
+
+    /// fails if an adopted sheep's stdin write end is not wired back to
+    /// `to_stdin`.
+    ///
+    /// The read half of this feature. Carrying the descriptor is only half
+    /// of it: the successor has to put a pump back on the daemon's end, or
+    /// every `shep whisper` after a handover answers on a channel with
+    /// nothing behind it.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn an_adopted_stdin_pipe_carries_a_line_to_the_child() {
+        let dir = tempfile::tempdir().unwrap();
+        let (mut child_end, daemon_end) = std::io::pipe().unwrap();
+        let daemon_end = tokio::net::unix::pipe::Sender::from_file(std::fs::File::from(
+            std::os::fd::OwnedFd::from(daemon_end),
+        ))
+        .expect("the daemon's end of a stdin pipe is writable");
+
+        let (_proc, io) = TokioRunner::new()
+            .adopt(adopt_spec(&dir, Some(daemon_end)))
+            .expect("the real runner must be able to adopt");
+
+        let (done, ack) = oneshot::channel();
+        io.to_stdin
+            .send(StdinWrite {
+                line: "whisper".to_string(),
+                done,
+            })
+            .await
+            .expect("an adopted sheep must still have a stdin pump");
+        timeout(PUMP_DEADLINE, ack)
+            .await
+            .expect("the write must be acknowledged")
+            .expect("the pump must outlive the write")
+            .expect("the write must succeed");
+
+        let mut buf = [0_u8; 8];
+        std::io::Read::read_exact(&mut child_end, &mut buf).expect("the child end must read");
+        assert_eq!(&buf, b"whisper\n");
+    }
+
+    /// fails if an adopted sheep that never had a stdin pipe is given a
+    /// channel nothing drains.
+    ///
+    /// `is_closed()` is the one question a caller asks about `to_stdin`
+    /// (see [`ProcIo::to_stdin`]), so a dangling receiver would have the
+    /// supervisor wait out its whole `STDIN_WRITE_TIMEOUT` on a sheep that
+    /// has no fd 0 at all.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn an_adopted_sheep_without_a_stdin_pipe_has_a_closed_channel() {
+        let dir = tempfile::tempdir().unwrap();
+
+        let (_proc, io) = TokioRunner::new()
+            .adopt(adopt_spec(&dir, None))
+            .expect("the real runner must be able to adopt");
+
+        assert!(io.to_stdin.is_closed());
+    }
+
+    /// The plainest adoption, with `stdin_pipe` the only handle it carries.
+    ///
+    /// Every other handle is `None`, which is the shape a sheep whose log
+    /// opens had failed arrives in; nothing here reads them. The pid is this
+    /// process's own because nothing below ever waits it: an adoption
+    /// records a number, and the reaper is what would go looking for it.
+    #[cfg(unix)]
+    fn adopt_spec(
+        dir: &tempfile::TempDir,
+        stdin_pipe: Option<tokio::net::unix::pipe::Sender>,
+    ) -> AdoptSpec {
+        AdoptSpec {
+            pid: std::process::id(),
+            out_file: dir.path().join("out.log"),
+            err_file: dir.path().join("err.log"),
+            out_pipe: None,
+            err_pipe: None,
+            out_log: None,
+            err_log: None,
+            stdin_pipe,
+            reaper: Arc::new(crate::runner::AdoptedReaper::new()),
+        }
+    }
+
+    /// A spec for a real child, whose fd 0 is the point of the two cases
+    /// below.
+    ///
+    /// A real child rather than a harness, because the question is what the
+    /// SPAWN reads off the handle it is about to give away: an in-memory
+    /// stand-in has no descriptor to read. `reap.rs` spawns real children
+    /// from the library tier for the same reason.
+    ///
+    /// The program is the caller's, and the choice matters more than it
+    /// looks: a child that exits before the report is answered takes its
+    /// log pump with it, and the case then fails on a dropped
+    /// acknowledgement rather than on anything about descriptors.
+    #[cfg(unix)]
+    fn child_spec(dir: &tempfile::TempDir, program: &str, args: &[&str], stdin: bool) -> SpawnSpec {
+        SpawnSpec {
+            name: "web".to_string(),
+            program: program.to_string(),
+            args: args.iter().map(|arg| (*arg).to_string()).collect(),
+            cwd: None,
+            env: BTreeMap::new(),
+            out_file: dir.path().join("out.log"),
+            err_file: dir.path().join("err.log"),
+            channel: false,
+            stdin,
+            credentials: None,
+        }
+    }
+
+    /// fails if a spawn does not report the descriptor it put on the child's
+    /// fd 0.
+    ///
+    /// The number is read off `child.stdin` before the spawn hands it to the
+    /// stdin pump, which is the only moment it is knowable, and getting that
+    /// order wrong reports `None` for every sheep an operator can whisper
+    /// to. Checked as a write end of a pipe rather than merely as some
+    /// number: a report that named the wrong one of the five handles a spawn
+    /// holds would still be `Some`.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn a_spawn_reports_the_write_end_it_put_on_the_childs_stdin() {
+        use nix::fcntl::{FcntlArg, OFlag, fcntl};
+
+        let dir = tempfile::tempdir().unwrap();
+        // `cat` with a real pipe on fd 0 waits on it, so it is still there
+        // to be reported on, and it exits when `io` is dropped below.
+        let (_proc, io) = TokioRunner::new()
+            .spawn(&child_spec(&dir, "/bin/cat", &[], true))
+            .unwrap();
+
+        let (done, ack) = oneshot::channel();
+        io.log_ctl.send(LogCtl::ReportFds { done }).await.unwrap();
+        let fds = timeout(PUMP_DEADLINE, ack)
+            .await
+            .expect("a descriptor report must be acknowledged")
+            .expect("the pump must answer rather than drop the acknowledgement");
+
+        let stdin = fds
+            .stdin
+            .expect("a sheep spawned with a stdin pipe carries its write end");
+        let flags = OFlag::from_bits_truncate(fcntl(stdin, FcntlArg::F_GETFL).unwrap());
+        assert_eq!(
+            flags & OFlag::O_ACCMODE,
+            OFlag::O_WRONLY,
+            "the number reported for stdin must be the end the daemon writes"
+        );
+        assert_ne!(Some(stdin), fds.out_pipe);
+        assert_ne!(Some(stdin), fds.err_pipe);
+        drop(io);
+    }
+
+    /// fails if a sheep that never asked for a pipe on fd 0 carries a
+    /// descriptor for one.
+    ///
+    /// `/dev/null` is what such a child has there, and it belongs to the
+    /// child alone: naming a number here would have the successor adopt
+    /// something no `shep whisper` will ever reach.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn a_spawn_without_stdin_reports_no_descriptor_for_it() {
+        let dir = tempfile::tempdir().unwrap();
+        // Not `cat` here: with `/dev/null` on fd 0 it reads EOF and exits at
+        // once, which ends its log pump and leaves this case racing a
+        // report against a pump that is already gone.
+        let (mut proc, io) = TokioRunner::new()
+            .spawn(&child_spec(&dir, "/bin/sleep", &["30"], false))
+            .unwrap();
+
+        let (done, ack) = oneshot::channel();
+        io.log_ctl.send(LogCtl::ReportFds { done }).await.unwrap();
+        let fds = timeout(PUMP_DEADLINE, ack)
+            .await
+            .expect("a descriptor report must be acknowledged")
+            .expect("the pump must answer rather than drop the acknowledgement");
+
+        assert_eq!(fds.stdin, None);
+        // Killed rather than waited out: nothing here reads the child, and
+        // a `sleep` left behind outlives the test binary.
+        proc.signal_process(OperatorSignal::Kill).unwrap();
+        drop(io);
     }
 
     /// A [`SpawnSpec`] carrying only what [`what_exec_will_find`] reads. Every

--- a/crates/shep-daemon/src/tokio_runner.rs
+++ b/crates/shep-daemon/src/tokio_runner.rs
@@ -91,6 +91,23 @@ const LOG_BUFFER: usize = 8 * 1024;
 /// buffer until its next one, which for some sheep is never.
 const IDLE_FLUSH: Duration = Duration::from_millis(50);
 
+/// Bytes a descriptor report writes out of a stream's reader before it
+/// stops, per stream.
+///
+/// A `BufReader` reads ahead by [`LOG_BUFFER`] and no further, so one
+/// bufferful is the whole of what a report can find stranded in userspace,
+/// and stranded is the word: those bytes are behind the descriptor the blob
+/// carries rather than in it, and the `execve` destroys them. What the
+/// drain declines to take is in no danger, because it is still in the
+/// kernel's pipe and the successor inherits the pipe by number.
+///
+/// The bound is what keeps the two apart. Without it a report served while
+/// a chatty sheep is writing would go on reading for as long as the sheep
+/// kept it fed, and the handover would wait on a sheep rather than on a
+/// buffer.
+#[cfg(unix)]
+const MAX_DRAIN: usize = LOG_BUFFER;
+
 /// Real [`crate::runner::ProcessRunner`] over actual OS processes.
 #[derive(Debug, Default)]
 pub struct TokioRunner;
@@ -1287,12 +1304,60 @@ struct LogFiles {
     /// the same moment, which closes the descriptor: a number the kernel is
     /// free to hand to the next `open` must never reach a handover blob.
     pipes: PipeFds,
+    /// Whether this pump has answered a [`LogCtl::ReportFds`] that no
+    /// [`LogCtl::Resume`] has ended, and so has stopped reading its
+    /// sheep's streams.
+    ///
+    /// See [`LogFiles::reading`] for why a report parks a pump at all.
+    #[cfg(unix)]
+    parked: bool,
 }
 
 impl LogFiles {
     /// The file a line from this stream is appended to (`err` picks stderr).
     fn stream(&mut self, err: bool) -> &mut LogFile {
         if err { &mut self.err } else { &mut self.out }
+    }
+
+    /// Whether the pump should still be reading its sheep's streams.
+    ///
+    /// False between a [`LogCtl::ReportFds`] and the exec that consumes it,
+    /// which is the whole of what parking means and the reason the variant
+    /// is more than a question.
+    ///
+    /// A report is a SNAPSHOT: two descriptor numbers the successor will
+    /// adopt, and a flush that empties the write buffer behind them. The
+    /// exec happens later. A pump that goes on reading in between appends
+    /// lines that the `execve` then destroys in the write buffer, and takes
+    /// bytes off the pipe that the successor can no longer find there, so
+    /// the same window loses a sheep's output twice over. Parking makes
+    /// every part of the snapshot still true when it is used, rather than
+    /// true when it was taken.
+    ///
+    /// It also pins the two stream numbers. A pump that is not reading
+    /// cannot reach EOF, so it cannot drop a reader, so a number in the
+    /// blob cannot be closed and handed to the next `open` before the
+    /// successor adopts it.
+    ///
+    /// # The residual
+    ///
+    /// A fragment of a line in flight at the exec is still lost.
+    /// [`tokio::io::Lines`] accumulates the line it is part-way through in
+    /// a private field and exposes only its inner reader, so bytes taken
+    /// towards a line whose newline has not arrived are reachable by
+    /// nothing here. What that costs is a fragment of the one line the
+    /// sheep had not finished writing, against the block the parking
+    /// itself saves. Closing it means the pump reading through a buffer it
+    /// owns rather than through `Lines`.
+    fn reading(&self) -> bool {
+        #[cfg(unix)]
+        {
+            !self.parked
+        }
+        #[cfg(not(unix))]
+        {
+            true
+        }
     }
 
     /// When the pump owes the older of the two buffers a flush, or `None`
@@ -1344,7 +1409,18 @@ impl LogFiles {
     /// OF THESE PER SHEEP (reopen) or PER PATH (flush) with `"; "`, so one
     /// separator at both levels would punctuate a single sheep that failed on
     /// both streams exactly like two that failed on one each.
-    async fn serve(&mut self, ctl: LogCtl) {
+    #[cfg_attr(
+        not(unix),
+        allow(
+            unused_variables,
+            reason = "`streams` is read only by `ReportFds`, and that variant is unix-only"
+        )
+    )]
+    async fn serve<O, E>(&mut self, ctl: LogCtl, streams: &mut Streams<O, E>)
+    where
+        O: AsyncRead + Unpin,
+        E: AsyncRead + Unpin,
+    {
         match ctl {
             LogCtl::Reopen { done } => {
                 let mut failures = Vec::new();
@@ -1392,13 +1468,29 @@ impl LogFiles {
             // for one, and the descriptor is still the one to carry, since
             // the successor inherits the same handle on the same file and is
             // the only party left that could write to it.
+            //
+            // The drain comes first, and for the same reason. What a reader
+            // has taken off its pipe and not yet emitted is on the far side
+            // of the descriptor the blob carries: the successor inherits
+            // the pipe, not this process's memory, so those bytes reach no
+            // file unless this one writes them. Draining them beats
+            // carrying them in the blob, which was tried and measured. A
+            // blob is a snapshot and a pump is live, so bytes copied at the
+            // report are bytes the predecessor then writes to the log
+            // ANYWAY before the exec, and the successor replays them: one
+            // real reload produced a duplicated line and 459 lines of
+            // reordered output. Parking is what makes the drain sound, and
+            // it is the same fix.
             #[cfg(unix)]
             LogCtl::ReportFds { done } => {
+                drain_ready(&mut streams.out, &mut self.out).await;
+                drain_ready(&mut streams.err, &mut self.err).await;
                 for file in [&mut self.out, &mut self.err] {
                     if let Err(error) = file.flush().await {
                         tracing::error!(%error, "log flush before a handover report failed");
                     }
                 }
+                self.parked = true;
                 let _ = done.send(crate::handover::CarriedFds {
                     out_pipe: self.pipes.out,
                     err_pipe: self.pipes.err,
@@ -1406,6 +1498,11 @@ impl LogFiles {
                     err_log: self.err.raw_fd(),
                 });
             }
+            // No acknowledgement to send, and nothing to undo but the flag:
+            // the drain above emptied the reader rather than copying it, so
+            // a resumed pump picks its sheep up wherever the pipe left off.
+            #[cfg(unix)]
+            LogCtl::Resume => self.parked = false,
         }
     }
 }
@@ -1425,17 +1522,22 @@ enum AfterLine {
 ///
 /// The wait for room on `logs_tx` keeps serving `ctl_rx` — see
 /// [`reserve_slot`] for the cycle that would otherwise close.
-async fn deliver_line(
+async fn deliver_line<O, E>(
     result: io::Result<Option<String>>,
     err: bool,
     files: &mut LogFiles,
     logs_tx: &mpsc::Sender<LogLine>,
     ctl_rx: &mut mpsc::Receiver<LogCtl>,
-) -> AfterLine {
+    streams: &mut Streams<O, E>,
+) -> AfterLine
+where
+    O: AsyncRead + Unpin,
+    E: AsyncRead + Unpin,
+{
     match result {
         Ok(Some(line)) => {
             files.stream(err).append(&line).await;
-            let Some(slot) = reserve_slot(logs_tx, files, ctl_rx).await else {
+            let Some(slot) = reserve_slot(logs_tx, files, ctl_rx, streams).await else {
                 return AfterLine::LogsClosed;
             };
             slot.send(LogLine { err, line });
@@ -1471,11 +1573,16 @@ async fn deliver_line(
 /// runs, the sheep task waits on the acknowledgement, and the pump cannot
 /// look at the request that would produce it. Serving control requests from
 /// inside the wait breaks that cycle by construction rather than by timing.
-async fn reserve_slot<'tx>(
+async fn reserve_slot<'tx, O, E>(
     logs_tx: &'tx mpsc::Sender<LogLine>,
     files: &mut LogFiles,
     ctl_rx: &mut mpsc::Receiver<LogCtl>,
-) -> Option<mpsc::Permit<'tx, LogLine>> {
+    streams: &mut Streams<O, E>,
+) -> Option<mpsc::Permit<'tx, LogLine>>
+where
+    O: AsyncRead + Unpin,
+    E: AsyncRead + Unpin,
+{
     loop {
         // Recomputed every iteration from the STORED mark, so losing the
         // race never extends the window (`snapshot::run_writer`'s debounce
@@ -1488,7 +1595,7 @@ async fn reserve_slot<'tx>(
         tokio::select! {
             slot = logs_tx.reserve() => return slot.ok(),
             ctl = ctl_rx.recv() => match ctl {
-                Some(ctl) => files.serve(ctl).await,
+                Some(ctl) => files.serve(ctl, streams).await,
                 // Nothing can reach the pump any more, but the line in hand
                 // is still owed to the receiver. Waiting for it outside the
                 // `select!` rather than looping avoids spinning on a closed
@@ -1522,6 +1629,67 @@ where
     match lines {
         Some(lines) => lines.next_line().await,
         None => core::future::pending().await,
+    }
+}
+
+/// A pump's two line readers, held in one place so a control request can
+/// reach them.
+///
+/// They were two locals in the pump's own task until a handover had to
+/// drain them: [`LogCtl::ReportFds`] is served from two places, the pump's
+/// own `select!` and [`reserve_slot`]'s, and only one of those could see a
+/// local. Nothing else about them changed, and neither reader is touched
+/// here between lines.
+///
+/// `None` per stream is one that has reached EOF or failed. The pump drops
+/// the reader at that moment, which closes the descriptor, so a stream with
+/// no reader has neither a number nor bytes left to write.
+struct Streams<O, E> {
+    /// The stdout reader, until stdout ends.
+    out: Option<Lines<BufReader<O>>>,
+    /// The stderr reader, until stderr ends.
+    err: Option<Lines<BufReader<E>>>,
+}
+
+/// Writes out whatever one stream's reader has already taken off its pipe,
+/// and stops as soon as the reader would have to wait for more.
+///
+/// This is what a descriptor report owes the successor, and it is bounded
+/// twice over: by [`MAX_DRAIN`], and by the reader having nothing ready.
+/// The bound is what keeps a report from following a sheep that is still
+/// writing, since on a busy stream the pipe is ready again the instant it
+/// is read.
+///
+/// EOF and a read failure both end the drain and are left for the pump's
+/// own loop to see, which it does when it resumes. A report that met one
+/// still names that stream's descriptor: the reader has not been dropped,
+/// so the number is still this process's, and the successor adopts a pipe
+/// that is at EOF exactly as this pump would have found it.
+///
+/// Nothing drained here is forwarded on `logs_tx`, deliberately. That
+/// channel feeds live `log.*` bus subscribers, and every one of them is
+/// about to go with the image; a wait for room on it would put the whole
+/// handover behind whoever is draining the bus. The file is the record, and
+/// the file gets every line.
+#[cfg(unix)]
+async fn drain_ready<R>(lines: &mut Option<Lines<BufReader<R>>>, file: &mut LogFile)
+where
+    R: AsyncRead + Unpin,
+{
+    let mut drained = 0;
+    while drained < MAX_DRAIN {
+        // `biased`, so the ready branch is the answer to "the reader had
+        // nothing waiting" rather than a coin flip against a reader that
+        // did. `next_line` is documented cancel-safe, so the poll that
+        // loses costs nothing: a partial line stays in the reader.
+        let ready = tokio::select! {
+            biased;
+            result = next_line(lines) => result,
+            () = core::future::ready(()) => return,
+        };
+        let Ok(Some(line)) = ready else { return };
+        drained += line.len() + 1;
+        file.append(&line).await;
     }
 }
 
@@ -1608,24 +1776,35 @@ fn spawn_log_pump<O, E>(
             out: LogFile::from_sink(out_sink).await,
             err: LogFile::from_sink(err_sink).await,
             pipes,
+            #[cfg(unix)]
+            parked: false,
         };
-        let mut out_lines = stdout.map(|reader| BufReader::new(reader).lines());
-        let mut err_lines = stderr.map(|reader| BufReader::new(reader).lines());
+        let mut streams = Streams {
+            out: stdout.map(|reader| BufReader::new(reader).lines()),
+            err: stderr.map(|reader| BufReader::new(reader).lines()),
+        };
 
-        while out_lines.is_some() || err_lines.is_some() {
+        while streams.out.is_some() || streams.err.is_some() {
             // Recomputed every iteration from the STORED mark; see
             // `reserve_slot`, which carries the same branch for the window
             // this loop cannot see.
             let flush_at = files.flush_deadline();
             tokio::select! {
-                result = next_line(&mut out_lines) => {
-                    match deliver_line(result, false, &mut files, &logs_tx, &mut ctl_rx).await {
+                result = next_line(&mut streams.out), if files.reading() => {
+                    // Bound before the `match` rather than matched on
+                    // directly: the future borrows `streams`, and a
+                    // scrutinee's temporaries outlive the arms, so an arm
+                    // could not clear the reader that future was reading.
+                    let after =
+                        deliver_line(result, false, &mut files, &logs_tx, &mut ctl_rx, &mut streams)
+                            .await;
+                    match after {
                         AfterLine::KeepReading => {}
                         // Dropping the reader closes the descriptor, so the
                         // number stops being ours in the same statement it
                         // stops being readable.
                         AfterLine::StreamEnded => {
-                            out_lines = None;
+                            streams.out = None;
                             #[cfg(unix)]
                             {
                                 files.pipes.out = None;
@@ -1634,12 +1813,15 @@ fn spawn_log_pump<O, E>(
                         AfterLine::LogsClosed => break,
                     }
                 }
-                result = next_line(&mut err_lines) => {
-                    match deliver_line(result, true, &mut files, &logs_tx, &mut ctl_rx).await {
+                result = next_line(&mut streams.err), if files.reading() => {
+                    let after =
+                        deliver_line(result, true, &mut files, &logs_tx, &mut ctl_rx, &mut streams)
+                            .await;
+                    match after {
                         AfterLine::KeepReading => {}
                         // As above: the number goes with the reader.
                         AfterLine::StreamEnded => {
-                            err_lines = None;
+                            streams.err = None;
                             #[cfg(unix)]
                             {
                                 files.pipes.err = None;
@@ -1650,7 +1832,7 @@ fn spawn_log_pump<O, E>(
                 }
                 ctl = ctl_rx.recv() => {
                     match ctl {
-                        Some(ctl) => files.serve(ctl).await,
+                        Some(ctl) => files.serve(ctl, &mut streams).await,
                         None => break, // nothing holds a `log_ctl` sender
                     }
                 }
@@ -2050,8 +2232,16 @@ mod tests {
                 pipes,
             }
         }
+    }
 
+    impl<W: AsyncWrite + Unpin> PumpHarness<W> {
         /// Sends a [`LogCtl::ReportFds`] and waits for the answer.
+        ///
+        /// Generic over the writing side rather than living with the
+        /// descriptor cases, because what a report does to the pump is not
+        /// about descriptors at all: it flushes, it drains, and it parks.
+        /// The cases about those three run over the cheaper in-memory pair.
+        #[cfg(unix)]
         async fn report_fds(&self) -> CarriedFds {
             let (done, ack) = oneshot::channel();
             self.ctl
@@ -2063,9 +2253,20 @@ mod tests {
                 .expect("a descriptor report must be acknowledged")
                 .expect("the pump must answer rather than drop the acknowledgement")
         }
-    }
 
-    impl<W: AsyncWrite + Unpin> PumpHarness<W> {
+        /// Sends a [`LogCtl::Resume`], which carries no acknowledgement.
+        ///
+        /// Nothing to wait for by design (see the variant): every case that
+        /// resumes a pump then waits on what the pump does next, which is a
+        /// stronger barrier than an answer would be.
+        #[cfg(unix)]
+        async fn resume(&self) {
+            self.ctl
+                .send(LogCtl::Resume)
+                .await
+                .expect("a parked pump must still be reading its control channel");
+        }
+
         /// Writes one line into the chosen stream and waits for the pump to
         /// hand it back on `logs` — which is proof the pump read it and
         /// issued its file write, and orders the two streams against each
@@ -2280,6 +2481,173 @@ mod tests {
         );
     }
 
+    /// How long a case watches a parked pump before believing it.
+    ///
+    /// Several [`IDLE_FLUSH`] windows, because that is what turns a pump
+    /// that read a line into a file that shows one: a pump still reading
+    /// appends within microseconds and the idle flush writes it through
+    /// 50ms later, so a file unchanged across six of those windows is a
+    /// pump that never read.
+    #[cfg(unix)]
+    const STILL_WINDOWS: u32 = 6;
+
+    /// Lines a case writes straight into a stream, bypassing
+    /// [`PumpHarness::feed`], when the point is a pump that has fallen
+    /// behind rather than one keeping up.
+    ///
+    /// More than `CHANNEL_CAPACITY`, so the pump fills `logs`, parks in
+    /// [`reserve_slot`], and holds the rest in its reader.
+    #[cfg(unix)]
+    const BURST: u32 = 60;
+
+    /// Fails if `path` changes at all over the next few flush windows.
+    ///
+    /// The negative half of the parking case, and the reason it is a window
+    /// rather than a single read: a pump that is still reading loses this
+    /// on its first poll, while a parked one cannot lose it at any length.
+    #[cfg(unix)]
+    async fn assert_file_holds_still(path: &Path, expected: &str) {
+        for window in 1..=STILL_WINDOWS {
+            tokio::time::sleep(IDLE_FLUSH).await;
+            assert_eq!(
+                fs::read_to_string(path).unwrap(),
+                expected,
+                "{}: a parked pump wrote during flush window {window}",
+                path.display()
+            );
+        }
+    }
+
+    /// Waits until nothing more will fit on `logs`, which is the state a
+    /// handover finds a chatty sheep's pump in.
+    ///
+    /// The forcing mechanism (IR-46) for both cases below: with the channel
+    /// full the pump is parked inside [`reserve_slot`], so everything it has
+    /// read past that point is in its reader and nothing but a report can
+    /// get it out.
+    #[cfg(unix)]
+    async fn wait_for_a_full_logs_channel(logs: &mpsc::Receiver<LogLine>) {
+        let filled = timeout(PUMP_DEADLINE, async {
+            while logs.len() < CHANNEL_CAPACITY {
+                tokio::time::sleep(Duration::from_millis(5)).await;
+            }
+        })
+        .await;
+        assert!(
+            filled.is_ok(),
+            "the pump must fall behind a burst it cannot forward"
+        );
+    }
+
+    /// Fails if a pump goes on reading its sheep's streams after it has
+    /// reported.
+    ///
+    /// This is the whole of the handover's read side. A report is a
+    /// SNAPSHOT — descriptors, and a flush that empties the write buffer
+    /// behind them — and the exec that consumes it happens later. Anything
+    /// the pump reads in between is written to the log file by an image
+    /// that is about to be replaced, and is then in neither the pipe the
+    /// successor inherits nor the buffer it could have been handed: a gap.
+    /// Parking makes the snapshot still true when it is used.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn a_pump_that_has_reported_stops_reading_until_it_is_resumed() {
+        let mut pump = PumpHarness::start();
+        pump.feed(false, "before-the-report").await;
+
+        let _ = pump.report_fds().await;
+
+        // The sheep does not stop writing because its shepherd is being
+        // replaced. Every one of these has to still be in the pipe at the
+        // exec, which is the same claim as the file not growing.
+        pump.out_writer
+            .write_all(b"after-1\nafter-2\n")
+            .await
+            .unwrap();
+        assert_file_holds_still(&pump.out_path, "before-the-report\n").await;
+
+        pump.resume().await;
+        assert_file_settles(&pump.out_path, "before-the-report\nafter-1\nafter-2\n").await;
+    }
+
+    /// Fails if a report leaves lines stranded in the pump's reader.
+    ///
+    /// The read side's other half, and the one a polite sheep hides: a
+    /// stream that emits a line and waits leaves the reader empty at every
+    /// instant a report could land, so a case built on one passes against
+    /// no implementation at all. A busy sheep fills `logs`, and everything
+    /// the pump has pulled off the pipe past that sits in a userspace
+    /// buffer that the exec destroys and no descriptor carries.
+    ///
+    /// Asserted with no settling: the report's own flush is the barrier.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn a_report_lands_what_the_reader_was_holding() {
+        let mut pump = PumpHarness::start();
+        let burst: String = (1..=BURST).map(|n| format!("{n}\n")).collect();
+        pump.out_writer.write_all(burst.as_bytes()).await.unwrap();
+        wait_for_a_full_logs_channel(&pump.logs).await;
+
+        let _ = pump.report_fds().await;
+
+        assert_eq!(
+            fs::read_to_string(&pump.out_path).unwrap(),
+            burst,
+            "every line the reader held must be on disk once, in order, \
+             before the report is answered"
+        );
+    }
+
+    /// The smallest buffer a pipe starts with on any host these cases run
+    /// on: macOS opens one at 16 KiB, Linux at 64.
+    ///
+    /// The case below writes its whole run in one go into a pipe whose
+    /// reader has stopped draining it, so the run has to fit under this or
+    /// the writing side parks and the test deadlocks instead of failing.
+    #[cfg(unix)]
+    const SMALLEST_PIPE: usize = 16 * 1024;
+
+    /// One line of the run below, sized so the arithmetic in it is exact.
+    #[cfg(unix)]
+    const RUN_LINE: usize = 8;
+
+    /// Fails if a report follows a sheep that is still writing instead of
+    /// rescuing what its reader already held.
+    ///
+    /// [`MAX_DRAIN`] is what stops the two from being the same loop. A
+    /// reader can strand at most one bufferful, and what the drain declines
+    /// to take is not lost: it is still in the kernel's pipe, which the
+    /// successor inherits by descriptor number. So the bound costs nothing
+    /// and is what keeps a report answerable while a chatty sheep runs.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn a_report_drains_at_most_one_bufferful() {
+        let mut pump = PumpHarness::start_over_pipes();
+        // Three quarters of the smallest pipe: over `MAX_DRAIN`, so the
+        // bound is really reached, and under the pipe, so the writer never
+        // parks.
+        let lines = u32::try_from(SMALLEST_PIPE * 3 / 4 / RUN_LINE).unwrap();
+        let run: String = (1..=lines).map(|n| format!("{n:07}\n")).collect();
+        assert!(run.len() > MAX_DRAIN, "the run must reach the bound");
+        pump.out_writer.write_all(run.as_bytes()).await.unwrap();
+        wait_for_a_full_logs_channel(&pump.logs).await;
+        pump.flush().await;
+        let before = fs::metadata(&pump.out_path).unwrap().len();
+
+        let _ = pump.report_fds().await;
+
+        let drained = fs::metadata(&pump.out_path).unwrap().len() - before;
+        assert!(
+            drained > 0,
+            "the report must rescue what the reader was holding"
+        );
+        assert!(
+            drained <= u64::try_from(MAX_DRAIN + RUN_LINE).unwrap(),
+            "the report drained {drained} bytes, which is more than one \
+             bufferful: it is following the sheep rather than catching up"
+        );
+    }
+
     /// A sink standing in for the [`tokio::fs::File`] a real [`LogFile`]
     /// holds, counting the writes that reach it.
     ///
@@ -2437,6 +2805,8 @@ mod tests {
             out: LogFile::open(dir.path().join("out.log")).await,
             err: LogFile::open(dir.path().join("err.log")).await,
             pipes: PipeFds::default(),
+            #[cfg(unix)]
+            parked: false,
         };
         assert_eq!(
             files.flush_deadline(),

--- a/crates/shep-daemon/src/tokio_runner.rs
+++ b/crates/shep-daemon/src/tokio_runner.rs
@@ -656,17 +656,17 @@ impl ProcessRunner for TokioRunner {
     /// the one the sheep has been running under all along. From the sheep's
     /// side the shepherd was never away.
     ///
-    /// The shepherd channel's two are closed here rather than left
-    /// dangling, exactly as a spawn closes the ones its own spec did not ask
-    /// for: the fitness gate refuses to carry a sheep with a shepherd
-    /// channel, so a carried sheep has none, and a caller's `is_closed()`
-    /// says so at once instead of a send buffering into a channel nobody
-    /// drains.
+    /// Stdin and the shepherd channel are both carried. A sheep whose blob
+    /// named a stdin write end gets a stdin pump on it again, so `shep
+    /// whisper` reaches the same fd 0 the child has had open all along; one
+    /// whose blob named a channel gets the same pair of pumps a spawn wires
+    /// put back on the same socketpair, so the child's fd 3 is undisturbed
+    /// in both directions.
     ///
-    /// Stdin is the one a handover does carry. A sheep whose blob named a
-    /// write end gets a stdin pump on it again, so `shep whisper` reaches
-    /// the same fd 0 the child has had open all along; one that named none
-    /// is closed like the two above.
+    /// What a blob named neither of is closed here rather than left
+    /// dangling, exactly as a spawn closes the ends its own spec did not
+    /// ask for: a caller's `is_closed()` then says so at once, instead of a
+    /// send buffering into a channel nobody drains.
     #[cfg(unix)]
     fn adopt(&self, spec: AdoptSpec) -> Result<(Self::Proc, ProcIo), RunnerError> {
         let AdoptSpec {
@@ -678,6 +678,7 @@ impl ProcessRunner for TokioRunner {
             out_log,
             err_log,
             stdin_pipe,
+            channel,
             reaper,
         } = spec;
 
@@ -691,6 +692,7 @@ impl ProcessRunner for TokioRunner {
             out: out_pipe.as_ref().map(AsRawFd::as_raw_fd),
             err: err_pipe.as_ref().map(AsRawFd::as_raw_fd),
             stdin: stdin_pipe.as_ref().map(AsRawFd::as_raw_fd),
+            channel: channel.as_ref().map(AsRawFd::as_raw_fd),
         };
         spawn_log_pump(
             out_pipe,
@@ -703,9 +705,13 @@ impl ProcessRunner for TokioRunner {
         );
 
         let (from_child_tx, from_child) = mpsc::channel(CHANNEL_CAPACITY);
-        drop(from_child_tx);
         let (to_child, to_child_rx) = mpsc::channel(CHANNEL_CAPACITY);
-        drop(to_child_rx);
+        if let Some(channel) = channel {
+            spawn_channel_pumps(channel, from_child_tx, to_child_rx);
+        } else {
+            drop(from_child_tx);
+            drop(to_child_rx);
+        }
         let (to_stdin, to_stdin_rx) = mpsc::channel(CHANNEL_CAPACITY);
         if let Some(stdin_pipe) = stdin_pipe {
             spawn_stdin_pump(Some(stdin_pipe), to_stdin_rx);
@@ -915,6 +921,11 @@ impl ProcessRunner for TokioRunner {
             drop(to_child_rx);
         }
 
+        // Declared out here because the block below moves `daemon_end` into
+        // its pumps, and `PipeFds` is assembled after the spawn: this is the
+        // one moment the number is in reach.
+        #[cfg(unix)]
+        let mut channel_fd: Option<RawFd> = None;
         #[cfg(unix)]
         if spec.channel {
             command.env("SHEP_CHANNEL_FD", "3");
@@ -957,6 +968,7 @@ impl ProcessRunner for TokioRunner {
                 .map_err(|error| {
                     RunnerError::SpawnFailed(format!("shepherd channel fd mapping: {error}"))
                 })?;
+            channel_fd = Some(daemon_end.as_raw_fd());
             spawn_channel_pumps(daemon_end, from_child_tx, to_child_rx);
         } else {
             // No channel requested: close both ends immediately rather than
@@ -1023,6 +1035,10 @@ impl ProcessRunner for TokioRunner {
             // the same reason the two above are read here: after it, there
             // is nothing left on `child` to read a number off.
             stdin: child.stdin.as_ref().map(AsRawFd::as_raw_fd),
+            // Read further up still, before the socketpair's daemon end was
+            // moved into its pumps. Nothing on `child` names it: the child's
+            // side is fd 3 over there, and this is the other end.
+            channel: channel_fd,
         };
         #[cfg(not(unix))]
         let pipes = PipeFds;
@@ -1315,6 +1331,31 @@ struct PipeFds {
     /// Unlike those two, it is never cleared as a stream ends. It has no
     /// EOF to reach, and the pump that could observe one is not this pump.
     stdin: Option<RawFd>,
+    /// The daemon's end of the child's shepherd-channel socketpair, held by
+    /// that channel's two pump tasks rather than by this one.
+    ///
+    /// Reported here for the reason [`Self::stdin`] gives: this pump is the
+    /// only party a snapshot asks, and a second seam for one number would
+    /// be a second thing to keep in step with the first.
+    ///
+    /// # What pins it, and the one thing that does not
+    ///
+    /// The writer task ends only when the last `to_child` sender drops, and
+    /// the supervisor's own slot holds one for as long as a process is
+    /// running under this id, so the socket cannot be closed and its number
+    /// handed to the next `open` while the sheep is up. That is the same
+    /// ownership argument stdin makes.
+    ///
+    /// It is weaker in one place, and the supervisor closes the gap rather
+    /// than this pump. The writer ALSO ends on a write that fails, which is
+    /// what a child that has closed its fd 3 produces, and this pump never
+    /// hears about it: the number here would go on naming a descriptor the
+    /// kernel has already reissued. `Actor::handle_handover_snapshot` reads
+    /// `SheepSlot::open_channel` in the same breath as it reads the slot,
+    /// and a snapshot masks this field when that says the channel is gone.
+    /// So this number is only ever as true as the pump can make it, and the
+    /// supervisor is what makes it true.
+    channel: Option<RawFd>,
 }
 
 /// See the unix definition above; there is nothing to carry here.
@@ -1543,6 +1584,7 @@ impl LogFiles {
                     out_log: self.out.raw_fd(),
                     err_log: self.err.raw_fd(),
                     stdin: self.pipes.stdin,
+                    channel: self.pipes.channel,
                 });
             }
             // No acknowledgement to send, and nothing to undo but the flag:
@@ -2297,6 +2339,7 @@ mod tests {
                 out: Some(out_reader.as_raw_fd()),
                 err: Some(err_reader.as_raw_fd()),
                 stdin: None,
+                channel: None,
             };
             let (logs_tx, logs) = mpsc::channel(CHANNEL_CAPACITY);
             let (ctl, ctl_rx) = mpsc::channel(CHANNEL_CAPACITY);
@@ -2724,6 +2767,7 @@ mod tests {
             out: Some(reader.as_raw_fd()),
             err: None,
             stdin: None,
+            channel: None,
         };
         spawn_log_pump(
             Some(reader),
@@ -3711,6 +3755,7 @@ mod tests {
             out: None,
             err: None,
             stdin: Some(daemon_end.as_raw_fd()),
+            channel: None,
         };
         spawn_log_pump(
             Some(out_reader),
@@ -3750,7 +3795,7 @@ mod tests {
         .expect("the daemon's end of a stdin pipe is writable");
 
         let (_proc, io) = TokioRunner::new()
-            .adopt(adopt_spec(&dir, Some(daemon_end)))
+            .adopt(adopt_spec(&dir, Some(daemon_end), None))
             .expect("the real runner must be able to adopt");
 
         let (done, ack) = oneshot::channel();
@@ -3785,13 +3830,132 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
 
         let (_proc, io) = TokioRunner::new()
-            .adopt(adopt_spec(&dir, None))
+            .adopt(adopt_spec(&dir, None, None))
             .expect("the real runner must be able to adopt");
 
         assert!(io.to_stdin.is_closed());
     }
 
-    /// The plainest adoption, with `stdin_pipe` the only handle it carries.
+    /// fails if a descriptor report leaves out the sheep's shepherd
+    /// channel.
+    ///
+    /// The number belongs to that channel's two pump tasks rather than to
+    /// this one, exactly as the stdin number belongs to the stdin pump, and
+    /// the log pump is told it for the same reason: it is the only party a
+    /// snapshot asks. A report that dropped it would hand the successor a
+    /// sheep whose fd 3 the exec closed, so a `shep trigger` reaches
+    /// nothing and the app sees its channel end for no reason it can
+    /// observe.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn a_report_names_the_shepherd_channel_it_was_told_about() {
+        let dir = tempfile::tempdir().unwrap();
+        // A real socketpair, held for the length of the case exactly as the
+        // channel's own pumps hold it in production.
+        let (daemon_end, _child_end) = std::os::unix::net::UnixStream::pair().unwrap();
+        let (_out_writer, out_reader) = tokio::io::duplex(STREAM_BUFFER);
+        let (logs_tx, _logs) = mpsc::channel(CHANNEL_CAPACITY);
+        let (ctl, ctl_rx) = mpsc::channel(CHANNEL_CAPACITY);
+        let pipes = PipeFds {
+            out: None,
+            err: None,
+            stdin: None,
+            channel: Some(daemon_end.as_raw_fd()),
+        };
+        spawn_log_pump(
+            Some(out_reader),
+            None::<DuplexStream>,
+            LogSink::Path(dir.path().join("out.log")),
+            LogSink::Path(dir.path().join("err.log")),
+            logs_tx,
+            ctl_rx,
+            pipes,
+        );
+
+        let (done, ack) = oneshot::channel();
+        ctl.send(LogCtl::ReportFds { done }).await.unwrap();
+        let fds = timeout(PUMP_DEADLINE, ack)
+            .await
+            .expect("a descriptor report must be acknowledged")
+            .expect("the pump must answer rather than drop the acknowledgement");
+
+        assert_eq!(fds.channel, Some(daemon_end.as_raw_fd()));
+    }
+
+    /// fails if an adopted shepherd channel is not wired back to both
+    /// `to_child` and `from_child`.
+    ///
+    /// Both directions in one case, because the failure to catch is a
+    /// successor that rebuilt one pump and not the other, and either half
+    /// alone looks healthy from the other side. Writing proves
+    /// `shutdown_with_message` and `shep trigger` still land; reading proves
+    /// `{"kind":"ready"}` and every action reply still come back, which is
+    /// what a `wait_ready` sheep's whole lifecycle turns on.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn an_adopted_shepherd_channel_carries_both_directions() {
+        use tokio::io::{AsyncBufReadExt as _, AsyncWriteExt as _};
+
+        let dir = tempfile::tempdir().unwrap();
+        // `child_end` is what an app holds on fd 3, unmoved by the handover.
+        // Both ends are async here rather than one of each: the write below
+        // is served by a task the adoption spawned, so a blocking read on
+        // this thread would park the runtime before that task ever ran.
+        let (daemon_end, child_end) = tokio::net::UnixStream::pair().unwrap();
+        let (child_read, mut child_write) = tokio::io::split(child_end);
+        let mut child = tokio::io::BufReader::new(child_read);
+
+        let (_proc, mut io) = TokioRunner::new()
+            .adopt(adopt_spec(&dir, None, Some(daemon_end)))
+            .expect("the real runner must be able to adopt");
+
+        io.to_child
+            .send(ShepherdMessage::Shutdown)
+            .await
+            .expect("an adopted sheep must still have a channel writer");
+        let mut line = String::new();
+        timeout(PUMP_DEADLINE, child.read_line(&mut line))
+            .await
+            .expect("the shepherd's message must reach the child's end")
+            .expect("the child end must read");
+        assert_eq!(line.trim_end(), r#"{"kind":"shutdown"}"#);
+
+        child_write
+            .write_all(b"{\"kind\":\"ready\"}\n")
+            .await
+            .unwrap();
+        let back = timeout(PUMP_DEADLINE, io.from_child.recv())
+            .await
+            .expect("an adopted sheep must still have a channel reader")
+            .expect("the reader must forward what the child said");
+        assert_eq!(back, ChildMessage::Ready);
+    }
+
+    /// fails if an adopted sheep that never had a channel is given ends
+    /// nothing drains.
+    ///
+    /// `is_closed()` is the one question the supervisor asks about
+    /// `to_child` (see `SheepSlot::open_channel`), so a dangling receiver
+    /// would have a `shep trigger` against a sheep with no fd 3 wait out its
+    /// whole `action_timeout` instead of answering `NoChannel` at once.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn an_adopted_sheep_without_a_channel_has_closed_channel_ends() {
+        let dir = tempfile::tempdir().unwrap();
+
+        let (_proc, mut io) = TokioRunner::new()
+            .adopt(adopt_spec(&dir, None, None))
+            .expect("the real runner must be able to adopt");
+
+        assert!(io.to_child.is_closed());
+        assert!(
+            io.from_child.recv().await.is_none(),
+            "a sheep with no channel must report one that is over, not one that is quiet"
+        );
+    }
+
+    /// The plainest adoption, with `stdin_pipe` and `channel` the only
+    /// handles it carries.
     ///
     /// Every other handle is `None`, which is the shape a sheep whose log
     /// opens had failed arrives in; nothing here reads them. The pid is this
@@ -3801,6 +3965,7 @@ mod tests {
     fn adopt_spec(
         dir: &tempfile::TempDir,
         stdin_pipe: Option<tokio::net::unix::pipe::Sender>,
+        channel: Option<tokio::net::UnixStream>,
     ) -> AdoptSpec {
         AdoptSpec {
             pid: std::process::id(),
@@ -3811,6 +3976,7 @@ mod tests {
             out_log: None,
             err_log: None,
             stdin_pipe,
+            channel,
             reaper: Arc::new(crate::runner::AdoptedReaper::new()),
         }
     }

--- a/crates/shep-daemon/src/tokio_runner.rs
+++ b/crates/shep-daemon/src/tokio_runner.rs
@@ -2530,6 +2530,96 @@ mod tests {
         assert_eq!(distinct.len(), 4, "four descriptors, four numbers: {fds:?}");
     }
 
+    /// Fails if two instances of one `merge_logs` app end up naming one
+    /// descriptor number for the file they share.
+    ///
+    /// The whole-blob refusal is what makes this worth a case of its own.
+    /// `handover::adopt::refuse_repeated_fds` rejects the ENTIRE handover
+    /// when any number appears twice, so a merged-log app whose instances
+    /// shared one open file description would not merely lose a log: it
+    /// would send every reload of every flock containing it down the
+    /// stop-and-start arm, with a message naming a descriptor rather than
+    /// the config responsible.
+    ///
+    /// One inode, two `open`s, two numbers. Each instance is its own sheep
+    /// with its own pump, and [`LogFile::open`] runs [`open_append`] per
+    /// pump rather than sharing a handle between them, which is the fact
+    /// asserted here.
+    ///
+    /// Two pumps over ONE pair of paths, which is what `merge_logs` really
+    /// produces: `assemble` drops the `-<instance>` suffix and every slot
+    /// of the name resolves to the same two files.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn two_pumps_on_one_log_path_report_different_numbers() {
+        let dir = tempfile::tempdir().unwrap();
+        let out_path = dir.path().join("merged-out.log");
+        let err_path = dir.path().join("merged-err.log");
+
+        // Held for the whole case: a reading end is only a valid number
+        // while its writing end is alive, and a pump that reached EOF clears
+        // the number it would otherwise report.
+        let mut writers = Vec::new();
+        let mut reports = Vec::new();
+        for _ in 0..2 {
+            let (out_writer, out_reader) = tokio::net::unix::pipe::pipe().unwrap();
+            let (err_writer, err_reader) = tokio::net::unix::pipe::pipe().unwrap();
+            let pipes = PipeFds {
+                out: Some(out_reader.as_raw_fd()),
+                err: Some(err_reader.as_raw_fd()),
+                stdin: None,
+                channel: None,
+            };
+            let (logs_tx, _logs) = mpsc::channel(CHANNEL_CAPACITY);
+            let (ctl, ctl_rx) = mpsc::channel(CHANNEL_CAPACITY);
+            spawn_log_pump(
+                Some(out_reader),
+                Some(err_reader),
+                LogSink::Path(out_path.clone()),
+                LogSink::Path(err_path.clone()),
+                logs_tx,
+                ctl_rx,
+                pipes,
+            );
+            let (done, ack) = oneshot::channel();
+            ctl.send(LogCtl::ReportFds { done }).await.unwrap();
+            let fds = timeout(PUMP_DEADLINE, ack)
+                .await
+                .expect("a descriptor report must be acknowledged")
+                .expect("the pump must answer rather than drop the acknowledgement");
+            // `_logs` and `ctl` are kept alive alongside the writers: a pump
+            // whose control channel closed would end and close the very
+            // handles whose numbers are being compared.
+            writers.push((out_writer, err_writer, ctl, _logs));
+            reports.push(fds);
+        }
+
+        let named: Vec<RawFd> = reports
+            .iter()
+            .flat_map(|fds| fds.all().into_iter().flatten())
+            .collect();
+        assert_eq!(
+            named.len(),
+            8,
+            "two running instances, four descriptors each: {reports:?}"
+        );
+        let distinct: BTreeSet<RawFd> = named.iter().copied().collect();
+        assert_eq!(
+            distinct.len(),
+            8,
+            "a repeat here refuses the whole handover, not just this app: {reports:?}"
+        );
+        // The pointed half of the assertion above: the two log handles are
+        // the pair that could plausibly have been shared, since they are the
+        // only two of the eight opened on the same path.
+        assert_ne!(
+            reports[0].out_log, reports[1].out_log,
+            "two instances sharing one log file must still hold two handles"
+        );
+        assert_ne!(reports[0].err_log, reports[1].err_log);
+        drop(writers);
+    }
+
     /// Fails if a report still names a stream whose descriptor the pump has
     /// already let go of.
     ///

--- a/crates/shep-daemon/src/tokio_runner.rs
+++ b/crates/shep-daemon/src/tokio_runner.rs
@@ -91,22 +91,18 @@ const LOG_BUFFER: usize = 8 * 1024;
 /// buffer until its next one, which for some sheep is never.
 const IDLE_FLUSH: Duration = Duration::from_millis(50);
 
-/// Bytes a descriptor report writes out of a stream's reader before it
-/// stops, per stream.
+/// Bytes each stream's reader may hold ahead of the lines it has emitted.
 ///
-/// A `BufReader` reads ahead by [`LOG_BUFFER`] and no further, so one
-/// bufferful is the whole of what a report can find stranded in userspace,
-/// and stranded is the word: those bytes are behind the descriptor the blob
-/// carries rather than in it, and the `execve` destroys them. What the
-/// drain declines to take is in no danger, because it is still in the
-/// kernel's pipe and the successor inherits the pipe by number.
-///
-/// The bound is what keeps the two apart. Without it a report served while
-/// a chatty sheep is writing would go on reading for as long as the sheep
-/// kept it fed, and the handover would wait on a sheep rather than on a
-/// buffer.
+/// Asked for explicitly rather than left to `BufReader`'s default, which is
+/// the same 8 KiB, because this number is load-bearing twice over and a
+/// default is a poor place to keep a bound someone has to reason about.
+/// It is the whole of what a handover can find stranded in userspace: bytes
+/// taken off the pipe and not yet written are behind the descriptor the
+/// blob carries rather than in it, and the `execve` destroys them. It is
+/// also the whole of what [`drain_ready`] can write, which is what keeps a
+/// descriptor report answerable while a chatty sheep runs.
 #[cfg(unix)]
-const MAX_DRAIN: usize = LOG_BUFFER;
+const READ_BUFFER: usize = 8 * 1024;
 
 /// Real [`crate::runner::ProcessRunner`] over actual OS processes.
 #[derive(Debug, Default)]
@@ -1339,16 +1335,24 @@ impl LogFiles {
     /// blob cannot be closed and handed to the next `open` before the
     /// successor adopts it.
     ///
-    /// # The residual
+    /// # The residual, measured
     ///
-    /// A fragment of a line in flight at the exec is still lost.
-    /// [`tokio::io::Lines`] accumulates the line it is part-way through in
-    /// a private field and exposes only its inner reader, so bytes taken
-    /// towards a line whose newline has not arrived are reachable by
-    /// nothing here. What that costs is a fragment of the one line the
-    /// sheep had not finished writing, against the block the parking
-    /// itself saves. Closing it means the pump reading through a buffer it
-    /// owns rather than through `Lines`.
+    /// One line per reload at most, and often none. The line the sheep was
+    /// part-way through at the exec is split between the tail of the
+    /// reader's buffer and [`tokio::io::Lines`]' own accumulator, which is
+    /// private, and its head dies with the image: the successor picks the
+    /// pipe up mid-line and writes the tail as a line of its own. Three
+    /// reloads of a sheep emitting about 1.6M lines/second lost 3, 1 and 2
+    /// lines across three runs (2026-08-30), against 2872 for the same
+    /// drill on the pump this replaced.
+    ///
+    /// Closing it means the pump reading through a buffer it owns rather
+    /// than through `Lines`, so that it can write the whole line. Writing
+    /// the reader's tail out verbatim instead is NOT the cheap version of
+    /// that: every write this pump makes is a whole line today, and several
+    /// sheep can share one file (`merge_logs`), where a partial write and
+    /// its continuation are two `write(2)`s that another instance's line
+    /// can land between. That would trade one torn line for two.
     fn reading(&self) -> bool {
         #[cfg(unix)]
         {
@@ -1483,6 +1487,13 @@ impl LogFiles {
             // it is the same fix.
             #[cfg(unix)]
             LogCtl::ReportFds { done } => {
+                // First, though nothing between here and the answer could
+                // read a stream anyway: `serve` runs to completion inside
+                // the pump's own task, which is the only reader either
+                // stream has. Setting it here makes that invariant local
+                // instead of something to re-derive from the task
+                // structure.
+                self.parked = true;
                 drain_ready(&mut streams.out, &mut self.out).await;
                 drain_ready(&mut streams.err, &mut self.err).await;
                 for file in [&mut self.out, &mut self.err] {
@@ -1490,7 +1501,6 @@ impl LogFiles {
                         tracing::error!(%error, "log flush before a handover report failed");
                     }
                 }
-                self.parked = true;
                 let _ = done.send(crate::handover::CarriedFds {
                     out_pipe: self.pipes.out,
                     err_pipe: self.pipes.err,
@@ -1632,6 +1642,23 @@ where
     }
 }
 
+/// One stream's reader, at the capacity a handover reasons about.
+///
+/// A free function rather than an inline `BufReader::with_capacity` at each
+/// of the two call sites, so the two cannot drift: [`drain_ready`]'s bound
+/// is this capacity, and a stream built at some other one would strand more
+/// than the bound says.
+#[cfg(unix)]
+fn with_read_buffer<R: AsyncRead>(reader: R) -> BufReader<R> {
+    BufReader::with_capacity(READ_BUFFER, reader)
+}
+
+/// See the unix definition above; nothing here reasons about the capacity.
+#[cfg(not(unix))]
+fn with_read_buffer<R: AsyncRead>(reader: R) -> BufReader<R> {
+    BufReader::new(reader)
+}
+
 /// A pump's two line readers, held in one place so a control request can
 /// reach them.
 ///
@@ -1651,20 +1678,46 @@ struct Streams<O, E> {
     err: Option<Lines<BufReader<E>>>,
 }
 
-/// Writes out whatever one stream's reader has already taken off its pipe,
-/// and stops as soon as the reader would have to wait for more.
+/// Writes out the whole lines one stream's reader is already holding, and
+/// touches the pipe behind it not at all.
 ///
-/// This is what a descriptor report owes the successor, and it is bounded
-/// twice over: by [`MAX_DRAIN`], and by the reader having nothing ready.
-/// The bound is what keeps a report from following a sheep that is still
-/// writing, since on a busy stream the pipe is ready again the instant it
-/// is read.
+/// This is what a descriptor report owes the successor. The reader has
+/// taken up to [`READ_BUFFER`] off the pipe that the successor will never
+/// see there, and the `execve` destroys it: those bytes reach a file only
+/// if this image writes them.
+///
+/// # Why it must not read the pipe
+///
+/// Measured, at about 1.6M lines/second (2026-08-30). A drain that reads
+/// while it writes refills the reader as fast as it empties it, so any
+/// budget it stops at leaves a reader holding bytes it has JUST taken out
+/// of the pipe. The loss is then buffer-shaped rather than rate-shaped and
+/// does not shrink with a larger budget, because a bigger budget reads more
+/// as well as writing more: three reloads at that rate lost 1954 lines
+/// through a drain bounded by an emitted-byte count.
+///
+/// Stopping at "no whole line is buffered" instead has neither problem. The
+/// buffer strictly shrinks, since a `read_line` that finds its delimiter
+/// already buffered returns without a syscall, so the loop cannot follow a
+/// sheep however fast it writes and needs no budget at all. What it leaves
+/// is bounded by [`READ_BUFFER`] because that is the reader's whole
+/// capacity.
+///
+/// # What it still leaves
+///
+/// The partial line at the end of the buffer, plus anything
+/// [`tokio::io::Lines`] is holding in the private accumulator it does not
+/// expose. Those are the same line: the one the sheep had not finished
+/// writing. It reaches the log as its own tail, since the successor picks
+/// the pipe up mid-line, so a reload's seam costs one line rather than a
+/// block. Closing that means the pump reading through a buffer it owns
+/// rather than through `Lines`.
 ///
 /// EOF and a read failure both end the drain and are left for the pump's
-/// own loop to see, which it does when it resumes. A report that met one
-/// still names that stream's descriptor: the reader has not been dropped,
-/// so the number is still this process's, and the successor adopts a pipe
-/// that is at EOF exactly as this pump would have found it.
+/// own loop to see when it resumes. A report that met one still names that
+/// stream's descriptor: the reader has not been dropped, so the number is
+/// still this process's, and the successor adopts a pipe at EOF exactly as
+/// this pump would have found it.
 ///
 /// Nothing drained here is forwarded on `logs_tx`, deliberately. That
 /// channel feeds live `log.*` bus subscribers, and every one of them is
@@ -1676,19 +1729,16 @@ async fn drain_ready<R>(lines: &mut Option<Lines<BufReader<R>>>, file: &mut LogF
 where
     R: AsyncRead + Unpin,
 {
-    let mut drained = 0;
-    while drained < MAX_DRAIN {
-        // `biased`, so the ready branch is the answer to "the reader had
-        // nothing waiting" rather than a coin flip against a reader that
-        // did. `next_line` is documented cancel-safe, so the poll that
-        // loses costs nothing: a partial line stays in the reader.
-        let ready = tokio::select! {
-            biased;
-            result = next_line(lines) => result,
-            () = core::future::ready(()) => return,
+    let Some(reader) = lines.as_mut() else {
+        return;
+    };
+    while reader.get_ref().buffer().contains(&b'\n') {
+        // Ready on the first poll, and that is the loop's whole argument: a
+        // delimiter already in the buffer means no `read(2)`, so nothing
+        // new arrives to replace what is written.
+        let Ok(Some(line)) = reader.next_line().await else {
+            return;
         };
-        let Ok(Some(line)) = ready else { return };
-        drained += line.len() + 1;
         file.append(&line).await;
     }
 }
@@ -1780,8 +1830,8 @@ fn spawn_log_pump<O, E>(
             parked: false,
         };
         let mut streams = Streams {
-            out: stdout.map(|reader| BufReader::new(reader).lines()),
-            err: stderr.map(|reader| BufReader::new(reader).lines()),
+            out: stdout.map(|reader| with_read_buffer(reader).lines()),
+            err: stderr.map(|reader| with_read_buffer(reader).lines()),
         };
 
         while streams.out.is_some() || streams.err.is_some() {
@@ -2598,6 +2648,124 @@ mod tests {
         );
     }
 
+    /// Fails if a report takes bytes off a pipe that it does not write.
+    ///
+    /// The invariant the successor depends on, and the one no other case
+    /// here can see. Every byte the sheep wrote has to be in one of two
+    /// places when the report is answered: in the log file, because this
+    /// pump wrote it, or still in the pipe, because the successor inherits
+    /// the pipe by descriptor number. A byte in neither is a byte the
+    /// `execve` destroys.
+    ///
+    /// A drain that reads the pipe while it writes produces those by the
+    /// bufferful, and nothing else in this module notices, because on this
+    /// side of an exec the stranded bytes are still in the reader and a
+    /// resumed pump emits them quite happily. It took a real reload at
+    /// about 1.6M lines/second to find, at 2872 lines lost across three
+    /// reloads. Hence the second handle: a `try_clone` shares one open file
+    /// description, so what it can still read is exactly what the successor
+    /// would have found.
+    ///
+    /// The one line of slack is [`drain_ready`]'s documented residual: the
+    /// line the sheep was part-way through is split between the reader's
+    /// buffer and `Lines`' private accumulator, and its head is not
+    /// reachable from here. Slack, not silence: this fails at two.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn a_report_leaves_in_the_pipe_everything_it_did_not_write() {
+        let dir = tempfile::tempdir().unwrap();
+        let out_path = dir.path().join("out.log");
+        let (reader, mut writer) = std::io::pipe().unwrap();
+        // The successor's view, taken before the pump owns the reader.
+        let inherited = reader.try_clone().unwrap();
+        let reader =
+            tokio::net::unix::pipe::Receiver::from_owned_fd(OwnedFd::from(reader)).unwrap();
+        let (logs_tx, logs) = mpsc::channel(CHANNEL_CAPACITY);
+        let (ctl, ctl_rx) = mpsc::channel(CHANNEL_CAPACITY);
+        let pipes = PipeFds {
+            out: Some(reader.as_raw_fd()),
+            err: None,
+        };
+        spawn_log_pump(
+            Some(reader),
+            None::<DuplexStream>,
+            LogSink::Path(out_path.clone()),
+            LogSink::Path(dir.path().join("err.log")),
+            logs_tx,
+            ctl_rx,
+            pipes,
+        );
+
+        // More than one `READ_BUFFER`, so the reader is full and the pipe
+        // still holds the rest; under `SMALLEST_PIPE`, so this write does
+        // not park against a pump that has stopped draining.
+        let lines = u32::try_from(SMALLEST_PIPE * 3 / 4 / RUN_LINE).unwrap();
+        let run: String = (1..=lines).map(|n| format!("{n:07}\n")).collect();
+        assert!(run.len() > READ_BUFFER, "the reader must fill");
+        std::io::Write::write_all(&mut writer, run.as_bytes()).unwrap();
+        wait_for_a_full_logs_channel(&logs).await;
+
+        let (done, ack) = oneshot::channel();
+        ctl.send(LogCtl::ReportFds { done }).await.unwrap();
+        timeout(PUMP_DEADLINE, ack)
+            .await
+            .expect("a descriptor report must be acknowledged")
+            .expect("the pump must answer rather than drop the acknowledgement");
+
+        // The sheep goes quiet, so the inherited handle reaches EOF rather
+        // than waiting for a writer that outlives the test.
+        drop(writer);
+        let rest = read_to_eof(inherited).await;
+        let written = fs::read_to_string(&out_path).unwrap();
+        assert!(
+            run.starts_with(&written),
+            "the pump must write the run's own bytes, in order"
+        );
+        assert!(
+            run.ends_with(&rest),
+            "what is left in the pipe must be the run's own tail"
+        );
+        assert!(
+            written.len() + rest.len() >= run.len() - RUN_LINE,
+            "{} of {} bytes reached neither the file ({}) nor the pipe ({}): the report read \
+             them out of the pipe and then dropped them",
+            run.len() - written.len() - rest.len(),
+            run.len(),
+            written.len(),
+            rest.len()
+        );
+    }
+
+    /// Everything still readable from a pipe handle, to EOF.
+    ///
+    /// `WouldBlock` is retried rather than treated as the end: the handle
+    /// shares its open file description with a `tokio` reader, which put
+    /// the description in non-blocking mode, so an empty moment reads as an
+    /// error rather than as a wait.
+    #[cfg(unix)]
+    async fn read_to_eof(handle: std::io::PipeReader) -> String {
+        let mut out = Vec::new();
+        let mut buf = [0_u8; 4096];
+        let drained = timeout(PUMP_DEADLINE, async {
+            loop {
+                match std::io::Read::read(&mut &handle, &mut buf) {
+                    Ok(0) => return,
+                    Ok(n) => out.extend_from_slice(&buf[..n]),
+                    Err(error) if error.kind() == io::ErrorKind::WouldBlock => {
+                        tokio::time::sleep(Duration::from_millis(5)).await;
+                    }
+                    Err(error) => panic!("the successor's handle must be readable: {error}"),
+                }
+            }
+        })
+        .await;
+        assert!(
+            drained.is_ok(),
+            "the pipe must reach EOF once the sheep is gone"
+        );
+        String::from_utf8(out).expect("a pipe of ASCII lines")
+    }
+
     /// The smallest buffer a pipe starts with on any host these cases run
     /// on: macOS opens one at 16 KiB, Linux at 64.
     ///
@@ -2614,11 +2782,11 @@ mod tests {
     /// Fails if a report follows a sheep that is still writing instead of
     /// rescuing what its reader already held.
     ///
-    /// [`MAX_DRAIN`] is what stops the two from being the same loop. A
-    /// reader can strand at most one bufferful, and what the drain declines
-    /// to take is not lost: it is still in the kernel's pipe, which the
-    /// successor inherits by descriptor number. So the bound costs nothing
-    /// and is what keeps a report answerable while a chatty sheep runs.
+    /// A reader can strand at most one [`READ_BUFFER`], and the drain
+    /// writes whole lines out of that buffer without reading the pipe
+    /// behind it, so it cannot write more than the buffer held however fast
+    /// the sheep is writing. The slack is one line: [`tokio::io::Lines`]
+    /// may have been part-way through one before the buffer was filled.
     #[cfg(unix)]
     #[tokio::test]
     async fn a_report_drains_at_most_one_bufferful() {
@@ -2628,7 +2796,7 @@ mod tests {
         // parks.
         let lines = u32::try_from(SMALLEST_PIPE * 3 / 4 / RUN_LINE).unwrap();
         let run: String = (1..=lines).map(|n| format!("{n:07}\n")).collect();
-        assert!(run.len() > MAX_DRAIN, "the run must reach the bound");
+        assert!(run.len() > READ_BUFFER, "the run must reach the bound");
         pump.out_writer.write_all(run.as_bytes()).await.unwrap();
         wait_for_a_full_logs_channel(&pump.logs).await;
         pump.flush().await;
@@ -2642,7 +2810,7 @@ mod tests {
             "the report must rescue what the reader was holding"
         );
         assert!(
-            drained <= u64::try_from(MAX_DRAIN + RUN_LINE).unwrap(),
+            drained <= u64::try_from(READ_BUFFER + RUN_LINE).unwrap(),
             "the report drained {drained} bytes, which is more than one \
              bufferful: it is following the sheep rather than catching up"
         );

--- a/crates/shep-daemon/tests/real_runner.rs
+++ b/crates/shep-daemon/tests/real_runner.rs
@@ -999,6 +999,7 @@ fn adopt_spec(dir: &tempfile::TempDir, pid: u32, reaper: &Arc<AdoptedReaper>) ->
         out_log: None,
         err_log: None,
         stdin_pipe: None,
+        channel: None,
         reaper: Arc::clone(reaper),
     }
 }
@@ -1142,4 +1143,98 @@ async fn an_adopted_pump_appends_the_carried_pipes_lines_through_the_carried_han
         .await
         .expect("the adopted pid must be reaped within the budget");
     assert_eq!(outcome.code, Some(0));
+}
+
+/// A `/bin/sh` child that holds the far end of a socketpair on fd 3 and
+/// echoes each shepherd message back once, exactly as
+/// [`channel_echo_script`] does for a spawned sheep.
+///
+/// Spawned with `command-fds` rather than through `TokioRunner::spawn`,
+/// which is the whole point of the fixture: the case below is about the
+/// SUCCESSOR's half, so the socketpair has to be one this test owns the
+/// daemon side of. A child the runner spawned would keep its half inside the
+/// pumps the runner wired, where nothing here can reach it.
+///
+/// A `std::process::Command`, so tokio holds no `Child` and the reaper is
+/// the only thing that will ever wait it — the same reason
+/// [`adopted_child`] uses one.
+fn child_holding_a_channel(child_end: std::os::fd::OwnedFd, rounds: u32) -> std::process::Child {
+    use command_fds::{CommandFdExt as _, FdMapping};
+
+    let mut command = std::process::Command::new("/bin/sh");
+    command.args(["-c", &channel_echo_script(rounds)]);
+    command
+        .fd_mappings(vec![FdMapping {
+            parent_fd: child_end,
+            child_fd: 3,
+        }])
+        .expect("map the socketpair onto the child's fd 3");
+    command.spawn().expect("spawn a shell holding fd 3")
+}
+
+/// fails if an adopted shepherd channel does not reach a real app that is
+/// blocking on `read -r line <&3`.
+///
+/// The successor's half of what 2b task 5 carries, against a real process
+/// rather than a socket pair with a test on both ends. Two things can only
+/// be checked here. The child is a separate open file description, so the
+/// `set_nonblocking(true)` the adoption puts on the daemon's end must not
+/// reach it: a plain shell `read` on a non-blocking fd 3 gets `EAGAIN` and
+/// the child dies with status 3 rather than waiting. And the reply has to
+/// come back up through the reader task the adoption rebuilt, which is what
+/// `{"kind":"ready"}` and every action reply ride.
+#[tokio::test]
+#[expect(
+    clippy::zombie_processes,
+    reason = "the reaper collects this status; a Child::wait would take it first"
+)]
+async fn an_adopted_channel_reaches_a_real_child_that_blocks_on_fd_3() {
+    let dir = tempfile::tempdir().unwrap();
+    let (daemon_end, child_end) = std::os::unix::net::UnixStream::pair().unwrap();
+    // Cleared for the child's end exactly as the spawn path clears it: both
+    // ends come back non-blocking from `pair()`, and a shell `read` on one
+    // fails instead of parking.
+    child_end.set_nonblocking(false).unwrap();
+    let child = child_holding_a_channel(std::os::fd::OwnedFd::from(child_end), 1);
+    let pid = child.id();
+
+    daemon_end.set_nonblocking(true).unwrap();
+    let daemon_end = tokio::net::UnixStream::from_std(daemon_end).unwrap();
+    let reaper = Arc::new(AdoptedReaper::new());
+    let mut spec = adopt_spec(&dir, pid, &reaper);
+    spec.channel = Some(daemon_end);
+
+    let (mut proc, mut io) = TokioRunner::new()
+        .adopt(spec)
+        .expect("the real runner must be able to adopt");
+
+    io.to_child
+        .send(ShepherdMessage::Action {
+            name: "round-1".to_string(),
+            params: None,
+            id: 1,
+        })
+        .await
+        .expect("an adopted sheep must still have a channel writer");
+    let reply = tokio::time::timeout(CHANNEL_DEADLINE, io.from_child.recv())
+        .await
+        .expect("the child must answer over the adopted channel")
+        .expect("the adopted reader must forward the reply");
+    assert_eq!(
+        reply,
+        ChildMessage::ActionReply {
+            action: "round-1".to_string(),
+            body: "ok".to_string(),
+            id: None,
+        }
+    );
+
+    let outcome = tokio::time::timeout(REAP_DEADLINE, proc.wait())
+        .await
+        .expect("the adopted pid must be reaped within the budget");
+    assert_eq!(
+        outcome.code,
+        Some(0),
+        "status 3 is the child's own `read` failing, which is a non-blocking fd 3"
+    );
 }

--- a/crates/shep-daemon/tests/real_runner.rs
+++ b/crates/shep-daemon/tests/real_runner.rs
@@ -998,6 +998,7 @@ fn adopt_spec(dir: &tempfile::TempDir, pid: u32, reaper: &Arc<AdoptedReaper>) ->
         err_pipe: None,
         out_log: None,
         err_log: None,
+        stdin_pipe: None,
         reaper: Arc::clone(reaper),
     }
 }

--- a/docs/brainstorming/specs/2026-08-29-daemon-handover-design.md
+++ b/docs/brainstorming/specs/2026-08-29-daemon-handover-design.md
@@ -238,6 +238,30 @@ back to the stop arm, which is correct rather than merely tolerable.
   containing anything else takes the stop arm.
 - **2b, the surface.** Shepherd channel, stdin, dogs, multi-instance, and
   re-arming watch, cron and memory limits.
+
+  **2a measured three more requirements into this stage, none of which the
+  fitness gate can refuse, because none is visible in an app's config.**
+
+  - **The pump's reader loses whatever it has consumed and not yet
+    emitted.** Measured during 2a with a sheep emitting as fast as the pipe
+    allows, three runs of three: after `10917` came `1916`, which is not a
+    suffix of `10918`, so roughly a thousand lines died and the successor
+    resumed mid-number. 8a's flush empties `LogFile`'s WRITE buffer; nothing
+    empties the reader's. 2b has to carry it, and until it does a busy
+    sheep's reload loses about a second of log.
+  - **`report_fds` has no deadline.** A stalled pump blocks the handover and
+    its graceful-stop fallback. The fix is not local: a timed-out live pump
+    must not collapse into `CarriedFds::none()`, since that is what a
+    STOPPED sheep reports, and the gate would then pass a wedged sheep with
+    its descriptors silently dropped. Telling the two apart changes the
+    snapshot's return type and reaches the gate.
+  - **A reported descriptor is not pinned until `execve`.** An EOF or a
+    `LogFile::reopen` can release a number the blob already names, and a
+    later open can reuse it. `adopt`'s kind check makes a pipe landing on a
+    log fail loudly; a log handle landing on a log handle stays quiet. This
+    one is an ownership design rather than a patch: either the reported
+    descriptors are duplicated into handover-owned storage, or retirement
+    and reopening are serialised against the exec.
 - **2c, the hard cases.** A handover mid-reload, `manual` and
   `pending_delete`, the counters, the reload deadline watchdog, and rollback
   when a rehydrate fails.

--- a/docs/brainstorming/specs/2026-08-29-daemon-handover-design.md
+++ b/docs/brainstorming/specs/2026-08-29-daemon-handover-design.md
@@ -513,12 +513,35 @@ Dog processes are children of the daemon, so they survive the exec exactly
 as sheep do. What does not survive is their accepted connection, because
 carrying an accepted connection would mean carrying mid-stream codec state
 and pending requests across the image swap. So every dog sees its
-connection drop and reconnects, which it already does today.
+connection drop.
 
-The reconnect re-handshakes against the new daemon. A compatible dog is
-back in seconds with **no process restart at all**. An incompatible one is
-refused at exactly the moment the daemon can see it, which is the trigger
-G8 needs.
+**It does not reconnect. This section said "which it already does today"
+until 2b measured it on 2026-08-30, and that clause was the whole reason
+this looked cheap.** There is no reconnect in `DogRuntime::start`, in
+`metrics::run`, or in `bark::run_loop`. What a carried dog actually
+becomes is a live process holding a dead socket: over six real reloads the
+metrics dog kept its pid, reported zero restarts, stayed `online`, wrote
+nothing to stderr, and answered HTTP 503 to every scrape from the first
+reload onward. Nothing anywhere says so, which makes it worse than G6's
+mismatched dog -- that one at least writes a line per interval.
+
+The two built-in dogs do not even fail alike. Bark survives by accident,
+exiting 0 on EOF so autorestart catches it, which is neither what this
+section describes nor what G7 wants.
+
+So the reconnect is work Phase 3 has to build, not behaviour it can
+assume. The layer is `shep-client` rather than each dog: every dog links
+it, G9 already has a plain `cargo install <dog>` picking it up, and the
+dog contract does not change. A dog-side fix would reach only dogs that
+adopt it, and a daemon-side one cannot work at all -- `Hello` carries no
+dog identity, so a successor cannot map a connection back to its dog.
+
+Once it exists, the reconnect re-handshakes against the new daemon. A
+compatible dog is back in seconds with **no process restart at all**. An
+incompatible one is refused at exactly the moment the daemon can see it,
+which is the trigger G8 needs -- and a reconnecting client is precisely
+where G8's refusal and G13's `Client::daemon()` staleness have to be
+answered, which is why 2b could not finish this and stopped.
 
 Contrast the stop arm, which respawns every dog from disk whether it needed
 it or not.

--- a/docs/specs/deferred.md
+++ b/docs/specs/deferred.md
@@ -487,6 +487,44 @@ something `just` plus three lines of shell does not already do should stop
 there.
 
 
+### Shepherd-channel libraries for the languages apps are written in
+
+The maintainer's, 2026-08-30, after asking whether an app could speak fd 3
+using something that already exists. Wanted, in her own list: **node, go,
+rust, python**.
+
+**Today an app can, badly.** `shep_core::protocol::channel` exports
+`ChildMessage`, `ShepherdMessage` and `CHANNEL_VERSION`, all serde-derived,
+and shep-core is published. But it is a daemon's core rather than a client:
+an app that wants two enums also gets toml, serde-saphyr, json5, regex,
+tokio, croner, chrono, chrono-tz, globset, tempfile and nix. Hand-rolling
+against [shepherd-channel.md](../shepherd-channel.md) is about forty lines
+and the better trade, which is an odd thing to have to say about one's own
+published crate. The other three languages have nothing at all.
+
+**There is no example anywhere.** `examples/` holds seven Rust binaries and
+four polyglot apps in Go, Node, Python and static HTML, and not one of them
+speaks fd 3. The contract doc has two code blocks and one of them is JSON.
+The wire is specified in prose and demonstrated nowhere, which is the real
+barrier for anyone deciding whether to adopt it.
+
+**Three things a hand-roll gets wrong**, each named in `channel.rs`'s own
+module doc: an app must reply to a `ShepherdMessage::Action` even when it
+does not recognise the name; it should echo the `id` so the reply is matched
+to its exact trigger, and the name-and-order fallback costs something when
+it does not; and there is a `params` quoting gap. Those are what a library
+encodes once and prose asks every author to get right separately. Windows is
+a fourth, since fd 3 is a named pipe there and every client needs two arms.
+
+**Sequencing, offered as a recommendation rather than a decision.** Working
+examples first, because the repository already has an app in every one of
+the four languages: Rust under `examples/src/bin/`, and Go, Node and Python
+under `examples/polyglot/`. Teaching those four to speak fd 3 is a small
+diff against files that already exist, and it gives every community app
+something to copy. A library second, for whichever language earns one. The
+four chosen are also the ones the surrounding ecosystem is written in, so
+the examples serve the whole audience on their own.
+
 ## A readiness probe cannot verify a reload's replacement
 
 Found on 2026-08-28 by deploying real repositories with shep-deploy against a

--- a/docs/specs/deferred.md
+++ b/docs/specs/deferred.md
@@ -365,6 +365,52 @@ tell it apart from a shep bug.
 The full postmortem, including the wrong diagnosis it took to get here, is in
 [deferred-history.md](deferred-history.md).
 
+### A config edit reaches nothing, and the warning about it is wrong
+
+Found 2026-08-30, from the maintainer's question: an app running four
+instances, `instances = 5` edited into the Flockfile, and no way to get the
+fifth without restarting the other four.
+
+For `instances` alone there is a way. `shep stock web 5` fills the lowest free
+slot and leaves 0 through 3 running, writing the new count onto the stored
+spec and into the muster roll. For every other field there is nothing.
+`handle_reload` and the restart path both say so in as many words --
+*"Nothing here re-reads configuration."* The only route is `shep delete`
+followed by `shep start`, which restarts every instance.
+
+`Request::ConfigDrift` closed half of this: an edit that will not apply is
+reported rather than vanishing without a word. Applying it was left open
+deliberately, in the code -- *"Whether `start` should reconcile by default, or
+grow an `--update` flag, is the maintainer's call and neither is taken here."*
+
+**The fields split three ways, and the first group is larger than "a config
+change needs a restart" suggests.**
+
+- **Read at decision time, so nothing need be restarted.** `autorestart`,
+  `max_restarts`, `min_uptime`, `restart_delay`, `exp_backoff_restart_delay`
+  and `stop_exit_codes` are read by `brain::decide` when a sheep exits;
+  `kill_signal`, `kill_timeout` and `graceful_timeout` when a kill ladder
+  runs; `max_memory`, `cron_restart`, `cron_timezone`, `watch` and the
+  liveness probe when `extras` arms a worker, which it already does through
+  `arm_instance`/`disarm_instance`. A write-back takes effect at the next such
+  decision with no disruption at all.
+- **Consumed at spawn, so they reach the next process rather than the running
+  one.** `listen_timeout` and `readiness_probe`.
+- **Baked into the child, so one instance swap each.** `script`, `args`,
+  `cwd`, `interpreter`, `env`, `user`, `group`, `out_file`, `err_file`,
+  `merge_logs`, `channel`, `stdin`, `wait_ready`.
+
+**`shep stock` already proves every mechanism a wider verb needs**: normalize
+before write, write-back onto the stored spec, partial-failure handling, and
+muster-roll persistence. `AppConfig::drifted_fields` already computes which
+fields moved. What is missing is the routing between the three groups.
+
+**One part of this is a bug rather than a gap.** The drift warning tells the
+operator that "`shep start` adds instances to a sheep the flock already has".
+True of the daemon's `Request::Start`, false of the `shep start` an operator
+types: the CLI sorts apps into resumed and fresh, and only fresh ones reach
+that request. The sentence describes something no terminal can produce.
+
 ## Ideas, recorded but not designed
 
 Not debt, not deferred spec surface, and not promised to anybody. Things worth

--- a/docs/writing-plans/plans/2026-08-30-handover-phase2b.md
+++ b/docs/writing-plans/plans/2026-08-30-handover-phase2b.md
@@ -333,6 +333,14 @@ Eight, each applied alone and reverted afterwards.
 
 One flake was created and fixed in passing. The first version of the adopt-side case wrote four lines through two `tokio::fs::File` handles with one flush at the end, and failed once in twelve runs on `zero-1/one-1/one-2/zero-2`: a `tokio::fs::File` buffers and hands the real `write(2)` to the blocking pool, so an ordered assertion over two handles is an assertion about that pool. Flushing after every line makes each write land before the next begins. Twelve clean runs afterwards.
 
+##### Follow-up defect: the serial sweep, fixed
+
+Task 6 measured the arithmetic and did not fix it: `spawn_handover_task` visited pumps one after another, so a flock of N wedged pumps cost N times `REPORT_DEADLINE` (2s) before the caller's own fallback could even start. Past six wedged pumps that sweep already outlasted `shep-cli`'s `admin::KILL_TEARDOWN_WAIT` (10s), and reaching six had just become `instances = 6` in one stanza rather than six separate app stanzas. Worse than a slow reload: the client gave up first, fell back to `connect_or_spawn_client`, connected to the PREDECESSOR (still serving, since only the snapshot task was blocked), mustered against it, and exited 0. The sweep then finished seconds later on the actual successor, `fitness` refused on `PumpUnresponsive`, and the daemon took the graceful-stop fallback: an operator who saw exit 0 was left with no flock seconds afterward.
+
+Fixed by visiting the pumps CONCURRENTLY (`futures_util::future::join_all`, the same primitive `spawn_send_line_task` already uses for `STDIN_WRITE_TIMEOUT`) instead of a `for` loop. The worst case is now one `REPORT_DEADLINE` regardless of N. `join_all` returns its results in input order rather than completion order, so the id-sorted order `handle_handover_snapshot` establishes before spawning the task survives into both the candidates and the blob with no re-sort needed, and each pump's report still carries its own sheep's identity, so attribution (`RefusedReason::PumpUnresponsive { sheep }`) is unaffected by the race. `spawn_reopen_task` was deliberately left serial: its caller carries `rpc`'s own per-request budget rather than a fixed client-side wait, so the same trade does not apply there.
+
+Measured: six wedged pumps, serial 12s, concurrent 2s (both virtual time, under a paused tokio clock). A normal single-sheep reload (three reloads of a chatty `awk` counter, no wedged pumps) was re-run by hand to confirm the drill is unaffected: every reload exit 0, shepherd pid and sheep pid both unmoved, 25,579,208 lines with zero gaps and zero duplicates after `shep stop`.
+
 ---
 
 ### Task 8: re-arm audit, and the end-to-end case
@@ -372,7 +380,7 @@ Baselines on that drill, three reloads: `origin/main` loses about 2900 lines, 2b
 - The rejected buffer-carry patch is at `stash@{0}` and in this session's scratchpad as `task1-carry.patch`. Read it for plumbing, not design.
 - `handover/mod.rs`'s module header names the three refusals left, all of them 2c's. Task 7 has one more to strike, `Dog`, and four tests currently using it as their refusal fixture will need moving with it.
 - PR #73 has two threads left open for 2b. Both are now addressed: the `report_fds` deadline is task 2, and descriptor pinning fell out of task 1's parking. They can be closed with a pointer to those commits.
-- `spawn_handover_task` visits sheep serially, so a flock of wedged pumps waits N x 2s before the fallback. Named in `REPORT_DEADLINE`'s doc, not fixed, and task 6 added the arithmetic against the client's own 10s: six wedged pumps is where the sweep outlasts the caller, and `instances = 6` is now a way to get there.
+- `spawn_handover_task` used to visit sheep serially, so a flock of wedged pumps waited N x 2s before the fallback, and past six that outlasted the client's 10s wait and reached exit 0 with no flock. Fixed by a follow-up defect task: see "Follow-up defect: the serial sweep, fixed" under Task 6.
 
 ## Phase gate
 

--- a/docs/writing-plans/plans/2026-08-30-handover-phase2b.md
+++ b/docs/writing-plans/plans/2026-08-30-handover-phase2b.md
@@ -93,21 +93,23 @@ A 950-line patch is preserved in this session's scratchpad as `task1-carry.patch
 
 Whether the blob still carries buffered bytes at all is now an open question rather than a given. A parked pump's reader may simply be empty by construction, in which case the field goes.
 
-- [ ] **Step 1: Write the failing test**
+**Answered: no field.** A parked pump's reader is NOT empty by construction, because `select!` can serve the report while a line sits ready in the `BufReader`, and a pump parked on a full `logs` channel holds a bufferful. So the report DRAINS the reader into the log file before it answers, bounded at one bufferful (`MAX_DRAIN`), instead of copying it into the blob. What the drain declines to take is not lost: it is still in the kernel's pipe, which the successor inherits by number. That leaves `CarriedFds` unchanged, so no wire or blob change, and no adopt-side prepend.
+
+- [x] **Step 1: Write the failing test**
 
 The measurement that matters is a chatty sheep across a reload, with every line appearing exactly once, in order. The rejected attempt's harness proved a test can pass while the log is duplicating, so assert absence of duplicates as well as absence of gaps.
 
-- [ ] **Step 2: Run to verify it fails**
+- [x] **Step 2: Run to verify it fails**
 
-- [ ] **Step 3: Implement, including the un-park**
+- [x] **Step 3: Implement, including the un-park**
 
-- [ ] **Step 4: Prove it non-vacuous**
+- [x] **Step 4: Prove it non-vacuous**
 
-- [ ] **Step 5: Drive a real reload, on a sheep fast enough to tear**
+- [x] **Step 5: Drive a real reload, on a sheep fast enough to tear**
 
 An `awk` or shell loop emitting with no sleep. The rejected design passed every suite it had and failed here, three runs of three.
 
-- [ ] **Step 6: Task gate, then commit**
+- [x] **Step 6: Task gate, then commit**
 
 ### Task 2: a deadline on `report_fds`, and an answer that is not ambiguous
 

--- a/docs/writing-plans/plans/2026-08-30-handover-phase2b.md
+++ b/docs/writing-plans/plans/2026-08-30-handover-phase2b.md
@@ -438,6 +438,121 @@ The mechanism needs no proving: bark is already running it, six times over, in t
 
 The end-to-end case is 2a's, widened: a flock containing every kind 2b now carries, reloaded, with pids unchanged and no gap in any sheep's log.
 
+- [x] **Step 1: Audit every H2 row against the code, and prove each by behaviour**
+- [x] **Step 2: Widen 2a's end-to-end case to every kind 2b carries**
+- [x] **Step 3: Prove each test non-vacuous**
+- [x] **Step 4: Drive the reload drill by hand, on a flock of all six kinds**
+- [x] **Step 5: Task gate, then commit**
+
+#### The audit
+
+Every row read off the code, then proved by watching the daemon do it. Reading `arm_extras` and finding a call is not the proof this phase accepts: an un-armed cron and a dead watch debouncer are both *alive but silently not working*, which is the shape that has now cost three separate defects. So every arm below was tripped AFTER the exec and the restart it produced was observed.
+
+| H2 row | what re-arms it | how it was proved | verdict |
+|---|---|---|---|
+| log file handles, pipe read ends | carried by number, `install_adopted` | 112,619,085 lines over 3 reloads of an 8-sheep flock: 0 lost, 0 duplicates, 0 seams | carried |
+| stdin pipe | carried (task 4) | `shep whisper` after 3 reloads, echo in the sheep's own log from the unmoved pid | carried |
+| shepherd channel | carried (task 5) | `shep trigger` answered `pong-21415`, the CHILD's own pid, after 3 reloads | carried |
+| readiness wait (`wait_ready`, `readiness_probe`) | re-armed in `install_adopted` from `listen_timeout` (task 5) | the channel sheep is `online` and answering after 3 reloads | re-armed |
+| per-instance sampling (`StatsState::watch`) | `arm_extras` -> `arm_instance` | `memory_bytes` non-null on every row immediately after the reload; it is filled only from a WATCHED root | re-armed |
+| memory limit | `arm_extras` -> `arm_instance` | a gated balloon opened after the exec: `greedy` 66614 -> 68846, and the daemon's record names `pid=66614`, the adopted pid | re-armed |
+| liveness probe | `arm_extras` -> `arm_instance` | a probe tripped after the exec: `probed` 69719 -> 70118 | re-armed |
+| cron schedule | `arm_extras` -> `arm_cron` (per name) | a `* * * * *` occurrence 50s after the exec: `scheduled` 69715 -> 70780 | re-armed |
+| filesystem watch | `arm_extras` -> `arm_watch` (per name) | a file written under the watched tree after the exec: `watched` 69714 -> 70101 | re-armed |
+| watch debouncer | nothing, and H2 says so | the debounce window lives inside a third-party thread; the watch above is rebuilt, the in-flight window is not | lost, accepted |
+| CPU% baseline | nothing; the next periodic tick rebuilds it | `cpu_percent` null on every row immediately after the reload, real figures back within one `MEMORY_POLL_INTERVAL` | lost, accepted |
+| in-flight RPCs | nothing | the exec drops every accepted connection | lost, accepted |
+| bus subscriptions | nothing | `lookout` repairs drift on its own two-second poll | lost, accepted |
+| pending action waiters | nothing; `actions: ActionWaits::default()` | each carries its own `action_timeout` | lost, accepted |
+| smits | nothing; `smits: Smits::new()` | not an H2 row, and consistent with one: a smit belongs to the connection that painted it, and every connection drops | lost, consistent |
+| the three counters | carried by the blob, restored before any slot (2a) | `the_successor_does_not_reissue_a_live_id` | carried |
+| **pending restart timer** | **nothing, and this is the finding** | see below | **was lost; now re-armed** |
+
+Five of the six things `ExtrasRegistry::arm` builds are covered by that one `arm_extras` call, and the sixth (the debouncer) is the row H2 already gives up. `arm` is name-aware, so a clustered app's instances join one `NameExtras` group and its cron and watch are built once (task 6). Nothing in H2's own list is unaccounted for.
+
+#### The finding: a sheep owed a restart never got one
+
+`Actor::schedule_restart` spawns a task that sleeps and then sends `Msg::RestartDue`. That task is a `tokio::spawn` of the predecessor's, and the `execve` takes it. `handle_restart_due` is the only thing that moves a sheep off `WaitingRestart`. So a successor installed the status and nothing was left to act on it.
+
+Measured on the release build before the fix, an app exiting immediately with `restart_delay = "45s"`:
+
+| | shepherd pid | sheep status | restarts |
+|---|---|---|---|
+| before the reload | 17353 | `waiting-restart` | 0 |
+| after, t+10s to t+70s | 17353 unmoved | `waiting-restart` | **0, every reading** |
+| control, no reload at all | - | `waiting-restart` -> respawned at t+45s | **1** |
+
+Seventy seconds past a forty-five second delay, on a shepherd whose pid proves the handover ran. The control is the attribution: the same app under the same daemon, not reloaded, restarts on time.
+
+**Not a narrow race.** The default `exp_backoff_restart_delay` climbs to 15s, so a crash-looping app spends most of its life in this status, and upgrading the shepherd is exactly what an operator does about a crash-looping app. The status is the worst part: `shep flock` keeps printing `waiting-restart`, which reads as *coming back*.
+
+Same shape as the `Starting` strand task 5 closed, and closed the same way. `install_adopted` re-arms from `crate::backoff::restart_delay(app.config(), 1)`: the elapsed part of the wait is a `tokio::time::Instant` from a runtime that no longer exists, so what is re-armed is the delay a FIRST unstable exit would get, which is what the fresh `RestartBudget` beside it already asserts this image believes. An explicit `restart_delay` is honoured in full (an operator's pacing is never shortened by a reload), an exponential-backoff app gets its initial step, and one that opted out of both restarts at once.
+
+One unit case and one end-to-end case. A second unit case was written, could not be made non-vacuous, and was deleted -- see the mutations below.
+
+#### The end-to-end cases
+
+Three added to `crates/shep-cli/tests/cli_e2e.rs`.
+
+`a_flock_of_every_carried_kind_survives_a_daemon_reload` is 2a's, widened to six apps and eight rows: a counter, a `stdin = true` echoer, a `channel` + `wait_ready` sheep, a `shutdown_with_message` sheep, a clustered app with separate logs and a clustered app with `merge_logs`. One flock rather than five, because the descriptor rules are whole-flock rules: `refuse_repeated_fds` refuses the ENTIRE blob over one repeated number, and a mixed flock is the only place six kinds of descriptor are ever numbered together. 2.5s.
+
+`every_lifecycle_extra_is_re_armed_across_a_daemon_reload` reloads first and only then writes the file, opens the balloon gates and trips the probe, because a watch armed by the predecessor and one armed by the successor are indistinguishable if the trigger fires before the exec. `control` runs the same ballooning script through its own gate and configures no extra at all, so a restart it shares is the case restarting sheep rather than an arm firing. 33s, dominated by the cron minute.
+
+`a_sheep_owed_a_restart_still_gets_one_after_a_daemon_reload` is the finding's case. Its precondition is asserted twice, and the second one is load-bearing: if the delay had elapsed while `daemon reload` was running, the predecessor would have respawned the sheep before the exec and the final assertion would pass without proving anything. 9.6s.
+
+**One fixture bug found while writing the third arm, worth recording because it cost an hour.** The probe was first written as `test ! -f <trip>` with the sheep's own script clearing `<trip>` on the way up, so a restart would heal itself. It never fired. The script's `rm` does not run when the sheep is spawned; it runs when the shell is first scheduled, which under a loaded debug build was **half a second after `shep flock` already reported the sheep `online`** -- and it deleted the file the case had just written. Inverted to `test -f <healthy>`, tripped by deleting and healed by the case rather than by the script. The same lag does not touch the other three arms: none of them has a script that consumes its own trigger.
+
+#### Drill, measured
+
+Eight sheep, all six kinds, three `shep daemon reload`s. `awk` with no sleep at roughly 1.6M lines a second for the four counters, `shep stop all` before counting.
+
+Every reload exit 0, shepherd unmoved at 21392, all eight pids unmoved at 21413, 21414, 21415, 21416, 21418, 21419, 21420 and 21421, restarts 0 throughout.
+
+| log | lines | groups it holds | lost | duplicates | seams |
+|---|---|---|---|---|---|
+| `fast-0-out.log` | 22,872,640 | plain counter | 0 | 0 | 0 |
+| `split-0-out.log` | 22,470,627 | `0\|21418` only | 0 | 0 | 0 |
+| `split-1-out.log` | 22,373,113 | `1\|21419` only | 0 | 0 | 0 |
+| `merged-out.log` | 44,902,705 | `0\|21420` and `1\|21421` | 0 | 0 | 0 |
+
+**112,619,085 lines, 0 whole lines lost, 0 duplicates, 0 seams, 0 unparsable.** Better than task 5 (4 seams in 52.3M) and task 6 (1 in 23.8M) measured, which is the residual behaving like the residual it is rather than anything changing.
+
+Afterwards, on the same never-restarted processes:
+
+- `shep whisper echoer after-reload` -> `heard: after-reload` in `echoer-0-out.log`, pid 21414, uptime continuous at 1m 25s.
+- `shep trigger chatty ping` -> `pong-21415`, the child's own pid.
+- `shep stop bye` -> `told: {"kind":"shutdown"}` in the log and a clean exit 0, so the write direction still reached a child three execs later.
+- `memory_bytes` non-null on every row the moment the reload returned; `cpu_percent` null on every row and back to real figures (5.9% to 10.7%) within one sampling window.
+
+The re-arm drill is its own flock and its own run: five apps, one reload, every trigger fired after the exec, shepherd unmoved at 69693.
+
+| arm | before | after the trigger | control |
+|---|---|---|---|
+| watch | `watched` 69714, restarts 0 | 70101, restarts 1, at t+5s | `control` unmoved |
+| liveness probe | `probed` 69719, restarts 0 | 70118, at t+5s | `control` unmoved |
+| memory limit | `greedy` 69716, restarts 0 | 70195, restarts 1, at t+15s | `control` ballooned identically, restarts 0 |
+| cron | `scheduled` 69715, restarts 0 | 70780, restarts 1, at t+50s | `control` unmoved |
+
+#### Mutations
+
+Five, each applied alone and reverted afterwards.
+
+| # | what was broken | what failed |
+|---|---|---|
+| 1 | `install_adopted` drops the `WaitingRestart` re-arm | `an_adopted_sheep_owed_a_restart_still_gets_one`, and nothing else in 647 daemon lib tests; plus the e2e case |
+| 2 | `install_adopted` drops `arm_extras` for an adopted `Online` sheep | **the e2e re-arm case ONLY**, at its sampling assertion, in 3.3s; all 646 daemon lib tests stay green, and so do the other four handover e2e cases |
+| 3 | `install_adopted` writes `instance: 0` on every adopted entry | **the two clustered e2e cases ONLY**; 646 daemon lib tests stay green |
+| 4 | the spawn side reports no stdin descriptor | `a_spawn_reports_the_write_end_it_put_on_the_childs_stdin`, and the widened e2e case at its pid assertion -- a stdin sheep the blob cannot number sends the whole flock down the stop arm |
+| 5 | `handle_restart_due` drops its status guard | `a_stopping_sheep_rejects_a_restart_due`, which is how the deleted case below was found |
+
+**Mutation 2 is the finding worth keeping.** The successor's extras arming has no unit-level cover at all, in either scope: not the per-instance half (sampling, memory limit, liveness) and not the name-group half (cron, watch). `ExtrasRegistry`'s own tier arms the registry by hand, so it can never see whether `install_adopted` calls it, and every daemon lib test stays green with the call deleted. The only thing that notices is a real flock, reloaded, with a real file written under a real watched tree afterwards.
+
+**One case was written and then deleted, which is the honest outcome of the exercise.** `an_adopted_stopped_sheep_is_not_respawned` asserted that the new re-arm does not reach a slot an operator had stopped. No mutation could redden it: making the re-arm unconditional leaves it green, because `handle_restart_due`'s own status guard refuses a `Stopped` slot, and that guard is already pinned by `a_stopping_sheep_rejects_a_restart_due`. A test nothing can break is noise in a file whose convention is a "fails if" line per case, so it went. The guard in `install_adopted` stays -- it is what stops a pointless timer task per registered-and-stopped slot -- but it is belt to `handle_restart_due`'s braces, not the only thing holding.
+
+#### Docs
+
+`web/src/pages/docs/getting-started.astro` said "The first reload after upgrading to this version always takes that path, because the shepherd being replaced predates the handover." That was written while the handover was unreleased. v0.1.18 shipped with it, so the sentence is now only true coming from 0.1.17 or earlier, and it reads to a 0.1.18 user as a promise that their first reload will restart their flock. Reworded to name 0.1.17 explicitly. The generated CLI reference is unchanged: this task added no verb, flag, key or exit code.
+
 ---
 
 ## The reload drill, exactly
@@ -464,8 +579,8 @@ Baselines on that drill, three reloads: `origin/main` loses about 2900 lines, 2b
 
 ## Working state, for whoever picks this up
 
-- Branch `feat/handover-2b`, unpushed, no PR. Tasks 1, 2, 4, 5 and 6 committed; task 3 folded into 1; task 7 measured and stopped, nothing committed but its writeup.
-- Counts after task 6: **644** daemon lib with `--skip ::slow::`, **2099** workspace.
+- Branch `feat/handover-2b`, unpushed, no PR. Tasks 1, 2, 4, 5, 6 and 8 committed; task 3 folded into 1; task 7 measured and stopped, nothing committed but its writeup.
+- Counts after task 8: **646** daemon lib with `--skip ::slow::`. The branch is based on 0.1.17 and `main` has since moved to 0.1.19; rebasing is the maintainer's, not a task's.
 - The rejected buffer-carry patch is at `stash@{0}` and in this session's scratchpad as `task1-carry.patch`. Read it for plumbing, not design.
 - `handover/mod.rs`'s module header names the three refusals left, all of them 2c's. Task 7 was going to strike `Dog` and did not: the carry works and leaves the metrics dog silently mute, so the gate still refuses. See Task 7's own section for the measurement and the two candidate designs. The four tests using `Dog` as their refusal fixture stay where they are until that decision is made.
 - PR #73 has two threads left open for 2b. Both are now addressed: the `report_fds` deadline is task 2, and descriptor pinning fell out of task 1's parking. They can be closed with a pointer to those commits.

--- a/docs/writing-plans/plans/2026-08-30-handover-phase2b.md
+++ b/docs/writing-plans/plans/2026-08-30-handover-phase2b.md
@@ -42,71 +42,72 @@ So: **drive a real reload by hand before pushing anything that touches the hando
 
 ---
 
-### Task 1: carry the pump's reader buffer
+### Task 1: quiesce the pump at the report
 
 **Files:**
-- Modify: `crates/shep-daemon/src/handover/mod.rs` (`CarriedSheep`)
 - Modify: `crates/shep-daemon/src/tokio_runner.rs` (the pump, `LogCtl::ReportFds`)
-- Modify: `crates/shep-daemon/src/handover/adopt.rs` (seed the successor's reader)
+- Modify: `crates/shep-daemon/src/handover/mod.rs` (an un-park path for the abort case)
 - Test: alongside
 
-**The defect, measured rather than reasoned.** The pump reads through `Lines<BufReader<ChildStdout>>`. At the exec, bytes the `BufReader` has consumed from the pipe and not yet emitted die with the image. 8a's flush empties `LogFile`'s WRITE buffer; nothing empties the reader's.
+**This task was "carry the pump's reader buffer" and that design was wrong.** It was built, measured on a real flock, and rejected. What follows replaces it, and Task 3 folds into it, because both are the same defect.
 
-2a measured it with a sheep emitting as fast as the pipe allows, three runs of three:
+#### Why carrying the buffer is not enough, measured
 
-| after | next line | expected |
-|---|---|---|
-| `7385` | `2` | `7386` |
-| `4872` | `00` | `4873` |
-| `10917` | `1916` | `10918` |
+The blob is a snapshot. The pump is live. Between `ReportFds` and the `execve` the pump keeps reading and emitting, so the bytes the successor prepends are bytes the predecessor has ALREADY written to the log file.
 
-The third is the shape of the whole thing. `1916` is not a suffix of `10918`, so what died was not one line: it was everything the reader held, and the resume landed about a thousand lines further on.
+From a real reload, with the carry in place:
 
-**The design.** The buffered bytes are just bytes. Carry them per stream in the blob, and have the successor prepend them to its fresh reader before it reads the pipe. Order is preserved because those bytes came off the pipe before anything still in the kernel buffer.
+```
+after 5082301 came 5060798, then 459 lines of old output, then 5083785
+459 lines x 8 bytes = 3672, exactly the out=3672 the report answered
+grep -c "^5060798$"  ->  2
+```
 
-Do NOT try to solve this by draining and emitting. A drain still has to do something with a trailing partial line, and writing it out as a line is a smaller tear rather than no tear.
+Once where the predecessor wrote it, once where the successor replayed it. So the carry adds duplication and reordering on top of the tear it was meant to remove.
 
-**A size bound is required.** `BufReader`'s default capacity is 8 KiB per stream, so a bounded flock's blob grows by a bounded amount. State the bound in the code and assert it, so a future capacity change cannot silently make the blob unbounded.
+#### The second loss, which was not on this plan at all
+
+A slower sheep leaves the reader empty at every report, so the carry does nothing, and **roughly 400 lines still vanish per reload**. Those are lines appended after the report's flush and killed in `LogFile`'s WRITE buffer at the exec.
+
+Read side and write side, same window.
+
+#### The design
+
+**After answering `ReportFds`, the pump stops reading its streams until the exec.** Then the snapshot, the flush and the reported descriptor numbers are all still true when the exec happens, because nothing has moved since they were taken.
+
+That is one change closing three residuals: the read-side tear, the write-side loss, and Task 3's unpinned descriptors, which cannot be pinned while their owner is still consuming.
+
+**An un-park path is required and is the sharp edge.** A handover that reports and then aborts must leave the pump reading again, or a failed reload silently stops a sheep's logging for the rest of the daemon's life. `exec_into` already has an error path that restores `FD_CLOEXEC`; the un-park belongs with it.
+
+#### What quiescing does NOT fix
+
+`tokio::io::Lines` exposes `get_ref` and `get_mut` but not its own partial-line accumulator, so a fragment in flight at the exec is still lost. That window is a pump parked mid-line with an empty `BufReader`, costing a fragment of one line rather than a block. Closing it means the pump reading through a buffer it owns rather than through `Lines`, which is a larger change and is not this task. Document the residual where the parking happens.
+
+#### What to keep from the rejected attempt
+
+A 950-line patch is preserved in this session's scratchpad as `task1-carry.patch`, and the work in it is not wasted:
+
+- `ReportFds` is served in TWO places, `LogFiles::serve` and `reserve_slot`, and neither could see the readers, which were locals in the spawned task. Threading them through as a `Streams<O, E>` struct is needed by the parking design too.
+- One borrow detail worth not rediscovering: bind `deliver_line(..).await`'s result before matching on it. A scrutinee's temporaries outlive the arms, and an arm clears the reader that future was reading.
+- `CarriedFds::MAX_BUFFERED = 8 * 1024`, asserted by a test that writes 11.6 KiB through a parked pump.
+
+Whether the blob still carries buffered bytes at all is now an open question rather than a given. A parked pump's reader may simply be empty by construction, in which case the field goes.
 
 - [ ] **Step 1: Write the failing test**
 
-```rust
-#[tokio::test]
-async fn a_carried_reader_buffer_survives_the_handover() {
-    // The regression is only visible when the reader is NOT empty at the
-    // exec, which is why the sheep has to outrun the pump rather than tick
-    // politely. A test with a sleeping writer passes without the fix.
-    let pump = PumpHarness::start_over_pipes();
-    write_fast(&pump, 1..=5_000).await;
-    let fds = report_fds(&pump).await;
-    assert!(
-        !fds.out_buffered.is_empty(),
-        "this case proves nothing unless the reader is holding bytes"
-    );
-
-    let adopted = adopt_with(fds);
-    let seen = read_all_lines(&adopted).await;
-    assert_unbroken_sequence(&seen);
-}
-```
-
-The first assertion is the important one. Without it the test silently degrades to the empty-buffer case and passes against no implementation at all, which is the failure mode three separate 2a tasks hit.
+The measurement that matters is a chatty sheep across a reload, with every line appearing exactly once, in order. The rejected attempt's harness proved a test can pass while the log is duplicating, so assert absence of duplicates as well as absence of gaps.
 
 - [ ] **Step 2: Run to verify it fails**
 
-- [ ] **Step 3: Implement**
+- [ ] **Step 3: Implement, including the un-park**
 
-- [ ] **Step 4: Run to verify it passes, and prove it non-vacuous**
+- [ ] **Step 4: Prove it non-vacuous**
 
-Drop the carried bytes on the floor in the successor and confirm the test fails with a tear. Report the mutation and its output.
+- [ ] **Step 5: Drive a real reload, on a sheep fast enough to tear**
 
-- [ ] **Step 5: Drive a real reload**
-
-Per the note above. A chatty sheep, several reloads, `shep bleats` unbroken across all of them.
+An `awk` or shell loop emitting with no sleep. The rejected design passed every suite it had and failed here, three runs of three.
 
 - [ ] **Step 6: Task gate, then commit**
-
----
 
 ### Task 2: a deadline on `report_fds`, and an answer that is not ambiguous
 
@@ -118,7 +119,11 @@ Sketch only; expand when Task 1 lands.
 
 ---
 
-### Task 3: pin a reported descriptor until the exec
+### Task 3: pin a reported descriptor until the exec (FOLDED INTO TASK 1)
+
+Quiescing the pump pins the descriptors by construction: a parked pump does not hit EOF and does not reopen, so a reported number cannot be released and reused before the exec. Keep this heading as the record of why the task disappeared, and verify the property holds once Task 1 lands rather than assuming it.
+
+The original statement follows.
 
 A reported number is not owned by anything between `ReportFds` and `Handover::write`. An EOF or a `LogFile::reopen` can release it, and a later open can reuse it. `adopt`'s kind check makes a pipe landing on a log fail loudly; a log handle landing on a log handle stays quiet.
 

--- a/docs/writing-plans/plans/2026-08-30-handover-phase2b.md
+++ b/docs/writing-plans/plans/2026-08-30-handover-phase2b.md
@@ -12,9 +12,9 @@
 
 **The three structural tasks come first.** The tear is not a property of the sheep 2b adds; it affects every sheep 2a already carries. Widening the gate first would ship a known defect to more apps and make it harder to attribute when it bites. Fix the foundation, then widen.
 
-1. carry the pump's reader buffer
+1. quiesce the pump at the report (was "carry the reader buffer"; that design was measured and rejected, see Task 1)
 2. give `report_fds` a deadline, with an answer that distinguishes a wedged pump from a stopped one
-3. pin a reported descriptor until the exec
+3. pin a reported descriptor until the exec (folded into 1: a parked pump cannot release a number)
 4. stdin
 5. the shepherd channel
 6. multi-instance

--- a/docs/writing-plans/plans/2026-08-30-handover-phase2b.md
+++ b/docs/writing-plans/plans/2026-08-30-handover-phase2b.md
@@ -134,11 +134,37 @@ The cheap fix was designed and rejected. Writing the reader's tail out verbatim 
 
 ### Task 2: a deadline on `report_fds`, and an answer that is not ambiguous
 
-A stalled pump blocks the handover AND its graceful-stop fallback, so the daemon has no way out.
+**Files:**
+- Modify: `crates/shep-daemon/src/supervisor.rs` (`handover_snapshot`)
+- Modify: `crates/shep-daemon/src/handover/mod.rs` (`fitness`, and whatever carries the answer)
+- Test: alongside
 
-The fix is not a timeout wrapper. `CarriedFds::none()` is what a STOPPED sheep reports, so collapsing a timed-out live pump into it would let the fitness gate carry a wedged sheep with its descriptors silently dropped, which is worse than the hang. The snapshot needs a third answer, and it has to reach the gate.
+A stalled pump blocks the handover AND its graceful-stop fallback, so the daemon has no way out at all.
 
-Sketch only; expand when Task 1 lands.
+**The fix is not a timeout wrapper.** `CarriedFds::none()` is what a STOPPED sheep reports. Collapsing a timed-out live pump into it would let the fitness gate carry a wedged sheep with its descriptors silently dropped, which is worse than the hang it replaces. The snapshot needs a third answer and it has to reach the gate, which is why this is a signature change rather than a local fix.
+
+**Task 1 sharpened this.** A pump that answers `ReportFds` now parks; one that times out never parked, so it is still reading while every other pump is frozen. Two things follow and neither is optional:
+
+- a timed-out pump must NOT appear in `ParkedPumps`, or the resume path will wake something that was never asleep
+- the already-parked pumps must be resumed when the snapshot refuses, exactly as the fitness refusal resumes them. A handover abandoned on a timeout leaves the rest of the flock parked otherwise, which is a silent logging stop for the life of the daemon and is worse than the wedge
+
+**The gate refuses on the third answer.** A sheep whose pump did not answer is not carryable, and the stop arm is correct for it.
+
+- [ ] **Step 1: Write the failing tests**
+
+At minimum: a pump that never answers makes the snapshot refuse rather than hang; the refusal names that sheep; a timed-out pump is not in the parked set; and every pump that DID park is resumed when the snapshot refuses.
+
+The last one is the easy one to omit and the expensive one to omit.
+
+- [ ] **Step 2: Run to verify they fail**
+
+- [ ] **Step 3: Implement**
+
+Pick the deadline deliberately and say why in the code. It bounds a flush plus a drain of at most one buffer per stream, so it is a small multiple of a disk write rather than a guess.
+
+- [ ] **Step 4: Prove non-vacuous, then task gate and commit**
+
+A real reload is not required here, since nothing about the healthy path changes. Say so rather than skipping it silently.
 
 ---
 

--- a/docs/writing-plans/plans/2026-08-30-handover-phase2b.md
+++ b/docs/writing-plans/plans/2026-08-30-handover-phase2b.md
@@ -200,6 +200,37 @@ The end-to-end case is 2a's, widened: a flock containing every kind 2b now carri
 
 ---
 
+## The reload drill, exactly
+
+Every task that touches the carried path needs this, and getting it slightly wrong hides the defect. Recorded verbatim because three attempts were lost to variations of it.
+
+```sh
+printf '#!/bin/sh\nawk '"'"'BEGIN{i=1; while(1){print i; i++}}'"'"'\n' > /tmp/qc/fast.sh
+chmod +x /tmp/qc/fast.sh
+printf '[[app]]\nname = "fast"\nscript = "/tmp/qc/fast.sh"\ninterpreter = "sh"\n' > /tmp/qc/Flockfile.toml
+export SHEP_HOME=/tmp/qc/home
+```
+
+Then start, reload three times with a `sleep 1` between, `shep stop fast`, and only then count.
+
+Four things that each cost real time to learn:
+
+- **The rate is the whole point.** A sheep with a `sleep` between lines does not tear. `awk` with no sleep gives roughly 1.6M lines a second; a shell `echo` loop gives about 10k and shows nothing. A defect measured as fixed at 10k reappeared at 100x.
+- **`$SHEP_HOME` must be short.** The control socket refuses a path over 103 bytes, and the session scratchpad path is 119. Use `/tmp/<short>/home`.
+- **Stop the sheep before counting.** The teardown produces its own seam, which otherwise reads as a duplicate and sends you chasing the wrong thing.
+- **Count seam-aware.** A tear shows as a gap PLUS one part-eaten line, for example `14097652 / 7828 / 14097829`, where `7828` is the tail of `14097828`. A counter that treats a non-increasing step as a rewind reports nonsense like "32M lines lost". Count forward gaps and duplicates separately.
+
+Baselines on that drill, three reloads: `origin/main` loses about 2900 lines, 2b task 1's first attempt about 1950, the shipped version 0 to 3.
+
+## Working state, for whoever picks this up
+
+- Branch `feat/handover-2b`, unpushed, no PR. Tasks 1 and 2 committed; task 3 folded into 1.
+- Counts after task 2: **623** daemon lib with `--skip ::slow::`, **2076** workspace.
+- The rejected buffer-carry patch is at `stash@{0}` and in this session's scratchpad as `task1-carry.patch`. Read it for plumbing, not design.
+- `handover/mod.rs`'s module header still says "Phase 2a carries only the plainest sheep", which goes wrong as tasks 4 to 7 land.
+- PR #73 has two threads left open for 2b. Both are now addressed: the `report_fds` deadline is task 2, and descriptor pinning fell out of task 1's parking. They can be closed with a pointer to those commits.
+- `spawn_handover_task` visits sheep serially, so a flock of wedged pumps waits N x 2s before the fallback. Named in `REPORT_DEADLINE`'s doc, not fixed.
+
 ## Phase gate
 
 The four per-task commands, plus:

--- a/docs/writing-plans/plans/2026-08-30-handover-phase2b.md
+++ b/docs/writing-plans/plans/2026-08-30-handover-phase2b.md
@@ -186,7 +186,7 @@ Sketch only.
 
 One refusal each, from `handover::fitness`: `Stdin`, `Channel`, `MultiInstance`, `Dog`.
 
-`Stdin` is one more descriptor through machinery that already carries four. The channel is a socketpair with two pump tasks, structurally the log pipes again. Multi-instance is the one to distrust: `merge_logs` gives several sheep handles on ONE inode, and 8a measured that the fd count does not fall when logs are merged. Dogs survive the exec as children for free; what needs designing is their reconnect, and Phase 3 owns their version axis.
+`Stdin` is one more descriptor through machinery that already carries four. The channel was sketched as "a socketpair with two pump tasks, structurally the log pipes again"; it is one descriptor rather than two, it needs no parking, and the work turned out to be in two places the sketch did not name — see task 5's outcome. Multi-instance is the one to distrust: `merge_logs` gives several sheep handles on ONE inode, and 8a measured that the fd count does not fall when logs are merged. Dogs survive the exec as children for free; what needs designing is their reconnect, and Phase 3 owns their version axis.
 
 Sketch only. Each removes exactly one variant and its test.
 
@@ -216,6 +216,64 @@ One residual, not closed and not new. A pump inside `write_all` at the exec leav
 ##### Drill, measured
 
 Six `shep daemon reload`s over a flock of two, one of them `/bin/cat` with `stdin = true`. Every reload exit 0, the shepherd's pid unmoved at 97553, both sheep unmoved at 97575 and 97576, uptime continuous. A `shep whisper` after each reload reached the same never-restarted `cat`, whose echo landed in its own log file in order, no gaps and no duplicates.
+
+#### Task 5: the shepherd channel
+
+- [x] **Step 1: Write the failing tests**
+- [x] **Step 2: Run to verify they fail**
+- [x] **Step 3: Implement**
+- [x] **Step 4: Prove each one non-vacuous**
+- [x] **Step 5: Drive a real reload, and trigger the sheep afterwards**
+- [x] **Step 6: Task gate, then commit**
+
+##### Outcome
+
+**One descriptor, not two, and no parking.** The sketch called it the log pipes again; it is neither shape. A socketpair is ONE open file description that is read and written at once, so `CarriedFds` grew a sixth field rather than a pair, and `tokio::io::split`'s two halves share it. And the read side needs no quiescence, for three reasons worth keeping:
+
+- the framing is newline-delimited and the reader's error arm warns and continues rather than breaking, so a frame torn at the exec costs one message and resynchronises at the next newline. There is no permanent desync to prevent.
+- every message the window can lose is already bounded. A lost `ready` is absorbed by the successor's re-armed wait, which puts the sheep `Online` at its deadline anyway; a lost `action-reply` had no client left to reach, because the exec dropped that connection; a `metric` is a debug log line.
+- parking a channel reader has a failure mode parking a log pump does not. A missed un-park stops draining fd 3, the socket fills, and the APP blocks on write. The log-pump version of that mistake stops logging.
+
+**The work was in two places the sketch did not name, and neither is about descriptors.**
+
+**The first is `wait_ready`, and it was a real bug rather than a new feature.** A sheep gated on readiness is `Starting`, and the wait that would resolve it is a task of the predecessor's that the `execve` takes away. Nothing else moves a sheep off `Starting` except its own exit, so a successor that adopted one left it there for the rest of that daemon's life: outside `listen_timeout`, outside every status an operator acts on, and without `arm_extras`'s watch, cron and memory limits, which fire at the `Online` transition. `install_adopted` now re-arms the wait from the app's own `listen_timeout`.
+
+That bug was NOT new to this task. `readiness_probe` gates a sheep the same way and the gate has never refused one, so a probe-gated sheep caught mid-start has been carried and stranded since 2a. The `Starting` comment in `install_adopted` recorded the behaviour as a residual; it was reachable on `main`.
+
+One race is not closeable from the successor's side and is documented at the re-arm. The blob is a snapshot taken on the actor loop, so a `{"kind":"ready"}` arriving between it and the exec flips the predecessor's slot without reaching the blob, and the successor then waits for a signal already sent. That wait ends at `listen_timeout` and `handle_ready_result` puts the sheep `Online` anyway, with a warning, so the cost is bounded at one `listen_timeout` of `Starting` on a sheep that was already serving. The alternative was refusing to carry a `Starting` sheep at all, which restarts a whole flock over one app in its first three seconds.
+
+**The second is that the log pump can report a channel number and be wrong about it.** The pump is told the number at the spawn, exactly as it is told stdin's, and stdin's pinning argument does not transfer. The stdin pump ends only when the last sender drops; the channel's WRITER also ends on a write that fails, which is what a child that has closed its fd 3 produces, and the socketpair's last reference goes with it. The number then names whatever the kernel has since handed to the next `open`, and `UnixStream::from(OwnedFd)` checks nothing, so the successor would write a shepherd message into a log file.
+
+`SheepSlot::open_channel` is the fact that actually decides delivery and it is only reachable from the actor loop, so `handle_handover_snapshot` reads it alongside the slot and the snapshot masks the field with it. `adopt_channel` adds the kind check the two pipe fields get free from `from_file`: `getpeername` refuses anything that is not a socket (`ENOTSOCK`) and anything listening rather than connected (`ENOTCONN`, which is what this daemon's own control listener answers).
+
+The drill below measures what that mask is worth, because a build without it was measured too.
+
+**Three refusals left**, and the module header says so now instead of naming 2a: a dog, more than one instance, an in-flight reload, and an operator's pending stop or delete. Two existing tests moved off `channel = true` onto `instances = 2`, since what they are about is the gate firing at all.
+
+##### Drill, measured
+
+Five `shep daemon reload`s over a flock of three: a `wait_ready` + `channel` sheep that answers a `ping` action with its own pid, an `awk` counter with no sleep, and a `shutdown_with_message` sheep.
+
+| | before | after 5 reloads |
+|---|---|---|
+| shepherd pid | 57775 | 57775 |
+| chatty / fast / bye pids | 57796 / 57797 / 57798 | 57796 / 57797 / 57798 |
+| `shep trigger chatty ping` | `replied pong-57796` | `replied pong-57796` after every one |
+
+Every reload exit 0. The reply body carries the CHILD's own pid, which is the assertion a pid check cannot make: a socketpair that survived as a number but was attached to the wrong end, or re-paired by the successor, answers nothing at all. `shep stop bye` afterwards put `told: {"kind":"shutdown"}` in that sheep's log, so the writer direction still reached a child five execs later.
+
+The counter, 52,320,601 lines across those five reloads: **0 whole lines lost, 0 duplicates, 4 seams.** Each seam is task 1's known residual and nothing else, for example `28182606 / 8182607 / 28182608`, where `8182607` is the tail of `28182607`. One of the five reloads produced no seam at all. So carrying the channel did not disturb the log path.
+
+**`wait_ready` across the exec, its own run.** An app that sleeps 8s before writing `{"kind":"ready"}`, with `listen_timeout = "60s"`, reloaded at t+2 while `starting`: shepherd unmoved at 58570, sheep unmoved at 58591, still `starting` at t+8, `online` at t+10, and a `trigger` afterwards answered `pong-58591`. The readiness signal was written AFTER the exec and came up the carried socketpair into a wait the successor armed.
+
+**The mask, measured both ways.** An app that does `exec 3>&-` and keeps running, then two `shep trigger`s (`timed_out`, then `no_channel` once the writer task had broken), then one reload:
+
+| build | reload | shepherd pid | sheep pid |
+|---|---|---|---|
+| shipped | exit 0, handover | 58954 unmoved | 58975 unmoved |
+| mask removed | exit 0, and `the shepherd did not come back on this version after the handover signal; starting one instead` | 59335 → 59461 | 59356 → 59483 |
+
+Without the mask the successor refused to boot on the stale descriptor, the predecessor had already exec'd away, and the CLI's fallback started a fresh shepherd that restarted the flock from the roll. `shep daemon reload` still exited 0. That is the whole cost of the handover, paid silently, after one `shep trigger` at a child that closed fd 3.
 
 ---
 
@@ -251,10 +309,10 @@ Baselines on that drill, three reloads: `origin/main` loses about 2900 lines, 2b
 
 ## Working state, for whoever picks this up
 
-- Branch `feat/handover-2b`, unpushed, no PR. Tasks 1, 2 and 4 committed; task 3 folded into 1.
-- Counts after task 4: **631** daemon lib with `--skip ::slow::`, **2084** workspace.
+- Branch `feat/handover-2b`, unpushed, no PR. Tasks 1, 2, 4 and 5 committed; task 3 folded into 1.
+- Counts after task 5: **641** daemon lib with `--skip ::slow::`, **2096** workspace.
 - The rejected buffer-carry patch is at `stash@{0}` and in this session's scratchpad as `task1-carry.patch`. Read it for plumbing, not design.
-- `handover/mod.rs`'s module header still says "Phase 2a carries only the plainest sheep". Task 4 struck stdin from its list; tasks 5 to 7 have the rest of it to strike.
+- `handover/mod.rs`'s module header now names phase 2b and the three refusals left. Tasks 6 and 7 have the rest of them to strike.
 - PR #73 has two threads left open for 2b. Both are now addressed: the `report_fds` deadline is task 2, and descriptor pinning fell out of task 1's parking. They can be closed with a pointer to those commits.
 - `spawn_handover_task` visits sheep serially, so a flock of wedged pumps waits N x 2s before the fallback. Named in `REPORT_DEADLINE`'s doc, not fixed.
 

--- a/docs/writing-plans/plans/2026-08-30-handover-phase2b.md
+++ b/docs/writing-plans/plans/2026-08-30-handover-phase2b.md
@@ -150,19 +150,19 @@ A stalled pump blocks the handover AND its graceful-stop fallback, so the daemon
 
 **The gate refuses on the third answer.** A sheep whose pump did not answer is not carryable, and the stop arm is correct for it.
 
-- [ ] **Step 1: Write the failing tests**
+- [x] **Step 1: Write the failing tests**
 
 At minimum: a pump that never answers makes the snapshot refuse rather than hang; the refusal names that sheep; a timed-out pump is not in the parked set; and every pump that DID park is resumed when the snapshot refuses.
 
 The last one is the easy one to omit and the expensive one to omit.
 
-- [ ] **Step 2: Run to verify they fail**
+- [x] **Step 2: Run to verify they fail**
 
-- [ ] **Step 3: Implement**
+- [x] **Step 3: Implement**
 
 Pick the deadline deliberately and say why in the code. It bounds a flush plus a drain of at most one buffer per stream, so it is a small multiple of a disk write rather than a guess.
 
-- [ ] **Step 4: Prove non-vacuous, then task gate and commit**
+- [x] **Step 4: Prove non-vacuous, then task gate and commit**
 
 A real reload is not required here, since nothing about the healthy path changes. Say so rather than skipping it silently.
 

--- a/docs/writing-plans/plans/2026-08-30-handover-phase2b.md
+++ b/docs/writing-plans/plans/2026-08-30-handover-phase2b.md
@@ -111,6 +111,27 @@ An `awk` or shell loop emitting with no sleep. The rejected design passed every 
 
 - [x] **Step 6: Task gate, then commit**
 
+#### Outcome, measured after the fact
+
+The drain was manufacturing the loss it existed to prevent. It counted bytes EMITTED against its budget, but every `next_line` on an empty reader issued a `read(2)` pulling up to 8 KiB out of the pipe. On a stream that is never empty the reader refilled as fast as it drained, so when the loop stopped it held bytes it had just taken from the pipe: gone from the pipe the successor inherits, never written, destroyed at the exec. A larger budget would have read more as well as written more, so raising the bound could never have helped.
+
+It now writes only whole lines already in the reader's buffer and stops when no newline remains, so the buffer strictly shrinks and nothing new arrives to replace what is written.
+
+Same drill each time, `awk` with no sleep at roughly 1.6M lines a second, three reloads, `shep stop` before counting:
+
+| build | lines | gaps | lines lost |
+|---|---|---|---|
+| `origin/main` | 19,892,398 | 3 | 2872 |
+| first attempt | 23,038,701 | 3 | 1954 |
+| shipped | 19.3M to 23.8M | 1 to 3 | **1 to 3** |
+| shipped, verified independently | 9,877,880 | 0 | **0** |
+
+Zero duplicates throughout, pid unmoved, every reload exit 0.
+
+**Known limitation, deliberately not closed here.** At most one line per reload, often none: the line the sheep was mid-way through when the report landed, split between the reader's buffer tail and `tokio::io::Lines`' private accumulator, whose head is unreachable. The tail lands in the log as a short line of its own, so the seam reads as a gap plus one part-eaten line rather than a rewind. A naive counter mistakes that for a rewind and reports nonsense.
+
+The cheap fix was designed and rejected. Writing the reader's tail out verbatim would make the seam byte-perfect, but every write this pump makes today is a whole line, and several sheep can share one file under `merge_logs`, where a partial write and its continuation are two `write(2)` calls that another instance's line can land between. That trades one torn line for two. Closing it properly means the pump owning its read buffer rather than using `Lines`, which this plan already defers.
+
 ### Task 2: a deadline on `report_fds`, and an answer that is not ambiguous
 
 A stalled pump blocks the handover AND its graceful-stop fallback, so the daemon has no way out.

--- a/docs/writing-plans/plans/2026-08-30-handover-phase2b.md
+++ b/docs/writing-plans/plans/2026-08-30-handover-phase2b.md
@@ -190,6 +190,33 @@ One refusal each, from `handover::fitness`: `Stdin`, `Channel`, `MultiInstance`,
 
 Sketch only. Each removes exactly one variant and its test.
 
+#### Task 4: stdin
+
+- [x] **Step 1: Write the failing tests**
+- [x] **Step 2: Run to verify they fail**
+- [x] **Step 3: Implement**
+- [x] **Step 4: Prove each one non-vacuous**
+- [x] **Step 5: Drive a real reload, and whisper to the sheep afterwards**
+- [x] **Step 6: Task gate, then commit**
+
+##### Outcome
+
+It was one more descriptor, and `CarriedFds` grew a fifth field for it. The direction changed three things, none of them structural:
+
+- The successor rebuilds it with `pipe::Sender::from_file` rather than `Receiver`, which is the check that refuses a blob naming the end the child reads from.
+- `CarriedFds`'s "all four or none" rule no longer holds. Four descriptors say whether a sheep is running; the fifth says whether its app asked for a pipe on fd 0, which is a different question.
+- The blob format grew a field without moving `VERSION`. Serde already lets an absent `Option` field load as `None`, and `None` is what an older predecessor's blob truthfully means: it refused to carry a stdin sheep at all. A hard parse failure here would leave a successor refusing to boot after its predecessor had exec'd itself away.
+
+**No parking, and the asymmetry is the reason.** A log pump is parked because it READS: bytes it takes off the pipe after the report are bytes the successor cannot find there, and lines it writes after the flush die in the write buffer at the exec. A stdin pump does neither. It writes what an operator hands it, and a line written before the exec is delivered.
+
+What parking also bought was pinning, and stdin gets that from ownership instead: the pump ends only when the last `to_stdin` sender drops, and the supervisor's own slot holds one for as long as the sheep is registered, so the number cannot be closed and reissued between the report and the exec.
+
+One residual, not closed and not new. A pump inside `write_all` at the exec leaves a partial line in the pipe, and the successor's next whisper lands behind it. Any daemon death has always done this, and `LineOutcome::NotWritten` is what the operator gets either way.
+
+##### Drill, measured
+
+Six `shep daemon reload`s over a flock of two, one of them `/bin/cat` with `stdin = true`. Every reload exit 0, the shepherd's pid unmoved at 97553, both sheep unmoved at 97575 and 97576, uptime continuous. A `shep whisper` after each reload reached the same never-restarted `cat`, whose echo landed in its own log file in order, no gaps and no duplicates.
+
 ---
 
 ### Task 8: re-arm audit, and the end-to-end case
@@ -224,10 +251,10 @@ Baselines on that drill, three reloads: `origin/main` loses about 2900 lines, 2b
 
 ## Working state, for whoever picks this up
 
-- Branch `feat/handover-2b`, unpushed, no PR. Tasks 1 and 2 committed; task 3 folded into 1.
-- Counts after task 2: **623** daemon lib with `--skip ::slow::`, **2076** workspace.
+- Branch `feat/handover-2b`, unpushed, no PR. Tasks 1, 2 and 4 committed; task 3 folded into 1.
+- Counts after task 4: **631** daemon lib with `--skip ::slow::`, **2084** workspace.
 - The rejected buffer-carry patch is at `stash@{0}` and in this session's scratchpad as `task1-carry.patch`. Read it for plumbing, not design.
-- `handover/mod.rs`'s module header still says "Phase 2a carries only the plainest sheep", which goes wrong as tasks 4 to 7 land.
+- `handover/mod.rs`'s module header still says "Phase 2a carries only the plainest sheep". Task 4 struck stdin from its list; tasks 5 to 7 have the rest of it to strike.
 - PR #73 has two threads left open for 2b. Both are now addressed: the `report_fds` deadline is task 2, and descriptor pinning fell out of task 1's parking. They can be closed with a pointer to those commits.
 - `spawn_handover_task` visits sheep serially, so a flock of wedged pumps waits N x 2s before the fallback. Named in `REPORT_DEADLINE`'s doc, not fixed.
 

--- a/docs/writing-plans/plans/2026-08-30-handover-phase2b.md
+++ b/docs/writing-plans/plans/2026-08-30-handover-phase2b.md
@@ -186,7 +186,7 @@ Sketch only.
 
 One refusal each, from `handover::fitness`: `Stdin`, `Channel`, `MultiInstance`, `Dog`.
 
-`Stdin` is one more descriptor through machinery that already carries four. The channel was sketched as "a socketpair with two pump tasks, structurally the log pipes again"; it is one descriptor rather than two, it needs no parking, and the work turned out to be in two places the sketch did not name — see task 5's outcome. Multi-instance is the one to distrust: `merge_logs` gives several sheep handles on ONE inode, and 8a measured that the fd count does not fall when logs are merged. Dogs survive the exec as children for free; what needs designing is their reconnect, and Phase 3 owns their version axis.
+`Stdin` is one more descriptor through machinery that already carries four. The channel was sketched as "a socketpair with two pump tasks, structurally the log pipes again"; it is one descriptor rather than two, it needs no parking, and the work turned out to be in two places the sketch did not name — see task 5's outcome. Multi-instance was called the one to distrust, on the grounds that `merge_logs` gives several sheep handles on ONE inode and that 8a measured the fd count not falling when logs are merged. Both halves are true and neither is a problem: several handles on one inode is several NUMBERS, which is what `refuse_repeated_fds` compares, and the fd count not falling is that fact stated the other way round. It was the cheapest of the four; see task 6's outcome. Dogs survive the exec as children for free; what needs designing is their reconnect, and Phase 3 owns their version axis.
 
 Sketch only. Each removes exactly one variant and its test.
 
@@ -275,6 +275,64 @@ The counter, 52,320,601 lines across those five reloads: **0 whole lines lost, 0
 
 Without the mask the successor refused to boot on the stale descriptor, the predecessor had already exec'd away, and the CLI's fallback started a fresh shepherd that restarted the flock from the roll. `shep daemon reload` still exited 0. That is the whole cost of the handover, paid silently, after one `shep trigger` at a child that closed fd 3.
 
+#### Task 6: multi-instance
+
+- [x] **Step 1: Write the failing tests**
+- [x] **Step 2: Run to verify they fail**
+- [x] **Step 3: Implement**
+- [x] **Step 4: Prove each one non-vacuous**
+- [x] **Step 5: Drive a real reload over a merged and an unmerged clustered app**
+- [x] **Step 6: Task gate, then commit**
+
+##### Outcome
+
+**Nothing was needed but striking the refusal, and the reason is that a slot has been a sheep all along.** The supervisor keys its slots on entry id, not on name; `handle_handover_snapshot` walks `self.sheep.values()`; `CarriedSheep` has carried an `instance` field since 2a; and `install_adopted` reassembles from `carried.instance()` rather than from a count. Every descriptor the blob names is per SHEEP, and an app running three instances is three sheep with three pumps and three sets of numbers. The gate was the only thing that had ever treated the app as the unit.
+
+**The `merge_logs` hazard is not real, and here is the measurement rather than the argument.** Each instance's pump runs its own `open_append` on its own `LogFile::open`, so one inode is reached through several open file descriptions with several numbers. On a live two-instance merged app the shepherd held `merged-out.log` on fd **32 and 36**, and `merged-err.log` on **33 and 37**, all four on inode `189235633`. After five reloads it held the same file on **33 and 36**. `refuse_repeated_fds` compares numbers, sees no repeat, and needs no rethinking. Had the premise gone the other way, the failure would have been ugly out of proportion to its cause: that function refuses the WHOLE blob, so every merged clustered app would have sent every reload of its flock down the stop arm forever, with a message naming a descriptor rather than the config that produced it. That is why it now has a case of its own at both ends, `two_pumps_on_one_log_path_report_different_numbers` on the spawn side and `two_instances_sharing_one_log_file_are_both_adopted` on the adopt side.
+
+**Slot identity was already carried, and the mutation run is what says so.** Rehydrating every adopted sheep into slot 0 leaves all **644** daemon lib tests green. So does assembling every adopted sheep's log paths at slot 0. Only the new end-to-end case notices either, and it notices because it reads each `shep flock` row's own `out_file` back and requires the lines in it to name that row's slot and that row's pid. A pid check cannot make that assertion: a slot swap leaves two live processes, both adopted, both `Online`, each answering to the other's name and writing under the other's `SHEP_INSTANCE`.
+
+**Three refusals left**, all 2c's, and the module header says so: a dog, an in-flight reload, and an operator's pending stop or delete. Four existing tests moved onto `Dog` for their refusal fixture, two in `handover` and two in `boot`, which task 7 will have to move again. `instances = 2` was the fixture task 5 had moved them onto for the same reason, so the churn is the phase working rather than a mistake.
+
+**One thing found and deliberately not fixed: `REPORT_DEADLINE`'s arithmetic is now one config line away.** The sweep visits pumps serially at 2s each, and `shep daemon reload` gives the successor `admin::KILL_TEARDOWN_WAIT`, which is 10s. Six wedged pumps is therefore where the sweep outlasts the client that asked; past that the client reports a failed handover and musters against the PREDECESSOR, which is still serving and which then refuses and stops gracefully seconds later, leaving an operator with exit 0 and no flock. Reaching six used to take six app stanzas and now takes `instances = 6`. Nothing about the cost changed and the trigger is still a filesystem that has stopped completing writes, so it is recorded at the constant rather than repaired: the fix is a different shape (visit the pumps concurrently, which still knows which one went quiet) and it belongs with whoever decides what the client should do when the sweep outlasts it.
+
+##### Drill, measured
+
+Five `shep daemon reload`s over six sheep: `split` at three instances with separate logs, `merged` at two instances with `merge_logs = true`, and a single-instance `solo`. Every sheep an `awk` counter with no sleep, tagged `slot|pid|n` so a line names which instance wrote it. Every reload exit 0, shepherd unmoved at 11270, all six pids unmoved at 11291, 11292, 11293, 11294, 11295 and 11298, restarts 0.
+
+| log | lines | groups it holds | lost | duplicates | seams |
+|---|---|---|---|---|---|
+| `split-0-out.log` | 3,952,105 | `0\|11291` only | 0 | 0 | 0 |
+| `split-1-out.log` | 3,961,309 | `1\|11292` only | 0 | 0 | 0 |
+| `split-2-out.log` | 3,965,357 | `2\|11293` only | 0 | 0 | 0 |
+| `solo-0-out.log` | 3,962,322 | `0\|11298` only | 0 | 0 | 0 |
+| `merged-out.log` | 7,946,256 | `0\|11294` and `1\|11295` | 0 | 0 | 1 |
+
+**23,787,349 lines, 0 whole lines lost, 0 duplicates, 1 seam**, and the seam is task 1's known residual wearing a shape only a merged app can wear. Instance 1's line `100030` lost the newline at the end of its write, so instance 0's next line landed on the same row as `1|11295|1000300|11294|100604`, and the orphaned newline turned up 546 lines later as a blank row. Both numbers are physically in the file. Nothing is missing; two lines are fused and one is blank.
+
+**Each split log holds exactly one slot.** That is the assertion the whole task is about, and it is stronger than the pid check beside it: a successor that swapped two slots would leave every pid alive, every log growing and every status `online`, with the only evidence being that slot 0's file says slot 1.
+
+**The `name:slot` selector still reaches one instance after the exec.** On a slower second run, `shep describe split:1` answered `split 1 11899` and `shep stop split:1` stopped exactly that pid, leaving `split:0` and `split:2` online. `merged-out.log` held 40 lines from each of `0|11901` and `1|11902`, interleaved line by line, so both carried handles were still independently writable.
+
+##### Mutations
+
+Eight, each applied alone and reverted afterwards.
+
+| # | what was broken | what failed |
+|---|---|---|
+| 1 | `refusal` refuses `instances > 1` again | `an_app_with_more_than_one_instance_is_carried`, and the e2e case at its refusal assertion |
+| 2 | `CarriedSheep::from_entry` writes `instance: 0` | `each_instance_carries_its_own_slot_and_descriptors` |
+| 3 | `refuse_repeated_fds` also refuses two rows of one name | `two_instances_sharing_one_log_file_are_both_adopted` |
+| 4 | `LogFile::raw_fd` reports one number per PATH rather than per handle | `two_pumps_on_one_log_path_report_different_numbers` |
+| 5 | `refusal` drops the `Dog` check | the four tests moved onto that fixture, plus `a_dog_refuses` |
+| 6 | `install_adopted` writes `instance: 0` on every adopted entry | the e2e case ONLY; 644 daemon lib tests stay green |
+| 7 | `install_adopted` assembles every adopted sheep at slot 0 | the e2e case ONLY; 644 daemon lib tests stay green |
+| 8 | `assemble` ignores `merge_logs` | the e2e case at its fixture check |
+
+6 and 7 are the finding worth keeping. The successor's slot binding has no unit-level cover at all, in either half: not the row's `instance`, and not the log paths assembled from it. Both are reachable only by reloading a real clustered flock and reading each row's own file back, which is what the new e2e case does and what nothing did before.
+
+One flake was created and fixed in passing. The first version of the adopt-side case wrote four lines through two `tokio::fs::File` handles with one flush at the end, and failed once in twelve runs on `zero-1/one-1/one-2/zero-2`: a `tokio::fs::File` buffers and hands the real `write(2)` to the blocking pool, so an ordered assertion over two handles is an assertion about that pool. Flushing after every line makes each write land before the next begins. Twelve clean runs afterwards.
+
 ---
 
 ### Task 8: re-arm audit, and the end-to-end case
@@ -309,12 +367,12 @@ Baselines on that drill, three reloads: `origin/main` loses about 2900 lines, 2b
 
 ## Working state, for whoever picks this up
 
-- Branch `feat/handover-2b`, unpushed, no PR. Tasks 1, 2, 4 and 5 committed; task 3 folded into 1.
-- Counts after task 5: **641** daemon lib with `--skip ::slow::`, **2096** workspace.
+- Branch `feat/handover-2b`, unpushed, no PR. Tasks 1, 2, 4, 5 and 6 committed; task 3 folded into 1.
+- Counts after task 6: **644** daemon lib with `--skip ::slow::`, **2099** workspace.
 - The rejected buffer-carry patch is at `stash@{0}` and in this session's scratchpad as `task1-carry.patch`. Read it for plumbing, not design.
-- `handover/mod.rs`'s module header now names phase 2b and the three refusals left. Tasks 6 and 7 have the rest of them to strike.
+- `handover/mod.rs`'s module header names the three refusals left, all of them 2c's. Task 7 has one more to strike, `Dog`, and four tests currently using it as their refusal fixture will need moving with it.
 - PR #73 has two threads left open for 2b. Both are now addressed: the `report_fds` deadline is task 2, and descriptor pinning fell out of task 1's parking. They can be closed with a pointer to those commits.
-- `spawn_handover_task` visits sheep serially, so a flock of wedged pumps waits N x 2s before the fallback. Named in `REPORT_DEADLINE`'s doc, not fixed.
+- `spawn_handover_task` visits sheep serially, so a flock of wedged pumps waits N x 2s before the fallback. Named in `REPORT_DEADLINE`'s doc, not fixed, and task 6 added the arithmetic against the client's own 10s: six wedged pumps is where the sweep outlasts the caller, and `instances = 6` is now a way to get there.
 
 ## Phase gate
 

--- a/docs/writing-plans/plans/2026-08-30-handover-phase2b.md
+++ b/docs/writing-plans/plans/2026-08-30-handover-phase2b.md
@@ -341,7 +341,18 @@ Fixed by visiting the pumps CONCURRENTLY (`futures_util::future::join_all`, the 
 
 Measured: six wedged pumps, serial 12s, concurrent 2s (both virtual time, under a paused tokio clock). A normal single-sheep reload (three reloads of a chatty `awk` counter, no wedged pumps) was re-run by hand to confirm the drill is unaffected: every reload exit 0, shepherd pid and sheep pid both unmoved, 25,579,208 lines with zero gaps and zero duplicates after `shep stop`.
 
-#### Task 7: dogs (NOT DONE, and the sketch's premise is wrong)
+#### Task 7: dogs (DESCOPED TO PHASE 3 by the maintainer, 2026-08-30)
+
+Moved out of 2b rather than left open. The carry itself works and is not
+the problem; finishing it needs a `shep-client` reconnect, and a
+reconnecting client has to rule on G8's refusal and G13's
+`Client::daemon()` staleness, both of which Phase 3 owns. 2b ships with
+`RefusedReason::Dog` still in place, and the four tests using it as their
+refusal fixture stay where they are.
+
+The spec's G7 has been corrected in the same commit: it claimed dogs
+reconnect "which it already does today", which is false and was the reason
+this task looked cheap. Everything measured below is why.
 
 - [ ] **Step 1: Write the failing tests**
 - [ ] **Step 2: Run to verify they fail**

--- a/docs/writing-plans/plans/2026-08-30-handover-phase2b.md
+++ b/docs/writing-plans/plans/2026-08-30-handover-phase2b.md
@@ -341,6 +341,84 @@ Fixed by visiting the pumps CONCURRENTLY (`futures_util::future::join_all`, the 
 
 Measured: six wedged pumps, serial 12s, concurrent 2s (both virtual time, under a paused tokio clock). A normal single-sheep reload (three reloads of a chatty `awk` counter, no wedged pumps) was re-run by hand to confirm the drill is unaffected: every reload exit 0, shepherd pid and sheep pid both unmoved, 25,579,208 lines with zero gaps and zero duplicates after `shep stop`.
 
+#### Task 7: dogs (NOT DONE, and the sketch's premise is wrong)
+
+- [ ] **Step 1: Write the failing tests**
+- [ ] **Step 2: Run to verify they fail**
+- [ ] **Step 3: Implement**
+- [ ] **Step 4: Prove each one non-vacuous**
+- [ ] **Step 5: Drive a real reload, and prove the dog still works afterwards**
+- [ ] **Step 6: Task gate, then commit**
+
+##### Why it stopped, measured
+
+The sketch says dogs "survive the exec as children for free; what needs designing is their reconnect". The first half is true and the second half is not a design, it is the whole task, and it cannot be finished inside 2b.
+
+The carry itself is four lines and was built to take the measurement: strike the `entry.dog.is_some()` check in `refusal`, give `CarriedSheep` a `dog: Option<DogSource>` field, restore it in `install_adopted`. That much works. What it produces is a live dog holding a dead socket, and the two built-in dogs answer that in two different ways, one of them silently.
+
+A real flock, release build, one `awk` sheep plus both built-in dogs, one `shep daemon reload`:
+
+| | before | after |
+|---|---|---|
+| shepherd pid | 14298 | 14298 |
+| sheep `fast` pid | 14319 | 14319 |
+| `metrics` pid / restarts | 14320 / 0 | 14320 / 0 |
+| `bark` pid / restarts | 14321 / 0 | **14468 / 1** |
+| `curl /metrics` | **HTTP 200**, 1 sheep row | **HTTP 503** |
+
+The handover worked. Every pid that mattered held. And the metrics dog was dead in the only sense that counts: six scrapes over the next 30 seconds, every one a 503, `metrics-0-err.log` still **0 bytes**, nothing in the shepherd's log, and `shep dogs` reporting it `online` with a climbing uptime and zero restarts the whole time.
+
+Five more reloads on the same flock, six in total: every one exit 0, the shepherd and `fast` unmoved the whole time (`fast` at 14319 for 6m 12s), and `metrics` still `online`, still pid 14320, still **restarts 0**, uptime 6m 22s, stderr still **0 bytes**, still answering 503. Six silent breakages with no signal on either side.
+
+That is worse than G6's mismatched dog, which at least writes a line per interval to its own stderr. This one is silent on both sides. `handle_connection` answers 503 because its `Request::ListFlock` fails, which is the honest answer to a scrape and tells the operator nothing about why.
+
+`bark` survives by accident rather than by design: `EventStream` ends when the connection dies, `run_loop`'s `None` arm breaks, the dog exits 0, and `autorestart` (a dog's default, see `dogs.rs`) starts a new one that connects to the successor. It works, and nothing in the contract asked for it.
+
+It also costs a restart per reload, and that number is carried: bark read `restarts 1, 2, 3, 4, 5, 6` across those six, coming back `online` every time. The budget is never exhausted, because `install_adopted` gives every adopted entry a fresh `RestartBudget` and says why, so each successor counts a new window. But the COUNT is carried on purpose, and a healthy dog reading `restarts 20` after twenty reloads is the thing G7 is trying not to produce.
+
+##### The spec sentence that is not true
+
+G7 reads: "So every dog sees its connection drop and reconnects, **which it already does today**."
+
+It does not. There is no reconnect anywhere: not in `DogRuntime`, which connects exactly once in `start`; not in `metrics::run`, which holds an `Arc<Client>` across an `accept_forever` loop and never re-examines it; not in `bark::run_loop`, which exits instead. G6 measured `shep-log-rotate` retrying its STARTUP handshake forever, which is a different loop from a mid-life reconnect and says nothing about this window.
+
+Nor could a dog have needed one before now. Every path that removed a shepherd also removed its dogs: the stop arm respawns them, a `shep kill` takes them with it, a crash takes them with it. A dog outliving the daemon it is connected to is a situation the handover invented, which is exactly why no dog handles it.
+
+##### Why the fix cannot be built here
+
+Muteness is a dog that is alive with a dead connection. There are two ways to break it and no third: revive the connection, or end the dog. Ending the dog is a restart, which this task's own brief puts in Phase 3.
+
+So it has to be a reconnect, and the reconnect has to reach ADOPTED dogs, not only the two built-ins. shep cannot make a third-party dog reconnect and cannot tell whether one did: `Hello` carries `client_version` and `protocol` and no dog identity, so the successor cannot map a connection back to the dog that owns it. (`Request::DogConfig` does carry the name, so a successor could notice which dogs asked again. That is a reconnect DETECTOR, which is G8's machinery, and it needs a deadline and a decision about what to do with the answer.)
+
+The one place a reconnect reaches every dog for free is `shep-client`, which every dog links and which G9 already establishes is picked up by a plain `cargo install <dog>`. The contract would not change at all. But an actor that reopens its own connection has to answer three questions, and two of them are already reserved:
+
+- **In-flight requests.** They must fail, never be retried; a re-issued `Restart` restarts twice. H2 already accepts losing these, so this one is settled.
+- **The handshake ack.** `Client::ack` is a value taken once at connect and handed out by `daemon()`. `metrics`'s own exposition prints `daemon_version` from it, so after a reconnect it would publish the predecessor's version. Fixing that is G13, which is about exactly when a dog's recorded version stops being evidence.
+- **A refused reconnect.** The successor can refuse on protocol skew, which is the entire point of the handover being a version change. What happens then is G8, word for word: restart once, then report, never loop.
+
+A reconnect cannot be built without ruling on the third one. That rule is Phase 3's, and the maintainer has said Phase 3 is not to be planned yet.
+
+##### What the two candidate designs cost
+
+Neither is free, and the second contradicts this task's brief, so both are recorded rather than chosen.
+
+**Carry every dog, put the reconnect in `shep-client`.** Delivers G7 exactly, no process restart for anyone, and builds the re-handshake that G8's detection needs rather than foreclosing it. Costs: the three questions above, one of which is G8's; and until an adopted dog is rebuilt, it is mute after a reload, which is a REGRESSION against today, where the gate refuses and everything restarts and works. Two adopted dogs are in `web/public/dogs.json` today, `shep-log-rotate` and `shep-deploy`, and the second one deploys and rolls back, so a mute one is not a monitoring gap.
+
+**Carry built-in dogs, keep refusing adopted ones.** No regression anywhere: `metrics` and `bark` stop sending the whole flock down the stop arm, and an adopted dog keeps today's behaviour until Phase 3 can vet it. The line is principled rather than arbitrary, since it is exactly the set whose connection behaviour shep controls and can fix in the same commit. Costs: a dog refusal survives, against the brief; `metrics` still needs its own fix (exiting when its shepherd connection is gone, which is what `bark` already does and what `run`'s own doc already argues for a refused bind, "worse than one `shep dogs` reports as `Errored`, because the first looks fine from the outside"); every dog then restarts on every reload and carries the count, which is the thing G7 exists to avoid; and Phase 3 has to lift the narrowed gate.
+
+The mechanism needs no proving: bark is already running it, six times over, in the table above.
+
+##### Whoever picks this up
+
+- The four tests using `RefusedReason::Dog` as their refusal fixture still need moving whenever it goes. The two in `handover/mod.rs` are one line each (`e.reload = ReloadState::Replacement`). The two in `boot.rs` are not: they boot a real daemon, and none of the three 2c refusals is reachable from `SupervisorHandle` without choreography. A pending stop needs a script that ignores signals, which then blocks the test's own 5s teardown on `kill_timeout`; a reload stuck in `AwaitReady` does not, because the kill ladder still works, so that is the one to build.
+- `VERSION` does not move for the `dog` field. An absent `Option` loads as `None`, and `None` is what a predecessor that refused to carry a dog at all truthfully meant. Same argument as stdin's and the channel's.
+- Losing the `dog` field is not cosmetic: `matching_ids` includes a dog only for an exact selector, so a carried dog without it leaves `shep dogs` and turns up in `shep flock` beside the operator's own apps.
+- `web/src/pages/docs/getting-started.astro` says "A dog or anything mid-reload sends the reload down the older path instead". It is still true, and it stops being true the moment any of this ships.
+
+##### Found in passing, unrelated and shipped
+
+`[[dog.bark.rules]]` cannot be parsed at all. The simplest possible rule makes the bark dog exit 4 with `[dog.bark] does not parse`, then crash-loop; deleting the rule brings it straight back online. Reproduced deterministically on the release build. `Rule` carries `#[serde(deny_unknown_fields)]` on the struct and `#[serde(flatten)]` on its `when` field, which serde documents as incompatible, and no test anywhere deserializes a `Rule` or a `BarkConfig` from TOML, which is how it shipped. Every test builds them in Rust. Not fixed here; it is not the handover.
+
 ---
 
 ### Task 8: re-arm audit, and the end-to-end case
@@ -375,10 +453,10 @@ Baselines on that drill, three reloads: `origin/main` loses about 2900 lines, 2b
 
 ## Working state, for whoever picks this up
 
-- Branch `feat/handover-2b`, unpushed, no PR. Tasks 1, 2, 4, 5 and 6 committed; task 3 folded into 1.
+- Branch `feat/handover-2b`, unpushed, no PR. Tasks 1, 2, 4, 5 and 6 committed; task 3 folded into 1; task 7 measured and stopped, nothing committed but its writeup.
 - Counts after task 6: **644** daemon lib with `--skip ::slow::`, **2099** workspace.
 - The rejected buffer-carry patch is at `stash@{0}` and in this session's scratchpad as `task1-carry.patch`. Read it for plumbing, not design.
-- `handover/mod.rs`'s module header names the three refusals left, all of them 2c's. Task 7 has one more to strike, `Dog`, and four tests currently using it as their refusal fixture will need moving with it.
+- `handover/mod.rs`'s module header names the three refusals left, all of them 2c's. Task 7 was going to strike `Dog` and did not: the carry works and leaves the metrics dog silently mute, so the gate still refuses. See Task 7's own section for the measurement and the two candidate designs. The four tests using `Dog` as their refusal fixture stay where they are until that decision is made.
 - PR #73 has two threads left open for 2b. Both are now addressed: the `report_fds` deadline is task 2, and descriptor pinning fell out of task 1's parking. They can be closed with a pointer to those commits.
 - `spawn_handover_task` used to visit sheep serially, so a flock of wedged pumps waited N x 2s before the fallback, and past six that outlasted the client's 10s wait and reached exit 0 with no flock. Fixed by a follow-up defect task: see "Follow-up defect: the serial sweep, fixed" under Task 6.
 

--- a/docs/writing-plans/plans/2026-08-30-handover-phase2b.md
+++ b/docs/writing-plans/plans/2026-08-30-handover-phase2b.md
@@ -1,0 +1,160 @@
+# Daemon handover, phase 2b: the surface
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Carry the sheep 2a refuses, and close the three defects 2a measured but did not fix.
+
+**Architecture:** 2a built the spine and gated everything it could not carry. This phase does two different kinds of work: it removes refusals from `handover::fitness`, and it repairs three things no gate can refuse because none of them is visible in an app's config.
+
+**Spec:** [docs/brainstorming/specs/2026-08-29-daemon-handover-design.md](../../brainstorming/specs/2026-08-29-daemon-handover-design.md), section H2a.
+
+## Order, and why it is not negotiable
+
+**The three structural tasks come first.** The tear is not a property of the sheep 2b adds; it affects every sheep 2a already carries. Widening the gate first would ship a known defect to more apps and make it harder to attribute when it bites. Fix the foundation, then widen.
+
+1. carry the pump's reader buffer
+2. give `report_fds` a deadline, with an answer that distinguishes a wedged pump from a stopped one
+3. pin a reported descriptor until the exec
+4. stdin
+5. the shepherd channel
+6. multi-instance
+7. dogs
+8. re-arm audit, and the end-to-end case
+
+## Global Constraints
+
+Same as 2a, and they are load-bearing rather than ceremony:
+
+- MSRV 1.88, edition 2024. No new dependencies.
+- The whole phase is `#[cfg(unix)]`. Windows has no `execve` and `Arm::for_daemon` must keep returning the stop arm there.
+- Unsafe only in `crates/shep-daemon/src/sys.rs`, per-block `// SAFETY:` (IR-22/23).
+- **Invoke the `shep-idiomatic-rust` skill before writing any Rust.** Cite `IR-<n>`.
+- **No em dashes** in doc comments or prose.
+- **One cargo shape per task.** Daemon-only work uses `cargo test -p shep-daemon --lib --all-features -- --skip ::slow::`; anything crossing crates uses `cargo test --workspace --all-features`.
+- **The Windows cross-check is in the PER-TASK gate**, with its own `CARGO_TARGET_DIR`. It caught two breaks in 2a that the host-only gate called green.
+- Repo-relative paths only. Do not name any person.
+
+## What 2a taught about verifying this particular feature
+
+Three fixes to `await_successor` shipped in one session, two found by review rather than by the suite. **The suite could not have caught any of them**, because every failure was in which daemon answered rather than in whether the flock survived, and the flock survived every time.
+
+So: **drive a real reload by hand before pushing anything that touches the handover path.** Build release, start a flock, reload it several times, and check the exit code as well as the pids. A green suite is not evidence for this feature.
+
+---
+
+### Task 1: carry the pump's reader buffer
+
+**Files:**
+- Modify: `crates/shep-daemon/src/handover/mod.rs` (`CarriedSheep`)
+- Modify: `crates/shep-daemon/src/tokio_runner.rs` (the pump, `LogCtl::ReportFds`)
+- Modify: `crates/shep-daemon/src/handover/adopt.rs` (seed the successor's reader)
+- Test: alongside
+
+**The defect, measured rather than reasoned.** The pump reads through `Lines<BufReader<ChildStdout>>`. At the exec, bytes the `BufReader` has consumed from the pipe and not yet emitted die with the image. 8a's flush empties `LogFile`'s WRITE buffer; nothing empties the reader's.
+
+2a measured it with a sheep emitting as fast as the pipe allows, three runs of three:
+
+| after | next line | expected |
+|---|---|---|
+| `7385` | `2` | `7386` |
+| `4872` | `00` | `4873` |
+| `10917` | `1916` | `10918` |
+
+The third is the shape of the whole thing. `1916` is not a suffix of `10918`, so what died was not one line: it was everything the reader held, and the resume landed about a thousand lines further on.
+
+**The design.** The buffered bytes are just bytes. Carry them per stream in the blob, and have the successor prepend them to its fresh reader before it reads the pipe. Order is preserved because those bytes came off the pipe before anything still in the kernel buffer.
+
+Do NOT try to solve this by draining and emitting. A drain still has to do something with a trailing partial line, and writing it out as a line is a smaller tear rather than no tear.
+
+**A size bound is required.** `BufReader`'s default capacity is 8 KiB per stream, so a bounded flock's blob grows by a bounded amount. State the bound in the code and assert it, so a future capacity change cannot silently make the blob unbounded.
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+#[tokio::test]
+async fn a_carried_reader_buffer_survives_the_handover() {
+    // The regression is only visible when the reader is NOT empty at the
+    // exec, which is why the sheep has to outrun the pump rather than tick
+    // politely. A test with a sleeping writer passes without the fix.
+    let pump = PumpHarness::start_over_pipes();
+    write_fast(&pump, 1..=5_000).await;
+    let fds = report_fds(&pump).await;
+    assert!(
+        !fds.out_buffered.is_empty(),
+        "this case proves nothing unless the reader is holding bytes"
+    );
+
+    let adopted = adopt_with(fds);
+    let seen = read_all_lines(&adopted).await;
+    assert_unbroken_sequence(&seen);
+}
+```
+
+The first assertion is the important one. Without it the test silently degrades to the empty-buffer case and passes against no implementation at all, which is the failure mode three separate 2a tasks hit.
+
+- [ ] **Step 2: Run to verify it fails**
+
+- [ ] **Step 3: Implement**
+
+- [ ] **Step 4: Run to verify it passes, and prove it non-vacuous**
+
+Drop the carried bytes on the floor in the successor and confirm the test fails with a tear. Report the mutation and its output.
+
+- [ ] **Step 5: Drive a real reload**
+
+Per the note above. A chatty sheep, several reloads, `shep bleats` unbroken across all of them.
+
+- [ ] **Step 6: Task gate, then commit**
+
+---
+
+### Task 2: a deadline on `report_fds`, and an answer that is not ambiguous
+
+A stalled pump blocks the handover AND its graceful-stop fallback, so the daemon has no way out.
+
+The fix is not a timeout wrapper. `CarriedFds::none()` is what a STOPPED sheep reports, so collapsing a timed-out live pump into it would let the fitness gate carry a wedged sheep with its descriptors silently dropped, which is worse than the hang. The snapshot needs a third answer, and it has to reach the gate.
+
+Sketch only; expand when Task 1 lands.
+
+---
+
+### Task 3: pin a reported descriptor until the exec
+
+A reported number is not owned by anything between `ReportFds` and `Handover::write`. An EOF or a `LogFile::reopen` can release it, and a later open can reuse it. `adopt`'s kind check makes a pipe landing on a log fail loudly; a log handle landing on a log handle stays quiet.
+
+Two shapes, and the choice is the task: duplicate every reported descriptor into handover-owned storage, or serialise retirement and reopening against the exec.
+
+Sketch only.
+
+---
+
+### Tasks 4 to 7: widen the gate
+
+One refusal each, from `handover::fitness`: `Stdin`, `Channel`, `MultiInstance`, `Dog`.
+
+`Stdin` is one more descriptor through machinery that already carries four. The channel is a socketpair with two pump tasks, structurally the log pipes again. Multi-instance is the one to distrust: `merge_logs` gives several sheep handles on ONE inode, and 8a measured that the fd count does not fall when logs are merged. Dogs survive the exec as children for free; what needs designing is their reconnect, and Phase 3 owns their version axis.
+
+Sketch only. Each removes exactly one variant and its test.
+
+---
+
+### Task 8: re-arm audit, and the end-to-end case
+
+8c added `arm_extras` for an adopted `Online` sheep. Audit what that actually covers against the spec's H2 table: watch debouncers, cron, memory limits, and the CPU baseline that H2 accepts losing.
+
+The end-to-end case is 2a's, widened: a flock containing every kind 2b now carries, reloaded, with pids unchanged and no gap in any sheep's log.
+
+---
+
+## Phase gate
+
+The four per-task commands, plus:
+
+```bash
+cargo test --workspace --all-features -- --test-threads=1
+```
+```bash
+CARGO_TARGET_DIR=/tmp/xcheck-linux cargo check -p shep-daemon --all-targets --all-features --target x86_64-unknown-linux-gnu
+```
+
+**And read the CI result.** 2a's headline bug reached four Linux jobs and never once failed on macOS.

--- a/web/src/pages/docs/getting-started.astro
+++ b/web/src/pages/docs/getting-started.astro
@@ -84,11 +84,11 @@ import CodeBlock from "../../components/docs/CodeBlock.astro";
     </p>
     <p class="fine">
       Not every flock can be carried yet. A sheep with a shepherd channel,
-      <code>stdin = true</code>, more than one instance, a dog, or anything
-      mid-reload sends the reload down the older path instead: the flock is
-      stopped and started, and the reload prints which sheep held it back.
-      The first reload after upgrading to this version always takes that
-      path, because the shepherd being replaced predates the handover.
+      more than one instance, a dog, or anything mid-reload sends the reload
+      down the older path instead: the flock is stopped and started, and the
+      reload prints which sheep held it back. The first reload after
+      upgrading to this version always takes that path, because the shepherd
+      being replaced predates the handover.
     </p>
     <Callout variant="careful">
       Skip <code>shep daemon reload</code> and the new binary answers

--- a/web/src/pages/docs/getting-started.astro
+++ b/web/src/pages/docs/getting-started.astro
@@ -83,12 +83,12 @@ import CodeBlock from "../../components/docs/CodeBlock.astro";
       again; the note below says which flocks those are.
     </p>
     <p class="fine">
-      Not every flock can be carried yet. A sheep with a shepherd channel,
-      more than one instance, a dog, or anything mid-reload sends the reload
-      down the older path instead: the flock is stopped and started, and the
-      reload prints which sheep held it back. The first reload after
-      upgrading to this version always takes that path, because the shepherd
-      being replaced predates the handover.
+      Not every flock can be carried yet. A sheep with more than one
+      instance, a dog, or anything mid-reload sends the reload down the older
+      path instead: the flock is stopped and started, and the reload prints
+      which sheep held it back. The first reload after upgrading to this
+      version always takes that path, because the shepherd being replaced
+      predates the handover.
     </p>
     <Callout variant="careful">
       Skip <code>shep daemon reload</code> and the new binary answers

--- a/web/src/pages/docs/getting-started.astro
+++ b/web/src/pages/docs/getting-started.astro
@@ -83,12 +83,11 @@ import CodeBlock from "../../components/docs/CodeBlock.astro";
       again; the note below says which flocks those are.
     </p>
     <p class="fine">
-      Not every flock can be carried yet. A sheep with more than one
-      instance, a dog, or anything mid-reload sends the reload down the older
-      path instead: the flock is stopped and started, and the reload prints
-      which sheep held it back. The first reload after upgrading to this
-      version always takes that path, because the shepherd being replaced
-      predates the handover.
+      Not every flock can be carried yet. A dog or anything mid-reload sends
+      the reload down the older path instead: the flock is stopped and
+      started, and the reload prints which sheep held it back. The first
+      reload after upgrading to this version always takes that path, because
+      the shepherd being replaced predates the handover.
     </p>
     <Callout variant="careful">
       Skip <code>shep daemon reload</code> and the new binary answers

--- a/web/src/pages/docs/getting-started.astro
+++ b/web/src/pages/docs/getting-started.astro
@@ -85,9 +85,10 @@ import CodeBlock from "../../components/docs/CodeBlock.astro";
     <p class="fine">
       Not every flock can be carried yet. A dog or anything mid-reload sends
       the reload down the older path instead: the flock is stopped and
-      started, and the reload prints which sheep held it back. The first
-      reload after upgrading to this version always takes that path, because
-      the shepherd being replaced predates the handover.
+      started, and the reload prints which sheep held it back. Coming from
+      0.1.17 or earlier, the first reload always takes that path too: the
+      shepherd being replaced predates the handover and has nothing to hand
+      over with.
     </p>
     <Callout variant="careful">
       Skip <code>shep daemon reload</code> and the new binary answers


### PR DESCRIPTION
Phase 2b of the daemon handover. `shep daemon reload` now carries a sheep with `stdin = true`, one with a shepherd channel (`channel`, `wait_ready`, or `shutdown_with_message`), and clustered apps with `merge_logs` either way. Dogs are descoped to phase 3, so `RefusedReason::Dog` stays and the spec's G7 is corrected: it claimed dogs already reconnect, and they do not.

Also fixes three bugs that are live in 0.1.19:

- a `wait_ready` or `readiness_probe` sheep caught mid-start was stranded `Starting` forever, since the waiter is a task the exec destroys
- a sheep in `WaitingRestart` was stranded the same way. Measured at 70s with `restart_delay = "45s"`, still 0 restarts, while an un-reloaded control respawned on time at 45s
- the pump sweep was serial and unbounded, so with enough wedged pumps `shep daemon reload` exited 0 against a predecessor that was about to stop and take the flock with it

All three leave the flock looking healthy and the suite green, which is why each is covered by a real reload rather than a unit test.

Measured across five reloads on a release build, six apps and eight rows:

| | |
|---|---|
| lines | 112,619,085 |
| lost | 0 |
| duplicates | 0 |
| seams | 0 |

Every H2 row proved by tripping it after the exec with a control alongside: watch, cron, memory limit, liveness probe, per-instance sampling. The watch debouncer and the CPU baseline are the two H2 gives up, and both behave as it says.

646 daemon lib tests pass. The full gate runs here in CI.

Worth a reviewer's eye: dropping `arm_extras` for adopted sheep leaves all 646 lib tests and four of the five end-to-end cases green. Only the new re-arm case notices. The successor's arming has no unit-level cover in either scope, so that tier is the only thing holding it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Reloads now preserve shepherd channels, standard input, multiple instances, logs, and process IDs where supported.
  * Deferred restarts and lifecycle readiness are restored after daemon reloads.
  * Handover safely resumes log processing when a reload is abandoned.

* **Bug Fixes**
  * Improved handling of stalled handovers, descriptor validation, buffered logs, and channel shutdowns.
  * Added fallback behavior for unsupported dog configurations and older shepherd versions.

* **Documentation**
  * Updated reload behavior, handover planning, known limitations, and test metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->