### PR TITLE
chore(docs): regenerate the CLI reference for 0.1.20

### DIFF
--- a/web/src/data/cli-reference.generated.txt
+++ b/web/src/data/cli-reference.generated.txt
@@ -1,5 +1,5 @@
 @@VERSION@@
-shep 0.1.18
+shep 0.1.20
 @@TOPLEVEL@@
 A process manager for your flock
 


### PR DESCRIPTION
Third regeneration of this file tonight. It was fixed for 0.1.18 a few hours ago, then v0.1.19 and v0.1.20 shipped and each one made it stale again.

- one line, `shep 0.1.18` to `shep 0.1.20`
- surface unchanged: still 2512 lines, 40 verbs
- generated from the release binary, not hand-edited

The one-line diff is worth stating rather than assuming. Regenerating this file has twice surfaced a real regression instead of a stale copy, most recently a grouped verb listing that had silently dropped every `[aliases: ...]` block. So a one-liner is evidence that nothing operator-visible moved across two releases.

This is a treadmill though, and another regeneration is not the fix. The version line is the only part that drifts on a release, and it drifts every time, because nothing in the release flow re-runs the generator and nothing fails when it is out of date. Making the docs read the version from the workspace `Cargo.toml` instead of from this committed file would end it, and would leave this file changing only when the CLI surface actually moves. That touches the docs data path and a published page, so it is not in here.
