### PR TITLE
feat(handover): carry pending commands and in-flight swaps, and rehearse the adoption before the exec

### DIFF
--- a/crates/shep-daemon/src/boot.rs
+++ b/crates/shep-daemon/src/boot.rs
@@ -2024,10 +2024,17 @@ async fn hand_over_now(seam: &HandoverSeam) -> Result<core::convert::Infallible,
 /// [`hand_over_now`]'s body, split out so a single resume can cover every
 /// way it refuses.
 ///
+/// Two gates, in this order, and they ask different questions. The first
+/// asks whether this FLOCK is a shape a handover carries. The second asks
+/// whether the BLOB describing it is one a successor could actually adopt,
+/// by running the successor's own adoption here, against duplicates, while
+/// this image still exists to fall back to.
+///
 /// # Errors
 ///
-/// The flock cannot be carried, or the exec itself failed. Both leave this
-/// process still itself, with no blob on disk.
+/// The flock cannot be carried, a successor could not have adopted the blob,
+/// or the exec itself failed. All three leave this process still itself,
+/// with no blob on disk.
 #[cfg(unix)]
 fn hand_over_carrying(
     candidates: &[crate::handover::OwnedCandidate],
@@ -2041,6 +2048,25 @@ fn hand_over_carrying(
     if let crate::handover::Fitness::Refused(reason) = crate::handover::fitness(&borrowed) {
         return Err(reason.to_string());
     }
+    // The gate with no way back if it is skipped. After the `execve` there
+    // is no image to refuse to: `rehydrate` returns `BootError::Adopt`, this
+    // daemon's replacement exits without ever serving, and the flock runs on
+    // with nothing supervising it — which is what that variant's own message
+    // tells the operator, pointing them at `shep muster`.
+    //
+    // Here rather than inside `handover::hand_over`, which would be harder
+    // for a future caller to bypass. The rehearsal registers objects with
+    // the tokio reactor and so needs a runtime, and `hand_over`'s own exec
+    // self-test runs from a plain `#[test]` with a tempfile standing in for
+    // the listener. This is the production seam and its only caller.
+    crate::handover::adopt::dry_run(blob).map_err(|err| {
+        format!(
+            "a successor could not have adopted this flock, so none was started: {err}. This is \
+             a shep bug worth reporting: the descriptors are ones this shepherd opened itself, \
+             and the check that refused them is the successor's own. The flock is stopped and \
+             started instead, which is the reload an operator had before handovers existed"
+        )
+    })?;
     crate::handover::hand_over(blob, &seam.paths).map_err(|err| err.to_string())
 }
 
@@ -3491,6 +3517,80 @@ mod tests {
         // Bounded, like the sibling above. The lock this case now holds is
         // held across this await, so a teardown that hung would stop every
         // other signal test in the module rather than failing this one.
+        tokio::time::timeout(Duration::from_secs(5), daemon.run())
+            .await
+            .unwrap()
+            .unwrap();
+    }
+
+    /// The second gate: a flock the fitness check passes, described by a
+    /// blob no successor could have adopted, refuses HERE rather than after
+    /// the `execve`.
+    ///
+    /// This is the failure with no way back. Past the exec there is no
+    /// predecessor to refuse to: `rehydrate` returns `BootError::Adopt`, the
+    /// successor exits without ever serving, and the flock keeps running
+    /// with nothing supervising it. So the rehearsal runs while this image
+    /// still exists, and a refusal takes the stop-and-start arm the operator
+    /// would have had before handovers existed.
+    ///
+    /// **Read the assertion, not just the `expect_err`.** These descriptors
+    /// were already refused before this gate existed, by the `FD_CLOEXEC`
+    /// sweep meeting `EBADF`, so a case that only checked for A refusal
+    /// would pass with the gate deleted. What is new is WHICH refusal: the
+    /// successor's own wording, reached before anything was written or
+    /// cleared. The wording is the whole test.
+    ///
+    /// **The descriptors stay deliberately invalid**, for the reason both
+    /// siblings above give. A blob that got past both gates would exec this
+    /// test binary into a re-run of the entire suite, so no case in this
+    /// module may offer one that could.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn a_sighup_over_a_blob_no_successor_could_adopt_refuses_before_it_execs() {
+        // As every sibling: a successful `boot()` installs real signal
+        // listeners for this test's whole duration.
+        let _guard = SIGNAL_TEST_LOCK.lock().await;
+        let dir = tempfile::tempdir().unwrap();
+        let paths = test_paths(&dir);
+        init_dirs(&paths).unwrap();
+        // No dog and no sheep, so the FIRST gate passes and this case is
+        // about the second one. An empty flock is carryable — see
+        // `handover::fitness`'s own doc.
+        let daemon = boot(
+            ScriptedRunner::new(Vec::new()),
+            paths.clone(),
+            BootOptions::default(),
+        )
+        .await
+        .unwrap();
+        let ctx = daemon.context();
+
+        let seam = HandoverSeam {
+            supervisor: ctx.supervisor.clone(),
+            fds: crate::handover::DaemonFds {
+                listener: -1,
+                pidfile: -2,
+            },
+            paths: paths.clone(),
+        };
+        let refusal = hand_over_now(&seam)
+            .await
+            .expect_err("a blob naming no real listener cannot be adopted");
+        assert!(
+            refusal.contains("a successor could not have adopted this flock"),
+            "the rehearsal must be what refuses, not the `FD_CLOEXEC` sweep further on: {refusal}"
+        );
+        assert!(
+            refusal.contains("-1"),
+            "the refusal must name the descriptor it refused: {refusal}"
+        );
+        assert!(
+            !crate::handover::Handover::path(&paths).exists(),
+            "a refusal before the exec must leave no blob on disk"
+        );
+
+        ctx.shutdown();
         tokio::time::timeout(Duration::from_secs(5), daemon.run())
             .await
             .unwrap()

--- a/crates/shep-daemon/src/boot.rs
+++ b/crates/shep-daemon/src/boot.rs
@@ -630,10 +630,11 @@ fn rehydrate(carried: Successor, paths: &ShepPaths) -> Result<Rehydrated, BootEr
         .map_err(|source| BootError::Adopt(source.to_string()))?;
     crate::handover::adopt::discard_blob(&path);
     let _ = paths;
+    let reloads = blob.reloads().to_vec();
     Ok((
         PidfileLock::from_locked(adopted.pidfile),
         Listener::from_unix_listener(adopted.listener),
-        (adopted.sheep, counters),
+        (adopted.sheep, counters, reloads),
     ))
 }
 
@@ -1216,12 +1217,12 @@ pub async fn boot<R: ProcessRunner>(
     let inherited_flock = inherited.is_some();
     #[cfg(unix)]
     let supervisor = match inherited {
-        Some((flock, counters)) => {
+        Some((flock, counters, reloads)) => {
             // Read before the flock is moved: the registry below is rebuilt
             // from these, and the roll would otherwise be written empty.
             carried_apps.extend(flock.iter().map(|sheep| sheep.carried.app().clone()));
             builder
-                .spawn_adopted(flock, counters)
+                .spawn_adopted(flock, counters, reloads)
                 .map_err(|source| BootError::Adopt(source.to_string()))?
         }
         None => builder.spawn(),
@@ -1946,7 +1947,8 @@ type InstalledSignals = (
 );
 
 /// What [`rehydrate`] rebuilds from a blob: the home's lock, the control
-/// listener, and the flock to install with the counters it ran under.
+/// listener, and the flock to install with the counters and the in-flight
+/// reloads it ran under.
 #[cfg(unix)]
 type Rehydrated = (
     PidfileLock,
@@ -1954,6 +1956,7 @@ type Rehydrated = (
     (
         Vec<crate::handover::adopt::AdoptedSheep>,
         crate::handover::Counters,
+        Vec<crate::supervisor::CarriedReload>,
     ),
 );
 

--- a/crates/shep-daemon/src/entry.rs
+++ b/crates/shep-daemon/src/entry.rs
@@ -3,6 +3,7 @@
 use core::time::Duration;
 use std::path::PathBuf;
 
+use serde::{Deserialize, Serialize};
 use shep_core::{
     config::ResolvedApp,
     protocol::{DogSource, ExitInfo},
@@ -166,7 +167,15 @@ impl RestartBudget {
 /// drainee's direction is answered here at all: the replacement's
 /// back-reference lives on that job, in the entry ids the machinery around it
 /// navigates by.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+///
+/// Serialized because a handover carries it: a successor that installed a
+/// drainee or a replacement without this would route that instance's exit to
+/// `decide_on_exit` rather than to the reload machinery, which for an
+/// `autorestart` app respawns the old code into a slot the replacement owns.
+/// `snake_case` on the wire to match `ProcStatus`'s own spelling, the blob's
+/// nearest neighbour, since the blob is a JSON file an operator may read.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum ReloadState {
     /// Not half of any swap
     None,

--- a/crates/shep-daemon/src/handover/adopt.rs
+++ b/crates/shep-daemon/src/handover/adopt.rs
@@ -370,6 +370,7 @@ mod tests {
             last_exit: None,
             credentials: SpawnIdentity::Resolved(None),
             fds,
+            pending_delete: Some(false),
             app: crate::testing::app_with("web", |_| {}).into_config(),
         }
     }

--- a/crates/shep-daemon/src/handover/adopt.rs
+++ b/crates/shep-daemon/src/handover/adopt.rs
@@ -1174,20 +1174,26 @@ mod tests {
     /// cannot be used to compare, because duplicating renumbers: a blob
     /// naming the same descriptor twice stops naming it twice here.
     fn adopt_a_copy(blob: &Handover) -> io::Result<()> {
-        fn dup_or_keep(fd: RawFd) -> RawFd {
-            fds::duplicate_raw(fd).unwrap_or(fd)
+        // Propagated, never `unwrap_or(fd)`. Falling back to the original
+        // hands `adopt` the fixture's own live descriptor, which it then
+        // closes -- the exact thing the doc above says the duplicates exist
+        // to prevent, reintroduced on the one path nobody watches. A case
+        // that hit it would fail somewhere else entirely, measuring a
+        // descriptor this helper had shut.
+        fn dup_or_fail(fd: RawFd) -> io::Result<RawFd> {
+            fds::duplicate_raw(fd)
         }
         let mut copy = blob.clone();
-        copy.listener_fd = dup_or_keep(copy.listener_fd);
-        copy.pidfile_fd = dup_or_keep(copy.pidfile_fd);
+        copy.listener_fd = dup_or_fail(copy.listener_fd)?;
+        copy.pidfile_fd = dup_or_fail(copy.pidfile_fd)?;
         for sheep in &mut copy.sheep {
             sheep.fds = CarriedFds {
-                out_pipe: sheep.fds.out_pipe.map(dup_or_keep),
-                err_pipe: sheep.fds.err_pipe.map(dup_or_keep),
-                out_log: sheep.fds.out_log.map(dup_or_keep),
-                err_log: sheep.fds.err_log.map(dup_or_keep),
-                stdin: sheep.fds.stdin.map(dup_or_keep),
-                channel: sheep.fds.channel.map(dup_or_keep),
+                out_pipe: sheep.fds.out_pipe.map(dup_or_fail).transpose()?,
+                err_pipe: sheep.fds.err_pipe.map(dup_or_fail).transpose()?,
+                out_log: sheep.fds.out_log.map(dup_or_fail).transpose()?,
+                err_log: sheep.fds.err_log.map(dup_or_fail).transpose()?,
+                stdin: sheep.fds.stdin.map(dup_or_fail).transpose()?,
+                channel: sheep.fds.channel.map(dup_or_fail).transpose()?,
             };
         }
         adopt(&copy).map(drop)

--- a/crates/shep-daemon/src/handover/adopt.rs
+++ b/crates/shep-daemon/src/handover/adopt.rs
@@ -371,6 +371,7 @@ mod tests {
             credentials: SpawnIdentity::Resolved(None),
             fds,
             pending_delete: Some(false),
+            manual: None,
             app: crate::testing::app_with("web", |_| {}).into_config(),
         }
     }

--- a/crates/shep-daemon/src/handover/adopt.rs
+++ b/crates/shep-daemon/src/handover/adopt.rs
@@ -1228,6 +1228,18 @@ mod tests {
                 channel: sheep.fds.channel.map(|fd| dups.of(fd)).transpose()?,
             };
         }
+        // Released BEFORE the fallible call, not after, and the asymmetry is
+        // deliberate. `adopt` consumes the numbers it reaches and drops the
+        // owners it had already built when it refuses, so on its error path
+        // some of these are closed and some are not, and it returns nothing
+        // that says which. Holding the guard across it would close the
+        // consumed ones a second time, and a double close can shut whatever
+        // number the kernel has since handed out. A leak bounded by a test
+        // binary is the better of those two.
+        //
+        // That the unreached ones leak is not this helper's invention: it is
+        // `adopt`'s own documented behaviour, which is why the pidfile is
+        // adopted last (see this module's header).
         dups.release();
         adopt(&copy).map(drop)
     }

--- a/crates/shep-daemon/src/handover/adopt.rs
+++ b/crates/shep-daemon/src/handover/adopt.rs
@@ -1173,6 +1173,40 @@ mod tests {
     /// fixture and then measure a closed one. Note the one thing this
     /// cannot be used to compare, because duplicating renumbers: a blob
     /// naming the same descriptor twice stops naming it twice here.
+    /// Closes every duplicate it holds, unless [`Self::release`] is called
+    /// first.
+    ///
+    /// `fds::duplicate_raw` hands back a bare number with no owner, so a `?`
+    /// part way through the copy below would leak every duplicate made
+    /// before the failing one. Nothing else would ever close them: the
+    /// numbers live in a `Handover` as plain integers, and dropping that
+    /// closes nothing.
+    ///
+    /// The release is not tidiness either. `adopt` takes ownership of the
+    /// numbers it is handed, so this must let go before that call or each
+    /// one is closed twice.
+    struct Duplicates(Vec<RawFd>);
+
+    impl Duplicates {
+        fn of(&mut self, fd: RawFd) -> io::Result<RawFd> {
+            let duplicate = fds::duplicate_raw(fd)?;
+            self.0.push(duplicate);
+            Ok(duplicate)
+        }
+
+        fn release(mut self) {
+            self.0.clear();
+        }
+    }
+
+    impl Drop for Duplicates {
+        fn drop(&mut self) {
+            for fd in self.0.drain(..) {
+                let _ = nix::unistd::close(fd);
+            }
+        }
+    }
+
     fn adopt_a_copy(blob: &Handover) -> io::Result<()> {
         // Propagated, never `unwrap_or(fd)`. Falling back to the original
         // hands `adopt` the fixture's own live descriptor, which it then
@@ -1180,22 +1214,21 @@ mod tests {
         // to prevent, reintroduced on the one path nobody watches. A case
         // that hit it would fail somewhere else entirely, measuring a
         // descriptor this helper had shut.
-        fn dup_or_fail(fd: RawFd) -> io::Result<RawFd> {
-            fds::duplicate_raw(fd)
-        }
+        let mut dups = Duplicates(Vec::new());
         let mut copy = blob.clone();
-        copy.listener_fd = dup_or_fail(copy.listener_fd)?;
-        copy.pidfile_fd = dup_or_fail(copy.pidfile_fd)?;
+        copy.listener_fd = dups.of(copy.listener_fd)?;
+        copy.pidfile_fd = dups.of(copy.pidfile_fd)?;
         for sheep in &mut copy.sheep {
             sheep.fds = CarriedFds {
-                out_pipe: sheep.fds.out_pipe.map(dup_or_fail).transpose()?,
-                err_pipe: sheep.fds.err_pipe.map(dup_or_fail).transpose()?,
-                out_log: sheep.fds.out_log.map(dup_or_fail).transpose()?,
-                err_log: sheep.fds.err_log.map(dup_or_fail).transpose()?,
-                stdin: sheep.fds.stdin.map(dup_or_fail).transpose()?,
-                channel: sheep.fds.channel.map(dup_or_fail).transpose()?,
+                out_pipe: sheep.fds.out_pipe.map(|fd| dups.of(fd)).transpose()?,
+                err_pipe: sheep.fds.err_pipe.map(|fd| dups.of(fd)).transpose()?,
+                out_log: sheep.fds.out_log.map(|fd| dups.of(fd)).transpose()?,
+                err_log: sheep.fds.err_log.map(|fd| dups.of(fd)).transpose()?,
+                stdin: sheep.fds.stdin.map(|fd| dups.of(fd)).transpose()?,
+                channel: sheep.fds.channel.map(|fd| dups.of(fd)).transpose()?,
             };
         }
+        dups.release();
         adopt(&copy).map(drop)
     }
 

--- a/crates/shep-daemon/src/handover/adopt.rs
+++ b/crates/shep-daemon/src/handover/adopt.rs
@@ -503,6 +503,7 @@ mod tests {
             fds,
             pending_delete: Some(false),
             manual: None,
+            reload: Some(crate::entry::ReloadState::None),
             app: crate::testing::app_with("web", |_| {}).into_config(),
         }
     }
@@ -524,6 +525,7 @@ mod tests {
             next_id: 9,
             next_deadline: 5,
             next_action_stamp: 2,
+            reloads: Some(Vec::new()),
         }
     }
 
@@ -1132,6 +1134,7 @@ mod tests {
                 next_id: 9,
                 next_deadline: 5,
                 next_action_stamp: 2,
+                reloads: Some(Vec::new()),
             }
         }
     }
@@ -1186,6 +1189,40 @@ mod tests {
         let predecessor = Predecessor::new();
 
         dry_run(&predecessor.blob()).expect("every descriptor here is the kind its slot wants");
+    }
+
+    /// Fails if a blob describing a flock mid-reload stops surviving the
+    /// reparse the rehearsal runs it through.
+    ///
+    /// The rehearsal is the predecessor running the successor's OWN checks
+    /// while there is still an image to refuse back to, and one of those
+    /// checks is the parse: it reads the whole blob back through
+    /// [`Handover::load_value`] before rehearsing a single descriptor. So a
+    /// swap in flight is covered by the rehearsal for free — nothing about a
+    /// carried reload is a descriptor, and `adopt` gains no refusal for one
+    /// — but "for free" is a claim that has to be pinned rather than
+    /// asserted, because the cost of it being wrong is the successor
+    /// refusing to boot with the predecessor already gone.
+    #[tokio::test]
+    async fn a_blob_carrying_a_swap_in_flight_passes_the_rehearsal() {
+        use crate::entry::ReloadState;
+        use crate::supervisor::{CarriedReload, ReloadMode, ReloadPhase, ReloadSwap};
+
+        let predecessor = Predecessor::new();
+        let mut blob = predecessor.blob();
+        blob.sheep[0].reload = Some(ReloadState::Drainee { new_id: Some(9) });
+        blob.reloads = Some(vec![CarriedReload {
+            app: "web".to_owned(),
+            queue: vec![4, 5],
+            mode: ReloadMode::Overlap,
+            swap: ReloadSwap {
+                old_id: 1,
+                new_id: Some(9),
+                phase: ReloadPhase::DrainOld,
+            },
+        }]);
+
+        dry_run(&blob).expect("a flock mid-reload is one a successor can adopt");
     }
 
     /// The whole reason the rehearsal runs against duplicates: the

--- a/crates/shep-daemon/src/handover/adopt.rs
+++ b/crates/shep-daemon/src/handover/adopt.rs
@@ -518,6 +518,7 @@ mod tests {
             pending_delete: Some(false),
             manual: None,
             reload: Some(crate::entry::ReloadState::None),
+            ready_failed: Some(false),
             app: crate::testing::app_with("web", |_| {}).into_config(),
         }
     }
@@ -1237,6 +1238,24 @@ mod tests {
         }]);
 
         dry_run(&blob).expect("a flock mid-reload is one a successor can adopt");
+    }
+
+    /// Fails if a blob carrying a failed readiness verdict cannot be
+    /// rehearsed.
+    ///
+    /// The rehearsal reparses the whole blob through the successor's own
+    /// [`Handover::load_value`] before it touches a descriptor, so a field
+    /// added to [`CarriedSheep`] rides the parse it already runs. That is
+    /// worth a case rather than an assumption: the rehearsal is what stands
+    /// between a bad blob and an `execve` with no way back, and a field it
+    /// could not parse would be found after the predecessor was gone.
+    #[tokio::test]
+    async fn a_blob_carrying_a_failed_readiness_verdict_passes_the_rehearsal() {
+        let predecessor = Predecessor::new();
+        let mut blob = predecessor.blob();
+        blob.sheep[0].ready_failed = Some(true);
+
+        dry_run(&blob).expect("an instance a reload gave up on is one a successor can adopt");
     }
 
     /// The whole reason the rehearsal runs against duplicates: the

--- a/crates/shep-daemon/src/handover/adopt.rs
+++ b/crates/shep-daemon/src/handover/adopt.rs
@@ -49,7 +49,7 @@ use std::os::fd::{OwnedFd, RawFd};
 
 use tokio::net::unix::pipe;
 
-use super::{CarriedFds, CarriedSheep, Handover};
+use super::{CarriedFds, CarriedSheep, Handover, SheepFd, fds};
 use crate::sys;
 
 /// Everything a successor was handed, rebuilt into objects it can use.
@@ -179,6 +179,137 @@ fn refuse_repeated_fds(blob: &Handover) -> io::Result<()> {
         }
     }
     Ok(())
+}
+
+/// Run everything [`adopt`] will run, in the PREDECESSOR, while there is
+/// still an image to refuse back to.
+///
+/// # Why this exists at all
+///
+/// The `execve` is one-way. Nothing re-execs a predecessor, and its image is
+/// gone the instant the successor starts, so a successor that cannot adopt
+/// its blob has no way back: `boot::rehydrate` returns `BootError::Adopt`,
+/// the daemon exits without ever serving, and the flock it was handed keeps
+/// running with nothing supervising it. The design called that case
+/// "rollback"; there is nothing to roll back to, and this is the honest
+/// shape of the same intent. Check first, exec second, and a failure becomes
+/// the ordinary stop-and-start reload rather than an unsupervised flock.
+///
+/// # Why it runs the real adoption instead of describing one
+///
+/// A second implementation of "is this descriptor adoptable" is worse than
+/// none. If the successor's checks tighten and a hand-written copy here does
+/// not, the rehearsal passes, the exec happens, and the boot still fails —
+/// with the predecessor now gone. So nothing here re-states a check: this
+/// walks [`CarriedFds::all_kinded`], the one place a number is paired with
+/// its slot, and hands each number to the SAME function the successor will
+/// hand it to. [`refuse_repeated_fds`] is called rather than re-derived, and
+/// [`sys::adoptable_fd`] is [`sys::adopt_handover_fd`]'s own two checks,
+/// shared rather than copied.
+///
+/// The parse is part of it too. A successor does not receive this struct; it
+/// reads bytes back off disk and rebuilds one, so the version gate and the
+/// deserialize are checks it makes as surely as the descriptors are. This
+/// runs them through [`Handover::load_value`], the successor's own entry
+/// point, and then rehearses the adoption against the REPARSED blob rather
+/// than against the one it was handed.
+///
+/// One seam is not shared, and it is worth naming rather than hiding: the
+/// successor reads bytes with `serde_json::from_str` while this goes through
+/// `serde_json::to_value`. Anything that survives one and not the other
+/// would slip past. The gap is the JSON text itself, and `Handover::write`
+/// has already proved that serializes.
+///
+/// # What it does to the descriptors it checks
+///
+/// It never takes one. Every adoption here is handed a duplicate
+/// ([`fds::duplicate_raw`]), takes ownership of THAT, and closes it when the
+/// value is dropped at the end of the call. Ownership is what matters,
+/// because this runs while the predecessor is still supervising the flock:
+/// the pumps are parked, not shut down, and a refusal resumes them and
+/// stops gracefully.
+///
+/// One thing does reach the original, and it is worth naming rather than
+/// claiming a clean sweep. [`adopt_listener`], [`adopt_pipe`],
+/// [`adopt_stdin`] and [`adopt_channel`] each set `O_NONBLOCK`, which is a
+/// property of the open file description rather than of the descriptor, so
+/// a duplicate does not insulate the original from it. In this daemon that
+/// is a write of the value already there: every one of those is a tokio
+/// object, and tokio does not accept a blocking one — `UnixListener::
+/// from_std` and `UnixStream::from_std` refuse it outright, and the two
+/// `pipe` constructors set it themselves. So the flag this could change is
+/// one nothing here holds unset.
+///
+/// # Errors
+///
+/// The blob does not parse as a successor would parse it, it names one
+/// descriptor number twice, or a number it names is reserved, is not open,
+/// or is not the kind of object its slot will be adopted as. The message is
+/// the successor's own, so it names the sheep and the stream.
+///
+/// # Panics
+///
+/// Panics if called outside a tokio runtime with IO enabled, exactly as
+/// [`adopt`] does and for the same reason: the objects it builds register
+/// with the runtime's reactor, which has nowhere to happen without one.
+#[track_caller]
+pub fn dry_run(blob: &Handover) -> io::Result<()> {
+    let value = serde_json::to_value(blob).map_err(io::Error::other)?;
+    let blob = Handover::load_value(value).map_err(|error| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("a successor could not have read this blob back: {error}"),
+        )
+    })?;
+
+    // `adopt`'s own order, so a rehearsal that stops early stops where the
+    // successor would: repeats first, then the listener, then each sheep,
+    // then the pidfile.
+    refuse_repeated_fds(&blob)?;
+    rehearse(blob.listener_fd, adopt_listener)?;
+    for carried in &blob.sheep {
+        let name = &carried.name;
+        for (fd, slot) in carried.fds.all_kinded() {
+            let Some(fd) = fd else { continue };
+            rehearse(fd, |dup| match slot {
+                SheepFd::OutPipe => adopt_pipe(Some(dup), name, "stdout").map(drop),
+                SheepFd::ErrPipe => adopt_pipe(Some(dup), name, "stderr").map(drop),
+                SheepFd::OutLog => adopt_log(Some(dup), name, "stdout").map(drop),
+                SheepFd::ErrLog => adopt_log(Some(dup), name, "stderr").map(drop),
+                SheepFd::Stdin => adopt_stdin(Some(dup), name).map(drop),
+                SheepFd::Channel => adopt_channel(Some(dup), name).map(drop),
+            })?;
+        }
+    }
+    rehearse(blob.pidfile_fd, |dup| {
+        adopt_fd(dup, "the pidfile lock").map(drop)
+    })?;
+    Ok(())
+}
+
+/// Hand `adopt_one` a duplicate of `fd`, so an adoption that takes ownership
+/// can be run against a descriptor this process must keep.
+///
+/// # Errors
+///
+/// `fd` is reserved or not open, it could not be duplicated, or the adoption
+/// refused the duplicate.
+fn rehearse<T>(fd: RawFd, adopt_one: impl FnOnce(RawFd) -> io::Result<T>) -> io::Result<()> {
+    // The BLOB's number is checked here, never the duplicate's, and the
+    // distinction is the whole reason this is not one line shorter.
+    // `sys::adopt_handover_fd` refuses a number below 3 or one that is not
+    // open, and a duplicate is always neither — so a rehearsal that only
+    // ever saw duplicates would wave through exactly the two blobs the
+    // successor is certain to refuse.
+    sys::adoptable_fd(fd).map_err(|error| io::Error::new(io::ErrorKind::InvalidInput, error))?;
+    let duplicate = fds::duplicate_raw(fd)?;
+    // `adopt_one` owns `duplicate` from here, on BOTH arms, and that is what
+    // makes this leak nothing. Every adoption in this module either builds
+    // an owner of the number or drops the `File` it had already built; the
+    // one arm that returns without consuming is `sys::adopt_handover_fd`
+    // refusing, and the check above is what rules that out for a number this
+    // call just created above the floor.
+    adopt_one(duplicate).map(drop)
 }
 
 /// Remove the blob at `path`, now that its descriptors are adopted.
@@ -344,8 +475,8 @@ mod tests {
 
     use tokio::io::{AsyncSeekExt as _, AsyncWriteExt as _};
 
-    use super::adopt;
-    use crate::handover::{CarriedFds, CarriedSheep, Handover, VERSION};
+    use super::{adopt, dry_run, fds, io};
+    use crate::handover::{CarriedFds, CarriedSheep, Handover, SheepFd, VERSION};
     use crate::privilege::SpawnIdentity;
     use shep_core::status::ProcStatus;
 
@@ -930,6 +1061,378 @@ mod tests {
         assert!(
             err.to_string().contains("shepherd channel"),
             "the refusal must name what could not be adopted: {err}"
+        );
+    }
+
+    /// A predecessor's live descriptors: one of everything a blob names,
+    /// still owned HERE rather than leaked into a number.
+    ///
+    /// [`blob_with`] above hands its listener and pidfile to
+    /// `into_raw_fd`, which is right for a case about `adopt`, since
+    /// `adopt` takes ownership and there is nobody left to take it from.
+    /// `dry_run` is the opposite situation and needs the opposite fixture:
+    /// its whole contract is that the caller still owns everything
+    /// afterwards, and nothing can check that against numbers no value
+    /// holds.
+    struct Predecessor {
+        dir: tempfile::TempDir,
+        listener: std::os::unix::net::UnixListener,
+        pidfile: std::fs::File,
+        out_log: std::fs::File,
+        out_read: std::io::PipeReader,
+        out_write: std::io::PipeWriter,
+        stdin_read: std::io::PipeReader,
+        stdin_write: std::io::PipeWriter,
+        channel: std::os::unix::net::UnixStream,
+        child_channel: std::os::unix::net::UnixStream,
+    }
+
+    impl Predecessor {
+        /// One of each kind, all open, all the right way round.
+        fn new() -> Self {
+            let dir = tempfile::tempdir().unwrap();
+            let (out_read, out_write) = std::io::pipe().unwrap();
+            let (stdin_read, stdin_write) = std::io::pipe().unwrap();
+            let (channel, child_channel) = std::os::unix::net::UnixStream::pair().unwrap();
+            Self {
+                listener: std::os::unix::net::UnixListener::bind(dir.path().join("shep.sock"))
+                    .unwrap(),
+                pidfile: tempfile::tempfile().unwrap(),
+                out_log: tempfile::tempfile().unwrap(),
+                out_read,
+                out_write,
+                stdin_read,
+                stdin_write,
+                channel,
+                child_channel,
+                dir,
+            }
+        }
+
+        /// Where this fixture's listener is bound.
+        fn socket(&self) -> std::path::PathBuf {
+            self.dir.path().join("shep.sock")
+        }
+
+        /// A blob naming every one of them, for one sheep called `web`.
+        fn blob(&self) -> Handover {
+            use std::os::fd::AsRawFd as _;
+            Handover {
+                version: VERSION,
+                sheep: vec![carried(CarriedFds {
+                    out_pipe: Some(self.out_read.as_raw_fd()),
+                    err_pipe: None,
+                    out_log: Some(self.out_log.as_raw_fd()),
+                    err_log: None,
+                    stdin: Some(self.stdin_write.as_raw_fd()),
+                    channel: Some(self.channel.as_raw_fd()),
+                })],
+                listener_fd: self.listener.as_raw_fd(),
+                pidfile_fd: self.pidfile.as_raw_fd(),
+                next_id: 9,
+                next_deadline: 5,
+                next_action_stamp: 2,
+            }
+        }
+    }
+
+    /// How many descriptors this process holds, counted the only way a
+    /// portable test can: by asking about every number up to a bound.
+    ///
+    /// The bound is generous rather than exact — this is used as a before
+    /// and after pair, so what matters is that the same numbers are asked
+    /// about both times, not that the total is the true one.
+    fn open_fd_count() -> usize {
+        (0..512)
+            .filter(|fd| crate::sys::adoptable_fd(*fd).is_ok())
+            .count()
+    }
+
+    /// Run the real [`adopt`] over DUPLICATES of `blob`'s descriptors.
+    ///
+    /// The point of the duplicates is that `adopt` takes ownership: a case
+    /// that ran it against a [`Predecessor`]'s own numbers would close the
+    /// fixture and then measure a closed one. Note the one thing this
+    /// cannot be used to compare, because duplicating renumbers: a blob
+    /// naming the same descriptor twice stops naming it twice here.
+    fn adopt_a_copy(blob: &Handover) -> io::Result<()> {
+        fn dup_or_keep(fd: RawFd) -> RawFd {
+            fds::duplicate_raw(fd).unwrap_or(fd)
+        }
+        let mut copy = blob.clone();
+        copy.listener_fd = dup_or_keep(copy.listener_fd);
+        copy.pidfile_fd = dup_or_keep(copy.pidfile_fd);
+        for sheep in &mut copy.sheep {
+            sheep.fds = CarriedFds {
+                out_pipe: sheep.fds.out_pipe.map(dup_or_keep),
+                err_pipe: sheep.fds.err_pipe.map(dup_or_keep),
+                out_log: sheep.fds.out_log.map(dup_or_keep),
+                err_log: sheep.fds.err_log.map(dup_or_keep),
+                stdin: sheep.fds.stdin.map(dup_or_keep),
+                channel: sheep.fds.channel.map(dup_or_keep),
+            };
+        }
+        adopt(&copy).map(drop)
+    }
+
+    /// The happy path, and the property everything else rests on: a blob a
+    /// successor could adopt is not refused here.
+    ///
+    /// Without this the suite could pass with a `dry_run` that refused
+    /// everything, which would turn every handover into a stop-and-start
+    /// and lose the feature while looking safe.
+    #[tokio::test]
+    async fn a_blob_a_successor_could_adopt_passes_the_rehearsal() {
+        let predecessor = Predecessor::new();
+
+        dry_run(&predecessor.blob()).expect("every descriptor here is the kind its slot wants");
+    }
+
+    /// The whole reason the rehearsal runs against duplicates: the
+    /// predecessor is still supervising this flock, and everything it holds
+    /// has to work afterwards.
+    ///
+    /// Each of the four is a different way `adopt` takes ownership —
+    /// `UnixListener::from_std`, `pipe::Receiver::from_file`,
+    /// `pipe::Sender::from_file`, `UnixStream::from_std` — and each would
+    /// close the fixture's own handle if the duplicate were skipped.
+    ///
+    /// The connection is queued BEFORE the rehearsal rather than after, and
+    /// that is the one place this fixture differs from a live daemon.
+    /// `adopt_listener` and `adopt_channel` each set `O_NONBLOCK`, which is
+    /// a property of the open file description and so reaches the original
+    /// through the duplicate. In the daemon every one of these is already
+    /// non-blocking because tokio owns it, so the `fcntl` writes back what
+    /// was already there; this fixture's listener is a plain `std` one and
+    /// really does change. Queueing first means the accept below has
+    /// something waiting either way.
+    #[tokio::test]
+    async fn a_rehearsal_leaves_every_descriptor_it_checked_working() {
+        use std::io::{Read as _, Write as _};
+
+        let mut predecessor = Predecessor::new();
+        predecessor.out_write.write_all(b"a bleat").unwrap();
+        let socket = predecessor.socket();
+        let connecting = tokio::task::spawn_blocking(move || {
+            std::os::unix::net::UnixStream::connect(&socket).unwrap()
+        });
+        let client = connecting.await.unwrap();
+
+        dry_run(&predecessor.blob()).expect("the fixture is adoptable");
+
+        // The listener still listens.
+        predecessor
+            .listener
+            .accept()
+            .expect("the checked listener still accepts");
+        drop(client);
+
+        // The stdout pipe still carries what was written before the check.
+        let mut buf = [0_u8; 7];
+        predecessor
+            .out_read
+            .read_exact(&mut buf)
+            .expect("the checked read end still reads");
+        assert_eq!(&buf, b"a bleat");
+
+        // The stdin pipe still carries a line the other way.
+        predecessor.stdin_write.write_all(b"whisper").unwrap();
+        let mut buf = [0_u8; 7];
+        predecessor
+            .stdin_read
+            .read_exact(&mut buf)
+            .expect("the checked write end still writes");
+        assert_eq!(&buf, b"whisper");
+
+        // The shepherd channel still has its child on the far end.
+        predecessor.channel.write_all(b"ping").unwrap();
+        let mut buf = [0_u8; 4];
+        predecessor
+            .child_channel
+            .read_exact(&mut buf)
+            .expect("the checked channel still reaches the child");
+        assert_eq!(&buf, b"ping");
+    }
+
+    /// A duplicate taken and never handed to an adoption leaks one
+    /// descriptor per named number, on a path that runs on every reload.
+    ///
+    /// Counted over a hundred passes rather than one, because the number
+    /// this can measure is the whole process's and the suite is running
+    /// other cases in other threads at the same time. A hundred passes of a
+    /// blob naming six descriptors leaks six hundred; the concurrent noise
+    /// is a few dozen either way, so the threshold sits comfortably between
+    /// them and needs no quiet machine.
+    #[tokio::test]
+    async fn a_rehearsal_leaks_no_descriptors() {
+        let predecessor = Predecessor::new();
+        let blob = predecessor.blob();
+        let before = open_fd_count();
+
+        for _ in 0..100 {
+            dry_run(&blob).expect("the fixture is adoptable");
+        }
+
+        let after = open_fd_count();
+        assert!(
+            after < before + 100,
+            "a hundred rehearsals of a blob naming six descriptors must not grow this \
+             process's descriptor table: {before} -> {after}"
+        );
+    }
+
+    /// The case with no recovery: a descriptor that is open, so the
+    /// `FD_CLOEXEC` sweep clears it without complaint, but is not the kind
+    /// its slot will be adopted as.
+    ///
+    /// This is the shape the whole task exists for. A closed number is
+    /// already refused before the exec, because clearing `FD_CLOEXEC` on it
+    /// meets `EBADF`; an OPEN one of the wrong kind sails through that,
+    /// reaches the `execve`, and is refused by a successor with no
+    /// predecessor left to hand the flock back to.
+    #[tokio::test]
+    async fn a_descriptor_that_is_open_but_not_a_pipe_is_refused_before_the_exec() {
+        use std::os::fd::AsRawFd as _;
+
+        let predecessor = Predecessor::new();
+        let not_a_pipe = std::fs::File::open("/dev/null").unwrap();
+        let mut blob = predecessor.blob();
+        blob.sheep[0].fds.out_pipe = Some(not_a_pipe.as_raw_fd());
+
+        // The premise, so the case cannot pass for the wrong reason: this
+        // number IS open, so nothing before the exec would have stopped it.
+        crate::sys::adoptable_fd(not_a_pipe.as_raw_fd())
+            .expect("the number must be open, or this proves nothing");
+        fds::keep_raw_across_exec(not_a_pipe.as_raw_fd())
+            .expect("the `FD_CLOEXEC` sweep must not refuse it either");
+
+        let err = dry_run(&blob).expect_err("/dev/null is not a readable pipe");
+
+        assert!(
+            err.to_string().contains("web") && err.to_string().contains("stdout"),
+            "the refusal must name the sheep and the stream: {err}"
+        );
+    }
+
+    /// The rehearsal and the adoption must agree, slot by slot.
+    ///
+    /// The failure this guards against is specific and is worse than not
+    /// rehearsing: a rehearsal that passes a blob the successor refuses
+    /// still reaches the `execve`, and by then there is no way back. Every
+    /// slot is walked because they are refused by four different mechanisms
+    /// — a readable-pipe check, a writable-pipe check, a `getpeername`, and
+    /// for the two log slots no kind check at all — and a pairing that put
+    /// the wrong one against a slot would pass on a narrower case.
+    #[tokio::test]
+    async fn the_rehearsal_and_the_adoption_agree_on_every_slot() {
+        use std::os::fd::AsRawFd as _;
+
+        for slot in [
+            SheepFd::OutPipe,
+            SheepFd::ErrPipe,
+            SheepFd::OutLog,
+            SheepFd::ErrLog,
+            SheepFd::Stdin,
+            SheepFd::Channel,
+        ] {
+            let predecessor = Predecessor::new();
+            let wrong = std::fs::File::open("/dev/null").unwrap();
+            let wrong = Some(wrong.as_raw_fd());
+            let mut blob = predecessor.blob();
+            let fds = &mut blob.sheep[0].fds;
+            match slot {
+                SheepFd::OutPipe => fds.out_pipe = wrong,
+                SheepFd::ErrPipe => fds.err_pipe = wrong,
+                SheepFd::OutLog => fds.out_log = wrong,
+                SheepFd::ErrLog => fds.err_log = wrong,
+                SheepFd::Stdin => fds.stdin = wrong,
+                SheepFd::Channel => fds.channel = wrong,
+            }
+
+            assert_eq!(
+                dry_run(&blob).is_err(),
+                adopt_a_copy(&blob).is_err(),
+                "the rehearsal and the adoption disagree about {slot:?}, so one of them is \
+                 checking something the other is not"
+            );
+        }
+    }
+
+    /// A repeated number is refused by the same function the successor
+    /// refuses it with, rather than by a second copy of the rule.
+    ///
+    /// It is a case the sweep before the exec cannot catch: clearing
+    /// `FD_CLOEXEC` twice on one number succeeds, deliberately and
+    /// idempotently, so a repeat reaches the successor untouched.
+    #[tokio::test]
+    async fn a_blob_naming_one_descriptor_twice_is_refused_before_the_exec() {
+        let predecessor = Predecessor::new();
+        let mut blob = predecessor.blob();
+        blob.sheep[0].fds.err_log = Some(blob.pidfile_fd);
+
+        let err = dry_run(&blob).expect_err("one number cannot have two owners");
+
+        assert!(
+            err.to_string().contains("more than once"),
+            "the refusal must be `refuse_repeated_fds`'s own: {err}"
+        );
+    }
+
+    /// A number below the stdio floor is refused here, not after the exec.
+    ///
+    /// The check runs against the BLOB's number rather than the duplicate's.
+    /// A duplicate is always open and always above the floor, so a
+    /// rehearsal that only ever inspected duplicates would wave through
+    /// exactly the two blobs `sys::adopt_handover_fd` is certain to refuse.
+    #[tokio::test]
+    async fn a_reserved_or_closed_number_is_refused_before_the_exec() {
+        let predecessor = Predecessor::new();
+
+        let mut reserved = predecessor.blob();
+        reserved.sheep[0].fds.out_log = Some(0);
+        let err = dry_run(&reserved).expect_err("stdio is owned elsewhere");
+        assert!(
+            err.to_string().contains("reserved for stdio"),
+            "the refusal must be the successor's own wording: {err}"
+        );
+
+        // `RawFd::MAX` rather than a number this case opened and closed. A
+        // closed number is the honest fixture and is also a race: the suite
+        // runs other cases in other threads of this same process, and one of
+        // them opening a file between the close and the assertion hands that
+        // number straight back. Caught once, on the unfiltered workspace run
+        // and never on the filtered one. A number above any process's
+        // descriptor limit is `EBADF` with nothing to race against, and the
+        // property under test is the same one — that the blob names no open
+        // descriptor.
+        let mut gone = predecessor.blob();
+        gone.sheep[0].fds.err_log = Some(RawFd::MAX);
+        let err = dry_run(&gone).expect_err("a number this high names nothing");
+        assert!(
+            err.to_string().contains("not an open descriptor"),
+            "the refusal must be the successor's own wording: {err}"
+        );
+    }
+
+    /// The successor reads the blob back off disk rather than being handed
+    /// this struct, so the parse is one of its checks too.
+    ///
+    /// A version it cannot read is the reachable case: a handover's whole
+    /// point is that the successor is a DIFFERENT build, and one that has
+    /// moved `VERSION` refuses the blob at `load_value` — after the exec,
+    /// with the predecessor gone.
+    #[tokio::test]
+    async fn a_blob_a_successor_could_not_read_back_is_refused_before_the_exec() {
+        let predecessor = Predecessor::new();
+        let mut blob = predecessor.blob();
+        blob.version = VERSION + 1;
+
+        let err = dry_run(&blob).expect_err("a version this image cannot read");
+
+        assert!(
+            err.to_string()
+                .contains("could not have read this blob back"),
+            "the refusal must say the parse failed, not the descriptors: {err}"
         );
     }
 }

--- a/crates/shep-daemon/src/handover/adopt.rs
+++ b/crates/shep-daemon/src/handover/adopt.rs
@@ -266,22 +266,26 @@ pub fn dry_run(blob: &Handover) -> io::Result<()> {
     // successor would: repeats first, then the listener, then each sheep,
     // then the pidfile.
     refuse_repeated_fds(&blob)?;
-    rehearse(blob.listener_fd, adopt_listener)?;
+    rehearse(blob.listener_fd, "the control listener", adopt_listener)?;
     for carried in &blob.sheep {
         let name = &carried.name;
         for (fd, slot) in carried.fds.all_kinded() {
             let Some(fd) = fd else { continue };
-            rehearse(fd, |dup| match slot {
-                SheepFd::OutPipe => adopt_pipe(Some(dup), name, "stdout").map(drop),
-                SheepFd::ErrPipe => adopt_pipe(Some(dup), name, "stderr").map(drop),
-                SheepFd::OutLog => adopt_log(Some(dup), name, "stdout").map(drop),
-                SheepFd::ErrLog => adopt_log(Some(dup), name, "stderr").map(drop),
-                SheepFd::Stdin => adopt_stdin(Some(dup), name).map(drop),
-                SheepFd::Channel => adopt_channel(Some(dup), name).map(drop),
-            })?;
+            rehearse(
+                fd,
+                &format!("sheep '{name}' {}", slot.describe()),
+                |dup| match slot {
+                    SheepFd::OutPipe => adopt_pipe(Some(dup), name, "stdout").map(drop),
+                    SheepFd::ErrPipe => adopt_pipe(Some(dup), name, "stderr").map(drop),
+                    SheepFd::OutLog => adopt_log(Some(dup), name, "stdout").map(drop),
+                    SheepFd::ErrLog => adopt_log(Some(dup), name, "stderr").map(drop),
+                    SheepFd::Stdin => adopt_stdin(Some(dup), name).map(drop),
+                    SheepFd::Channel => adopt_channel(Some(dup), name).map(drop),
+                },
+            )?;
         }
     }
-    rehearse(blob.pidfile_fd, |dup| {
+    rehearse(blob.pidfile_fd, "the pidfile lock", |dup| {
         adopt_fd(dup, "the pidfile lock").map(drop)
     })?;
     Ok(())
@@ -294,14 +298,24 @@ pub fn dry_run(blob: &Handover) -> io::Result<()> {
 ///
 /// `fd` is reserved or not open, it could not be duplicated, or the adoption
 /// refused the duplicate.
-fn rehearse<T>(fd: RawFd, adopt_one: impl FnOnce(RawFd) -> io::Result<T>) -> io::Result<()> {
+fn rehearse<T>(
+    fd: RawFd,
+    what: &str,
+    adopt_one: impl FnOnce(RawFd) -> io::Result<T>,
+) -> io::Result<()> {
     // The BLOB's number is checked here, never the duplicate's, and the
     // distinction is the whole reason this is not one line shorter.
     // `sys::adopt_handover_fd` refuses a number below 3 or one that is not
     // open, and a duplicate is always neither — so a rehearsal that only
     // ever saw duplicates would wave through exactly the two blobs the
     // successor is certain to refuse.
-    sys::adoptable_fd(fd).map_err(|error| io::Error::new(io::ErrorKind::InvalidInput, error))?;
+    // Labelled, because `sys::adoptable_fd` names only the NUMBER. A blob
+    // carries six descriptors per sheep, so `fd 7 is not an open descriptor`
+    // is a refusal an operator cannot map back to a stream. `dry_run`'s doc
+    // promises the message names the sheep and the stream, and this arm is
+    // the one that would otherwise make that false.
+    sys::adoptable_fd(fd)
+        .map_err(|error| io::Error::new(io::ErrorKind::InvalidInput, format!("{what}: {error}")))?;
     let duplicate = fds::duplicate_raw(fd)?;
     // `adopt_one` owns `duplicate` from here, on BOTH arms, and that is what
     // makes this leak nothing. Every adoption in this module either builds

--- a/crates/shep-daemon/src/handover/fds.rs
+++ b/crates/shep-daemon/src/handover/fds.rs
@@ -91,6 +91,36 @@ pub fn close_raw_after_exec(fd: RawFd) -> io::Result<()> {
     Ok(())
 }
 
+/// Duplicate `fd` onto a fresh number, for a caller that needs to inspect a
+/// descriptor it must not take.
+///
+/// The duplicate refers to the same open file description, so every question
+/// an adoption asks answers identically through it: what kind of object it
+/// is, which direction it is open for, whether a socket is connected, which
+/// status flags it carries. What it does not share is ownership, and that is
+/// the whole point — closing the duplicate leaves the original open and
+/// still owned by whoever in this process owns it.
+///
+/// `F_DUPFD_CLOEXEC` rather than a bare `dup(2)`, and both halves of that
+/// are load-bearing here. The floor keeps a duplicate off stdio, so
+/// [`crate::sys::adoptable_fd`] cannot refuse it as reserved and report a
+/// problem the blob does not have. Close-on-exec means a duplicate that
+/// somehow outlived its inspection still cannot leak into a successor's
+/// image, which is precisely the failure [`close_raw_after_exec`] exists to
+/// undo for the named descriptors.
+///
+/// # Errors
+///
+/// Returns an error if `fcntl` fails, which is what a number naming no open
+/// descriptor looks like, and what a process at its descriptor limit looks
+/// like too.
+pub fn duplicate_raw(fd: RawFd) -> io::Result<RawFd> {
+    Ok(fcntl(
+        fd,
+        FcntlArg::F_DUPFD_CLOEXEC(crate::sys::RESERVED_FD_FLOOR),
+    )?)
+}
+
 /// Whether `fd` currently survives an `execve` (i.e. `FD_CLOEXEC` is
 /// clear).
 ///

--- a/crates/shep-daemon/src/handover/mod.rs
+++ b/crates/shep-daemon/src/handover/mod.rs
@@ -2,12 +2,11 @@
 //! place, the [`Handover`] blob that describes it, and (in a later task) the
 //! exec that carries it.
 //!
-//! Three things are still not carried: a dog, an in-flight reload, and an
-//! operator's pending stop. A sheep's
-//! stdout, stderr, log files, stdin pipe and shepherd channel all cross the
-//! exec, and every one of those is per SHEEP rather than per app, so an app
-//! running several instances crosses as several sets and needs nothing of
-//! its own. [`fitness`] is the gate: get it wrong in the permissive
+//! Two things are still not carried: a dog, and an in-flight reload. A
+//! sheep's stdout, stderr, log files, stdin pipe and shepherd channel all
+//! cross the exec, and every one of those is per SHEEP rather than per app,
+//! so an app running several instances crosses as several sets and needs
+//! nothing of its own. [`fitness`] is the gate: get it wrong in the permissive
 //! direction and a half-built handover corrupts a live flock; get it wrong
 //! in the strict direction and the caller merely falls back to the
 //! stop-and-start arm that already works. That asymmetry is why an unclear
@@ -36,6 +35,7 @@ use shep_core::status::ProcStatus;
 
 use crate::entry::ProcessEntry;
 use crate::privilege::SpawnIdentity;
+use crate::supervisor::PendingManual;
 
 /// Whether a flock can be handed over in place, or must fall back to a
 /// stop-and-start.
@@ -61,7 +61,7 @@ pub enum Fitness {
 /// held-without, and there is no fourth state). This one is closed by
 /// nothing but how much of the handover has shipped. Every phase so far has
 /// turned one of these into something the daemon carries, and 2c still has
-/// two to go, so a match here must keep tolerating a variant this module
+/// one to go, so a match here must keep tolerating a variant this module
 /// has not named yet.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
@@ -88,12 +88,6 @@ pub enum RefusedReason {
         /// The sheep's name.
         sheep: String,
     },
-    /// An operator's `stop` is waiting on this sheep's next exit, which 2c
-    /// carries.
-    PendingStop {
-        /// The sheep's name.
-        sheep: String,
-    },
 }
 
 impl core::fmt::Display for RefusedReason {
@@ -112,7 +106,6 @@ impl core::fmt::Display for RefusedReason {
             }
             Self::Dog { sheep } => (sheep, "being a dog"),
             Self::ReloadInFlight { sheep } => (sheep, "an in-flight reload"),
-            Self::PendingStop { sheep } => (sheep, "a pending manual stop"),
         };
         write!(
             f,
@@ -124,23 +117,20 @@ impl core::fmt::Display for RefusedReason {
 
 /// One sheep's carryability-relevant facts.
 ///
-/// Bundles a [`ProcessEntry`] with the one fact that does not live on it: a
-/// pending manual stop lives on the supervisor's private slot type, not on
-/// the entry it wraps, so `fitness` cannot reach it through `entry` alone.
-/// The caller, the supervisor, which owns it, builds this view; `fitness`
-/// stays a pure function over data it is handed rather than reaching into
-/// the registry itself.
+/// Bundles a [`ProcessEntry`] with the one fact that does not live on it:
+/// whether this sheep's log pump answered the snapshot's deadline, which
+/// only the task that asked it knows. `fitness` stays a pure function over
+/// data it is handed rather than reaching into the registry itself.
 ///
-/// A pending delete used to live here too. It is no longer a refusal —
-/// [`CarriedSheep::pending_delete`] carries it instead — so it is no longer
-/// a carryability-relevant fact and this view has nothing left to say about
-/// it.
+/// A pending delete and a pending manual stop both used to live here too.
+/// Neither is a refusal any more — [`CarriedSheep::pending_delete`] and
+/// [`CarriedSheep::manual`] carry them instead — so neither is a
+/// carryability-relevant fact and this view has nothing left to say about
+/// either.
 #[derive(Debug, Clone, Copy)]
 pub struct Candidate<'a> {
     /// The sheep's lifecycle entry.
     pub entry: &'a ProcessEntry,
-    /// Whether an operator's `stop` is waiting on this sheep's next exit.
-    pub pending_stop: bool,
     /// Whether this sheep's log pump was asked for its descriptors and did
     /// not answer in time.
     ///
@@ -166,8 +156,6 @@ pub struct Candidate<'a> {
 pub struct OwnedCandidate {
     /// The sheep's lifecycle entry, cloned off the supervisor's slot.
     pub entry: ProcessEntry,
-    /// Whether an operator's command is waiting on this sheep's next exit.
-    pub pending_stop: bool,
     /// Whether this sheep's log pump missed the snapshot's deadline; see
     /// [`Candidate::pump_unresponsive`].
     pub pump_unresponsive: bool,
@@ -179,7 +167,6 @@ impl OwnedCandidate {
     pub fn as_candidate(&self) -> Candidate<'_> {
         Candidate {
             entry: &self.entry,
-            pending_stop: self.pending_stop,
             pump_unresponsive: self.pump_unresponsive,
         }
     }
@@ -214,9 +201,6 @@ fn refusal(candidate: &Candidate<'_>) -> Option<RefusedReason> {
     }
     if !matches!(entry.reload, crate::entry::ReloadState::None) {
         return Some(RefusedReason::ReloadInFlight { sheep: name() });
-    }
-    if candidate.pending_stop {
-        return Some(RefusedReason::PendingStop { sheep: name() });
     }
     None
 }
@@ -578,6 +562,22 @@ pub struct CarriedSheep {
     /// "no" — not "unknown", so [`VERSION`] stays unmoved: nothing an older
     /// reader must understand has changed.
     pending_delete: Option<bool>,
+    /// The manual command that owned this instance's next exit before the
+    /// exec, and who asked for it.
+    ///
+    /// One `Option`, not the two [`Self::pending_delete`] needs, and the
+    /// difference is what "absent" means rather than a style choice. A
+    /// missing key loads as `None`, and `None` is already this field's own
+    /// word for "no command owns this exit" — the same thing a predecessor
+    /// that refused to carry a marker at all was saying. There is no third
+    /// state to distinguish, so [`VERSION`] stays unmoved here for the same
+    /// reason it did there.
+    ///
+    /// Nothing on it is sensitive: two closed enums naming which verb and
+    /// whether a person or the daemon raised it (IR-41). The blob's
+    /// `AppConfig` already carries the app's whole environment, and this
+    /// adds nothing to what a reader of that file can see.
+    manual: Option<PendingManual>,
     /// The resolved config this instance runs under, environment included.
     ///
     /// This is the `AppConfig` beneath [`ProcessEntry::spec`]'s
@@ -611,18 +611,19 @@ pub struct CarriedSheep {
 impl CarriedSheep {
     /// Describe `entry` for the successor.
     ///
-    /// `epoch`, `fds` and `pending_delete` are arguments rather than reads
-    /// off `entry` because none of them lives there: the respawn epoch and
-    /// the pending-delete marker are on the supervisor's private slot type,
-    /// and the descriptor numbers are known only to whichever code holds
-    /// the open descriptors. This is the same split [`Candidate`] makes,
-    /// for the same reason.
+    /// `epoch`, `fds`, `pending_delete` and `manual` are arguments rather
+    /// than reads off `entry` because none of them lives there: the respawn
+    /// epoch, the pending-delete marker and the manual-command marker are on
+    /// the supervisor's private slot type, and the descriptor numbers are
+    /// known only to whichever code holds the open descriptors. This is the
+    /// same split [`Candidate`] makes, for the same reason.
     #[must_use]
     pub fn from_entry(
         entry: &ProcessEntry,
         epoch: u64,
         fds: CarriedFds,
         pending_delete: bool,
+        manual: Option<PendingManual>,
     ) -> Self {
         Self {
             id: entry.id,
@@ -636,6 +637,7 @@ impl CarriedSheep {
             credentials: entry.credentials,
             fds,
             pending_delete: Some(pending_delete),
+            manual,
             app: entry.spec.config().clone(),
         }
     }
@@ -654,6 +656,16 @@ impl CarriedSheep {
     #[must_use]
     pub const fn pending_delete(&self) -> Option<bool> {
         self.pending_delete
+    }
+
+    /// The manual command that owned this instance's next exit before the
+    /// exec, or `None` for an instance no command was waiting on — which is
+    /// also what a blob written before this field existed says, and
+    /// truthfully, since that predecessor refused to carry a marker at all.
+    /// See the field's own doc.
+    #[must_use]
+    pub const fn manual(&self) -> Option<PendingManual> {
+        self.manual
     }
 
     /// The supervisor slot's respawn epoch at the moment of the handover.
@@ -1183,6 +1195,7 @@ mod tests {
     use super::*;
     use crate::entry::{ReloadState, RestartBudget};
     use crate::privilege::SpawnIdentity;
+    use crate::supervisor::{CommandOrigin, ManualKind};
     use crate::testing::{app_with, test_paths};
 
     /// A plain, `Online` entry: no channel, not a dog, one instance, no
@@ -1212,7 +1225,6 @@ mod tests {
     fn plain(entry: &ProcessEntry) -> Candidate<'_> {
         Candidate {
             entry,
-            pending_stop: false,
             pump_unresponsive: false,
         }
     }
@@ -1261,7 +1273,6 @@ mod tests {
         let e = entry_fixture(|_| {});
         let candidate = Candidate {
             entry: &e,
-            pending_stop: false,
             pump_unresponsive: true,
         };
         let Fitness::Refused(r) = fitness(&[candidate]) else {
@@ -1388,8 +1399,8 @@ mod tests {
 
         let blob = Handover::new(
             vec![
-                CarriedSheep::from_entry(&zero, 7, fds_at(11), false),
-                CarriedSheep::from_entry(&one, 8, fds_at(21), false),
+                CarriedSheep::from_entry(&zero, 7, fds_at(11), false, None),
+                CarriedSheep::from_entry(&one, 8, fds_at(21), false, None),
             ],
             DaemonFds {
                 listener: 3,
@@ -1441,18 +1452,38 @@ mod tests {
         ));
     }
 
+    /// Fails if a pending manual command refuses the flock again.
+    ///
+    /// The inverse of the case this replaces. A `stop`, `restart` or
+    /// `delete` already claimed against a sheep used to turn the whole flock
+    /// away; [`CarriedSheep::manual`] carries the marker now, and
+    /// `Actor::install_adopted` re-arms the ladder that carries it out, so
+    /// the fact is no longer carryability-relevant at all — which is why
+    /// `Candidate` has nothing left to say about it and this case asserts
+    /// through the blob instead of through the gate.
     #[test]
-    fn a_pending_manual_stop_refuses() {
+    fn a_pending_manual_command_no_longer_refuses_and_reaches_the_blob() {
         let e = entry_fixture(|_| {});
-        let candidate = Candidate {
-            entry: &e,
-            pending_stop: true,
-            pump_unresponsive: false,
-        };
-        assert!(matches!(
-            fitness(&[candidate]),
-            Fitness::Refused(RefusedReason::PendingStop { .. })
-        ));
+        assert_eq!(fitness(&[plain(&e)]), Fitness::Carryable);
+
+        let marked = CarriedSheep::from_entry(
+            &e,
+            7,
+            fds_at(11),
+            false,
+            Some(PendingManual {
+                kind: ManualKind::Delete,
+                origin: CommandOrigin::Automatic,
+            }),
+        );
+        assert_eq!(
+            marked.manual(),
+            Some(PendingManual {
+                kind: ManualKind::Delete,
+                origin: CommandOrigin::Automatic,
+            }),
+            "both halves of the marker must survive the blob, not just that one exists"
+        );
     }
 
     /// The six descriptor numbers a running sheep would have, counting up
@@ -1475,7 +1506,7 @@ mod tests {
     /// One carried sheep off `entry`, with the descriptor numbers a
     /// running sheep would have.
     fn carried(entry: &ProcessEntry) -> CarriedSheep {
-        CarriedSheep::from_entry(entry, 7, fds_at(11), false)
+        CarriedSheep::from_entry(entry, 7, fds_at(11), false, None)
     }
 
     fn handover_over(entry: &ProcessEntry) -> Handover {
@@ -1673,6 +1704,59 @@ mod tests {
         );
     }
 
+    /// fails if a blob written before this daemon carried a manual marker
+    /// stops loading, or if the marker does not survive one that has it.
+    ///
+    /// Same shape and same stakes as the pending-delete case above. A
+    /// predecessor from before [`CarriedSheep::manual`] existed refused to
+    /// hand over a sheep with a `stop`, `restart` or `delete` already
+    /// claimed against it, so its blobs never have the key, and `None` is
+    /// the truthful reading of that: no command owns this exit. A hard
+    /// parse failure instead would leave the successor refusing to boot
+    /// after the predecessor had already exec'd itself away.
+    ///
+    /// The sample is given a marker first, so the removal below removes
+    /// something: a blob whose `manual` was `None` all along could not tell
+    /// an absent key from a present `null`.
+    #[test]
+    fn a_blob_written_before_a_manual_marker_was_carried_still_loads() {
+        let marker = PendingManual {
+            kind: ManualKind::Restart,
+            origin: CommandOrigin::Automatic,
+        };
+        let mut blob = sample_handover();
+        blob.sheep[0] =
+            CarriedSheep::from_entry(&entry_fixture(|_| {}), 7, fds_at(11), false, Some(marker));
+        let value = serde_json::to_value(&blob).unwrap();
+
+        assert_eq!(
+            Handover::load_value(value.clone())
+                .expect("a current blob loads")
+                .sheep[0]
+                .manual(),
+            Some(marker),
+            "a marker on the wire must come back whole, kind and origin both"
+        );
+
+        let mut older = value;
+        let sheep = older["sheep"][0]
+            .as_object_mut()
+            .expect("a carried sheep is an object");
+        assert!(
+            sheep.remove("manual").is_some(),
+            "the field this case removes must be there to remove"
+        );
+
+        let loaded = Handover::load_value(older).expect("an older blob must still load");
+
+        assert_eq!(loaded.sheep[0].manual(), None);
+        assert_eq!(
+            loaded.sheep[0].id(),
+            blob.sheep[0].id(),
+            "the rest of the row is unchanged by the one field that was absent"
+        );
+    }
+
     #[test]
     fn the_exec_target_exists_and_is_a_file() {
         let p = exec_target().unwrap();
@@ -1759,7 +1843,7 @@ mod tests {
     ) -> Handover {
         Handover {
             version: VERSION,
-            sheep: vec![CarriedSheep::from_entry(entry, 7, fds, false)],
+            sheep: vec![CarriedSheep::from_entry(entry, 7, fds, false, None)],
             listener_fd,
             pidfile_fd,
             next_id: 9,

--- a/crates/shep-daemon/src/handover/mod.rs
+++ b/crates/shep-daemon/src/handover/mod.rs
@@ -2,7 +2,7 @@
 //! place, the [`Handover`] blob that describes it, and (in a later task) the
 //! exec that carries it.
 //!
-//! Two things are still not carried: a dog, and an in-flight reload. A
+//! One thing is still not carried: a dog. A
 //! sheep's stdout, stderr, log files, stdin pipe and shepherd channel all
 //! cross the exec, and every one of those is per SHEEP rather than per app,
 //! so an app running several instances crosses as several sets and needs
@@ -33,9 +33,9 @@ use shep_core::paths::ShepPaths;
 use shep_core::protocol::ExitInfo;
 use shep_core::status::ProcStatus;
 
-use crate::entry::ProcessEntry;
+use crate::entry::{ProcessEntry, ReloadState};
 use crate::privilege::SpawnIdentity;
-use crate::supervisor::PendingManual;
+use crate::supervisor::{CarriedReload, PendingManual};
 
 /// Whether a flock can be handed over in place, or must fall back to a
 /// stop-and-start.
@@ -60,9 +60,9 @@ pub enum Fitness {
 /// closed by its mechanism (a pidfile lock is either free, held-with-pid or
 /// held-without, and there is no fourth state). This one is closed by
 /// nothing but how much of the handover has shipped. Every phase so far has
-/// turned one of these into something the daemon carries, and 2c still has
-/// one to go, so a match here must keep tolerating a variant this module
-/// has not named yet.
+/// turned one of these into something the daemon carries, and a dog is still
+/// to go, so a match here must keep tolerating a variant this module has not
+/// named yet.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum RefusedReason {
@@ -83,11 +83,6 @@ pub enum RefusedReason {
         /// The sheep's name.
         sheep: String,
     },
-    /// The sheep is mid-reload, drainee or replacement, which 2c carries.
-    ReloadInFlight {
-        /// The sheep's name.
-        sheep: String,
-    },
 }
 
 impl core::fmt::Display for RefusedReason {
@@ -105,7 +100,6 @@ impl core::fmt::Display for RefusedReason {
                 );
             }
             Self::Dog { sheep } => (sheep, "being a dog"),
-            Self::ReloadInFlight { sheep } => (sheep, "an in-flight reload"),
         };
         write!(
             f,
@@ -122,11 +116,12 @@ impl core::fmt::Display for RefusedReason {
 /// only the task that asked it knows. `fitness` stays a pure function over
 /// data it is handed rather than reaching into the registry itself.
 ///
-/// A pending delete and a pending manual stop both used to live here too.
-/// Neither is a refusal any more — [`CarriedSheep::pending_delete`] and
-/// [`CarriedSheep::manual`] carry them instead — so neither is a
+/// A pending delete, a pending manual stop and a swap in flight all used to
+/// live here too. None of them is a refusal any more —
+/// [`CarriedSheep::pending_delete`], [`CarriedSheep::manual`] and
+/// [`CarriedSheep::reload`] carry them instead — so none of them is a
 /// carryability-relevant fact and this view has nothing left to say about
-/// either.
+/// any of them.
 #[derive(Debug, Clone, Copy)]
 pub struct Candidate<'a> {
     /// The sheep's lifecycle entry.
@@ -198,9 +193,6 @@ fn refusal(candidate: &Candidate<'_>) -> Option<RefusedReason> {
     }
     if entry.dog.is_some() {
         return Some(RefusedReason::Dog { sheep: name() });
-    }
-    if !matches!(entry.reload, crate::entry::ReloadState::None) {
-        return Some(RefusedReason::ReloadInFlight { sheep: name() });
     }
     None
 }
@@ -287,6 +279,19 @@ pub struct Handover {
     next_deadline: u64,
     /// The supervisor's next action-wait stamp.
     next_action_stamp: u64,
+    /// Every app whose reload was still in flight at the exec.
+    ///
+    /// `Option` for the reason [`CarriedSheep::pending_delete`] gives at
+    /// length: a predecessor from before this field existed refused to carry
+    /// a flock with any reload in flight, so a blob it wrote never has the
+    /// key, and an absent field loads as `None` rather than failing to
+    /// parse. `None` is what that blob truthfully means — no app was
+    /// mid-reload — so [`VERSION`] stays unmoved.
+    ///
+    /// Sorted by app name by its writer, since [`HashMap`](std::collections::HashMap)
+    /// iteration order is arbitrary and the blob is a file an operator may
+    /// read.
+    reloads: Option<Vec<CarriedReload>>,
 }
 
 impl Handover {
@@ -297,7 +302,12 @@ impl Handover {
     /// slots and its pumps, `fds` from `boot`, and `counters` from the
     /// actor. Nothing in this crate can see all three.
     #[must_use]
-    pub fn new(sheep: Vec<CarriedSheep>, fds: DaemonFds, counters: Counters) -> Self {
+    pub fn new(
+        sheep: Vec<CarriedSheep>,
+        fds: DaemonFds,
+        counters: Counters,
+        reloads: Vec<CarriedReload>,
+    ) -> Self {
         Self {
             version: VERSION,
             sheep,
@@ -306,6 +316,7 @@ impl Handover {
             next_id: counters.next_id,
             next_deadline: counters.next_deadline,
             next_action_stamp: counters.next_action_stamp,
+            reloads: Some(reloads),
         }
     }
 
@@ -343,6 +354,16 @@ impl Handover {
             next_deadline: self.next_deadline,
             next_action_stamp: self.next_action_stamp,
         }
+    }
+
+    /// Every app whose reload was still in flight at the exec.
+    ///
+    /// Empty both for a flock with nothing mid-reload and for a blob written
+    /// before this daemon carried one at all, which say the same thing: see
+    /// the field's own doc.
+    #[must_use]
+    pub fn reloads(&self) -> &[CarriedReload] {
+        self.reloads.as_deref().unwrap_or_default()
     }
 
     /// Where the blob lives under `paths`: `$SHEP_HOME/run/handover.json`.
@@ -578,6 +599,19 @@ pub struct CarriedSheep {
     /// `AppConfig` already carries the app's whole environment, and this
     /// adds nothing to what a reader of that file can see.
     manual: Option<PendingManual>,
+    /// Which half of a reload's swap this instance is, if either.
+    ///
+    /// `Option` for the reason [`Self::pending_delete`] gives: a predecessor
+    /// from before this field existed refused to carry a sheep mid-swap at
+    /// all, so a blob it wrote never has the key, and `None` is what that
+    /// blob truthfully means — [`ReloadState::None`] — rather than
+    /// "unknown". [`VERSION`] stays unmoved.
+    ///
+    /// It is the marker that ROUTES this instance's next exit. A successor
+    /// that dropped it would send a drainee's exit to `decide_on_exit`
+    /// instead of to the reload machinery, which for an `autorestart` app
+    /// respawns the old code into a slot the replacement owns.
+    reload: Option<ReloadState>,
     /// The resolved config this instance runs under, environment included.
     ///
     /// This is the `AppConfig` beneath [`ProcessEntry::spec`]'s
@@ -638,6 +672,9 @@ impl CarriedSheep {
             fds,
             pending_delete: Some(pending_delete),
             manual,
+            // Read off the entry rather than passed in, unlike the two
+            // markers above: this one does live on `ProcessEntry`.
+            reload: Some(entry.reload),
             app: entry.spec.config().clone(),
         }
     }
@@ -666,6 +703,15 @@ impl CarriedSheep {
     #[must_use]
     pub const fn manual(&self) -> Option<PendingManual> {
         self.manual
+    }
+
+    /// Which half of a reload's swap this instance is, or `None` for a blob
+    /// written before this field existed — which truthfully means
+    /// [`ReloadState::None`], since that predecessor refused to carry a
+    /// sheep mid-swap at all. See the field's own doc.
+    #[must_use]
+    pub const fn reload(&self) -> Option<ReloadState> {
+        self.reload
     }
 
     /// The supervisor slot's respawn epoch at the moment of the handover.
@@ -1248,7 +1294,7 @@ mod tests {
     use super::*;
     use crate::entry::{ReloadState, RestartBudget};
     use crate::privilege::SpawnIdentity;
-    use crate::supervisor::{CommandOrigin, ManualKind};
+    use crate::supervisor::{CommandOrigin, ManualKind, ReloadMode, ReloadPhase, ReloadSwap};
     use crate::testing::{app_with, test_paths};
 
     /// A plain, `Online` entry: no channel, not a dog, one instance, no
@@ -1464,6 +1510,7 @@ mod tests {
                 next_deadline: 5,
                 next_action_stamp: 2,
             },
+            Vec::new(),
         );
         let back: Handover = serde_json::from_str(&serde_json::to_string(&blob).unwrap()).unwrap();
 
@@ -1495,14 +1542,37 @@ mod tests {
         );
     }
 
+    /// Fails if a sheep mid-swap refuses the flock again, or if the marker
+    /// that routes its next exit is lost on the way into the blob.
+    ///
+    /// The inverse of the case this replaces, in the shape
+    /// [`a_pending_manual_command_no_longer_refuses_and_reaches_the_blob`]
+    /// set. Both halves of a swap are asserted, and the drainee's linked id
+    /// with them: `Drainee { new_id }` is what tells the successor which
+    /// entry is coming to take this one's place, and a marker that arrived
+    /// as a bare "drainee" would leave the successor unable to finish the
+    /// swap it inherited.
     #[test]
-    fn an_in_flight_reload_refuses() {
-        let mut e = entry_fixture(|_| {});
-        e.reload = ReloadState::Replacement;
-        assert!(matches!(
-            fitness(&[plain(&e)]),
-            Fitness::Refused(RefusedReason::ReloadInFlight { .. })
-        ));
+    fn a_swap_in_flight_no_longer_refuses_and_reaches_the_blob() {
+        let mut drainee = entry_fixture(|_| {});
+        drainee.reload = ReloadState::Drainee { new_id: Some(9) };
+        let mut replacement = entry_fixture(|_| {});
+        replacement.id = 9;
+        replacement.reload = ReloadState::Replacement;
+        assert_eq!(
+            fitness(&[plain(&drainee), plain(&replacement)]),
+            Fitness::Carryable
+        );
+
+        assert_eq!(
+            carried(&drainee).reload(),
+            Some(ReloadState::Drainee { new_id: Some(9) }),
+            "the id linking the two halves must survive the blob, not just the role"
+        );
+        assert_eq!(
+            carried(&replacement).reload(),
+            Some(ReloadState::Replacement)
+        );
     }
 
     /// Fails if a pending manual command refuses the flock again.
@@ -1571,6 +1641,7 @@ mod tests {
             next_id: 9,
             next_deadline: 5,
             next_action_stamp: 2,
+            reloads: Some(Vec::new()),
         }
     }
 
@@ -1846,6 +1917,79 @@ mod tests {
         );
     }
 
+    /// fails if a blob written before this daemon carried a swap in flight
+    /// stops loading, or if a swap that IS carried does not survive the
+    /// wire whole.
+    ///
+    /// Same shape and same stakes as the two cases above, in both halves.
+    /// A predecessor from before this daemon carried a reload refused the
+    /// whole flock over one sheep mid-swap, so its blobs have neither
+    /// `sheep[].reload` nor the top-level `reloads` array — and `None` is
+    /// the truthful reading of both: nothing was mid-reload. A hard parse
+    /// failure instead would leave the successor refusing to boot after the
+    /// predecessor had already exec'd itself away.
+    ///
+    /// The current-blob half is asserted first so the removals below remove
+    /// something, and it asserts the JOB as well as the marker: the marker
+    /// alone tells a successor an instance is half of a swap without
+    /// telling it which swap, and a job restored without its phase or its
+    /// mode would be continued down the wrong ordering.
+    #[test]
+    fn a_blob_written_before_a_swap_was_carried_still_loads() {
+        let job = CarriedReload {
+            app: "web".to_owned(),
+            queue: vec![11, 12],
+            mode: ReloadMode::Serial,
+            swap: ReloadSwap {
+                old_id: 1,
+                new_id: Some(9),
+                phase: ReloadPhase::AwaitReady,
+            },
+        };
+        let mut blob = sample_handover();
+        let mut drainee = entry_fixture(|_| {});
+        drainee.reload = ReloadState::Drainee { new_id: Some(9) };
+        blob.sheep[0] = carried(&drainee);
+        blob.reloads = Some(vec![job.clone()]);
+        let value = serde_json::to_value(&blob).unwrap();
+
+        let current = Handover::load_value(value.clone()).expect("a current blob loads");
+        assert_eq!(
+            current.sheep[0].reload(),
+            Some(ReloadState::Drainee { new_id: Some(9) }),
+            "the marker on the wire must come back whole, role and linked id both"
+        );
+        assert_eq!(
+            current.reloads(),
+            &[job],
+            "the job must come back whole: queue, mode and every field of the swap"
+        );
+
+        let mut older = value;
+        let object = older.as_object_mut().expect("a blob is an object");
+        assert!(
+            object.remove("reloads").is_some(),
+            "the field this case removes must be there to remove"
+        );
+        let sheep = older["sheep"][0]
+            .as_object_mut()
+            .expect("a carried sheep is an object");
+        assert!(
+            sheep.remove("reload").is_some(),
+            "the field this case removes must be there to remove"
+        );
+
+        let loaded = Handover::load_value(older).expect("an older blob must still load");
+
+        assert_eq!(loaded.sheep[0].reload(), None);
+        assert!(loaded.reloads().is_empty());
+        assert_eq!(
+            loaded.sheep[0].id(),
+            blob.sheep[0].id(),
+            "the rest of the row is unchanged by the two fields that were absent"
+        );
+    }
+
     #[test]
     fn the_exec_target_exists_and_is_a_file() {
         let p = exec_target().unwrap();
@@ -1938,6 +2082,7 @@ mod tests {
             next_id: 9,
             next_deadline: 5,
             next_action_stamp: 2,
+            reloads: Some(Vec::new()),
         }
     }
 

--- a/crates/shep-daemon/src/handover/mod.rs
+++ b/crates/shep-daemon/src/handover/mod.rs
@@ -2,7 +2,11 @@
 //! place, the [`Handover`] blob that describes it, and (in a later task) the
 //! exec that carries it.
 //!
-//! One thing is still not carried: a dog. A
+//! Two things are still refused, and they are not the same kind of thing. A
+//! DOG is deferred: phase 3 carries it, and the refusal goes when it does. An
+//! unresponsive log pump is PERMANENT, because it is a live sheep whose
+//! descriptors this daemon does not know, and carrying it would hand the
+//! successor a sheep it cannot read. A
 //! sheep's stdout, stderr, log files, stdin pipe and shepherd channel all
 //! cross the exec, and every one of those is per SHEEP rather than per app,
 //! so an app running several instances crosses as several sets and needs
@@ -62,7 +66,9 @@ pub enum Fitness {
 /// nothing but how much of the handover has shipped. Every phase so far has
 /// turned one of these into something the daemon carries, and a dog is still
 /// to go, so a match here must keep tolerating a variant this module has not
-/// named yet.
+/// named yet. [`RefusedReason::PumpUnresponsive`] is the exception that will
+/// not go: it answers a question about THIS daemon's knowledge rather than
+/// about the handover's coverage.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum RefusedReason {

--- a/crates/shep-daemon/src/handover/mod.rs
+++ b/crates/shep-daemon/src/handover/mod.rs
@@ -890,6 +890,26 @@ pub(crate) enum SheepFd {
     Channel,
 }
 
+impl SheepFd {
+    /// What this slot is called in a refusal, in the wording the adoption
+    /// functions already use.
+    ///
+    /// Kept beside the variants rather than at the one call site so the two
+    /// cannot drift: `adopt_pipe` says "stdout pipe" and this has to say the
+    /// same, or an operator reads one name from a rehearsal and a different
+    /// one from the successor for the identical descriptor.
+    pub(crate) const fn describe(self) -> &'static str {
+        match self {
+            Self::OutPipe => "stdout pipe",
+            Self::ErrPipe => "stderr pipe",
+            Self::OutLog => "stdout log",
+            Self::ErrLog => "stderr log",
+            Self::Stdin => "stdin pipe",
+            Self::Channel => "shepherd channel",
+        }
+    }
+}
+
 impl CarriedFds {
     /// The six numbers, listener-order irrelevant but fixed: stdout's pipe,
     /// stderr's pipe, stdout's log, stderr's log, stdin's pipe, the

--- a/crates/shep-daemon/src/handover/mod.rs
+++ b/crates/shep-daemon/src/handover/mod.rs
@@ -819,6 +819,31 @@ pub struct CarriedFds {
     pub channel: Option<RawFd>,
 }
 
+/// Which of a sheep's six descriptors a number is.
+///
+/// Not a description of the object — that is what the adoption itself
+/// discovers — but of the SLOT, which is what decides which adoption runs.
+/// A stdout pipe and a stdin pipe are both pipes and are refused by opposite
+/// checks, so the slot is the part a caller has to carry with the number.
+///
+/// `Debug` is derived and carries nothing: six unit variants, no descriptor
+/// number, no path, no environment (IR-41).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) enum SheepFd {
+    /// The read end of the sheep's stdout pipe ([`CarriedFds::out_pipe`]).
+    OutPipe,
+    /// The read end of the sheep's stderr pipe ([`CarriedFds::err_pipe`]).
+    ErrPipe,
+    /// The appending handle on its stdout log ([`CarriedFds::out_log`]).
+    OutLog,
+    /// The appending handle on its stderr log ([`CarriedFds::err_log`]).
+    ErrLog,
+    /// The WRITE end of its stdin pipe ([`CarriedFds::stdin`]).
+    Stdin,
+    /// The daemon's end of its shepherd channel ([`CarriedFds::channel`]).
+    Channel,
+}
+
 impl CarriedFds {
     /// The six numbers, listener-order irrelevant but fixed: stdout's pipe,
     /// stderr's pipe, stdout's log, stderr's log, stdin's pipe, the
@@ -836,6 +861,34 @@ impl CarriedFds {
             self.err_log,
             self.stdin,
             self.channel,
+        ]
+    }
+
+    /// [`Self::all`], with each number labelled by which of the six it is,
+    /// and so by the adoption a successor will attempt on it.
+    ///
+    /// The pairing lives here rather than at either caller because there are
+    /// two callers and they must not disagree. [`adopt::adopt`] runs these
+    /// adoptions for real in the successor; [`adopt::dry_run`] runs the same
+    /// ones in the PREDECESSOR, against duplicates, so that a blob the
+    /// successor would refuse never reaches an `execve`. A number rehearsed
+    /// as the wrong kind is a rehearsal that passes and a boot that still
+    /// fails, which is worse than not rehearsing at all.
+    ///
+    /// Three things hold the two in step, and none of them is a promise to
+    /// remember. This array is the only pairing either side reads;
+    /// `every_carried_number_is_kinded_in_the_same_order` pins it against
+    /// [`Self::all`], which is what the `FD_CLOEXEC` sweep already walks; and
+    /// a seventh descriptor changes that function's return type, so this one
+    /// stops compiling until it grows a seventh entry too.
+    pub(crate) const fn all_kinded(&self) -> [(Option<RawFd>, SheepFd); 6] {
+        [
+            (self.out_pipe, SheepFd::OutPipe),
+            (self.err_pipe, SheepFd::ErrPipe),
+            (self.out_log, SheepFd::OutLog),
+            (self.err_log, SheepFd::ErrLog),
+            (self.stdin, SheepFd::Stdin),
+            (self.channel, SheepFd::Channel),
         ]
     }
 
@@ -1523,6 +1576,42 @@ mod tests {
 
     fn sample_handover() -> Handover {
         handover_over(&entry_fixture(|_| {}))
+    }
+
+    /// [`CarriedFds::all`] and [`CarriedFds::all_kinded`] must name the same
+    /// six numbers, in the same order, one slot each.
+    ///
+    /// `all` is what the `FD_CLOEXEC` sweep walks, and `all_kinded` is what
+    /// the pre-exec rehearsal walks. A slot paired with the wrong field
+    /// there would have the rehearsal check a stdout pipe against the stdin
+    /// check, which passes for the wrong reason on a fixture where both are
+    /// pipes and fails on a real flock. Nothing else would notice: both
+    /// arrays are six long and both are full of plausible numbers.
+    ///
+    /// Six DISTINCT numbers, so the equality below is about the pairing
+    /// rather than about the length, and a second pass over the slots, so a
+    /// copy-paste that repeated one cannot ride along behind numbers that
+    /// happen to line up.
+    #[test]
+    fn every_carried_number_is_kinded_in_the_same_order() {
+        let fds = CarriedFds {
+            out_pipe: Some(10),
+            err_pipe: Some(11),
+            out_log: Some(12),
+            err_log: Some(13),
+            stdin: Some(14),
+            channel: Some(15),
+        };
+
+        assert_eq!(
+            fds.all_kinded().map(|(fd, _)| fd),
+            fds.all(),
+            "the kinded walk and the `FD_CLOEXEC` walk must see the same numbers"
+        );
+
+        let slots: std::collections::HashSet<SheepFd> =
+            fds.all_kinded().iter().map(|(_, slot)| *slot).collect();
+        assert_eq!(slots.len(), 6, "each slot must appear exactly once");
     }
 
     fn sample_handover_with_secret_env() -> Handover {

--- a/crates/shep-daemon/src/handover/mod.rs
+++ b/crates/shep-daemon/src/handover/mod.rs
@@ -2,8 +2,8 @@
 //! place, the [`Handover`] blob that describes it, and (in a later task) the
 //! exec that carries it.
 //!
-//! Three things are still not carried: a dog, an in-flight reload, and
-//! anything an operator has already asked to stop or delete. A sheep's
+//! Three things are still not carried: a dog, an in-flight reload, and an
+//! operator's pending stop. A sheep's
 //! stdout, stderr, log files, stdin pipe and shepherd channel all cross the
 //! exec, and every one of those is per SHEEP rather than per app, so an app
 //! running several instances crosses as several sets and needs nothing of
@@ -61,7 +61,7 @@ pub enum Fitness {
 /// held-without, and there is no fourth state). This one is closed by
 /// nothing but how much of the handover has shipped. Every phase so far has
 /// turned one of these into something the daemon carries, and 2c still has
-/// three to go, so a match here must keep tolerating a variant this module
+/// two to go, so a match here must keep tolerating a variant this module
 /// has not named yet.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
@@ -94,11 +94,6 @@ pub enum RefusedReason {
         /// The sheep's name.
         sheep: String,
     },
-    /// An operator's `delete` targets this sheep, which 2c carries.
-    PendingDelete {
-        /// The sheep's name.
-        sheep: String,
-    },
 }
 
 impl core::fmt::Display for RefusedReason {
@@ -118,7 +113,6 @@ impl core::fmt::Display for RefusedReason {
             Self::Dog { sheep } => (sheep, "being a dog"),
             Self::ReloadInFlight { sheep } => (sheep, "an in-flight reload"),
             Self::PendingStop { sheep } => (sheep, "a pending manual stop"),
-            Self::PendingDelete { sheep } => (sheep, "a pending delete"),
         };
         write!(
             f,
@@ -130,20 +124,23 @@ impl core::fmt::Display for RefusedReason {
 
 /// One sheep's carryability-relevant facts.
 ///
-/// Bundles a [`ProcessEntry`] with the two facts that do not live on it: a
-/// pending manual stop and a pending delete both live on the supervisor's
-/// private slot type, not on the entry it wraps, so `fitness` cannot reach
-/// them through `entry` alone. The caller, the supervisor, which owns both
-/// of them, builds this view; `fitness` stays a pure function over data it is
-/// handed rather than reaching into the registry itself.
+/// Bundles a [`ProcessEntry`] with the one fact that does not live on it: a
+/// pending manual stop lives on the supervisor's private slot type, not on
+/// the entry it wraps, so `fitness` cannot reach it through `entry` alone.
+/// The caller, the supervisor, which owns it, builds this view; `fitness`
+/// stays a pure function over data it is handed rather than reaching into
+/// the registry itself.
+///
+/// A pending delete used to live here too. It is no longer a refusal —
+/// [`CarriedSheep::pending_delete`] carries it instead — so it is no longer
+/// a carryability-relevant fact and this view has nothing left to say about
+/// it.
 #[derive(Debug, Clone, Copy)]
 pub struct Candidate<'a> {
     /// The sheep's lifecycle entry.
     pub entry: &'a ProcessEntry,
     /// Whether an operator's `stop` is waiting on this sheep's next exit.
     pub pending_stop: bool,
-    /// Whether an operator's `delete` targets this sheep.
-    pub pending_delete: bool,
     /// Whether this sheep's log pump was asked for its descriptors and did
     /// not answer in time.
     ///
@@ -171,8 +168,6 @@ pub struct OwnedCandidate {
     pub entry: ProcessEntry,
     /// Whether an operator's command is waiting on this sheep's next exit.
     pub pending_stop: bool,
-    /// Whether an operator's `delete` targets this sheep.
-    pub pending_delete: bool,
     /// Whether this sheep's log pump missed the snapshot's deadline; see
     /// [`Candidate::pump_unresponsive`].
     pub pump_unresponsive: bool,
@@ -185,7 +180,6 @@ impl OwnedCandidate {
         Candidate {
             entry: &self.entry,
             pending_stop: self.pending_stop,
-            pending_delete: self.pending_delete,
             pump_unresponsive: self.pump_unresponsive,
         }
     }
@@ -220,9 +214,6 @@ fn refusal(candidate: &Candidate<'_>) -> Option<RefusedReason> {
     }
     if !matches!(entry.reload, crate::entry::ReloadState::None) {
         return Some(RefusedReason::ReloadInFlight { sheep: name() });
-    }
-    if candidate.pending_delete {
-        return Some(RefusedReason::PendingDelete { sheep: name() });
     }
     if candidate.pending_stop {
         return Some(RefusedReason::PendingStop { sheep: name() });
@@ -576,6 +567,17 @@ pub struct CarriedSheep {
     credentials: SpawnIdentity,
     /// The descriptor numbers this instance's output travels on.
     fds: CarriedFds,
+    /// Whether an operator's `delete` targeted this instance before the
+    /// exec.
+    ///
+    /// `Option` rather than `bool` for the reason [`CarriedFds::stdin`]
+    /// gives at length: a predecessor from before this field existed
+    /// refused to carry a sheep with a delete pending at all, so a blob it
+    /// wrote never has the key, and an absent field loads as `None` rather
+    /// than failing to parse. `None` is what that blob truthfully means —
+    /// "no" — not "unknown", so [`VERSION`] stays unmoved: nothing an older
+    /// reader must understand has changed.
+    pending_delete: Option<bool>,
     /// The resolved config this instance runs under, environment included.
     ///
     /// This is the `AppConfig` beneath [`ProcessEntry::spec`]'s
@@ -609,13 +611,19 @@ pub struct CarriedSheep {
 impl CarriedSheep {
     /// Describe `entry` for the successor.
     ///
-    /// `epoch` and `fds` are arguments rather than reads off `entry`
-    /// because neither lives there: the respawn epoch is on the
-    /// supervisor's private slot, and the descriptor numbers are known only
-    /// to whichever code holds the open descriptors. This is the same split
-    /// [`Candidate`] makes, for the same reason.
+    /// `epoch`, `fds` and `pending_delete` are arguments rather than reads
+    /// off `entry` because none of them lives there: the respawn epoch and
+    /// the pending-delete marker are on the supervisor's private slot type,
+    /// and the descriptor numbers are known only to whichever code holds
+    /// the open descriptors. This is the same split [`Candidate`] makes,
+    /// for the same reason.
     #[must_use]
-    pub fn from_entry(entry: &ProcessEntry, epoch: u64, fds: CarriedFds) -> Self {
+    pub fn from_entry(
+        entry: &ProcessEntry,
+        epoch: u64,
+        fds: CarriedFds,
+        pending_delete: bool,
+    ) -> Self {
         Self {
             id: entry.id,
             name: entry.spec.config().name.clone(),
@@ -627,6 +635,7 @@ impl CarriedSheep {
             last_exit: entry.last_exit,
             credentials: entry.credentials,
             fds,
+            pending_delete: Some(pending_delete),
             app: entry.spec.config().clone(),
         }
     }
@@ -636,6 +645,15 @@ impl CarriedSheep {
     #[allow(dead_code, reason = "read by this crate's own tests")]
     pub const fn fds(&self) -> CarriedFds {
         self.fds
+    }
+
+    /// Whether an operator's `delete` targeted this instance before the
+    /// exec, or `None` for a blob written before this field existed — which
+    /// truthfully means "no", since that predecessor refused to carry a
+    /// pending delete at all. See the field's own doc.
+    #[must_use]
+    pub const fn pending_delete(&self) -> Option<bool> {
+        self.pending_delete
     }
 
     /// The supervisor slot's respawn epoch at the moment of the handover.
@@ -1195,7 +1213,6 @@ mod tests {
         Candidate {
             entry,
             pending_stop: false,
-            pending_delete: false,
             pump_unresponsive: false,
         }
     }
@@ -1245,7 +1262,6 @@ mod tests {
         let candidate = Candidate {
             entry: &e,
             pending_stop: false,
-            pending_delete: false,
             pump_unresponsive: true,
         };
         let Fitness::Refused(r) = fitness(&[candidate]) else {
@@ -1372,8 +1388,8 @@ mod tests {
 
         let blob = Handover::new(
             vec![
-                CarriedSheep::from_entry(&zero, 7, fds_at(11)),
-                CarriedSheep::from_entry(&one, 8, fds_at(21)),
+                CarriedSheep::from_entry(&zero, 7, fds_at(11), false),
+                CarriedSheep::from_entry(&one, 8, fds_at(21), false),
             ],
             DaemonFds {
                 listener: 3,
@@ -1431,7 +1447,6 @@ mod tests {
         let candidate = Candidate {
             entry: &e,
             pending_stop: true,
-            pending_delete: false,
             pump_unresponsive: false,
         };
         assert!(matches!(
@@ -1460,7 +1475,7 @@ mod tests {
     /// One carried sheep off `entry`, with the descriptor numbers a
     /// running sheep would have.
     fn carried(entry: &ProcessEntry) -> CarriedSheep {
-        CarriedSheep::from_entry(entry, 7, fds_at(11))
+        CarriedSheep::from_entry(entry, 7, fds_at(11), false)
     }
 
     fn handover_over(entry: &ProcessEntry) -> Handover {
@@ -1627,19 +1642,35 @@ mod tests {
         );
     }
 
+    /// fails if a blob written before this daemon carried a pending delete
+    /// stops loading.
+    ///
+    /// A predecessor from before [`CarriedSheep::pending_delete`] existed
+    /// refused to hand over a sheep with a delete pending at all, so its
+    /// blobs never have the key and `None` is what that truthfully means:
+    /// "no", not "unknown". Failing to parse instead would leave the
+    /// successor refusing to boot after the predecessor had already exec'd
+    /// itself away, which is a whole flock unsupervised for one added
+    /// field.
     #[test]
-    fn a_pending_delete_refuses() {
-        let e = entry_fixture(|_| {});
-        let candidate = Candidate {
-            entry: &e,
-            pending_stop: false,
-            pending_delete: true,
-            pump_unresponsive: false,
-        };
-        assert!(matches!(
-            fitness(&[candidate]),
-            Fitness::Refused(RefusedReason::PendingDelete { .. })
-        ));
+    fn a_blob_written_before_pending_delete_was_carried_still_loads() {
+        let mut value = serde_json::to_value(sample_handover()).unwrap();
+        let sheep = value["sheep"][0]
+            .as_object_mut()
+            .expect("a carried sheep is an object");
+        assert!(
+            sheep.remove("pending_delete").is_some(),
+            "the field this case removes must be there to remove"
+        );
+
+        let loaded = Handover::load_value(value).expect("an older blob must still load");
+
+        assert_eq!(loaded.sheep[0].pending_delete(), None);
+        assert_eq!(
+            loaded.sheep[0].id(),
+            sample_handover().sheep[0].id(),
+            "the rest of the row is unchanged by the one field that was absent"
+        );
     }
 
     #[test]
@@ -1728,7 +1759,7 @@ mod tests {
     ) -> Handover {
         Handover {
             version: VERSION,
-            sheep: vec![CarriedSheep::from_entry(entry, 7, fds)],
+            sheep: vec![CarriedSheep::from_entry(entry, 7, fds, false)],
             listener_fd,
             pidfile_fd,
             next_id: 9,

--- a/crates/shep-daemon/src/handover/mod.rs
+++ b/crates/shep-daemon/src/handover/mod.rs
@@ -618,6 +618,30 @@ pub struct CarriedSheep {
     /// instead of to the reload machinery, which for an `autorestart` app
     /// respawns the old code into a slot the replacement owns.
     reload: Option<ReloadState>,
+    /// Whether a reload's readiness verification has already failed against
+    /// this instance.
+    ///
+    /// `Option` for the same reason the three fields above are, but NOT for
+    /// the same argument, and the difference is worth stating rather than
+    /// borrowing. Each of those was a gate refusal before it was a field, so
+    /// an absent key proves the fact was false. This was never a refusal: a
+    /// predecessor from before this field existed carried such an instance
+    /// happily and simply dropped the flag, so an absent key is that
+    /// predecessor staying silent rather than saying "no". `false` is still
+    /// the right reading of the silence — it is exactly what a successor
+    /// assumed before the field existed, so an older blob adopts the way it
+    /// always did — and it is the only reading available, since a hard parse
+    /// failure would leave a successor refusing to boot after its
+    /// predecessor had exec'd itself away. [`VERSION`] stays unmoved.
+    ///
+    /// It is what keeps a failed reload's leftovers REACHABLE. A reload
+    /// replaces `Online` instances, and an abandoned one is deliberately
+    /// left `Starting` so the daemon does not report a release that never
+    /// served as serving; `reload_eligible` reads this flag beside the
+    /// status, so the reload that rolls the release back can still reach the
+    /// instance. A successor that dropped it would answer that rollback with
+    /// `Ok` and replace nothing.
+    ready_failed: Option<bool>,
     /// The resolved config this instance runs under, environment included.
     ///
     /// This is the `AppConfig` beneath [`ProcessEntry::spec`]'s
@@ -651,12 +675,13 @@ pub struct CarriedSheep {
 impl CarriedSheep {
     /// Describe `entry` for the successor.
     ///
-    /// `epoch`, `fds`, `pending_delete` and `manual` are arguments rather
-    /// than reads off `entry` because none of them lives there: the respawn
-    /// epoch, the pending-delete marker and the manual-command marker are on
-    /// the supervisor's private slot type, and the descriptor numbers are
-    /// known only to whichever code holds the open descriptors. This is the
-    /// same split [`Candidate`] makes, for the same reason.
+    /// `epoch`, `fds`, `pending_delete`, `manual` and `ready_failed` are
+    /// arguments rather than reads off `entry` because none of them lives
+    /// there: the respawn epoch, the pending-delete marker, the
+    /// manual-command marker and the failed-readiness verdict are on the
+    /// supervisor's private slot type, and the descriptor numbers are known
+    /// only to whichever code holds the open descriptors. This is the same
+    /// split [`Candidate`] makes, for the same reason.
     #[must_use]
     pub fn from_entry(
         entry: &ProcessEntry,
@@ -664,6 +689,7 @@ impl CarriedSheep {
         fds: CarriedFds,
         pending_delete: bool,
         manual: Option<PendingManual>,
+        ready_failed: bool,
     ) -> Self {
         Self {
             id: entry.id,
@@ -678,9 +704,10 @@ impl CarriedSheep {
             fds,
             pending_delete: Some(pending_delete),
             manual,
-            // Read off the entry rather than passed in, unlike the two
-            // markers above: this one does live on `ProcessEntry`.
+            // Read off the entry rather than passed in, unlike the markers
+            // either side of it: this one does live on `ProcessEntry`.
             reload: Some(entry.reload),
+            ready_failed: Some(ready_failed),
             app: entry.spec.config().clone(),
         }
     }
@@ -718,6 +745,16 @@ impl CarriedSheep {
     #[must_use]
     pub const fn reload(&self) -> Option<ReloadState> {
         self.reload
+    }
+
+    /// Whether a reload's readiness verification has already failed against
+    /// this instance, or `None` for a blob written before this field
+    /// existed. That `None` reads as `false` — which is not the same claim
+    /// the three getters above make about their own, and the field's own doc
+    /// says why.
+    #[must_use]
+    pub const fn ready_failed(&self) -> Option<bool> {
+        self.ready_failed
     }
 
     /// The supervisor slot's respawn epoch at the moment of the handover.
@@ -1524,8 +1561,8 @@ mod tests {
 
         let blob = Handover::new(
             vec![
-                CarriedSheep::from_entry(&zero, 7, fds_at(11), false, None),
-                CarriedSheep::from_entry(&one, 8, fds_at(21), false, None),
+                CarriedSheep::from_entry(&zero, 7, fds_at(11), false, None, false),
+                CarriedSheep::from_entry(&one, 8, fds_at(21), false, None, false),
             ],
             DaemonFds {
                 listener: 3,
@@ -1624,6 +1661,7 @@ mod tests {
                 kind: ManualKind::Delete,
                 origin: CommandOrigin::Automatic,
             }),
+            false,
         );
         assert_eq!(
             marked.manual(),
@@ -1655,7 +1693,7 @@ mod tests {
     /// One carried sheep off `entry`, with the descriptor numbers a
     /// running sheep would have.
     fn carried(entry: &ProcessEntry) -> CarriedSheep {
-        CarriedSheep::from_entry(entry, 7, fds_at(11), false, None)
+        CarriedSheep::from_entry(entry, 7, fds_at(11), false, None, false)
     }
 
     fn handover_over(entry: &ProcessEntry) -> Handover {
@@ -1911,8 +1949,14 @@ mod tests {
             origin: CommandOrigin::Automatic,
         };
         let mut blob = sample_handover();
-        blob.sheep[0] =
-            CarriedSheep::from_entry(&entry_fixture(|_| {}), 7, fds_at(11), false, Some(marker));
+        blob.sheep[0] = CarriedSheep::from_entry(
+            &entry_fixture(|_| {}),
+            7,
+            fds_at(11),
+            false,
+            Some(marker),
+            false,
+        );
         let value = serde_json::to_value(&blob).unwrap();
 
         assert_eq!(
@@ -2016,6 +2060,60 @@ mod tests {
         );
     }
 
+    /// fails if a blob written before this daemon carried a failed
+    /// readiness verdict stops loading, or if a verdict that IS carried does
+    /// not survive the wire.
+    ///
+    /// Same stakes as the three cases above and a different argument, which
+    /// is why it is asserted rather than assumed. Each of those was a gate
+    /// refusal before it was a field, so an absent key proves the fact was
+    /// false; this was never a refusal, and a predecessor from before the
+    /// field existed carried such an instance while silently dropping the
+    /// flag. `None` is therefore that predecessor saying nothing rather than
+    /// saying "no" — and `false` is still the only reading available, since
+    /// it is what a successor of that blob assumed anyway and a hard parse
+    /// failure would leave this one refusing to boot after its predecessor
+    /// had exec'd itself away.
+    ///
+    /// The current-blob half is asserted first so the removal below removes
+    /// something: a blob whose `ready_failed` was `false` all along could
+    /// not tell an absent key from a present one.
+    #[test]
+    fn a_blob_written_before_ready_failed_was_carried_still_loads() {
+        let mut blob = sample_handover();
+        blob.sheep[0] =
+            CarriedSheep::from_entry(&entry_fixture(|_| {}), 7, fds_at(11), false, None, true);
+        let value = serde_json::to_value(&blob).unwrap();
+
+        assert_eq!(
+            Handover::load_value(value.clone())
+                .expect("a current blob loads")
+                .sheep[0]
+                .ready_failed(),
+            Some(true),
+            "a verdict on the wire must come back as one, or the rollback it keeps reachable \
+             cannot reach anything"
+        );
+
+        let mut older = value;
+        let sheep = older["sheep"][0]
+            .as_object_mut()
+            .expect("a carried sheep is an object");
+        assert!(
+            sheep.remove("ready_failed").is_some(),
+            "the field this case removes must be there to remove"
+        );
+
+        let loaded = Handover::load_value(older).expect("an older blob must still load");
+
+        assert_eq!(loaded.sheep[0].ready_failed(), None);
+        assert_eq!(
+            loaded.sheep[0].id(),
+            blob.sheep[0].id(),
+            "the rest of the row is unchanged by the one field that was absent"
+        );
+    }
+
     #[test]
     fn the_exec_target_exists_and_is_a_file() {
         let p = exec_target().unwrap();
@@ -2102,7 +2200,7 @@ mod tests {
     ) -> Handover {
         Handover {
             version: VERSION,
-            sheep: vec![CarriedSheep::from_entry(entry, 7, fds, false, None)],
+            sheep: vec![CarriedSheep::from_entry(entry, 7, fds, false, None, false)],
             listener_fd,
             pidfile_fd,
             next_id: 9,

--- a/crates/shep-daemon/src/supervisor.rs
+++ b/crates/shep-daemon/src/supervisor.rs
@@ -1570,6 +1570,10 @@ impl<R: ProcessRunner> SupervisorBuilder<R> {
     /// the `execve`. Nothing here spawns, signals or reopens anything: from
     /// each sheep's own side the shepherd was never away.
     ///
+    /// `reloads` is the apps that were mid-swap, restored once the flock is
+    /// in — see [`Actor::install_carried_reloads`] for what each one is owed
+    /// beyond its own restoration.
+    ///
     /// # Why the counters are restored before any slot is installed
     ///
     /// [`Actor::next_id`], [`Actor::next_deadline`] and
@@ -1603,6 +1607,7 @@ impl<R: ProcessRunner> SupervisorBuilder<R> {
         self,
         flock: Vec<AdoptedSheep>,
         counters: Counters,
+        reloads: Vec<CarriedReload>,
     ) -> Result<SupervisorHandle, AdoptError> {
         let (tx, rx) = mpsc::channel(MAILBOX_CAPACITY);
         let mut actor = self.build(tx.clone());
@@ -1617,6 +1622,13 @@ impl<R: ProcessRunner> SupervisorBuilder<R> {
         for sheep in flock {
             actor.install_adopted(sheep, &reaper)?;
         }
+        // After the loop, and before the actor runs. A job names two entries
+        // and arms against one of them, so it has nowhere to go until every
+        // sheep is in; and the readiness waits `install_adopted` armed report
+        // back through the mailbox, which nothing drains until the line
+        // below — so a replacement that resolves instantly still finds its
+        // job.
+        actor.install_carried_reloads(reloads);
         tokio::spawn(actor.run(rx));
         Ok(SupervisorHandle { tx })
     }
@@ -1808,6 +1820,48 @@ struct ReloadJob {
     deadline: u64,
 }
 
+/// One app's in-flight reload, as it crosses a handover.
+///
+/// A [`ReloadJob`] minus the one field a successor must not inherit. The
+/// queue, the mode and the pair mid-swap are facts about a deploy the
+/// operator asked for and are carried unchanged; [`ReloadJob::deadline`] is a
+/// stamp on a timer that died with the predecessor's image, so the successor
+/// takes a fresh one off its own (carried) `next_deadline` when it re-arms.
+/// Carrying the old stamp would name a watchdog that no longer exists.
+///
+/// The app name rides on the row rather than keying a map, so the blob holds
+/// an array in a stable order — the same reason its sheep are sorted by id.
+///
+/// `Debug` is derived and nothing here is sensitive: an app name an operator
+/// typed, two entry ids and three closed enums (IR-41).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+// The handover is a unix feature: both sites that build one of these —
+// `Actor::handle_handover_snapshot` and `Actor::install_carried_reloads` —
+// are `cfg(unix)`, while this type travels on `Handover`, which is not. So
+// on a Windows target it is a shape nothing constructs. Scoped to that
+// target rather than blanket-allowed, and an `expect` rather than an
+// `allow`, so that a Windows handover would have to delete this line rather
+// than inherit it.
+#[cfg_attr(
+    not(unix),
+    expect(dead_code, reason = "no target without a handover ever builds one")
+)]
+pub(crate) struct CarriedReload {
+    /// The app whose reload this is — [`Actor::reloads`]' own key.
+    pub(crate) app: String,
+    /// Instances not yet taken, in slot order.
+    ///
+    /// A `Vec` rather than the [`VecDeque`] it comes off and goes back into:
+    /// the two serialize identically as a JSON array, and the queue
+    /// discipline is the actor's business rather than the blob's.
+    pub(crate) queue: Vec<u32>,
+    /// Whether this job overlaps its two instances or replaces them one
+    /// after the other.
+    pub(crate) mode: ReloadMode,
+    /// The pair mid-swap right now.
+    pub(crate) swap: ReloadSwap,
+}
+
 /// Which of two orderings a reload runs, decided from the app's config.
 ///
 /// # Why there are two
@@ -1824,8 +1878,12 @@ struct ReloadJob {
 ///
 /// The two orderings are the two ways out of that, and the app picks which by
 /// whether it can share a port.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum ReloadMode {
+///
+/// Serialized because a handover carries the job it belongs to, `snake_case`
+/// on the wire for the reason [`ManualKind`] gives.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum ReloadMode {
     /// `SpawnNew → AwaitReady → DrainOld → ReapOld`. Both instances run at
     /// once, so the app is never short one.
     ///
@@ -1904,23 +1962,27 @@ impl ReloadMode {
 }
 
 /// The drainee/replacement pair a reload is working on right now.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-struct ReloadSwap {
+///
+/// Serialized because a handover carries the job it belongs to, `snake_case`
+/// on the wire for the reason [`ManualKind`] gives.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) struct ReloadSwap {
     /// The instance being replaced. Carries `ProcStatus::Stopping` and
     /// [`ReloadState::Drainee`] from the moment the swap starts — which under
     /// [`ReloadMode::Overlap`] is when its replacement is spawned, and under
     /// [`ReloadMode::Serial`] is a whole drain before that.
-    old_id: u32,
+    pub(crate) old_id: u32,
     /// Its replacement, in the same instance slot under a new id. Carries
     /// [`ReloadState::Replacement`] until the swap finishes.
     ///
     /// `None` exactly while the phase is [`ReloadPhase::DrainFirst`]: a
     /// serial reload has no replacement to name until the instance it is
     /// replacing has gone.
-    new_id: Option<u32>,
+    pub(crate) new_id: Option<u32>,
     /// How far along this pair is — see [`ReloadPhase`], whose variants name
     /// the steps of both orderings.
-    phase: ReloadPhase,
+    pub(crate) phase: ReloadPhase,
 }
 
 /// Where a [`ReloadSwap`] is in the spec's per-instance state machine.
@@ -1930,8 +1992,12 @@ struct ReloadSwap {
 /// `ReapOld` is the drainee's `Msg::Exited` arriving. What a handler actually
 /// has to ask is the question these two answer — is the old instance still
 /// there to go back to?
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum ReloadPhase {
+///
+/// Serialized because a handover carries the swap it belongs to,
+/// `snake_case` on the wire for the reason [`ManualKind`] gives.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum ReloadPhase {
     /// [`ReloadMode::Serial`] only: the instance being replaced is on its
     /// kill ladder and nothing has been spawned yet, so `swap.new_id` is
     /// `None`.
@@ -3545,6 +3611,10 @@ impl<R: ProcessRunner> Actor<R> {
         let spec = assemble(&app, carried.instance(), &self.paths, credentials);
         let id = carried.id();
         let status = carried.status();
+        // `None` for a blob written before this daemon carried a swap at
+        // all, which said the same thing by refusing to carry one; see
+        // `CarriedSheep::reload`.
+        let reload = carried.reload().unwrap_or(ReloadState::None);
         let mut entry = ProcessEntry {
             id,
             spec: app.clone(),
@@ -3561,9 +3631,15 @@ impl<R: ProcessRunner> Actor<R> {
             // app amnesty it did not earn), while the window it is counted
             // over is a run of wall-clock this image did not observe.
             budget: RestartBudget::default(),
-            // Phase 2a's fitness gate refuses to carry a flock with a reload
-            // in flight, so there is no reload state to restore.
-            reload: ReloadState::None,
+            // Restored, and it is the marker that decides where this
+            // instance's next exit goes: `handle_exited` routes a `Drainee`
+            // to `reap_drainee` and reads a `Replacement` out of the swap,
+            // where an entry carrying `None` takes `decide_on_exit` instead
+            // — which for an `autorestart` app respawns the old code into a
+            // slot the replacement owns. The job the two halves belong to is
+            // restored separately, after every sheep is installed: see
+            // `install_carried_reloads`.
+            reload,
             credentials: carried.credentials(),
             out_file: spec.out_file.clone(),
             err_file: spec.err_file.clone(),
@@ -3702,16 +3778,24 @@ impl<R: ProcessRunner> Actor<R> {
         // to carry a `Starting` sheep at all, which restarts a whole flock
         // over one app in its first three seconds.
         //
-        // `manually` is `false` and cannot be anything else: it belongs to
-        // the spawn that armed the original wait, which is not this image's
-        // to know. It reaches only the `Online` event's own flag.
+        // `manually` reaches only the `Online` event's own flag, and it is
+        // knowable for exactly one of the two shapes that reach here. An
+        // ordinary `Starting` sheep's flag belongs to the spawn that armed
+        // the original wait, which is not this image's to know, so it is
+        // `false`. A REPLACEMENT's is knowable: `spawn_replacement` passes
+        // `true` unconditionally, because a reload is an operator's doing,
+        // so a carried `Replacement` marker is the same claim arriving by a
+        // different route. Reporting `false` there would broadcast an
+        // operator's deploy as the daemon's own doing, which is the lie the
+        // flag exists to prevent.
+        let manually = matches!(reload, ReloadState::Replacement);
         let ready_tx = (status == ProcStatus::Starting).then(|| {
             let source = ReadinessSource::of(app.config())
                 .expect("ResolvedApp already passed ProbeTarget::parse in normalize");
             spawn_readiness_task(
                 id,
                 carried.epoch(),
-                false,
+                manually,
                 source,
                 app.config().listen_timeout.as_duration(),
                 spec_prober(&spec),
@@ -3787,14 +3871,31 @@ impl<R: ProcessRunner> Actor<R> {
         // repeated `SIGTERM` (or one repeated `{"kind":"shutdown"}`) to a
         // child that is already on its way out.
         //
-        // `LadderCap::Stop` and not the app's `graceful_timeout`, because
-        // every marker the gate can carry today was claimed under that cap:
-        // the two sites that pass `LadderCap::Drain` are a reload's drain,
-        // and both leave `ReloadState::Drainee` on the entry, which
-        // `handover::fitness` still refuses as `ReloadInFlight`. The task
-        // that removes that refusal has to revisit this line.
+        // The cap comes off the ROLE, because the role is the only record of
+        // which ask is in hand. Both sites that pass `LadderCap::Drain` are
+        // a reload's drain and both leave `ReloadState::Drainee` on the
+        // entry, so a carried drainee is an instance that was asked to
+        // finish the work it already had and go — `graceful_timeout`'s own
+        // definition — while everything else was asked under `kill_timeout`.
+        // This line read `LadderCap::Stop` unconditionally while the gate
+        // still refused a flock mid-reload, and said at the time that the
+        // task removing that refusal would have to revisit it.
+        //
+        // One residual, and it is the same unrecoverable fact as the elapsed
+        // grace above. Which cap the ladder ACTUALLY started under is not
+        // recorded anywhere: an operator's `stop` reaching a drainee during
+        // the overlap's `AwaitReady` window claims the marker first, under
+        // `LadderCap::Stop`, and the drain that follows rides that ladder
+        // rather than starting one of its own. A successor re-arming that
+        // sheep uses the drain's cap instead. The cost is bounded by
+        // whichever of the app's two timeouts is longer, and the ending is
+        // the same either way: the ladder still escalates to `SIGKILL`.
         if let Some(manual) = carried.manual() {
-            self.claim_manual(id, manual, LadderCap::Stop);
+            let cap = match reload {
+                ReloadState::Drainee { .. } => LadderCap::Drain,
+                ReloadState::None | ReloadState::Replacement => LadderCap::Stop,
+            };
+            self.claim_manual(id, manual, cap);
         }
         // The same arming a spawn gets on its way to `Online`, and for the
         // same reason: a watch, a schedule or a memory limit this image did
@@ -3805,6 +3906,111 @@ impl<R: ProcessRunner> Actor<R> {
             self.arm_extras(id);
         }
         Ok(())
+    }
+
+    /// Restores the reload jobs the blob carried, and re-arms every timer
+    /// each of them was waiting on.
+    ///
+    /// Runs after the whole flock is installed, not per sheep: a job names
+    /// two entries and reads an app's timings off one of them, so it has
+    /// nowhere to be armed until both halves are in the registry.
+    ///
+    /// # What is re-armed, and why a carried swap without this is worse than
+    /// a refused one
+    ///
+    /// Fourth and fifth instances of the class this phase exists to close: a
+    /// state whose only way forward is a `tokio::spawn`ed timer of the
+    /// predecessor's, which the `execve` takes while the successor installs
+    /// the status that timer was going to resolve.
+    ///
+    /// - **The watchdog.** [`Self::arm_reload_deadline`] is the only thing
+    ///   that ever removes a [`ReloadJob`] nothing else can finish. Without
+    ///   it a carried swap sits in its phase for the rest of this daemon's
+    ///   life, and `handle_reload` refuses on the presence of the map key —
+    ///   so that app answers `<name> is already being reloaded` forever, and
+    ///   takes `shep reload all` down with it because the refusal is
+    ///   whole-selector. The stamp is a fresh one off the carried
+    ///   `next_deadline` rather than the predecessor's, which named a timer
+    ///   that no longer exists.
+    /// - **The post-drain probe.** A swap in [`ReloadPhase::Verify`] is
+    ///   waiting on a `Msg::ReloadVerified` from
+    ///   [`Self::spawn_verify_task`], and that task went with the image too.
+    ///   Re-armed through the same [`Self::post_drain_probe`] the original
+    ///   went through, so a successor cannot answer the question differently
+    ///   from the predecessor that asked it. Without this the swap would
+    ///   reach its watchdog instead and be abandoned — the replacement left
+    ///   serving, but a `Reloaded` that never fires and a `ReloadAbandoned`
+    ///   for a deploy that actually worked.
+    ///
+    /// The readiness wait a [`ReloadPhase::AwaitReady`] swap is on is the
+    /// third, and it is re-armed a step earlier, in [`Self::install_adopted`]
+    /// with every other `Starting` sheep's.
+    ///
+    /// # Why an inherited swap is continued rather than abandoned
+    ///
+    /// `abort_reload` exists and is simpler. But a reload an operator asked
+    /// for, silently abandoned by an unrelated shepherd upgrade, is a
+    /// surprise with no notice: the flock comes back on the old code and
+    /// nothing says why. Continuing adds no failure mode the swap did not
+    /// already have, because the watchdog above IS the ending an unfinishable
+    /// swap gets with or without a handover.
+    ///
+    /// # The one job that is dropped
+    ///
+    /// A job whose swap names no registered entry at all. It cannot be
+    /// produced by a snapshot — that is taken on the actor loop, so a job and
+    /// the entries it names are read in one step — but the blob is a file,
+    /// and this is the same residual `refuse_repeated_fds` guards on the
+    /// descriptor side. Dropping it is the ending the watchdog would give it
+    /// anyway; keeping it would leave an app permanently unreloadable, and
+    /// arming against a missing entry would panic.
+    #[cfg(unix)]
+    fn install_carried_reloads(&mut self, reloads: Vec<CarriedReload>) {
+        for carried in reloads {
+            let CarriedReload {
+                app,
+                queue,
+                mode,
+                swap,
+            } = carried;
+            // The replacement first, because it is the half that exists in
+            // every phase but `DrainFirst`. Either will do — they are two
+            // instances of one app and carry the same `ResolvedApp` — so
+            // this is about which one is REGISTERED: a serial reload
+            // deregisters its drainee at `ReapOld` and keeps the job, so
+            // `old_id` is a dangling id by design from `AwaitReady` onwards.
+            let anchor = swap
+                .new_id
+                .filter(|id| self.sheep.contains_key(id))
+                .or_else(|| self.sheep.contains_key(&swap.old_id).then_some(swap.old_id));
+            let Some(anchor) = anchor else {
+                tracing::warn!(
+                    name = app,
+                    old_id = swap.old_id,
+                    new_id = swap.new_id,
+                    "a carried reload named no instance this shepherd was given, so it was                      dropped rather than left unfinishable"
+                );
+                continue;
+            };
+            self.reloads.insert(
+                app.clone(),
+                ReloadJob {
+                    queue: queue.into_iter().collect(),
+                    mode,
+                    swap,
+                    // Overwritten by the arm below, which is the one site
+                    // that stamps a live watchdog.
+                    deadline: 0,
+                },
+            );
+            self.arm_reload_deadline(&app, anchor);
+            if swap.phase == ReloadPhase::Verify
+                && let Some(new_id) = swap.new_id
+                && let Some(source) = self.post_drain_probe(new_id, mode)
+            {
+                self.spawn_verify_task(&app, new_id, source);
+            }
+        }
     }
 
     /// Respawns an already-registered id in place: reassembles from its
@@ -6097,6 +6303,27 @@ impl<R: ProcessRunner> Actor<R> {
         // a file an operator may read: id order makes two snapshots of an
         // unchanged flock identical.
         drafts.sort_unstable_by_key(|draft| draft.entry.id);
+        // Read here, on the actor loop, in the same synchronous step as the
+        // entries above: a job and the two entries it names are one picture,
+        // and reading them a moment apart would let a swap finish between
+        // the two halves of the description of it.
+        let mut reloads: Vec<CarriedReload> = self
+            .reloads
+            .iter()
+            .map(|(app, job)| CarriedReload {
+                app: app.clone(),
+                queue: job.queue.iter().copied().collect(),
+                mode: job.mode,
+                swap: job.swap,
+                // `ReloadJob::deadline` is deliberately absent: it stamps a
+                // timer that dies with this image, and the successor takes a
+                // fresh stamp off the carried `next_deadline` when it
+                // re-arms. See `CarriedReload`'s own doc.
+            })
+            .collect();
+        // `HashMap` iteration order is arbitrary, for the reason the sheep
+        // are sorted a few lines up.
+        reloads.sort_unstable_by(|left, right| left.app.cmp(&right.app));
         spawn_handover_task(
             drafts,
             fds,
@@ -6105,6 +6332,7 @@ impl<R: ProcessRunner> Actor<R> {
                 next_deadline: self.next_deadline,
                 next_action_stamp: self.next_action_stamp,
             },
+            reloads,
             reply,
         );
     }
@@ -7936,6 +8164,7 @@ fn spawn_handover_task(
     drafts: Vec<HandoverDraft>,
     fds: DaemonFds,
     counters: Counters,
+    reloads: Vec<CarriedReload>,
     reply: oneshot::Sender<Result<Snapshot, SupervisorError>>,
 ) {
     tokio::spawn(async move {
@@ -8000,7 +8229,7 @@ fn spawn_handover_task(
                 parked.0.push(log_ctl);
             }
         }
-        let blob = Handover::new(carried, fds, counters);
+        let blob = Handover::new(carried, fds, counters, reloads);
         let _ = reply.send(Ok((candidates, blob, parked)));
     });
 }
@@ -18095,6 +18324,7 @@ mod tests {
                     entry.status = ProcStatus::Starting;
                 }))],
                 counters(9),
+                Vec::new(),
             )
             .expect("a carried flock installs");
 
@@ -18224,6 +18454,7 @@ mod tests {
                     without_handles(carried("api", 8, Some(4243), |_| {})),
                 ],
                 counters(9),
+                Vec::new(),
             )
             .expect("a carried flock installs");
 
@@ -18262,6 +18493,7 @@ mod tests {
                     });
                 }))],
                 counters(9),
+                Vec::new(),
             )
             .expect("a carried flock installs");
 
@@ -18311,6 +18543,7 @@ mod tests {
             .spawn_adopted(
                 vec![without_handles(carried("web", 7, Some(pid), |_| {}))],
                 counters(9),
+                Vec::new(),
             )
             .expect("a carried flock installs");
 
@@ -18382,6 +18615,7 @@ mod tests {
                     |_| {},
                 ))],
                 counters(9),
+                Vec::new(),
             )
             .expect("a carried flock installs");
 
@@ -18532,6 +18766,7 @@ mod tests {
                     respawnable(|app| app.autorestart = true),
                 ))],
                 counters(9),
+                Vec::new(),
             )
             .expect("a carried flock installs");
 
@@ -18627,6 +18862,7 @@ mod tests {
                     }),
                 ))],
                 counters(9),
+                Vec::new(),
             )
             .expect("a carried flock installs");
 
@@ -18685,6 +18921,7 @@ mod tests {
                     respawnable(|app| app.autorestart = false),
                 ))],
                 counters(9),
+                Vec::new(),
             )
             .expect("a carried flock installs");
 
@@ -18737,6 +18974,7 @@ mod tests {
             .spawn_adopted(
                 vec![without_handles(carried("web", 7, Some(4242), |_| {}))],
                 counters(9),
+                Vec::new(),
             )
             .expect("a carried flock installs");
 
@@ -18773,6 +19011,7 @@ mod tests {
                     entry.status = ProcStatus::WaitingRestart;
                 }))],
                 counters(9),
+                Vec::new(),
             )
             .expect("a carried flock installs");
 
@@ -18792,5 +19031,635 @@ mod tests {
             Some(STAND_IN_SPAWN_PID),
             "the restart must be a real respawn, not a status edit: {info:?}"
         );
+    }
+
+    // --- a swap in flight, carried across the exec ----------------------
+
+    /// Fails if a snapshot taken while an app is mid-swap describes the
+    /// flock as though nothing were.
+    ///
+    /// The other side of every case below, and it is a separate assertion
+    /// rather than an implied one: they all hand `spawn_adopted` a job built
+    /// by hand, so a snapshot that silently reported no reloads at all would
+    /// leave every one of them green while no live handover ever carried a
+    /// swap.
+    ///
+    /// A SERIAL drain is what holds still long enough to be snapshotted. The
+    /// app configures a `readiness_probe` and no `reuse_port`, which is the
+    /// one arrangement `ReloadMode::of` sends down the serial ordering, so
+    /// the reload's first act is to drain the instance rather than to spawn
+    /// beside it — and [`ProcScript::never_reports_its_exit`] models the one
+    /// child a kill ladder cannot end, so the swap stays in
+    /// [`ReloadPhase::DrainFirst`] instead of advancing under the snapshot.
+    ///
+    /// A real clock, unlike its neighbours: a paused one auto-advances
+    /// whenever every task is idle, and the awaits inside
+    /// `handover_snapshot` are exactly such a window — the first draft of
+    /// this case reached `DrainOld` with a replacement already spawned. The
+    /// short `listen_timeout` is what keeps the real-clock cost at a
+    /// fraction of a second.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn a_snapshot_taken_mid_swap_carries_the_job_and_the_markers() {
+        let (events, _rx) = crate::bus::test_bus(64);
+        let runner = ScriptedRunner::new(vec![ProcScript::never_reports_its_exit(); 2]);
+        let dir = tempfile::tempdir().unwrap();
+        let (fds, _held) = daemon_fds(&dir);
+        let handle = spawn_supervisor(runner, test_paths(&dir), events);
+        let mut app = AppConfig::minimal("web", "./srv");
+        app.listen_timeout = UpDuration::from_millis(200);
+        app.readiness_probe = Some(probe_config(ProbeKind::Tcp, "127.0.0.1:9"));
+        handle.start(vec![normalize(app).unwrap()]).await.unwrap();
+        // A probed app is `Starting` until its probe answers or
+        // `listen_timeout` elapses, and `reload_eligible` refuses anything
+        // that is not serving — so without this the reload would skip the
+        // only instance there is and end before it began.
+        let online = loop {
+            let info = handle.list().await;
+            if info[0].status == ProcStatus::Online {
+                break info;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        };
+        let old_id = online[0].id;
+
+        handle
+            .reload(ProcessSelector::All)
+            .await
+            .expect("an online app reloads");
+
+        let (_candidates, blob, _parked) = handle.handover_snapshot(fds).await.unwrap();
+
+        assert_eq!(
+            blob.reloads(),
+            &[CarriedReload {
+                app: "web".to_owned(),
+                queue: Vec::new(),
+                mode: ReloadMode::Serial,
+                swap: ReloadSwap {
+                    old_id,
+                    new_id: None,
+                    phase: ReloadPhase::DrainFirst,
+                },
+            }],
+            "the job the successor continues has to be in the blob, whole"
+        );
+        assert_eq!(
+            blob.sheep()[0].reload(),
+            Some(ReloadState::Drainee { new_id: None }),
+            "and the marker that routes this instance's exit with it"
+        );
+    }
+
+    /// A carried sheep that is half of a swap, with the role and the status
+    /// the predecessor's own entry carried.
+    ///
+    /// Separate from [`carried_marked`] rather than two more arguments on
+    /// it, for the reason that split already gives: the many cases that are
+    /// about neither would otherwise grow two arguments they always pass the
+    /// same values for.
+    #[cfg(unix)]
+    fn carried_in_swap(
+        name: &str,
+        id: u32,
+        pid: Option<u32>,
+        role: ReloadState,
+        status: ProcStatus,
+        manual: Option<PendingManual>,
+        mutate: impl FnOnce(&mut ProcessEntry),
+    ) -> CarriedSheep {
+        carried_marked(name, id, pid, false, manual, move |entry| {
+            mutate(entry);
+            entry.reload = role;
+            entry.status = status;
+        })
+    }
+
+    /// One app's in-flight reload, as a blob carries it, with an empty queue.
+    ///
+    /// Empty because these cases are about ONE swap surviving the exec, and
+    /// a queue behind it would let a case pass on the next instance's swap
+    /// rather than on the carried one.
+    #[cfg(unix)]
+    fn carried_job(
+        app: &str,
+        mode: ReloadMode,
+        old_id: u32,
+        new_id: Option<u32>,
+        phase: ReloadPhase,
+    ) -> CarriedReload {
+        CarriedReload {
+            app: app.to_owned(),
+            queue: Vec::new(),
+            mode,
+            swap: ReloadSwap {
+                old_id,
+                new_id,
+                phase,
+            },
+        }
+    }
+
+    /// Fails if a carried swap is left in its phase with nothing that can
+    /// ever end it.
+    ///
+    /// The watchdog is a `tokio::spawn`ed sleep of the predecessor's, and
+    /// the `execve` takes it — the same class as the readiness wait, the
+    /// pending restart and the kill ladder before it. This is the one that
+    /// makes carrying a swap safe at all: with the job restored and no timer
+    /// over it, an instance that never exits leaves a `ReloadJob` nothing can
+    /// remove, and `handle_reload` refuses on the presence of the map key. So
+    /// the app answers `web is already being reloaded` for the rest of the
+    /// daemon's life, and takes `shep reload all` down with it because the
+    /// refusal is whole-selector.
+    ///
+    /// That refusal IS the assertion, in both directions: it must be there
+    /// while the job is, and gone once the watchdog has ended it. Nothing
+    /// here ever exits — [`AdoptingRunner`]'s `wait` never resolves — so the
+    /// only thing that can produce the second half is a timer this image
+    /// armed.
+    #[cfg(unix)]
+    #[tokio::test(start_paused = true)]
+    async fn a_carried_swap_that_cannot_finish_is_still_abandoned_on_time() {
+        let dir = tempfile::tempdir().unwrap();
+        let (events, mut rx) = crate::bus::test_bus(64);
+        let sup = SupervisorBuilder::new(AdoptingRunner, test_paths(&dir), events)
+            .spawn_adopted(
+                vec![
+                    without_handles(carried_in_swap(
+                        "web",
+                        7,
+                        Some(4242),
+                        ReloadState::Drainee { new_id: Some(8) },
+                        ProcStatus::Stopping,
+                        None,
+                        |_| {},
+                    )),
+                    without_handles(carried_in_swap(
+                        "web",
+                        8,
+                        Some(4243),
+                        ReloadState::Replacement,
+                        ProcStatus::Online,
+                        None,
+                        |_| {},
+                    )),
+                ],
+                counters(9),
+                vec![carried_job(
+                    "web",
+                    ReloadMode::Overlap,
+                    7,
+                    Some(8),
+                    ReloadPhase::DrainOld,
+                )],
+            )
+            .expect("a carried flock installs");
+
+        let refused = sup.reload(ProcessSelector::All).await;
+        assert!(
+            matches!(refused, Err(SupervisorError::ReloadInFlight(ref name)) if name == "web"),
+            "the carried job must be in the map, or this case proves nothing: {refused:?}"
+        );
+
+        // Parking on `recv` is what advances the paused clock, so this waits
+        // out `listen_timeout + graceful_timeout + RELOAD_DEADLINE_SLACK`
+        // (16s at the defaults) without costing the suite a millisecond.
+        // Bounded well past that, and the bound is load-bearing rather than
+        // belt-and-braces: with no timer armed at all there is nothing for
+        // the paused clock to advance TO, so an unbounded wait here would
+        // hang the whole suite instead of failing this case.
+        tokio::time::timeout(
+            Duration::from_secs(3600),
+            await_event(&mut rx, 8, ProcessEventKind::ReloadAbandoned),
+        )
+        .await
+        .expect("a carried swap must still be bounded by a watchdog this image armed");
+
+        sup.reload(ProcessSelector::All)
+            .await
+            .expect("once the watchdog has ended the job, the app must be reloadable again");
+    }
+
+    /// Fails if a carried reload naming no registered instance panics or is
+    /// kept.
+    ///
+    /// A snapshot cannot produce one: it is taken on the actor loop, so a
+    /// job and the entries it names are read in one step. The blob is a
+    /// file, though, and this is the same residual `refuse_repeated_fds`
+    /// guards on the descriptor side. Keeping such a job would leave the app
+    /// permanently unreloadable, and arming a watchdog against an entry that
+    /// is not there panics — so the reload below is the assertion, and a
+    /// build without the guard fails it by aborting rather than by refusing.
+    #[cfg(unix)]
+    #[tokio::test(start_paused = true)]
+    async fn a_carried_reload_naming_no_registered_instance_is_dropped() {
+        let dir = tempfile::tempdir().unwrap();
+        let (events, _rx) = crate::bus::test_bus(64);
+        let sup = SupervisorBuilder::new(AdoptingRunner, test_paths(&dir), events)
+            .spawn_adopted(
+                vec![without_handles(carried("web", 7, Some(4242), |_| {}))],
+                counters(9),
+                vec![carried_job(
+                    "web",
+                    ReloadMode::Overlap,
+                    98,
+                    Some(99),
+                    ReloadPhase::DrainOld,
+                )],
+            )
+            .expect("a carried flock installs");
+
+        sup.reload(ProcessSelector::All)
+            .await
+            .expect("a job naming nothing must be dropped, not left refusing every later reload");
+    }
+
+    /// Fails if a carried swap in [`ReloadPhase::Verify`] is left to its
+    /// watchdog instead of being asked again.
+    ///
+    /// The second timer an overlapping probed reload arms, and the one a
+    /// half fix misses: `spawn_verify_task` is a task of the predecessor's
+    /// too, so a successor that re-arms only the watchdog abandons a deploy
+    /// that actually worked — the replacement stays serving, but the
+    /// `Reloaded` never fires, the rest of a clustered app's queue is
+    /// dropped, and the operator gets a `ReloadAbandoned` for a swap whose
+    /// replacement is fine.
+    ///
+    /// A real listener and a real clock. The probe answers in microseconds
+    /// where the watchdog is `listen_timeout + graceful_timeout +
+    /// RELOAD_DEADLINE_SLACK` (16s at the defaults), so the bound below
+    /// separates the two by an order of magnitude without depending on how
+    /// fast the host is.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn a_carried_swap_in_verify_is_asked_again_rather_than_abandoned() {
+        let probe_target = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = probe_target.local_addr().unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let (events, mut rx) = crate::bus::test_bus(64);
+        // Bound, never used: this case asserts on the bus rather than on the
+        // flock, and dropping the handle would take a sender off the actor's
+        // mailbox for no reason.
+        let _sup = SupervisorBuilder::new(AdoptingRunner, test_paths(&dir), events)
+            .spawn_adopted(
+                vec![without_handles(carried_in_swap(
+                    "web",
+                    8,
+                    Some(4243),
+                    ReloadState::Replacement,
+                    ProcStatus::Online,
+                    None,
+                    move |entry| {
+                        let mut app = AppConfig::minimal("web", "./srv");
+                        app.autorestart = false;
+                        // `Probe` readiness alone takes the serial ordering,
+                        // which has no post-drain probe to re-arm;
+                        // `reuse_port` is what puts this app on the
+                        // overlapping one, where the drainee may have
+                        // answered the first probe on the replacement's
+                        // behalf.
+                        app.reuse_port = true;
+                        app.readiness_probe = Some(probe_config(ProbeKind::Tcp, &addr.to_string()));
+                        entry.spec = normalize(app).unwrap();
+                    },
+                ))],
+                counters(9),
+                // No drainee: `Verify` is entered once the drainee is
+                // reaped, which is the whole point of asking again with one
+                // process left.
+                vec![carried_job(
+                    "web",
+                    ReloadMode::Overlap,
+                    7,
+                    Some(8),
+                    ReloadPhase::Verify,
+                )],
+            )
+            .expect("a carried flock installs");
+
+        tokio::time::timeout(
+            Duration::from_secs(5),
+            await_event(&mut rx, 8, ProcessEventKind::Reloaded),
+        )
+        .await
+        .expect("a carried swap in Verify must be probed again, not left to its watchdog");
+    }
+
+    /// Fails if a carried serial drain never spawns the replacement it was
+    /// draining for.
+    ///
+    /// [`ReloadPhase::DrainFirst`] is the one phase with no replacement yet:
+    /// the marker on the entry is `Drainee { new_id: None }`, and it is what
+    /// routes this instance's exit to `reap_drainee` — and so to
+    /// `spawn_serial_replacement` — instead of to `decide_on_exit`. A
+    /// successor that dropped it would deregister a `Stopping` sheep and
+    /// leave the instance slot empty, with the job still in the map.
+    ///
+    /// A real child and the real runner, for the reason
+    /// [`a_carried_manual_stop_stops_the_sheep_instead_of_respawning_it`]
+    /// gives: only the real reaper's `Msg::Exited` proves a carried marker
+    /// reaches `handle_exited`.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn a_carried_serial_drain_still_spawns_its_replacement() {
+        let dir = tempfile::tempdir().unwrap();
+        let (events, _rx) = crate::bus::test_bus(64);
+        let pid = adoptable_child("sleep 30");
+        let sup = SupervisorBuilder::new(TokioRunner::new(), test_paths(&dir), events)
+            .spawn_adopted(
+                vec![without_handles(carried_in_swap(
+                    "web",
+                    7,
+                    Some(pid),
+                    ReloadState::Drainee { new_id: None },
+                    ProcStatus::Stopping,
+                    Some(PendingManual {
+                        kind: ManualKind::Stop,
+                        origin: CommandOrigin::Operator,
+                    }),
+                    swappable,
+                ))],
+                counters(9),
+                vec![carried_job(
+                    "web",
+                    ReloadMode::Serial,
+                    7,
+                    None,
+                    ReloadPhase::DrainFirst,
+                )],
+            )
+            .expect("a carried flock installs");
+
+        let info = flock_until(
+            &sup,
+            |info| info.len() == 1 && info[0].id != 7,
+            "a carried serial drain must spawn its replacement once the instance it drained goes",
+        )
+        .await;
+
+        assert_eq!(
+            info[0].id, 9,
+            "the replacement takes the next carried id, not a reissued one"
+        );
+        assert_eq!(
+            info[0].restarts, 0,
+            "a reload is not a restart, so the count carries across the swap unchanged"
+        );
+        assert_ne!(info[0].pid, Some(pid), "the replacement is a new process");
+
+        sup.shutdown().await;
+    }
+
+    /// Fails if a carried replacement still awaiting readiness never commits
+    /// its swap.
+    ///
+    /// Three things have to survive for this to pass, and each one alone
+    /// leaves the operator worse off than the refusal it replaces:
+    ///
+    /// 1. The readiness wait is re-armed. `install_adopted` does that for
+    ///    every `Starting` sheep, and without it the replacement sits
+    ///    `Starting` forever with the drainee still serving beside it —
+    ///    two live instances of a one-instance app.
+    /// 2. The `Replacement` marker is restored, or `handle_ready_result`
+    ///    takes the ordinary path: the sheep goes `Online` and the swap
+    ///    never commits, so the drainee is never drained. The `manually`
+    ///    flag asserted below is that route's own fingerprint —
+    ///    `spawn_replacement` passes `true` because a reload is an
+    ///    operator's doing, and an adopted sheep that is not a replacement
+    ///    is armed with `false`.
+    /// 3. The job is restored, or `reload_ready_result` finds no reload to
+    ///    belong to and takes the same ordinary transition.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn a_carried_replacement_awaiting_readiness_commits_its_swap() {
+        let dir = tempfile::tempdir().unwrap();
+        let (events, mut rx) = crate::bus::test_bus(64);
+        let drainee = adoptable_child("sleep 30");
+        let replacement = adoptable_child("sleep 30");
+        let sup = SupervisorBuilder::new(TokioRunner::new(), test_paths(&dir), events)
+            .spawn_adopted(
+                vec![
+                    without_handles(carried_in_swap(
+                        "web",
+                        7,
+                        Some(drainee),
+                        ReloadState::Drainee { new_id: Some(8) },
+                        ProcStatus::Stopping,
+                        // No marker: an overlapping swap does not ask the
+                        // drainee to go until its replacement is serving.
+                        None,
+                        swappable,
+                    )),
+                    without_handles(carried_in_swap(
+                        "web",
+                        8,
+                        Some(replacement),
+                        ReloadState::Replacement,
+                        ProcStatus::Starting,
+                        None,
+                        swappable,
+                    )),
+                ],
+                counters(9),
+                vec![carried_job(
+                    "web",
+                    ReloadMode::Overlap,
+                    7,
+                    Some(8),
+                    ReloadPhase::AwaitReady,
+                )],
+            )
+            .expect("a carried flock installs");
+
+        let manually = tokio::time::timeout(
+            Duration::from_secs(20),
+            await_event(&mut rx, 8, ProcessEventKind::Online),
+        )
+        .await
+        .expect("a carried replacement must still resolve its readiness after the exec");
+        assert!(
+            manually,
+            "a replacement's Online is an operator's doing; reporting otherwise broadcasts a \
+             deploy as the daemon's own"
+        );
+
+        let info = flock_until(
+            &sup,
+            |info| info.len() == 1,
+            "committing the swap must drain the instance it replaced",
+        )
+        .await;
+        assert_eq!(info[0].id, 8, "the replacement is what is left: {info:?}");
+        assert_eq!(info[0].pid, Some(replacement));
+
+        sup.shutdown().await;
+    }
+
+    /// Fails if a carried drainee's exit does not finish the swap it was
+    /// half of.
+    ///
+    /// [`ReloadPhase::DrainOld`] is the committed phase: the replacement is
+    /// serving and the instance it replaced is on its ladder. The
+    /// `Drainee` marker is what sends that instance's exit to
+    /// `reap_drainee` rather than to `decide_on_exit`, and this app has
+    /// `autorestart` on, so a successor that dropped the marker would
+    /// respawn the OLD code into an instance slot the replacement owns —
+    /// two live processes for one instance, one of them the release the
+    /// operator was replacing.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn a_carried_drainee_still_finishes_its_swap() {
+        let dir = tempfile::tempdir().unwrap();
+        let (events, mut rx) = crate::bus::test_bus(64);
+        let drainee = adoptable_child("sleep 30");
+        let replacement = adoptable_child("sleep 30");
+        let sup = SupervisorBuilder::new(TokioRunner::new(), test_paths(&dir), events)
+            .spawn_adopted(
+                vec![
+                    without_handles(carried_in_swap(
+                        "web",
+                        7,
+                        Some(drainee),
+                        ReloadState::Drainee { new_id: Some(8) },
+                        ProcStatus::Stopping,
+                        Some(PendingManual {
+                            kind: ManualKind::Stop,
+                            origin: CommandOrigin::Operator,
+                        }),
+                        |entry| swappable_with(entry, |app| app.autorestart = true),
+                    )),
+                    without_handles(carried_in_swap(
+                        "web",
+                        8,
+                        Some(replacement),
+                        ReloadState::Replacement,
+                        ProcStatus::Online,
+                        None,
+                        |entry| swappable_with(entry, |app| app.autorestart = true),
+                    )),
+                ],
+                counters(9),
+                vec![carried_job(
+                    "web",
+                    ReloadMode::Overlap,
+                    7,
+                    Some(8),
+                    ReloadPhase::DrainOld,
+                )],
+            )
+            .expect("a carried flock installs");
+
+        tokio::time::timeout(
+            Duration::from_secs(20),
+            await_event(&mut rx, 8, ProcessEventKind::Reloaded),
+        )
+        .await
+        .expect("a carried drainee's exit must finish the swap it was half of");
+
+        let info = sup.list().await;
+        assert_eq!(
+            info.len(),
+            1,
+            "the drainee is deregistered by the swap, never respawned: {info:?}"
+        );
+        assert_eq!(info[0].id, 8);
+        assert_eq!(info[0].pid, Some(replacement));
+
+        sup.shutdown().await;
+    }
+
+    /// Fails if a carried drainee's ladder is re-armed under `kill_timeout`
+    /// rather than `graceful_timeout`.
+    ///
+    /// The cap is not recorded anywhere, so it is derived from the role: a
+    /// `Drainee` is an instance that was asked to finish the work already in
+    /// hand and go, which is `graceful_timeout`'s own definition, and both
+    /// sites that pass `LadderCap::Drain` leave that marker on the entry.
+    /// This line read `LadderCap::Stop` unconditionally while a flock
+    /// mid-reload was still refused outright.
+    ///
+    /// The child ignores `SIGTERM`, so only the escalation can end it, and
+    /// the app's two timeouts are three orders of magnitude apart: under the
+    /// drain's cap the `SIGKILL` lands a quarter of a second in, and under
+    /// the stop's it would land five minutes later — well past
+    /// [`flock_until`]'s own bound, which is what fails the case.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn a_carried_drainee_is_capped_by_graceful_timeout_not_kill_timeout() {
+        let dir = tempfile::tempdir().unwrap();
+        let (events, _rx) = crate::bus::test_bus(64);
+        let drainee = adoptable_child("trap '' TERM; sleep 300");
+        let replacement = adoptable_child("sleep 30");
+        let capped = |entry: &mut ProcessEntry| {
+            swappable_with(entry, |app| {
+                app.graceful_timeout = UpDuration::from_millis(250);
+                app.kill_timeout = UpDuration::from_millis(300_000);
+            });
+        };
+        let sup = SupervisorBuilder::new(TokioRunner::new(), test_paths(&dir), events)
+            .spawn_adopted(
+                vec![
+                    without_handles(carried_in_swap(
+                        "web",
+                        7,
+                        Some(drainee),
+                        ReloadState::Drainee { new_id: Some(8) },
+                        ProcStatus::Stopping,
+                        Some(PendingManual {
+                            kind: ManualKind::Stop,
+                            origin: CommandOrigin::Operator,
+                        }),
+                        capped,
+                    )),
+                    without_handles(carried_in_swap(
+                        "web",
+                        8,
+                        Some(replacement),
+                        ReloadState::Replacement,
+                        ProcStatus::Online,
+                        None,
+                        capped,
+                    )),
+                ],
+                counters(9),
+                vec![carried_job(
+                    "web",
+                    ReloadMode::Overlap,
+                    7,
+                    Some(8),
+                    ReloadPhase::DrainOld,
+                )],
+            )
+            .expect("a carried flock installs");
+
+        flock_until(
+            &sup,
+            |info| info.len() == 1,
+            "a carried drainee must escalate at graceful_timeout, not at kill_timeout",
+        )
+        .await;
+
+        sup.shutdown().await;
+    }
+
+    /// The app a carried swap's two halves run: a real `sleep`, so a
+    /// replacement can actually be spawned and a drainee actually signalled,
+    /// and a `listen_timeout` short enough that a real-clock case does not
+    /// wait out the 3s default.
+    #[cfg(unix)]
+    fn swappable(entry: &mut ProcessEntry) {
+        swappable_with(entry, |_| {});
+    }
+
+    /// [`swappable`], with `mutate` free to change the app first.
+    #[cfg(unix)]
+    fn swappable_with(entry: &mut ProcessEntry, mutate: impl FnOnce(&mut AppConfig)) {
+        let mut app = AppConfig::minimal("web", "/bin/sh");
+        app.args = vec!["-c".to_owned(), "sleep 30".to_owned()];
+        app.autorestart = false;
+        app.listen_timeout = UpDuration::from_millis(200);
+        mutate(&mut app);
+        entry.spec = normalize(app).unwrap();
     }
 }

--- a/crates/shep-daemon/src/supervisor.rs
+++ b/crates/shep-daemon/src/supervisor.rs
@@ -42,6 +42,7 @@ use std::io;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
+use serde::{Deserialize, Serialize};
 use tokio::sync::{mpsc, oneshot};
 
 use shep_core::config::{AppConfig, ResolvedApp, normalize};
@@ -1961,8 +1962,14 @@ enum ReloadPhase {
 
 /// Which manual command is pending against a sheep, cleared the moment its
 /// `Msg::Exited` is processed.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum ManualKind {
+///
+/// Serialized because a handover carries it: see [`PendingManual`], which is
+/// what actually crosses. `snake_case` on the wire to match
+/// [`ProcStatus`]'s own spelling, the blob's nearest neighbour, since the
+/// blob is a JSON file an operator may read.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum ManualKind {
     /// A `Stop` command targeted this sheep.
     Stop,
     /// A `Restart` command targeted this sheep.
@@ -1976,7 +1983,8 @@ enum ManualKind {
 /// sheep's next exit, and the two sites that carry the command out
 /// ([`Actor::handle_exited`] and [`Actor::apply_immediate`]), which report it
 /// as the `manually` flag on every bus event the restart emits.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub(crate) enum CommandOrigin {
     /// A person asked for it: a `Stop`, `Restart` or `Delete` off the control
     /// socket, or the daemon-wide `Shutdown`. An operator is waiting on the
@@ -1996,16 +2004,41 @@ pub(crate) enum CommandOrigin {
 }
 
 /// The manual command that owns a sheep's next exit, and who asked for it.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-struct PendingManual {
+///
+/// # Why this crosses a handover whole
+///
+/// A successor that installed the sheep without this marker would install
+/// the sheep an operator has already asked to go away and then supervise it
+/// as if nothing had been asked: `handle_exited` would read `kind` as `None`
+/// and hand an `autorestart` app its ordinary respawn, so a `shep stop`
+/// would come back as a running sheep. So [`CarriedSheep::manual`] carries
+/// it, and `Actor::install_adopted` re-claims it.
+///
+/// [`Self::origin`] crosses UNCHANGED, which is a decision rather than the
+/// obvious default. The connection behind an operator's command dies at the
+/// `execve` along with every other in-flight RPC, so it is tempting to read
+/// the far side as "nobody is waiting any more" and carry `Automatic`.
+/// That would be wrong twice. `origin` answers who CAUSED this exit, not who
+/// is still connected — both of its readers are about cause — and the reply
+/// it looks like it is tracking does not live here at all: it lives on a
+/// `PendingReply`, which is not carried, so there is nobody to answer either
+/// way. Downgrading would make the `manually` flag on this exit's own bus
+/// events say the daemon restarted the app itself, which is exactly the lie
+/// that flag exists to prevent, and it would let a later operator command
+/// take the marker off a ladder that is already running under
+/// [`Actor::claim_manual`]'s carve-out and give it a different ending.
+///
+/// [`CarriedSheep::manual`]: crate::handover::CarriedSheep::manual
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct PendingManual {
     /// What that exit will be turned into.
-    kind: ManualKind,
+    pub(crate) kind: ManualKind,
     /// Who asked. What the command DOES once the sheep is down is decided
     /// entirely by `kind`; `origin` survives into `handle_exited` for one
     /// purpose, the `manually` flag on the events that exit produces —
     /// otherwise a cron, watch, memory-breach or liveness restart would be
     /// broadcast as a user action.
-    origin: CommandOrigin,
+    pub(crate) origin: CommandOrigin,
 }
 
 /// One action the daemon has put on a sheep's shepherd channel and has not
@@ -3458,6 +3491,15 @@ impl<R: ProcessRunner> Actor<R> {
     /// [`CarriedFds`] are `CarriedFds::none()` for that same reason; neither
     /// is a refusal, and the fitness gate does not treat it as one.
     ///
+    /// # What a sheep mid-stop installs as
+    ///
+    /// The marker AND a fresh kill ladder. A carried [`PendingManual`] says
+    /// a command already owns this sheep's next exit, and the ladder that
+    /// was going to produce that exit died with the predecessor's image, so
+    /// restoring the marker alone would leave a sheep nothing is trying to
+    /// stop. The re-arm is at the bottom of this function and makes the
+    /// argument in full.
+    ///
     /// # Why nothing is emitted on the bus
     ///
     /// A `Start` or an `Online` would announce a transition to a sheep that
@@ -3544,11 +3586,21 @@ impl<R: ProcessRunner> Actor<R> {
                     to_child: None,
                     signals: None,
                     to_stdin: None,
+                    // `None`, and not restored from the blob even though the
+                    // blob may carry one. A marker is only ever claimed
+                    // against a sheep with a live task (`begin_manual_ids`
+                    // gates on `ctl.is_some()`, and `claim_manual` sends its
+                    // `Kill` down that same `ctl`), so a carried instance
+                    // with no pid should not have one — and if it somehow
+                    // did, there is no ladder here to re-arm and no
+                    // `Msg::Exited` coming to clear it, so restoring it
+                    // would leave a marker nothing in this image can ever
+                    // consume.
                     manual: None,
-                    // The gate refuses a flock with a manual stop waiting on
-                    // an exit, so there is no `manual` marker to carry. A
-                    // pending delete is no longer refused; it is restored
-                    // from the blob below.
+                    // A pending delete IS restored: unlike the marker above
+                    // it needs no task to act on it, and the one exit that
+                    // consumes it is whatever this slot's next spawn ends
+                    // with.
                     pending_delete: carried.pending_delete().unwrap_or(false),
                     epoch: carried.epoch(),
                     ready_tx: None,
@@ -3686,10 +3738,10 @@ impl<R: ProcessRunner> Actor<R> {
                 to_child: Some(to_child),
                 signals: Some(handles.signals),
                 to_stdin: Some(to_stdin),
-                // The gate refuses a flock with a manual stop waiting on an
-                // exit, so there is no `manual` marker to carry. A pending
-                // delete is no longer refused; it is restored from the blob
-                // below.
+                // `None` here and re-claimed below rather than written in
+                // directly, because restoring the marker is only half of
+                // what a carried one means: see the `claim_manual` call
+                // after this insert.
                 manual: None,
                 pending_delete: carried.pending_delete().unwrap_or(false),
                 epoch: carried.epoch(),
@@ -3702,6 +3754,48 @@ impl<R: ProcessRunner> Actor<R> {
                 ready_failed: false,
             },
         );
+        // A sheep the blob reports a `manual` marker for is one an operator
+        // (or the daemon itself) has already asked to go away, and the kill
+        // ladder that was going to make that happen ran inside the
+        // predecessor's own sheep task — `run_sheep`'s `SheepCtl::Kill` arm,
+        // and `kill_process`'s `tokio::time::timeout` inside it. The
+        // `execve` takes both. So a successor that restored only the marker
+        // would install a sheep that is never signalled again: the operator's
+        // `shep stop` leaves a process that will never die, and the row keeps
+        // reporting `online` while nothing at all is trying to stop it.
+        // Worse than the refusal this replaces, which at least stopped the
+        // flock.
+        //
+        // Fifth member of the same class as the readiness wait and the
+        // pending restart above, and re-armed the same way. It goes through
+        // `claim_manual` rather than writing `manual` into the slot directly
+        // so that the marker and the one `Kill` that produces its exit stay
+        // in the single place that pairs them, `try_send` rule (CRITICAL-2)
+        // included.
+        //
+        // What cannot be re-armed is how much of the ladder already ran.
+        // Nothing records when it started — the remaining grace is a
+        // `tokio::time::timeout` deadline inside a task of the
+        // predecessor's, monotonic and meaningless outside the runtime that
+        // read it — so the successor runs the WHOLE ladder again, polite
+        // rung first. Erring long is deliberate, exactly as
+        // `restart_delay(config, 1)` above errs long: a re-arm that jumped
+        // straight to `kill_tree` would `SIGKILL` a child that may never
+        // have been asked politely at all, since the predecessor's `Kill`
+        // could still have been sitting unread in the ctl mailbox at the
+        // exec. The cost is one extra `kill_timeout` at worst, and one
+        // repeated `SIGTERM` (or one repeated `{"kind":"shutdown"}`) to a
+        // child that is already on its way out.
+        //
+        // `LadderCap::Stop` and not the app's `graceful_timeout`, because
+        // every marker the gate can carry today was claimed under that cap:
+        // the two sites that pass `LadderCap::Drain` are a reload's drain,
+        // and both leave `ReloadState::Drainee` on the entry, which
+        // `handover::fitness` still refuses as `ReloadInFlight`. The task
+        // that removes that refusal has to revisit this line.
+        if let Some(manual) = carried.manual() {
+            self.claim_manual(id, manual, LadderCap::Stop);
+        }
         // The same arming a spawn gets on its way to `Online`, and for the
         // same reason: a watch, a schedule or a memory limit this image did
         // not arm is one the app quietly stops having. Only for an instance
@@ -5986,11 +6080,13 @@ impl<R: ProcessRunner> Actor<R> {
             .values()
             .map(|slot| HandoverDraft {
                 entry: slot.entry.clone(),
-                // Any manual command owning this sheep's next exit, not just
-                // a `Stop`. A `Restart` or a `Delete` waiting on that exit
-                // is as unsafe to carry, and the gate refuses in the strict
-                // direction by design.
-                pending_stop: slot.manual.is_some(),
+                // Whole, not `is_some()`. Which command owns this exit
+                // decides what the successor's `handle_exited` turns it
+                // into, and the origin decides what its bus events say
+                // about who caused it; a boolean would collapse a carried
+                // `Delete` into a `Stop` and broadcast an automatic restart
+                // as a user action.
+                manual: slot.manual,
                 pending_delete: slot.pending_delete,
                 epoch: slot.epoch,
                 log_ctl: slot.log_ctl.clone(),
@@ -6033,11 +6129,6 @@ impl<R: ProcessRunner> Actor<R> {
             .iter()
             .map(|slot| Candidate {
                 entry: &slot.entry,
-                // Any manual command owning this sheep's next exit, exactly
-                // as `handle_handover_snapshot` reads it: the two must answer
-                // the same question, or a flock passes the gate and then
-                // fails it.
-                pending_stop: slot.manual.is_some(),
                 // Always `false` here, and it has to be: this gate awaits
                 // nothing, so it cannot ask a pump anything, and a pump that
                 // is wedged right now may well have answered by the time a
@@ -7784,8 +7875,8 @@ impl ParkedPumps {
 struct HandoverDraft {
     /// The sheep's lifecycle entry, cloned off the slot.
     entry: ProcessEntry,
-    /// Whether a manual command owns this sheep's next exit.
-    pending_stop: bool,
+    /// The manual command owning this sheep's next exit, if one does.
+    manual: Option<PendingManual>,
     /// Whether a `Delete` targets this sheep.
     pending_delete: bool,
     /// The slot's respawn epoch, so a timer armed before the exec is still
@@ -7880,11 +7971,15 @@ fn spawn_handover_task(
             if !draft.channel_open {
                 fds.channel = None;
             }
-            let carried =
-                CarriedSheep::from_entry(&draft.entry, draft.epoch, fds, draft.pending_delete);
+            let carried = CarriedSheep::from_entry(
+                &draft.entry,
+                draft.epoch,
+                fds,
+                draft.pending_delete,
+                draft.manual,
+            );
             let candidate = OwnedCandidate {
                 entry: draft.entry,
-                pending_stop: draft.pending_stop,
                 pump_unresponsive,
             };
             (candidate, carried, parked_pump)
@@ -17826,11 +17921,14 @@ mod tests {
     ///
     /// These are the reason this is a command rather than a getter, and each
     /// one is load-bearing on its own: a successor that reissued a live id
-    /// would collide with a caller still holding it, and a manual stop the
-    /// gate never saw is a flock carried while an operator is waiting on its
-    /// exit. A pending delete used to reach the candidate the same way
-    /// `pending_stop` still does; it now reaches the successor on the blob
-    /// instead, which is what this asserts against since task 1.
+    /// would collide with a caller still holding it, and a manual command
+    /// the successor never sees is an operator's `stop` that comes back as a
+    /// running sheep.
+    ///
+    /// Both slot facts used to reach the CANDIDATE, where they were
+    /// refusals. Neither is one any more, so both are asserted against the
+    /// blob instead — the marker whole rather than as a boolean, since the
+    /// kind and the origin decide different things on the far side.
     ///
     /// The sheep here has no live pump, which is also the registered-but-not
     /// -running case: it reports no descriptors, and that is not a refusal.
@@ -17850,8 +17948,16 @@ mod tests {
         let (candidates, blob, _parked) = rx.await.unwrap().unwrap();
 
         assert!(
-            candidates[0].pending_stop,
-            "a pending stop must reach the gate"
+            !candidates.is_empty(),
+            "the flock must still reach the gate at all"
+        );
+        assert_eq!(
+            blob.sheep()[0].manual(),
+            Some(PendingManual {
+                kind: ManualKind::Stop,
+                origin: CommandOrigin::Operator,
+            }),
+            "a manual stop must reach the successor, kind and origin both"
         );
         assert_eq!(
             blob.sheep()[0].pending_delete(),
@@ -18021,20 +18127,25 @@ mod tests {
         pid: Option<u32>,
         mutate: impl FnOnce(&mut ProcessEntry),
     ) -> CarriedSheep {
-        carried_with_pending_delete(name, id, pid, false, mutate)
+        carried_marked(name, id, pid, false, None, mutate)
     }
 
-    /// [`carried`], with the blob's `pending_delete` fact set explicitly.
+    /// [`carried`], with the two slot facts a blob carries beside the entry
+    /// set explicitly: a pending delete, and the manual command that owns
+    /// this sheep's next exit.
     ///
-    /// A separate function rather than a sixth parameter every existing
-    /// call site would have to grow, since only the cases that are actually
-    /// about a pending delete need to say anything about it.
+    /// One function for both rather than one per fact, since a `Delete`
+    /// sets them together and a case about either usually has something to
+    /// say about the other. Separate from [`carried`] so the many cases that
+    /// are about neither do not grow two arguments they would always pass
+    /// the same values for.
     #[cfg(unix)]
-    fn carried_with_pending_delete(
+    fn carried_marked(
         name: &str,
         id: u32,
         pid: Option<u32>,
         pending_delete: bool,
+        manual: Option<PendingManual>,
         mutate: impl FnOnce(&mut ProcessEntry),
     ) -> CarriedSheep {
         let mut app = AppConfig::minimal(name, "./srv");
@@ -18059,7 +18170,7 @@ mod tests {
             last_exit: None,
         };
         mutate(&mut entry);
-        CarriedSheep::from_entry(&entry, 0, CarriedFds::none(), pending_delete)
+        CarriedSheep::from_entry(&entry, 0, CarriedFds::none(), pending_delete, manual)
     }
 
     /// A carried sheep with no descriptors to rebuild, which is every case
@@ -18262,11 +18373,12 @@ mod tests {
         let pid = child.id();
         let sup = SupervisorBuilder::new(TokioRunner::new(), test_paths(&dir), events)
             .spawn_adopted(
-                vec![without_handles(carried_with_pending_delete(
+                vec![without_handles(carried_marked(
                     "web",
                     7,
                     Some(pid),
                     true,
+                    None,
                     |_| {},
                 ))],
                 counters(9),
@@ -18298,6 +18410,316 @@ mod tests {
             info.is_empty(),
             "the deleted sheep must be gone, not just stopped"
         );
+    }
+
+    /// A real child for the adoption cases below to take over, running
+    /// `script` under `/bin/sh`, and its pid.
+    ///
+    /// **Its own process group, which is load-bearing rather than tidiness.**
+    /// `TokioProc::signal` and `kill_tree` both address the GROUP
+    /// (`signal_group`), exactly as the real spawn path leaves them able to:
+    /// a child that inherited this test binary's group is not a group leader,
+    /// so `killpg` answers `ESRCH`, the ladder logs a warning and delivers
+    /// nothing, and a case about a stop would fail for a reason that has
+    /// nothing to do with the stop. The cases that hand-send a signal to the
+    /// pid instead do not need this and do not use it.
+    ///
+    /// The `Child` handle is dropped rather than waited on, deliberately: the
+    /// adopted flock's own reaper is what collects this status, and a
+    /// `Child::wait` here would take it first and leave the daemon's targeted
+    /// wait with nothing to find.
+    #[cfg(unix)]
+    fn adoptable_child(script: &str) -> u32 {
+        use std::os::unix::process::CommandExt as _;
+
+        std::process::Command::new("/bin/sh")
+            .args(["-c", script])
+            .process_group(0)
+            // Null, not inherited, and this is not tidiness either. An
+            // inherited stdout is the TEST HARNESS's, which under
+            // `cargo test ... | <anything>` is a pipe: a child that outlives
+            // a failing case then holds that pipe open, and the reader waits
+            // on a sheep nothing is going to stop. A failed assertion turns
+            // into a hang, which is the worst way to learn a mutation
+            // worked.
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn()
+            .expect("a test host can spawn a shell")
+            .id()
+    }
+
+    /// The app an adopted sheep in these cases runs, respawnable for real:
+    /// `mutate` gets it before it is normalized onto the entry.
+    #[cfg(unix)]
+    fn respawnable(mutate: impl FnOnce(&mut AppConfig)) -> impl FnOnce(&mut ProcessEntry) {
+        move |entry: &mut ProcessEntry| {
+            let mut app = AppConfig::minimal("web", "/bin/sh");
+            // Real, because one of these cases lets the successor respawn
+            // the sheep and then asserts on the pid it comes back with.
+            // `./srv` would fail to spawn and land in `Errored`, which is a
+            // different assertion entirely.
+            app.args = vec!["-c".to_owned(), "sleep 30".to_owned()];
+            mutate(&mut app);
+            entry.spec = normalize(app).unwrap();
+        }
+    }
+
+    /// Polls the flock until `done` accepts it, or fails the case.
+    ///
+    /// Real children and real signals, so the clock is real too: nothing
+    /// here can advance a paused one on the child's behalf. The bound is
+    /// far past anything these cases ask for, so a sheep nothing is trying
+    /// to stop fails here rather than hanging.
+    #[cfg(unix)]
+    async fn flock_until(
+        sup: &SupervisorHandle,
+        done: impl Fn(&[ProcessInfo]) -> bool,
+        what: &str,
+    ) -> Vec<ProcessInfo> {
+        tokio::time::timeout(Duration::from_secs(20), async {
+            loop {
+                let info = sup.list().await;
+                if done(&info) {
+                    return info;
+                }
+                tokio::time::sleep(Duration::from_millis(20)).await;
+            }
+        })
+        .await
+        .unwrap_or_else(|_| panic!("{what}"))
+    }
+
+    /// Fails if a carried manual stop is dropped by the adopt path, either
+    /// half of it.
+    ///
+    /// Two things have to happen for an operator's `shep stop` to survive a
+    /// handover, and this asserts both because either one alone leaves the
+    /// operator worse off than the refusal this replaces:
+    ///
+    /// 1. The ladder is re-armed. It ran inside the predecessor's own sheep
+    ///    task and the `execve` took it, so a successor that restores only
+    ///    the marker installs a sheep that is never signalled again. That is
+    ///    what the sheep reaching a terminal status at all proves; without
+    ///    the re-arm nothing here ever touches the child and this times out.
+    /// 2. The marker is restored. `decide_on_exit` reads it as
+    ///    `manual_stop`, and this app has `autorestart` on, so a successor
+    ///    that armed a ladder without the marker would kill the sheep and
+    ///    then respawn it — a `stop` that comes back as a running process.
+    ///
+    /// A real child and the real runner, for the reason
+    /// [`a_carried_pending_delete_deregisters_on_the_next_exit`] gives: only
+    /// the real reaper's `Msg::Exited` proves a carried marker reaches
+    /// `handle_exited`.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn a_carried_manual_stop_stops_the_sheep_instead_of_respawning_it() {
+        let dir = tempfile::tempdir().unwrap();
+        let (events, _rx) = crate::bus::test_bus(64);
+        let pid = adoptable_child("sleep 30");
+        let sup = SupervisorBuilder::new(TokioRunner::new(), test_paths(&dir), events)
+            .spawn_adopted(
+                vec![without_handles(carried_marked(
+                    "web",
+                    7,
+                    Some(pid),
+                    false,
+                    Some(PendingManual {
+                        kind: ManualKind::Stop,
+                        origin: CommandOrigin::Operator,
+                    }),
+                    respawnable(|app| app.autorestart = true),
+                ))],
+                counters(9),
+            )
+            .expect("a carried flock installs");
+
+        let info = flock_until(
+            &sup,
+            |info| info[0].status == ProcStatus::Stopped,
+            "a carried manual stop must still stop the sheep after the exec",
+        )
+        .await;
+
+        assert_eq!(
+            info[0].restarts, 0,
+            "a stop must not come back as a respawn"
+        );
+        assert_eq!(
+            info[0].last_exit,
+            Some(ExitInfo {
+                code: None,
+                signal: Some(15)
+            }),
+            "the re-armed ladder starts at its polite rung, not at SIGKILL"
+        );
+        assert_eq!(info[0].pid, None, "a stopped sheep holds no pid");
+    }
+
+    /// Fails if a carried kill ladder never escalates from `SIGTERM` to
+    /// `SIGKILL`.
+    ///
+    /// The fifth member of the stranded-timer class, and the one found by
+    /// driving a real reload rather than by reading code. The escalation is
+    /// a `tokio::time::timeout` inside `kill_process`, which runs on the
+    /// sheep task, which is a `tokio::spawn` of the predecessor's that the
+    /// `execve` takes. A successor that restores the marker and re-sends
+    /// only the polite signal leaves a child that traps `SIGTERM` running
+    /// forever, with an operator's `stop` outstanding and no rung left: a
+    /// strictly worse outcome than refusing the handover, which at least
+    /// stopped the flock.
+    ///
+    /// The signal in `last_exit` is the whole assertion. A pid check cannot
+    /// tell a ladder that escalated from one that merely got lucky, which is
+    /// exactly why this defect survived a green suite.
+    ///
+    /// `kill_timeout` is shortened to a second so the case does not sit out
+    /// the 1600ms default plus its own polling; the bound in
+    /// [`flock_until`] is far past both.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn a_carried_manual_stop_still_escalates_to_sigkill() {
+        let dir = tempfile::tempdir().unwrap();
+        let (events, _rx) = crate::bus::test_bus(64);
+        // `trap "" TERM` around a sleeping loop is `tests/real_runner.rs`'s
+        // own defiant sheep, and the loop rather than a bare `sleep` is part
+        // of it: the polite rung reaches the whole GROUP, so a shell waiting
+        // on one `sleep` would exit carrying that sleep's own status and
+        // look like it had obeyed.
+        //
+        // The touchfile closes the startup race `real_runner.rs` documents
+        // and answers with a real sleep. The install below sends the polite
+        // signal within microseconds of the spawn, and a `SIGTERM` that
+        // arrives before `trap` has run kills the shell on the default
+        // disposition — a green-looking failure of exactly the assertion
+        // this case exists to make.
+        let armed = dir.path().join("trap-armed");
+        //
+        // The loop is bounded rather than `while true` so that a case which
+        // fails before the ladder reaches it still leaves a child that goes
+        // away on its own, well inside `flock_until`'s own bound.
+        let pid = adoptable_child(&format!(
+            "trap '' TERM; : > {}; i=0; while [ $i -lt 60 ]; do sleep 1; i=$((i+1)); done",
+            armed.display()
+        ));
+        tokio::time::timeout(Duration::from_secs(20), async {
+            while !armed.exists() {
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("the defiant child must arm its trap before anything signals it");
+        let sup = SupervisorBuilder::new(TokioRunner::new(), test_paths(&dir), events)
+            .spawn_adopted(
+                vec![without_handles(carried_marked(
+                    "web",
+                    7,
+                    Some(pid),
+                    false,
+                    Some(PendingManual {
+                        kind: ManualKind::Stop,
+                        origin: CommandOrigin::Operator,
+                    }),
+                    respawnable(|app| {
+                        app.autorestart = false;
+                        app.kill_timeout = "1000".parse().unwrap();
+                    }),
+                ))],
+                counters(9),
+            )
+            .expect("a carried flock installs");
+
+        let info = flock_until(
+            &sup,
+            |info| info[0].status == ProcStatus::Stopped,
+            "a sheep carried mid-ladder must still die on its own, without a hand-sent SIGKILL",
+        )
+        .await;
+
+        assert_eq!(
+            info[0].last_exit,
+            Some(ExitInfo {
+                code: None,
+                signal: Some(9)
+            }),
+            "the ladder must escalate: this child ignores SIGTERM, so anything else means it \
+             was never killed"
+        );
+    }
+
+    /// Fails if a carried manual RESTART is read as a stop, or if its origin
+    /// is rewritten on the way across.
+    ///
+    /// The kind and the origin are two separate facts on one marker and this
+    /// is what keeps either from being defaulted. A successor that armed a
+    /// ladder under a hardcoded `Stop` would leave the sheep down when an
+    /// operator had asked for it to come back, and one that hardcoded
+    /// `Operator` would broadcast a memory breach or a cron occurrence as a
+    /// user action — the exact lie [`PendingManual::origin`] exists to
+    /// prevent, and one a subscriber cannot tell from a deploy.
+    ///
+    /// `Automatic` rather than `Operator` for that second half: the flag has
+    /// to be able to come back `false`, and an operator's own restart is
+    /// what the rest of the suite already covers.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn a_carried_manual_restart_respawns_and_keeps_its_origin() {
+        let dir = tempfile::tempdir().unwrap();
+        let (events, mut rx) = crate::bus::test_bus(64);
+        let pid = adoptable_child("sleep 30");
+        let sup = SupervisorBuilder::new(TokioRunner::new(), test_paths(&dir), events)
+            .spawn_adopted(
+                vec![without_handles(carried_marked(
+                    "web",
+                    7,
+                    Some(pid),
+                    false,
+                    Some(PendingManual {
+                        kind: ManualKind::Restart,
+                        origin: CommandOrigin::Automatic,
+                    }),
+                    // Off, so the respawn below can only be the carried
+                    // Restart: an `autorestart` app would come back from the
+                    // crash loop whatever the marker said.
+                    respawnable(|app| app.autorestart = false),
+                ))],
+                counters(9),
+            )
+            .expect("a carried flock installs");
+
+        let manually = tokio::time::timeout(
+            Duration::from_secs(20),
+            await_event(&mut rx, 7, ProcessEventKind::Restart),
+        )
+        .await
+        .expect("a carried manual restart must respawn the sheep after the exec");
+        assert!(
+            !manually,
+            "an automatic restart carried across a handover must not be broadcast as a user \
+             action"
+        );
+
+        let info = flock_until(
+            &sup,
+            |info| info[0].restarts == 1,
+            "the respawn must be counted against the sheep that was carried",
+        )
+        .await;
+        assert_ne!(
+            info[0].pid,
+            Some(pid),
+            "a restart is a new process, not the adopted one"
+        );
+        assert_eq!(
+            info[0].status,
+            ProcStatus::Online,
+            "an ungated app is Online the moment it respawns"
+        );
+
+        // The respawn is a real `sleep 30` this case started; the shutdown
+        // is what stops it being left behind when the tempdir goes.
+        sup.shutdown().await;
     }
 
     /// Fails if a successor hands a fresh sheep an id a caller is still

--- a/crates/shep-daemon/src/supervisor.rs
+++ b/crates/shep-daemon/src/supervisor.rs
@@ -3988,7 +3988,8 @@ impl<R: ProcessRunner> Actor<R> {
                     name = app,
                     old_id = swap.old_id,
                     new_id = swap.new_id,
-                    "a carried reload named no instance this shepherd was given, so it was                      dropped rather than left unfinishable"
+                    "a carried reload named no instance this shepherd was given, so it was \
+                     dropped rather than left unfinishable"
                 );
                 continue;
             };

--- a/crates/shep-daemon/src/supervisor.rs
+++ b/crates/shep-daemon/src/supervisor.rs
@@ -3615,6 +3615,17 @@ impl<R: ProcessRunner> Actor<R> {
         // all, which said the same thing by refusing to carry one; see
         // `CarriedSheep::reload`.
         let reload = carried.reload().unwrap_or(ReloadState::None);
+        // Read here rather than at either `SheepSlot` literal below, because
+        // the readiness re-arm between them has to see it: a `ready_failed`
+        // instance is `Starting` by construction, so a gate that could not
+        // tell the two apart would arm a wait over the one shape that must
+        // not get one. See the re-arm itself for what that would cost.
+        //
+        // `false` for a blob written before this daemon carried the flag,
+        // which is what a successor of that blob's predecessor assumed
+        // anyway — the field is new, the assumption is not. See
+        // `CarriedSheep::ready_failed`.
+        let ready_failed = carried.ready_failed().unwrap_or(false);
         let mut entry = ProcessEntry {
             id,
             spec: app.clone(),
@@ -3681,7 +3692,14 @@ impl<R: ProcessRunner> Actor<R> {
                     epoch: carried.epoch(),
                     ready_tx: None,
                     actions: ActionWaits::default(),
-                    ready_failed: false,
+                    // Restored for the reason the pending delete above is:
+                    // it needs no task to act on it, and what consumes it is
+                    // whatever this slot's next spawn or exit does. A slot
+                    // with no process can still carry it — an abandoned
+                    // replacement that then exited is `WaitingRestart` with
+                    // the verdict still standing — and `respawn` clears it
+                    // at the spawn that answers it.
+                    ready_failed,
                 },
             );
             // A sheep the blob reports as `WaitingRestart` is owed a respawn,
@@ -3789,7 +3807,23 @@ impl<R: ProcessRunner> Actor<R> {
         // operator's deploy as the daemon's own doing, which is the lie the
         // flag exists to prevent.
         let manually = matches!(reload, ReloadState::Replacement);
-        let ready_tx = (status == ProcStatus::Starting).then(|| {
+        // `ready_failed` is the one `Starting` sheep that gets no wait, and
+        // skipping it is the faithful adoption rather than an exception to
+        // one. An abandoned reload's leftover has already had its verdict:
+        // the predecessor's wait ran, failed, and was not replaced — the
+        // instance is left `Starting` precisely because that is the one
+        // status literally true of a process that is up and not serving.
+        //
+        // Arming a fresh wait over it would invent a second chance the
+        // predecessor had ended, and `handle_ready_result` would spend it
+        // the wrong way in both directions. Its `TimedOut` arm goes `Online`
+        // ANYWAY, so a successor would promote an abandoned release to
+        // serving one `listen_timeout` after the exec — the exact false
+        // success `reload_ready_result` and `handle_reload_verified` refuse
+        // to write — and `went_online` would clear the carried flag on its
+        // way past, so the rollback this whole field exists for would find
+        // the instance `Online` for a reason that is not true.
+        let ready_tx = (status == ProcStatus::Starting && !ready_failed).then(|| {
             let source = ReadinessSource::of(app.config())
                 .expect("ResolvedApp already passed ProbeTarget::parse in normalize");
             spawn_readiness_task(
@@ -3832,10 +3866,17 @@ impl<R: ProcessRunner> Actor<R> {
                 // Armed above for an instance the blob reports as
                 // `Starting`, and `None` for one it reports as `Online`,
                 // which has already resolved its readiness and has nothing
-                // left to wait for.
+                // left to wait for — or for one whose readiness already
+                // failed, which has nothing left to wait for either.
                 ready_tx,
                 actions: ActionWaits::default(),
-                ready_failed: false,
+                // Restored, and it is what keeps an abandoned reload's
+                // leftover reachable: `reload_eligible` reads it beside the
+                // status, so the rollback reload can replace an instance
+                // that never reached `Online`. A successor that dropped it
+                // would answer that rollback `Ok` and skip the only instance
+                // there was.
+                ready_failed,
             },
         );
         // A sheep the blob reports a `manual` marker for is one an operator
@@ -6296,6 +6337,7 @@ impl<R: ProcessRunner> Actor<R> {
                 manual: slot.manual,
                 pending_delete: slot.pending_delete,
                 epoch: slot.epoch,
+                ready_failed: slot.ready_failed,
                 log_ctl: slot.log_ctl.clone(),
                 channel_open: slot.open_channel().is_some(),
             })
@@ -8111,6 +8153,9 @@ struct HandoverDraft {
     /// The slot's respawn epoch, so a timer armed before the exec is still
     /// recognised as stale after it.
     epoch: u64,
+    /// Whether a reload's readiness verification has already failed against
+    /// this sheep. See [`SheepSlot::ready_failed`].
+    ready_failed: bool,
     /// This sheep's log pump, or `None` for a slot whose spawn never
     /// succeeded.
     log_ctl: Option<mpsc::Sender<LogCtl>>,
@@ -8207,6 +8252,7 @@ fn spawn_handover_task(
                 fds,
                 draft.pending_delete,
                 draft.manual,
+                draft.ready_failed,
             );
             let candidate = OwnedCandidate {
                 entry: draft.entry,
@@ -18146,7 +18192,7 @@ mod tests {
         );
     }
 
-    /// Fails if a snapshot loses the three actor counters or the two slot
+    /// Fails if a snapshot loses the three actor counters or the three slot
     /// facts nothing outside the actor can see.
     ///
     /// These are the reason this is a command rather than a getter, and each
@@ -18155,10 +18201,13 @@ mod tests {
     /// the successor never sees is an operator's `stop` that comes back as a
     /// running sheep.
     ///
-    /// Both slot facts used to reach the CANDIDATE, where they were
-    /// refusals. Neither is one any more, so both are asserted against the
-    /// blob instead — the marker whole rather than as a boolean, since the
-    /// kind and the origin decide different things on the far side.
+    /// Two of the three slot facts used to reach the CANDIDATE, where they
+    /// were refusals. Neither is one any more, so both are asserted against
+    /// the blob instead — the marker whole rather than as a boolean, since
+    /// the kind and the origin decide different things on the far side. The
+    /// third, `ready_failed`, was never a refusal and so was never asserted
+    /// anywhere: a snapshot that silently left it behind is the quiet half
+    /// of the same loss, and it is only visible here, on the write side.
     ///
     /// The sheep here has no live pump, which is also the registered-but-not
     /// -running case: it reports no descriptors, and that is not a refusal.
@@ -18172,6 +18221,7 @@ mod tests {
             kind: ManualKind::Stop,
             origin: CommandOrigin::Operator,
         });
+        actor.sheep.get_mut(&0).unwrap().ready_failed = true;
 
         let (reply, rx) = oneshot::channel();
         actor.handle_handover_snapshot(fds, reply);
@@ -18193,6 +18243,12 @@ mod tests {
             blob.sheep()[0].pending_delete(),
             Some(false),
             "nothing asked for this sheep to be deleted"
+        );
+        assert_eq!(
+            blob.sheep()[0].ready_failed(),
+            Some(true),
+            "an earlier reload's failed verdict must reach the successor, or the rollback that \
+             follows it has nothing left to replace"
         );
         assert!(
             blob.next_id() > 0,
@@ -18358,18 +18414,36 @@ mod tests {
         pid: Option<u32>,
         mutate: impl FnOnce(&mut ProcessEntry),
     ) -> CarriedSheep {
-        carried_marked(name, id, pid, false, None, mutate)
+        carried_marked(name, id, pid, false, None, false, mutate)
     }
 
-    /// [`carried`], with the two slot facts a blob carries beside the entry
-    /// set explicitly: a pending delete, and the manual command that owns
-    /// this sheep's next exit.
+    /// [`carried`], for an instance an earlier reload's readiness
+    /// verification failed against.
     ///
-    /// One function for both rather than one per fact, since a `Delete`
-    /// sets them together and a case about either usually has something to
-    /// say about the other. Separate from [`carried`] so the many cases that
-    /// are about neither do not grow two arguments they would always pass
-    /// the same values for.
+    /// Separate from [`carried_marked`] for the reason [`carried_in_swap`]
+    /// is: the many cases that are about none of this would otherwise grow
+    /// an argument they always pass the same value for.
+    #[cfg(unix)]
+    fn carried_ready_failed(
+        name: &str,
+        id: u32,
+        pid: Option<u32>,
+        mutate: impl FnOnce(&mut ProcessEntry),
+    ) -> CarriedSheep {
+        carried_marked(name, id, pid, false, None, true, mutate)
+    }
+
+    /// [`carried`], with the slot facts a blob carries beside the entry set
+    /// explicitly: a pending delete, the manual command that owns this
+    /// sheep's next exit, and an earlier reload's failed readiness verdict.
+    ///
+    /// One function for the first two rather than one per fact, since a
+    /// `Delete` sets them together and a case about either usually has
+    /// something to say about the other. Separate from [`carried`] so the
+    /// many cases that are about neither do not grow two arguments they
+    /// would always pass the same values for — which is also why the third
+    /// reaches this through [`carried_ready_failed`] rather than being
+    /// spelled out at every call.
     #[cfg(unix)]
     fn carried_marked(
         name: &str,
@@ -18377,6 +18451,7 @@ mod tests {
         pid: Option<u32>,
         pending_delete: bool,
         manual: Option<PendingManual>,
+        ready_failed: bool,
         mutate: impl FnOnce(&mut ProcessEntry),
     ) -> CarriedSheep {
         let mut app = AppConfig::minimal(name, "./srv");
@@ -18401,7 +18476,14 @@ mod tests {
             last_exit: None,
         };
         mutate(&mut entry);
-        CarriedSheep::from_entry(&entry, 0, CarriedFds::none(), pending_delete, manual)
+        CarriedSheep::from_entry(
+            &entry,
+            0,
+            CarriedFds::none(),
+            pending_delete,
+            manual,
+            ready_failed,
+        )
     }
 
     /// A carried sheep with no descriptors to rebuild, which is every case
@@ -18613,6 +18695,7 @@ mod tests {
                     Some(pid),
                     true,
                     None,
+                    false,
                     |_| {},
                 ))],
                 counters(9),
@@ -18764,6 +18847,7 @@ mod tests {
                         kind: ManualKind::Stop,
                         origin: CommandOrigin::Operator,
                     }),
+                    false,
                     respawnable(|app| app.autorestart = true),
                 ))],
                 counters(9),
@@ -18857,6 +18941,7 @@ mod tests {
                         kind: ManualKind::Stop,
                         origin: CommandOrigin::Operator,
                     }),
+                    false,
                     respawnable(|app| {
                         app.autorestart = false;
                         app.kill_timeout = "1000".parse().unwrap();
@@ -18916,6 +19001,7 @@ mod tests {
                         kind: ManualKind::Restart,
                         origin: CommandOrigin::Automatic,
                     }),
+                    false,
                     // Off, so the respawn below can only be the carried
                     // Restart: an `autorestart` app would come back from the
                     // crash loop whatever the marker said.
@@ -19129,7 +19215,7 @@ mod tests {
         manual: Option<PendingManual>,
         mutate: impl FnOnce(&mut ProcessEntry),
     ) -> CarriedSheep {
-        carried_marked(name, id, pid, false, manual, move |entry| {
+        carried_marked(name, id, pid, false, manual, false, move |entry| {
             mutate(entry);
             entry.reload = role;
             entry.status = status;
@@ -19642,6 +19728,121 @@ mod tests {
         .await;
 
         sup.shutdown().await;
+    }
+
+    /// Fails if a reload can no longer reach an instance an earlier reload's
+    /// readiness verification failed against, once that instance has crossed
+    /// a handover.
+    ///
+    /// The status alone rules it out. An abandoned reload leaves its
+    /// replacement `Starting` deliberately — up, and never having proved it
+    /// can serve — and a reload replaces `Online` instances, so
+    /// `SheepSlot::ready_failed` is the whole of what keeps the leftover
+    /// reachable. A successor that dropped the flag would answer the
+    /// rollback that follows a bad release with `Ok` and replace nothing,
+    /// which is the failure the flag exists to prevent, arriving through a
+    /// door that used to be shut by refusing the flock instead.
+    ///
+    /// Asserted through a real reload rather than by reading the slot back:
+    /// what an operator meets is the reload's own answer, and `handle_reload`
+    /// replies `Ok` with the row in it either way — before its selector pass
+    /// has decided that this instance is not eligible.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn a_carried_ready_failed_instance_is_still_replaceable() {
+        let dir = tempfile::tempdir().unwrap();
+        let (events, _rx) = crate::bus::test_bus(64);
+        let pid = adoptable_child("sleep 30");
+        let sup = SupervisorBuilder::new(TokioRunner::new(), test_paths(&dir), events)
+            .spawn_adopted(
+                vec![without_handles(carried_ready_failed(
+                    "web",
+                    7,
+                    Some(pid),
+                    |entry| {
+                        swappable(entry);
+                        entry.status = ProcStatus::Starting;
+                    },
+                ))],
+                counters(9),
+                Vec::new(),
+            )
+            .expect("a carried flock installs");
+
+        sup.reload(ProcessSelector::All)
+            .await
+            .expect("a registered app is one a reload can name");
+
+        let info = flock_until(
+            &sup,
+            |info| info.len() == 1 && info[0].id != 7,
+            "a carried `ready_failed` instance must still be replaceable by the reload that \
+             rolls its release back",
+        )
+        .await;
+
+        assert_eq!(
+            info[0].id, 9,
+            "the replacement takes the next carried id, not a reissued one"
+        );
+        assert_ne!(info[0].pid, Some(pid), "the replacement is a new process");
+
+        sup.shutdown().await;
+    }
+
+    /// Fails if a successor arms a readiness wait over an instance whose
+    /// readiness has already failed.
+    ///
+    /// The exact inverse of
+    /// [`an_adopted_sheep_that_was_still_starting_reaches_online`], and the
+    /// two together are why `install_adopted` reads the carried flag before
+    /// it decides: both sheep are `Starting`, and only the flag tells them
+    /// apart. An ordinary one is mid-wait and owed a fresh one; this one's
+    /// wait already ran, failed, and was deliberately not replaced.
+    ///
+    /// Arming one anyway would spend it the wrong way whichever answer came
+    /// back. `handle_ready_result`'s `TimedOut` arm goes `Online` ANYWAY, so
+    /// the successor would report an abandoned release as serving one
+    /// `listen_timeout` after the exec — the false success both abandonment
+    /// arms refuse to write — and `went_online` clears `ready_failed` on its
+    /// way past, so the rollback the sibling case above asserts would arrive
+    /// to find the instance `Online` for a reason that is not true.
+    ///
+    /// The clock is paused and then run well past the app's own
+    /// `listen_timeout`, so a wait that WAS armed has fired and been handled
+    /// by the time the status is read.
+    #[cfg(unix)]
+    #[tokio::test(start_paused = true)]
+    async fn a_carried_ready_failed_instance_gets_no_fresh_readiness_wait() {
+        let dir = tempfile::tempdir().unwrap();
+        let (events, _rx) = crate::bus::test_bus(64);
+        let sup = SupervisorBuilder::new(AdoptingRunner, test_paths(&dir), events)
+            .spawn_adopted(
+                vec![without_handles(carried_ready_failed(
+                    "web",
+                    7,
+                    Some(4242),
+                    |entry| {
+                        let mut app = AppConfig::minimal("web", "./srv");
+                        app.autorestart = false;
+                        app.wait_ready = true;
+                        entry.spec = normalize(app).unwrap();
+                        entry.status = ProcStatus::Starting;
+                    },
+                ))],
+                counters(9),
+                Vec::new(),
+            )
+            .expect("a carried flock installs");
+
+        tokio::time::sleep(Duration::from_secs(120)).await;
+
+        assert_eq!(
+            sup.list().await[0].status,
+            ProcStatus::Starting,
+            "an instance whose readiness already failed must not be handed a second verdict by \
+             the successor that adopted it"
+        );
     }
 
     /// The app a carried swap's two halves run: a real `sleep`, so a

--- a/crates/shep-daemon/src/supervisor.rs
+++ b/crates/shep-daemon/src/supervisor.rs
@@ -1963,8 +1963,15 @@ impl ReloadMode {
 
 /// The drainee/replacement pair a reload is working on right now.
 ///
-/// Serialized because a handover carries the job it belongs to, `snake_case`
-/// on the wire for the reason [`ManualKind`] gives.
+/// Serialized because a handover carries the job it belongs to.
+///
+/// Its `rename_all` is INERT, unlike the one on [`ReloadMode`] and
+/// [`ReloadPhase`] beside it, and that is worth a line rather than leaving a
+/// reader to work out which. Those two are enums, where the attribute
+/// renames VARIANTS and fixes their wire spelling. This is a struct, so it
+/// renames fields, and every field here is snake_case already. It stays for
+/// symmetry: the handover's types disagreeing about whether they declare
+/// their wire case costs more to read than an attribute that does nothing.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub(crate) struct ReloadSwap {

--- a/crates/shep-daemon/src/supervisor.rs
+++ b/crates/shep-daemon/src/supervisor.rs
@@ -3545,7 +3545,11 @@ impl<R: ProcessRunner> Actor<R> {
                     signals: None,
                     to_stdin: None,
                     manual: None,
-                    pending_delete: false,
+                    // The gate refuses a flock with a manual stop waiting on
+                    // an exit, so there is no `manual` marker to carry. A
+                    // pending delete is no longer refused; it is restored
+                    // from the blob below.
+                    pending_delete: carried.pending_delete().unwrap_or(false),
                     epoch: carried.epoch(),
                     ready_tx: None,
                     actions: ActionWaits::default(),
@@ -3682,10 +3686,12 @@ impl<R: ProcessRunner> Actor<R> {
                 to_child: Some(to_child),
                 signals: Some(handles.signals),
                 to_stdin: Some(to_stdin),
-                // The gate refuses a flock with a manual stop or a pending
-                // delete waiting on an exit, so there is no marker to carry.
+                // The gate refuses a flock with a manual stop waiting on an
+                // exit, so there is no `manual` marker to carry. A pending
+                // delete is no longer refused; it is restored from the blob
+                // below.
                 manual: None,
-                pending_delete: false,
+                pending_delete: carried.pending_delete().unwrap_or(false),
                 epoch: carried.epoch(),
                 // Armed above for an instance the blob reports as
                 // `Starting`, and `None` for one it reports as `Online`,
@@ -6032,7 +6038,6 @@ impl<R: ProcessRunner> Actor<R> {
                 // the same question, or a flock passes the gate and then
                 // fails it.
                 pending_stop: slot.manual.is_some(),
-                pending_delete: slot.pending_delete,
                 // Always `false` here, and it has to be: this gate awaits
                 // nothing, so it cannot ask a pump anything, and a pump that
                 // is wedged right now may well have answered by the time a
@@ -7875,11 +7880,11 @@ fn spawn_handover_task(
             if !draft.channel_open {
                 fds.channel = None;
             }
-            let carried = CarriedSheep::from_entry(&draft.entry, draft.epoch, fds);
+            let carried =
+                CarriedSheep::from_entry(&draft.entry, draft.epoch, fds, draft.pending_delete);
             let candidate = OwnedCandidate {
                 entry: draft.entry,
                 pending_stop: draft.pending_stop,
-                pending_delete: draft.pending_delete,
                 pump_unresponsive,
             };
             (candidate, carried, parked_pump)
@@ -17817,13 +17822,15 @@ mod tests {
     }
 
     /// Fails if a snapshot loses the three actor counters or the two slot
-    /// fields nothing outside the actor can see.
+    /// facts nothing outside the actor can see.
     ///
     /// These are the reason this is a command rather than a getter, and each
     /// one is load-bearing on its own: a successor that reissued a live id
     /// would collide with a caller still holding it, and a manual stop the
     /// gate never saw is a flock carried while an operator is waiting on its
-    /// exit.
+    /// exit. A pending delete used to reach the candidate the same way
+    /// `pending_stop` still does; it now reaches the successor on the blob
+    /// instead, which is what this asserts against since task 1.
     ///
     /// The sheep here has no live pump, which is also the registered-but-not
     /// -running case: it reports no descriptors, and that is not a refusal.
@@ -17846,8 +17853,9 @@ mod tests {
             candidates[0].pending_stop,
             "a pending stop must reach the gate"
         );
-        assert!(
-            !candidates[0].pending_delete,
+        assert_eq!(
+            blob.sheep()[0].pending_delete(),
+            Some(false),
             "nothing asked for this sheep to be deleted"
         );
         assert!(
@@ -18013,6 +18021,22 @@ mod tests {
         pid: Option<u32>,
         mutate: impl FnOnce(&mut ProcessEntry),
     ) -> CarriedSheep {
+        carried_with_pending_delete(name, id, pid, false, mutate)
+    }
+
+    /// [`carried`], with the blob's `pending_delete` fact set explicitly.
+    ///
+    /// A separate function rather than a sixth parameter every existing
+    /// call site would have to grow, since only the cases that are actually
+    /// about a pending delete need to say anything about it.
+    #[cfg(unix)]
+    fn carried_with_pending_delete(
+        name: &str,
+        id: u32,
+        pid: Option<u32>,
+        pending_delete: bool,
+        mutate: impl FnOnce(&mut ProcessEntry),
+    ) -> CarriedSheep {
         let mut app = AppConfig::minimal(name, "./srv");
         // Nothing in these cases wants a respawn: the install path is what
         // is under test, and an automatic restart would spawn a second
@@ -18035,7 +18059,7 @@ mod tests {
             last_exit: None,
         };
         mutate(&mut entry);
-        CarriedSheep::from_entry(&entry, 0, CarriedFds::none())
+        CarriedSheep::from_entry(&entry, 0, CarriedFds::none(), pending_delete)
     }
 
     /// A carried sheep with no descriptors to rebuild, which is every case
@@ -18204,6 +18228,75 @@ mod tests {
                 signal: Some(9)
             }),
             "the exit must be recorded, not lost"
+        );
+    }
+
+    /// Fails if a carried pending delete is dropped by the adopt path.
+    ///
+    /// `install_adopted` used to hardcode `pending_delete: false` on every
+    /// installed slot, since the gate refused to carry one at all. Now that
+    /// [`handover::fitness`] carries it instead of refusing it, a sheep
+    /// whose delete was already in flight when the predecessor exec'd must
+    /// still be deregistered on its next exit rather than left registered
+    /// (which the operator's dropped connection would then never learn) or,
+    /// worse, respawned.
+    ///
+    /// A real child and the real runner, for the same reason
+    /// [`an_adopted_sheeps_exit_flows_through_the_ordinary_path`] gives: an
+    /// adopted pid has no `Child` handle, and only the real reaper's
+    /// `Msg::Exited` proves the carried marker actually reaches
+    /// `handle_exited`.
+    #[cfg(unix)]
+    #[tokio::test]
+    #[expect(
+        clippy::zombie_processes,
+        reason = "the adopted flock's reaper collects this status; a Child::wait would take it first"
+    )]
+    async fn a_carried_pending_delete_deregisters_on_the_next_exit() {
+        let dir = tempfile::tempdir().unwrap();
+        let (events, _rx) = crate::bus::test_bus(64);
+        let child = std::process::Command::new("/bin/sh")
+            .args(["-c", "sleep 30"])
+            .spawn()
+            .expect("a test host can spawn a shell");
+        let pid = child.id();
+        let sup = SupervisorBuilder::new(TokioRunner::new(), test_paths(&dir), events)
+            .spawn_adopted(
+                vec![without_handles(carried_with_pending_delete(
+                    "web",
+                    7,
+                    Some(pid),
+                    true,
+                    |_| {},
+                ))],
+                counters(9),
+            )
+            .expect("a carried flock installs");
+
+        nix::sys::signal::kill(
+            nix::unistd::Pid::from_raw(i32::try_from(pid).unwrap()),
+            nix::sys::signal::Signal::SIGKILL,
+        )
+        .expect("the adopted child is signalable");
+
+        let info = tokio::time::timeout(Duration::from_secs(20), async {
+            loop {
+                let info = sup.list().await;
+                if info.is_empty() {
+                    return info;
+                }
+                tokio::time::sleep(Duration::from_millis(20)).await;
+            }
+        })
+        .await
+        .expect(
+            "a carried pending delete must deregister the sheep on its next exit, not merely \
+             stop it",
+        );
+
+        assert!(
+            info.is_empty(),
+            "the deleted sheep must be gone, not just stopped"
         );
     }
 

--- a/crates/shep-daemon/src/sys.rs
+++ b/crates/shep-daemon/src/sys.rs
@@ -107,7 +107,47 @@ use std::os::unix::io::{FromRawFd, RawFd};
 /// the logger and inherited-terminal plumbing elsewhere in the process —
 /// adopting one of those into an owning [`File`] would silently steal it out
 /// from under whatever already holds it.
-const RESERVED_FD_FLOOR: RawFd = 3;
+pub(crate) const RESERVED_FD_FLOOR: RawFd = 3;
+
+/// Whether `fd` is a number this process could adopt at all: not stdio, and
+/// open right now.
+///
+/// [`adopt_fd`]'s two checks and nothing else, split out for the one caller
+/// that has to ask the question WITHOUT taking ownership. The predecessor in
+/// a handover rehearses its successor's adoption before the `execve` — see
+/// `handover::adopt::dry_run` — and a rehearsal that closed the descriptors
+/// it was checking would be worse than no rehearsal at all. It asks this
+/// rather than keeping a second copy of the same two checks: a copy that
+/// drifted lax would pass a blob the successor still refuses, and by then
+/// there is no image left to refuse back to.
+///
+/// Safe, unlike [`adopt_fd`], and the reason is that it takes nothing. That
+/// function's `# Safety` section is entirely about who owns the number
+/// afterwards, and afterwards this owns nothing, so the recycling hazard has
+/// nowhere to land. It asks a question about a number rather than making a
+/// claim on one.
+///
+/// # Errors
+/// - [`SysError::ReservedFd`]: `fd` is below 3 (stdio is owned elsewhere).
+/// - [`SysError::BadFd`]: `fd` names no open descriptor in this process,
+///   which is what a blob naming a descriptor that did not survive the exec
+///   looks like.
+pub fn adoptable_fd(fd: RawFd) -> Result<(), SysError> {
+    if fd < RESERVED_FD_FLOOR {
+        return Err(SysError::ReservedFd(fd));
+    }
+    // `F_GETFD` only succeeds on a descriptor this process actually has open
+    // right now, so a stale or never-opened number is rejected here instead
+    // of being handed to `from_raw_fd`. (This does NOT prove the number is
+    // the caller's intended inherited pipe rather than something recycled —
+    // that half of the contract is [`adopt_fd`]'s caller's, per that fn's
+    // own `# Safety` section.)
+    nix::fcntl::fcntl(fd, nix::fcntl::FcntlArg::F_GETFD).map_err(|errno| SysError::BadFd {
+        fd,
+        errno: errno.to_string(),
+    })?;
+    Ok(())
+}
 
 /// Takes ownership of a descriptor inherited across `exec`.
 ///
@@ -136,22 +176,14 @@ const RESERVED_FD_FLOOR: RawFd = 3;
 /// [`crate::boot::BootOptions::ready_fd`] and never touches a raw fd
 /// itself — see that field's own doc for why adoption moved out of `boot`.
 pub unsafe fn adopt_fd(fd: RawFd) -> Result<File, SysError> {
-    if fd < RESERVED_FD_FLOOR {
-        return Err(SysError::ReservedFd(fd));
-    }
-    // Probe before adopting: F_GETFD only succeeds on a descriptor this
-    // process actually has open right now, so a stale or never-opened
-    // number is rejected here instead of being handed to `from_raw_fd`.
-    // (This does NOT prove the number is the caller's intended inherited
-    // pipe rather than something recycled — that half of the contract is
-    // the caller's, per this fn's own `# Safety` section above.)
-    nix::fcntl::fcntl(fd, nix::fcntl::FcntlArg::F_GETFD).map_err(|errno| SysError::BadFd {
-        fd,
-        errno: errno.to_string(),
-    })?;
-    // SAFETY: `fd` is >= RESERVED_FD_FLOOR (checked above), so it cannot
-    // alias stdio, and the `fcntl` probe just above proved it names a
-    // descriptor genuinely open in this process. The caller's own contract
+    adoptable_fd(fd)?;
+    // SAFETY: `adoptable_fd` returned `Ok`, so `fd` is >= RESERVED_FD_FLOOR
+    // and cannot alias stdio, and the `fcntl` probe inside it proved the
+    // number names a descriptor genuinely open in this process. That check
+    // is shared with the predecessor's pre-exec rehearsal rather than
+    // inlined here, and sharing it costs this block nothing: the two
+    // conditions the `unsafe` below rests on are the two that function
+    // returns `Ok` for. The caller's own contract
     // (this fn's `# Safety` section) is what proves that open descriptor is
     // the intended inherited pipe rather than something this process opened
     // itself in the meantime. `adopt_fd` is the only place in this crate

--- a/docs/writing-plans/plans/2026-08-31-handover-phase2c.md
+++ b/docs/writing-plans/plans/2026-08-31-handover-phase2c.md
@@ -71,12 +71,28 @@ Implementation proceeds on the stated assumption in each case. Say the word on a
 
 A `bool` on the blob, restored onto the entry. No timer, no linked id, no waiter beyond D1's reply.
 
-- [ ] **Step 1: Write the failing test.** A carried sheep with `pending_delete` set is adopted with it still set, and its next exit deregisters it rather than respawning it.
-- [ ] **Step 2: Run it, watch it fail** on `Refused(PendingDelete)`.
-- [ ] **Step 3: Implement.** Field on `CarriedSheep`, `Option<bool>` so an older blob loads as `None` — do NOT move `VERSION`, per tasks 4, 5 and 6's precedent.
-- [ ] **Step 4: Prove it non-vacuous.** Drop the field from the blob; that test and only that test fails.
-- [ ] **Step 5: Real reload.** `shep delete` a sheep whose exit is slow, reload mid-delete, confirm the delete still completes and the row is gone.
-- [ ] **Step 6: Commit** with the plan section updated.
+- [x] **Step 1: Write the failing test.** A carried sheep with `pending_delete` set is adopted with it still set, and its next exit deregisters it rather than respawning it.
+- [x] **Step 2: Run it, watch it fail** on `Refused(PendingDelete)`.
+- [x] **Step 3: Implement.** Field on `CarriedSheep`, `Option<bool>` so an older blob loads as `None` — do NOT move `VERSION`, per tasks 4, 5 and 6's precedent.
+- [x] **Step 4: Prove it non-vacuous.** Drop the field from the blob; that test and only that test fails.
+- [x] **Step 5: Real reload.** `shep delete` a sheep whose exit is slow, reload mid-delete, confirm the delete still completes and the row is gone.
+- [x] **Step 6: Commit** with the plan section updated.
+
+##### Outcome
+
+The mapped facts held, with one imprecision: the brief said "restored onto the entry," but `pending_delete` lives on `SheepSlot`, not on `ProcessEntry` — `install_adopted` restores it onto the slot it builds, same as `epoch` and `manual`.
+
+`Candidate` and `OwnedCandidate` lost their own `pending_delete` field entirely rather than keeping it unread. `refusal()` was its only reader; once that check comes out, a `pub` field nothing reads inside a `pub(crate)` module is `dead_code` under `-D warnings`, so dropping it was forced, not a style call. `CarriedSheep` gained a fifth non-descriptor field, `pending_delete: Option<bool>`, following stdin's and the channel's own precedent exactly: `None` is what a predecessor from before this field existed truthfully meant (it refused a pending delete outright), so `VERSION` does not move.
+
+**The finding beyond the mapped facts: `pending_delete` and `manual` are inseparable today, so task 1 alone cannot be observed end to end.** Both sites that set `SheepSlot::pending_delete = true` (`Delete`, and the failed-respawn-during-a-reload path) also call `claim_manual` in the same breath, and both `handle_handover_snapshot` and `handle_handover_fitness` derive `pending_stop` from `slot.manual.is_some()` — not from a stop-specific flag. So a flock mid-delete still refuses today, on `PendingStop` (task 2's, not yet removed) exactly where it used to refuse on `PendingDelete`. Removing `PendingDelete` alone changes nothing about whether a live `shep daemon reload` actually carries a pending-delete sheep — tasks 1 and 2 are independently steppable in the code (per the plan's own "Order" section) but not independently observable end to end. The first drill below, against the committed binary, shows this directly. To still prove task 1's own mechanism live, the second drill was run against a build with the (still-active) `PendingStop` check bypassed by one line, verified, then reverted before the gate ran; nothing from that bypass is in this diff.
+
+##### Drill, measured
+
+**Against the committed binary** (task 1 alone; `PendingStop` still refuses). `shep delete sticky` backgrounded, `shep daemon reload` fired 1s later, against a `kill_timeout = "20s"` sheep that traps `SIGTERM`. The client's own upfront fitness check refused, correctly naming the surviving reason rather than the removed one: `sheep 'sticky' has a pending manual stop, which this daemon cannot yet hand over; reload falls back to a stop-and-start instead`. `reload exit=8` (`deadline_exceeded`: teardown still in progress when the client's own wait ran out). Shepherd pid 69458, sheep pid 69480; both processes gone once the predecessor's own teardown finished on its own, past the client's wait. Out of scope for this task, but recorded rather than silently noticed: the saved roll afterward held `sticky` as `stopped`, not deleted — a delete claimed against a daemon that then takes an interrupted stop-and-start is not the carry path at all (`install_adopted` is never called on it), so this is unrelated to `pending_delete`'s carrying and pre-dates this task; flagged separately rather than fixed here.
+
+**Against a one-line, uncommitted, reverted-before-the-gate bypass of the `PendingStop` check** (to isolate task 1's own mechanism). Same script, `kill_timeout = "30s"`, delete backgrounded then reload fired 1s later. `reload exit=0`, `notice[reload]: the shepherd is now 0.1.20 (pid 67398)` — shepherd 67398 unmoved, sheep 67419 unmoved and still `online` immediately after. `shep delete`'s own client got `the connection closed before a reply arrived`, exactly D1's prediction. Sticky's own kill ladder never escalated to `SIGKILL` on its own — a second, separate stranded-timer defect in `manual`'s escalation, task 2's territory and not this one — so the `SIGKILL` was sent by hand; the successor (still pid 67398) then deregistered the sheep entirely: `shep flock` afterward listed zero rows, and the saved roll's `apps` array was empty, not `stopped`. Shepherd pid unmoved, sheep pid unmoved until deliberately killed, row gone: the carry worked.
+
+`diff` against the pre-bypass file was empty after reverting it, and the full lib suite (647/647) was re-run before any gate command.
 
 ### Task 2: `manual`
 

--- a/docs/writing-plans/plans/2026-08-31-handover-phase2c.md
+++ b/docs/writing-plans/plans/2026-08-31-handover-phase2c.md
@@ -748,6 +748,99 @@ Ten, each applied alone against `cargo test -p shep-daemon --lib --all-features 
 
 ---
 
+### Review finding, closed after the tasks: `ready_failed` was not carried
+
+Found in review of the finished phase, not by a task. The blob carries
+`pending_delete`, `manual` and `reload`; `SheepSlot::ready_failed` is the
+fourth slot fact and it was still going out with the predecessor's image.
+
+**It is the same class as the four above, arriving by the one route none of
+them took.** Nothing about it is a timer. It is a VERDICT — the flag both
+abandonment arms set when a reload's readiness verification fails — and
+`reload_eligible` is `status == Online || ready_failed`, so it is the whole of
+what keeps an abandoned reload's leftover replaceable. That instance is left
+`Starting` on purpose, because `Online` over a process that is up and not
+serving is the false success the serial mode exists to remove. Drop the flag
+and the status is all that is left, and the status says the instance cannot be
+replaced. `handle_reload` still answers `Ok`, because it replies to the caller
+before its selector pass runs — so the rollback reload a deploy tool issues
+after a bad release reports success and replaces nothing. Exactly the
+looks-fine-is-not shape.
+
+#### What was built
+
+`CarriedSheep::ready_failed: Option<bool>`, threaded through `from_entry` and
+restored in `install_adopted`, `VERSION` unmoved and no `#[serde(default)]`,
+following the three siblings. One thing is NOT copied from them: what an
+absent key means. Each of those was a gate refusal before it was a field, so a
+missing key proves the fact was false. This was never a refusal — a
+predecessor carried such an instance happily and silently dropped the flag —
+so `None` is that predecessor saying nothing rather than saying "no". `false`
+is still the only reading available, and it is exactly what a successor
+assumed before the field existed, so an older blob adopts the way it always
+did. The field's own doc makes that argument rather than borrowing the
+sibling's.
+
+**The readiness re-arm is now gated on the flag, and that is the half the
+finding did not name.** `install_adopted` re-arms a wait for every `Starting`
+sheep, which is right for one still mid-start and wrong for one whose wait
+already ran and failed. `handle_ready_result`'s `TimedOut` arm goes `Online`
+ANYWAY, and `went_online` clears `ready_failed` on the way past, so an ungated
+re-arm writes the false success the abandonment arms refuse to write AND
+spends the carried flag one `listen_timeout` after the exec, before any
+rollback can use it. Both `Starting` sheep look identical; the carried flag is
+the only thing that tells them apart, which is why it is read before the
+re-arm decides rather than at either `SheepSlot` literal.
+
+#### Drill, measured
+
+An app with an exec `readiness_probe` gated on a sentinel file, `autorestart =
+false`, `listen_timeout = "20s"`, under an isolated `$SHEP_HOME`. Serial
+reload, since a probe without `reuse_port` takes it. Start with the sentinel
+present, remove it, reload: the drain finishes, the replacement never answers,
+and the reload is abandoned at 20s leaving `id 1` `starting` with
+`ready_failed` set. Then `shep daemon reload`, then the rollback.
+
+| after the handover | before | after |
+|---|---|---|
+| shepherd pid across the exec | unmoved | unmoved |
+| sentinel restored, `shep reload probed` | exit 0, `id 1` untouched | exit 0, `id 1` drained |
+| the flock 6s later | `id 1`, pid unchanged, `online` | `id 2`, new pid, `online` |
+
+The `online` in the before column is the second failure in one row: the
+rollback replaced nothing, and the release that never served is being reported
+as serving. A control run with no handover at all replaces the instance
+correctly, which is what pins the loss on the exec rather than on the
+abandonment.
+
+The re-arm gate has its own pair, same setup with the sentinel left absent, so
+the probe keeps failing:
+
+| 28s after the handover, probe still failing | before | after |
+|---|---|---|
+| `shep flock` | `online` | `starting` |
+
+#### Mutations
+
+| mutation | reddens |
+|---|---|
+| the restore in `install_adopted` dropped (both slot literals) | `a_carried_ready_failed_instance_is_still_replaceable` only |
+| the `&& !ready_failed` gate on the readiness re-arm removed | `a_carried_ready_failed_instance_gets_no_fresh_readiness_wait` only |
+| `HandoverDraft` reads `false` instead of the slot | `the_snapshot_carries_the_actors_counters_and_slot_state` only |
+| `#[serde(skip_serializing)]` on the field | `a_blob_written_before_ready_failed_was_carried_still_loads`, plus the two existing round-trip cases |
+| the field made non-optional | `a_blob_written_before_ready_failed_was_carried_still_loads` at its legacy half |
+
+The third is the one worth keeping. The write side was a hole: every other
+case builds its own `CarriedSheep`, so a daemon that never put the flag IN the
+blob passed all of them. It was found by mutating rather than by reading, and
+it is the half of a carry that is easiest to leave out.
+
+`a_blob_carrying_a_failed_readiness_verdict_passes_the_rehearsal` has no
+mutation of its own and is not claimed to: `dry_run` reparses whatever struct
+it is handed, so nothing short of a hand-written refusal reddens it. It is a
+regression guard on the reparse, the same shape and the same worth as
+`a_blob_carrying_a_swap_in_flight_passes_the_rehearsal`.
+
 ## Inherited from 2b, for a second look
 
 **The re-armed restart delay is a judgement call, and it shipped in v0.1.20.**

--- a/docs/writing-plans/plans/2026-08-31-handover-phase2c.md
+++ b/docs/writing-plans/plans/2026-08-31-handover-phase2c.md
@@ -319,12 +319,12 @@ drill can stand on.
 
 Third instance of the timer-strand class. The stamp counter is already carried (2a's `Counters::next_deadline`), so this is a re-arm, not a carry.
 
-- [ ] **Step 1: Write the failing test.** A carried swap past its deadline is abandoned, rather than sitting in its phase forever.
-- [ ] **Step 2: Run it, watch it fail.**
-- [ ] **Step 3: Implement** the re-arm, from the same `listen_timeout + graceful_timeout + RELOAD_DEADLINE_SLACK` the original used. **Note the Overlap+probe case arms twice** (`:5380`); a re-arm that handles only the first is a half fix.
-- [ ] **Step 4: Prove it non-vacuous.**
-- [ ] **Step 5: Real reload,** measured the way task 8 measured the restart strand: a control daemon that was not reloaded, and a real wall clock.
-- [ ] **Step 6: Commit.**
+- [x] **Step 1: Write the failing test.** A carried swap past its deadline is abandoned, rather than sitting in its phase forever.
+- [x] **Step 2: Run it, watch it fail.**
+- [x] **Step 3: Implement** the re-arm, from the same `listen_timeout + graceful_timeout + RELOAD_DEADLINE_SLACK` the original used. **Note the Overlap+probe case arms twice** (`:5380`); a re-arm that handles only the first is a half fix.
+- [x] **Step 4: Prove it non-vacuous.**
+- [x] **Step 5: Real reload,** measured the way task 8 measured the restart strand: a control daemon that was not reloaded, and a real wall clock.
+- [x] **Step 6: Commit.**
 
 ### Task 4: a swap in flight
 
@@ -332,14 +332,312 @@ Third instance of the timer-strand class. The stamp counter is already carried (
 
 The hard one, and it depends on task 3 because a carried swap with no watchdog is worse than a refused one.
 
-Carry, per D3: each entry's `ReloadState`, and the `ReloadJob` for each app mid-swap — `queue`, `mode`, `swap { old_id, new_id, phase }`. The ids are entry ids and 2a already carries `next_id`, so they stay valid across the exec.
+Carry, per D3: each entry's `ReloadState`, and the `ReloadJob` for each app mid-swap: `queue`, `mode`, `swap { old_id, new_id, phase }`. The ids are entry ids and 2a already carries `next_id`, so they stay valid across the exec.
 
-- [ ] **Step 1: Write the failing tests**, one per `ReloadPhase`. `DrainFirst`, `AwaitReady`, `DrainOld` and `Verify` fail differently and a single case will not cover them.
-- [ ] **Step 2: Run them, watch them fail.**
-- [ ] **Step 3: Implement.**
-- [ ] **Step 4: Prove each non-vacuous.** Report which mutations only the end-to-end tier catches; 2b found several that all 646 lib tests missed.
-- [ ] **Step 5: Real reload in each phase**, both `Serial` and `Overlap`, with pids checked on both halves of every swap.
-- [ ] **Step 6: Commit.**
+- [x] **Step 1: Write the failing tests**, one per `ReloadPhase`. `DrainFirst`, `AwaitReady`, `DrainOld` and `Verify` fail differently and a single case will not cover them.
+- [x] **Step 2: Run them, watch them fail.**
+- [x] **Step 3: Implement.**
+- [x] **Step 4: Prove each non-vacuous.** Report which mutations only the end-to-end tier catches; 2b found several that all 646 lib tests missed.
+- [x] **Step 5: Real reload in each phase**, both `Serial` and `Overlap`, with pids checked on both halves of every swap.
+- [x] **Step 6: Commit.**
+
+##### Outcome
+
+**Three timers, not one, and the brief named one of them.** The mapped facts
+held (`ReloadState` on the entry, `ReloadJob` per app, the ids valid across
+the exec), but the count of what the exec strands was short. A swap is driven
+by whichever of three tasks its phase is waiting on:
+
+| phase | what ends it | where the re-arm is |
+|---|---|---|
+| `DrainFirst` | the drainee's own exit, produced by its kill ladder | task 2's `claim_manual`, now under the drain's cap |
+| `AwaitReady` | `Msg::ReadyResult` from a readiness task | `install_adopted`, already there since 2b task 5 for every `Starting` sheep |
+| `DrainOld` | the drainee's exit again | as `DrainFirst` |
+| `Verify` | `Msg::ReloadVerified` from `spawn_verify_task` | **new**, `install_carried_reloads` |
+| any of the four | `Msg::ReloadDeadline`, if none of the above ever comes | **new**, `install_carried_reloads` |
+
+So `AwaitReady` needed no new code at all: a carried replacement is a
+`Starting` sheep, and the wait 2b re-armed for those is the same wait. The
+post-drain probe is the one the brief did not name, and it is a fourth
+instance of the class rather than a detail of the third. A successor that
+re-armed only the watchdog would abandon a deploy whose replacement is fine,
+16s later, with a `ReloadAbandoned` for a swap that had already worked.
+Drill 5 below measures exactly that gap.
+
+**`ReloadJob::deadline` is deliberately not carried**, which is the one field
+of the four that does not cross. It stamps a timer that dies with the image,
+and the successor takes a fresh stamp off the carried `next_deadline` when it
+arms its own. Carrying it would name a watchdog that does not exist.
+
+**D3's "continue" held in all four phases, and two of them were not obvious.**
+`DrainFirst` and `DrainOld` both route on the `Drainee` marker, which is what
+sends the exit to `reap_drainee` rather than to `decide_on_exit`, and for an
+`autorestart` app the latter respawns the old code into a slot the
+replacement owns. `AwaitReady` routes on `Replacement`, which is what
+`handle_ready_result` reads to send the result to `reload_ready_result`
+instead of straight to `Online`. `Verify` needed the probe above. Nothing in
+any of the four turned out to be unsound, so the escape hatch was not used.
+
+**One residual is worth naming, and it is 2b task 5's own race widened.** The
+blob is a snapshot taken on the actor loop, so a `{"kind":"ready"}` that
+arrives between it and the exec flips the predecessor's slot without reaching
+the blob. For an ordinary `Starting` sheep that costs one `listen_timeout` of
+`Starting` and then `Online` anyway. For a `wait_ready` REPLACEMENT it costs
+the reload: the signal is not sent twice, the successor's re-armed wait times
+out, and `reload_ready_result` reads a `TimedOut` replacement as a failure and
+abandons: the drainee goes back to serving and the replacement is killed. The
+window is narrow (the mailbox is FIFO, so it is only the gap between the child
+writing and the readiness task reporting, plus the snapshot's own descriptor
+sweep), the ending is one the reload already has when a ready signal is
+genuinely lost, and the operator gets a `ReloadAbandoned` rather than silence.
+Recorded rather than fixed: closing it would mean carrying "readiness already
+resolved" as a fact separate from the status, which is a wider change than
+this residual is worth.
+
+**Task 2's `LadderCap::Stop` line, revisited as its call site asked.** The cap
+now comes off the role: `ReloadState::Drainee` takes `LadderCap::Drain`,
+everything else keeps `Stop`. That is the same rule the two live sites follow
+(both pass `Drain`, and both leave `Drainee` on the entry), read backwards
+from the marker, which is the only record of which ask is in hand. The
+residual is the same shape as the elapsed grace task 2 could not recover:
+which cap the ladder ACTUALLY started under is recorded nowhere, and an
+operator's `stop` reaching a drainee during the overlap's `AwaitReady` window
+claims the marker first, under `kill_timeout`, with the drain that follows
+riding that ladder. A successor re-arming that sheep uses `graceful_timeout`
+instead. The cost is bounded by whichever of the two is longer and the ending
+is the same either way. Drill 4b measures the cap live, against an app whose
+two timeouts are 8s and 120s.
+
+**`manually` is knowable for a replacement, and was `false`.**
+`install_adopted` arms a carried `Starting` sheep's readiness with
+`manually: false`, on the argument that the flag belongs to the spawn that
+armed the original wait and is not this image's to know. That is right for an
+ordinary sheep and wrong for a replacement: `spawn_replacement` passes `true`
+unconditionally, because a reload is an operator's doing, so a carried
+`Replacement` marker is the same claim arriving by a different route. Left
+alone it would have broadcast an operator's deploy as the daemon's own.
+
+**A carried job naming no registered instance is dropped rather than
+refused.** A snapshot cannot produce one, because the job and the entries it
+names are read in one synchronous step on the actor loop. But a blob is a file,
+and this is the residual `refuse_repeated_fds` already guards on the
+descriptor side. Note that "registered" is weaker than it looks: a SERIAL
+reload deregisters its drainee at `ReapOld` and keeps the job, so `swap.old_id`
+is a dangling id by design from `AwaitReady` onwards, and the anchor the
+watchdog reads its timings off is `new_id` first, `old_id` only as a fallback.
+That asymmetry is why this is a drop-with-a-warning rather than a validation:
+the invariants are mode- and phase-dependent, and a second statement of them
+in `adopt` would be exactly the drift task 5 was told not to ship.
+
+**Which is also why `handover::adopt::dry_run` needed no change, and the
+reason is not "nothing was added".** The rehearsal runs the successor's own
+checks, and the successor gains no new refusal here. What it does gain is two
+new fields in a blob it parses, and the rehearsal already covers those for
+free: `dry_run` reads the whole blob back through `Handover::load_value`
+before rehearsing a single descriptor, so a `reloads` array or a `reload`
+marker that could not survive the round trip is refused before the exec like
+anything else. `a_blob_carrying_a_swap_in_flight_passes_the_rehearsal` pins
+that claim rather than leaving it asserted.
+
+**`VERSION` unmoved**, on tasks 1 and 2's precedent exactly. Two `Option`
+fields, `CarriedSheep::reload` and `Handover::reloads`, where an absent key
+loads as `None`, and `None` is what a predecessor that refused to carry a swap
+at all truthfully meant. `ReloadState`, `ReloadMode`, `ReloadSwap` and
+`ReloadPhase` gained `Serialize`/`Deserialize` and `snake_case`, matching
+`ProcStatus`'s spelling in the same blob. Nothing on any of them is sensitive
+(an app name, two entry ids and three closed enums), so a derived `Debug` is
+the deliberate answer for IR-41.
+
+**One new Windows dead-code warning, scoped rather than blanket-allowed.**
+Both sites that build a `CarriedReload` are `cfg(unix)` while the type travels
+on `Handover`, which is not, so a Windows target reports it as never
+constructed. `#[cfg_attr(not(unix), expect(dead_code, ...))]`: an `expect`
+rather than an `allow` so a Windows handover would have to delete the line
+rather than inherit it, and scoped to the target where it is genuinely dead
+rather than hiding anything on unix.
+
+**Tasks 3 and 4 are one commit, as the plan's own correction said.** Removing
+`RefusedReason::ReloadInFlight` without the two re-arms ships a swap that sits
+in its phase for the rest of the daemon's life, taking `shep reload all` down
+with it; building the re-arms without removing the refusal leaves them with
+nothing to fire against, which is task 1's mistake for the third time. A
+bisect landing between them would find a daemon that loses reloads.
+
+##### Drills, measured
+
+Release build, isolated `SHEP_HOME` at `/tmp/rl/home`. Shepherd **34375**
+throughout every drill below: it never moved across any of the seven
+handovers, which is what says a handover happened rather than a
+stop-and-start. Every `shep daemon reload` exit 0, every one answering
+`notice[reload]: the shepherd is now 0.1.20 (pid 34375)`.
+
+**Two of the eight phase-and-mode cells are unreachable by construction, and
+the drills say which.** `DrainFirst` is `Serial`-only (an overlap spawns
+before it drains) and `Verify` is `Overlap`-only (`post_drain_probe` returns
+`None` for a serial reload, which already asked with the slot empty).
+Serial's own `AwaitReady` is a single synchronous call inside `reap_drainee`,
+which moves it to `DrainOld` before returning, so it cannot be snapshotted at
+all. That leaves five reachable cells and five drills.
+
+**1. `Serial`, `DrainFirst`.** A probed app with no `reuse_port`, whose
+script traps `SIGTERM`, `graceful_timeout = 25s`.
+
+| | |
+|---|---|
+| `shep reload sticky` | serial drain begins; the sheep goes `stopping` |
+| `shep daemon reload` | 1s in, exit 0 |
+| immediately after | shepherd 34375 unmoved, sheep 34396 unmoved, still `stopping` |
+| the drain ends | within 21s of the poll starting, which began seconds after the exec, by `SIGKILL`. The child traps `SIGTERM`, so only the escalation could have ended it |
+| the replacement | id 1, pid **34917**, `online`, `restarts=0` |
+
+The replacement is the assertion: `DrainFirst` is the one phase with no
+replacement yet, so a successor that dropped the `Drainee { new_id: None }`
+marker would have deregistered a `stopping` sheep and left the instance slot
+empty.
+
+**2. `Serial`, `DrainOld`.** The drain is over, the replacement is `starting`,
+and its probe is gated on a file. `listen_timeout = 40s`.
+
+| | |
+|---|---|
+| before | shepherd 34375, replacement id 3 pid **35158** `starting` |
+| `shep daemon reload` | exit 0 |
+| immediately after | shepherd 34375 unmoved, 35158 unmoved, still `starting` |
+| the probe allowed to pass, **after the exec** | `online` within 2s, same pid |
+| the job afterwards | gone: a second `shep reload quick` was accepted rather than refused |
+
+**3. `Overlap`, `AwaitReady`.** A `wait_ready` app whose child sleeps 20s
+before writing `{"kind":"ready"}` to fd 3.
+
+| | |
+|---|---|
+| before | drainee id 5 pid **35651** `stopping`, replacement id 6 pid **36002** `starting` |
+| `shep daemon reload` | exit 0 |
+| immediately after | shepherd 34375 unmoved, **both** pids unmoved, both statuses unchanged |
+| the replacement reports ready | **after the exec**, up the carried socketpair into the successor's re-armed wait |
+| the swap completes | once the child's own 20s delay elapsed: 36002 `online`, 35651 drained and reaped, one row left |
+
+The strongest of the five. The readiness signal was written by a child the
+successor never spawned, over a descriptor the successor inherited, into a
+wait the successor armed, and it committed a swap the successor did not start.
+
+**4. `Overlap`, `DrainOld`.** Both instances up, the drainee on its ladder
+ignoring `SIGTERM`, `graceful_timeout = 30s`.
+
+| | |
+|---|---|
+| before | drainee id 7 pid **36580** `stopping`, replacement id 8 pid **36637** `online` |
+| `shep daemon reload` | exit 0 |
+| immediately after | shepherd 34375 unmoved, both pids unmoved |
+| the drain ends | **t+31s from the exec**, which is `graceful_timeout`, by `SIGKILL` |
+| afterwards | one row, 36637, unmoved and `online` |
+
+**4b. The ladder cap.** The same drill with the app's two timeouts three
+orders of magnitude apart: `graceful_timeout = 8s`, `kill_timeout = 120s`.
+
+| | |
+|---|---|
+| before | drainee 39285 `stopping`, replacement 39311 `online` |
+| after the exec | both unmoved |
+| the drainee dies | **t+8s from the exec** |
+
+8s is `graceful_timeout`. Under task 2's unconditional `LadderCap::Stop` it
+would have been 120s.
+
+**5. `Overlap`, `Verify`.** A probed `reuse_port` app, held in `Verify` by
+removing the file its probe tests for during the drain. `listen_timeout = 90s`.
+
+| | |
+|---|---|
+| in `Verify` | replacement id 14 pid **39740** `online`; a second `shep reload verified` refused: `verified is already being reloaded` |
+| `shep daemon reload` | exit 0 |
+| immediately after | shepherd 34375 unmoved, 39740 unmoved, **still refused**, so the job crossed the exec |
+| the probe allowed to pass, after the exec | the job ends **1s** later, with `reload abandoned` nowhere in the log |
+
+Without the second re-arm the job would have ended at the watchdog instead:
+`listen_timeout + graceful_timeout + RELOAD_DEADLINE_SLACK`, 105s, with a
+`ReloadAbandoned` for a swap whose replacement was serving the whole time.
+
+**The bound, with a control.** Same app, same route into `Verify`, with the
+probe now unable to pass at all: `listen_timeout = 15s`,
+`graceful_timeout = 5s`, so the three candidate endings are 15s (the probe's
+own deadline), 25s (the watchdog) and never (nothing re-armed).
+
+| | control, no daemon reload | carried, reloaded mid-`Verify` |
+|---|---|---|
+| shepherd | 34375 | 34375 → 34375 |
+| the replacement | 40857 | 42067 → 42067 |
+| the job ended | **14.8s** after `Verify` began | **15.4s** after `Verify` began |
+| the log line | `reload abandoned: the replacement did not answer its readiness probe once the instance it replaced was gone` | the same line, `new_id=22` |
+
+The offset is what discriminates, and it lands on the probe. Across all seven
+handovers: zero panics, zero "the flock is still running and nothing is
+supervising it", no `run/handover.json` left behind, and no stray sheep
+process.
+
+**What could NOT be drilled, and why it is the unit tier's job.** The
+watchdog's own trigger is a message that never comes at all, and the only
+child that produces one is wedged in uninterruptible sleep past its own
+`SIGKILL`, which is not producible on demand on a Mac. Every other ending is
+bounded
+by `listen_timeout` or `graceful_timeout`, and the watchdog is
+`listen_timeout + graceful_timeout + 5s` by construction, so it can never
+fire first against a killable child. `ProcScript::never_reports_its_exit`
+exists for exactly this and its doc says so; mutation 1 below is what proves
+the re-arm.
+
+##### Mutations
+
+Ten, each applied alone against
+`cargo test -p shep-daemon --lib --all-features -- --skip ::slow::` and
+reverted afterwards, with the file compared against a pre-mutation copy each
+time. Baseline 671 passing.
+
+| # | what was broken | what failed |
+|---|---|---|
+| 1 | `install_carried_reloads` arms no watchdog | `a_carried_swap_that_cannot_finish_is_still_abandoned_on_time` ONLY (670 pass) |
+| 2 | the `Verify` probe re-arm dropped | `a_carried_swap_in_verify_is_asked_again_rather_than_abandoned` ONLY |
+| 3 | `install_adopted` writes `ReloadState::None` over every carried marker | four: both drain cases, the serial spawn, and the `AwaitReady` commit |
+| 4 | the ladder cap hardcoded to `LadderCap::Stop` | `a_carried_drainee_is_capped_by_graceful_timeout_not_kill_timeout` ONLY |
+| 5 | `manually` hardcoded `false` for an adopted replacement | `a_carried_replacement_awaiting_readiness_commits_its_swap` ONLY, at its flag assertion |
+| 6 | `install_carried_reloads` never called | five, every carried-swap case including the watchdog |
+| 7 | `reloads` made required on the wire | `a_blob_written_before_a_swap_was_carried_still_loads`, **plus `boot::tests::a_blob_on_disk_makes_this_process_a_successor`** |
+| 8 | `sheep[].reload` made required on the wire | `a_blob_written_before_a_swap_was_carried_still_loads` ONLY |
+| 9 | the dropped-job guard removed | `a_carried_reload_naming_no_registered_instance_is_dropped`, by PANIC inside `arm_reload_deadline` rather than by assertion |
+| 10 | the snapshot reports no reloads at all | `a_snapshot_taken_mid_swap_carries_the_job_and_the_markers` ONLY |
+
+**Nothing here is caught only by the end-to-end tier, and 10 is why.** 2b's
+lesson was that the successor's arming had no unit-level cover in either
+scope, so `install_adopted` could drop `arm_extras` with all 646 lib tests
+green. The mirror of that here would have been a snapshot that carried no job:
+every one of the nine cases below it builds a `CarriedReload` by hand and
+hands it to `spawn_adopted`, so all nine stay green with the snapshot half
+deleted. `a_snapshot_taken_mid_swap_carries_the_job_and_the_markers` is the
+case that closes it, and it is the only one that drives a real reload on a
+live actor and then takes a real snapshot of it.
+
+**Two test-infrastructure findings, each of which cost a run.** An unbounded
+`await_event` under a paused clock does not fail when the timer it is waiting
+for was never armed. It HANGS, because auto-advance has nothing to advance
+to, and mutation 1 took the whole suite down with it before the wait was
+bounded. And the paused clock auto-advances inside `handover_snapshot`'s own
+awaits, so the first draft of the snapshot case reached `DrainOld` with a
+replacement already spawned before the snapshot was taken; it runs on a real
+clock with a 200ms `listen_timeout` instead.
+
+##### Docs
+
+`web/src/pages/docs/getting-started.astro` said "A dog or anything mid-reload
+sends the reload down the older path instead". This task makes the second half
+false, so the clause is gone and a dog is named alone. The generated CLI
+reference was regenerated as the docs rule requires: the only drift is the
+version banner, `0.1.18` to `0.1.20`, which is two releases of pre-existing
+staleness rather than anything this task added: no verb, flag, key, exit code
+or payload field changed. `astro build` and `astro check` both clean.
+
+**The phase is complete.** All five tasks are in, `handover::fitness` is down
+to two refusals (a wedged log pump, which is a fault rather than a gap, and a
+dog, which is phase 3's), and every refusal 2c set out to remove is gone.
 
 ### Task 5: validate before the exec
 

--- a/docs/writing-plans/plans/2026-08-31-handover-phase2c.md
+++ b/docs/writing-plans/plans/2026-08-31-handover-phase2c.md
@@ -21,7 +21,7 @@
 | task 5 | `Starting`, waiting on readiness | re-arm from `listen_timeout` |
 | task 8 | `WaitingRestart`, owed a respawn | re-arm from `backoff::restart_delay` |
 | this phase | a reload waiting on its deadline | task 3 below |
-| task 1's drill | **a kill ladder's SIGTERM→SIGKILL escalation** | task 2 below |
+| task 1's drill | **a kill ladder's SIGTERM→SIGKILL escalation** | task 2, done |
 
 The fifth was found by task 1 driving a real reload: a sheep carried
 mid-ladder never escalated, and had to be killed by hand. That is the same
@@ -81,6 +81,9 @@ That was a defect in this plan, not in the code. It came from reading the two
 fields as two facts because they are two struct members, without checking
 whether anything ever sets one without the other.
 
+**Both are in as of task 2, and the unit held: task 1's carry is demonstrated
+end to end there, on a plain build with nothing patched out.**
+
 5 is independent. 3 and 4 are coupled, and 4 depends on 3. Everything touches
 `refusal()` in `handover/mod.rs`, so tasks run one at a time unless they are
 in separate worktrees.
@@ -116,18 +119,185 @@ The mapped facts held, with one imprecision: the brief said "restored onto the e
 
 `diff` against the pre-bypass file was empty after reverting it, and the full lib suite (647/647) was re-run before any gate command.
 
+##### Demonstrated for real, by task 2
+
+Task 2 removed `RefusedReason::PendingStop`, so the carry above no longer
+needs a bypass to be observed. Its second drill is task 1's, run against a
+plain release build with nothing patched out: `shep delete sticky`
+backgrounded, `shep daemon reload` two seconds later, `reload exit=0`,
+shepherd 63605 unmoved, sheep 66479 unmoved and still `online` the moment the
+reload returned, the delete client answered
+`error[daemon_unreachable]: the connection closed before a reply arrived`
+(exit 5) exactly as D1 predicts, and thirty seconds later the row was GONE:
+`shep flock` listed nothing and the saved roll's `apps` array was `[]`. No
+hand-sent `SIGKILL` this time either, because the ladder task 2 re-arms
+finished the delete on its own.
+
 ### Task 2: `manual`
 
 **Files:** same two, plus `PendingManual` needs to cross the wire.
 
 `PendingManual { kind, origin }` is not `Serialize` today. Carry the `kind`; `origin` says who asked, and after the exec the answer is "a client that is gone", which D1 settles.
 
-- [ ] **Step 1: Write the failing test.** A carried sheep with a manual stop pending still stops, and does not respawn, after the exec.
-- [ ] **Step 2: Run it, watch it fail.**
-- [ ] **Step 3: Implement.** Decide what `origin` becomes on the far side and say why in the commit; do not invent a new variant without arguing for it.
-- [ ] **Step 4: Prove it non-vacuous**, including that a manual *restart* still restarts rather than being read as a stop.
-- [ ] **Step 5: Real reload.** `shep stop` a sheep with a long `kill_timeout`, reload during the ladder, confirm it still stops.
-- [ ] **Step 6: Commit.**
+**That last clause turned out to be the wrong reading, and the Outcome below
+says why.** D1 is about the reply, which lives on a `PendingReply` and is not
+carried at all; `origin` is about cause, and it crosses unchanged.
+
+- [x] **Step 1: Write the failing test.** A carried sheep with a manual stop pending still stops, and does not respawn, after the exec.
+- [x] **Step 2: Run it, watch it fail.**
+- [x] **Step 3: Implement.** Decide what `origin` becomes on the far side and say why in the commit; do not invent a new variant without arguing for it.
+- [x] **Step 4: Prove it non-vacuous**, including that a manual *restart* still restarts rather than being read as a stop.
+- [x] **Step 5: Real reload.** `shep stop` a sheep with a long `kill_timeout`, reload during the ladder, confirm it still stops.
+- [x] **Step 6: Commit.**
+
+##### Outcome
+
+**`origin` crosses unchanged, and no new variant.** The temptation is to
+read the far side as "nobody is waiting any more" and carry `Automatic`,
+since the connection behind the command dies at the exec. That is wrong
+twice. `origin` answers who CAUSED this exit rather than who is still
+connected, and both of its readers are about cause: the `manually` flag on
+the bus events the exit produces, and `claim_manual`'s carve-out. Carrying
+`Automatic` for an operator's stop would broadcast that exit as the daemon's
+own doing — the exact lie the flag exists to prevent — and would let a later
+`shep restart` take the marker off a ladder already running and give it a
+different ending. And the reply `origin` looks like it is tracking does not
+live on the marker at all: it lives on a `PendingReply`, which is not
+carried, so there is nobody to answer either way. D1 is about that reply, not
+about the origin.
+
+**The kill ladder needed a re-arm, and the elapsed portion is not
+recoverable.** `install_adopted` now ends the running-sheep branch with
+`claim_manual(id, manual, LadderCap::Stop)`, which is the one site that pairs
+a marker with the single `Kill` that produces its exit, `try_send` rule
+included. What cannot be re-armed is how much of the ladder already ran:
+nothing anywhere records when it started, and the remaining grace is a
+`tokio::time::timeout` deadline inside a task of the predecessor's —
+monotonic, and meaningless outside the runtime that read it. Unlike 2b task
+8's restart delay, it is not even a value the actor holds; making it
+carryable would need a new `SheepSlot` field. So the successor runs the WHOLE
+ladder again, polite rung first, which errs long for the same reason
+`restart_delay(config, 1)` does: a re-arm that jumped straight to
+`kill_tree` would `SIGKILL` a child that may never have been asked politely
+at all, since the predecessor's `Kill` could still have been unread in the
+ctl mailbox at the exec. The cost is one extra `kill_timeout` and one
+repeated `SIGTERM`, both measured below.
+
+`LadderCap::Stop` rather than `graceful_timeout`, because every marker the
+gate can carry today was claimed under that cap: the two sites passing
+`LadderCap::Drain` are a reload's drain, and both leave `ReloadState::Drainee`
+on the entry, which `ReloadInFlight` still refuses. **Task 4 has to revisit
+that line**, and the code says so at the call site.
+
+`Candidate` and `OwnedCandidate` lost `pending_stop` outright, the same way
+they lost `pending_delete` in task 1 and for the same forced reason:
+`refusal()` was its only reader, so a `pub` field nothing reads inside a
+`pub(crate)` module is `dead_code` under `-D warnings`. `handover::fitness`
+is down to two refusals, a dog and an in-flight reload, and
+`web/src/pages/docs/getting-started.astro` already named exactly those two
+("A dog or anything mid-reload sends the reload down the older path
+instead"). That sentence was incomplete before this task and is exact now, so
+`web/` needed no edit — the generated CLI reference is untouched too, since
+nothing here adds a verb, flag, key, exit code or payload field.
+
+`ManualKind`, `CommandOrigin` and `PendingManual` became `pub(crate)` and
+gained `Serialize`/`Deserialize`, `snake_case` on the wire to match
+`ProcStatus`'s spelling in the same file. `VERSION` does NOT move: `manual`
+is `Option<PendingManual>`, one `Option` rather than the two
+`pending_delete` needs, because a missing key and "no command owns this
+exit" are the same statement here and there is no third state. Nothing on
+the marker is sensitive — two closed enums — so a derived `Debug` is the
+deliberate answer for IR-41.
+
+**A and B are one commit, deliberately.** Removing `RefusedReason::PendingStop`
+without the re-arm ships a strictly worse outcome than the refusal it
+replaces: an operator's `shep stop` would leave a sheep that never dies. The
+marker restore and the ladder arm are also literally the same `claim_manual`
+call. A bisect landing between them would find a daemon that loses processes.
+
+##### Drill, measured
+
+Release build, isolated `SHEP_HOME` at `/tmp/mn/home`, one app: a `sh` script
+that does `trap '' TERM` and then sleeps, `kill_timeout = "30s"`,
+`autorestart = false`. Shepherd 63605 throughout — it never moved across any
+of the three reloads, which is what says a handover happened rather than a
+stop-and-start.
+
+**1. `shep stop`, reload mid-ladder.** Sheep 64440.
+
+| | |
+|---|---|
+| `shep stop sticky` (backgrounded) | t+0 |
+| `shep daemon reload` | t+2s, **exit 0**, `notice[reload]: the shepherd is now 0.1.20 (pid 63605)` |
+| immediately after the reload | shepherd 63605 unmoved, sheep 64440 unmoved, still `online` |
+| sheep terminal | **t+30s from the RELOAD** (t+32s from the stop), `stopped`, `EXIT = SIGKILL` |
+| processes left | none |
+| the stop's own client | `error[daemon_unreachable]: the connection closed before a reply arrived`, exit 5 |
+
+The child traps `SIGTERM`, so `SIGKILL` in the EXIT column is the whole
+assertion: only the escalation could have ended it, and **nothing was killed
+by hand**. Against the committed binary, task 1's drill got `exit=8` and a
+refusal naming `PendingStop`, and its bypassed build needed a hand-sent
+`SIGKILL` because this rung was missing.
+
+**The control, same drill with no reload at all:** terminal at **t+31s from
+the stop**, `EXIT = SIGKILL`. So the reloaded run's 30s is measured from the
+exec rather than from the stop — the whole ladder run again, exactly as the
+re-arm's comment claims, at a cost of the 2s already spent.
+
+**2. `shep delete`, reload mid-delete.** Sheep 66479. This is task 1's carry,
+finally observable with nothing patched out.
+
+| | |
+|---|---|
+| `shep delete sticky` (backgrounded) | t+0 |
+| `shep daemon reload` | t+2s, **exit 0** |
+| immediately after | shepherd 63605 unmoved, sheep 66479 unmoved, still `online` |
+| row gone | **t+30s from the reload**; `shep flock` lists zero rows |
+| saved roll | `apps: []` — deleted, not `stopped` |
+| the delete's own client | `daemon_unreachable`, exit 5 |
+
+**3. `shep restart`, reload mid-ladder.** Sheep 67565. The kind has to
+survive, not just the marker.
+
+| | |
+|---|---|
+| `shep daemon reload` | t+2s, exit 0, shepherd 63605 unmoved, sheep 67565 unmoved and `online` |
+| respawned | **t+30s from the reload**: `online`, pid **68487**, `restarts=1`, previous `EXIT` recorded as `SIGKILL` |
+
+Read as a stop, this row would be `stopped` with `restarts=0`. It is not.
+
+##### Mutations
+
+Five, each applied alone against the daemon lib suite (651 with
+`--skip ::slow::`) and reverted afterwards, with the file byte-compared to a
+pre-mutation copy each time.
+
+| # | what was broken | what failed |
+|---|---|---|
+| 1 | `install_adopted` drops the re-arm entirely | the three new adoption cases, **and nothing else in 651** |
+| 2 | the marker is written onto the slot but no ladder is armed | the same three, all by timeout — this is the half the plan called "worse than the refusal", and no unit case outside these three notices |
+| 3 | the ladder is armed under a hardcoded `ManualKind::Stop` | `a_carried_manual_restart_respawns_and_keeps_its_origin` ONLY (650 pass) |
+| 4 | `manual` made required on the wire (`deserialize_with = "Option::deserialize"`) | `a_blob_written_before_a_manual_marker_was_carried_still_loads` ONLY, with serde's `missing field` error naming it |
+| 5 | the ladder is armed under a hardcoded `CommandOrigin::Operator` | the restart case ONLY, at its `manually` assertion |
+
+**What only the end-to-end tier catches: nothing here, and that is the
+finding.** Unlike 2b's mutation 2 (`arm_extras`, invisible to all 646 lib
+tests), every mutation above is caught by a unit case, because a real child
+under `TokioRunner` is reachable from the lib tier: `adoptable_child` gives
+the ladder a real process, its own process group, and a real trap. What the
+lib tier could NOT have told anyone is that the defect existed at all — it
+was found by driving a reload by hand, and the tests were written afterwards
+to pin it.
+
+**Two test-infrastructure findings worth keeping**, both of which cost a run
+each. A child that inherits the test binary's process group is not a group
+leader, so `killpg` answers `ESRCH`, the ladder logs a warning and delivers
+nothing, and a case about a stop fails for a reason that has nothing to do
+with the stop; `adoptable_child` sets `process_group(0)` and says so. And a
+child that inherits the test binary's stdout holds that pipe open, so under
+`cargo test | <anything>` a mutation run turned a failing assertion into a
+hang; the same helper now uses `Stdio::null()` and bounds its loop.
 
 ### Task 3: the reload deadline watchdog
 
@@ -213,6 +383,6 @@ Unchanged from 2b's, in `docs/writing-plans/plans/2026-08-30-handover-phase2b.md
 
 Per `CLAUDE.md`. Inner loop `cargo test -p shep-daemon --lib --all-features -- --skip ::slow::`. One cargo shape per task. The Windows cross-check gets its own `CARGO_TARGET_DIR`.
 
-Counts at the branch point: **647** daemon lib, roughly **2110** workspace. A shape, not a checksum.
+Counts at the branch point: **647** daemon lib, roughly **2110** workspace. A shape, not a checksum. After task 2: **651** daemon lib with `--skip ::slow::`, **2125** workspace.
 
 **CI's `slow` tier flaked three times on 2b's night** — a macOS `EIO` on a pidfile, and the Windows node-pipe budget test twice. Both are documented as machine-speed-sensitive. Read a `slow` failure against `main`'s own history before treating it as yours.

--- a/docs/writing-plans/plans/2026-08-31-handover-phase2c.md
+++ b/docs/writing-plans/plans/2026-08-31-handover-phase2c.md
@@ -21,6 +21,11 @@
 | task 5 | `Starting`, waiting on readiness | re-arm from `listen_timeout` |
 | task 8 | `WaitingRestart`, owed a respawn | re-arm from `backoff::restart_delay` |
 | this phase | a reload waiting on its deadline | task 3 below |
+| task 1's drill | **a kill ladder's SIGTERM→SIGKILL escalation** | task 2 below |
+
+The fifth was found by task 1 driving a real reload: a sheep carried
+mid-ladder never escalated, and had to be killed by hand. That is the same
+shape again, and it is why task 2 owns it.
 
 Each was invisible to the whole suite and to a pid check, and each left the flock looking healthy. **The lesson 2c must not relearn: a green suite is not evidence here. Every task drives a real reload.**
 
@@ -61,7 +66,24 @@ Implementation proceeds on the stated assumption in each case. Say the word on a
 
 ## Order
 
-1, 2 and 5 are independent. 3 and 4 are coupled and 4 depends on 3. Nothing after 2 may start before 1 and 2 are green, because all five touch `refusal()` in `handover/mod.rs` and would conflict.
+**Corrected 2026-08-31, after task 1 shipped: tasks 1 and 2 are ONE unit,
+not two.** `pending_delete` and `manual` are inseparable in the code. Every
+site that sets `pending_delete = true` also calls `claim_manual` in the same
+breath, and `PendingStop` is derived from `manual.is_some()` rather than from
+a stop-specific flag. So removing `RefusedReason::PendingDelete` on its own
+changes nothing an operator can observe: the sheep is still refused, now on
+`PendingStop`. Task 1's carry could only be demonstrated at all through a
+temporary bypass of the `PendingStop` check, which was reverted before its
+gate. Task 2 is what makes task 1 real, and neither is finished until both
+are in.
+
+That was a defect in this plan, not in the code. It came from reading the two
+fields as two facts because they are two struct members, without checking
+whether anything ever sets one without the other.
+
+5 is independent. 3 and 4 are coupled, and 4 depends on 3. Everything touches
+`refusal()` in `handover/mod.rs`, so tasks run one at a time unless they are
+in separate worktrees.
 
 ---
 

--- a/docs/writing-plans/plans/2026-08-31-handover-phase2c.md
+++ b/docs/writing-plans/plans/2026-08-31-handover-phase2c.md
@@ -136,6 +136,37 @@ A failure here is not an error the operator sees. It is the stop-and-start arm, 
 
 ---
 
+## Inherited from 2b, for a second look
+
+**The re-armed restart delay is a judgement call, and it shipped in v0.1.20.**
+2b's task 8 re-arms a carried `WaitingRestart` sheep with
+`backoff::restart_delay(config, 1)`, which is the delay a FIRST unstable exit
+would get. So an app with `restart_delay = "1h"` reloaded at minute 59 waits
+another full hour rather than the minute it had left.
+
+The reasoning is sound as far as it goes: what elapsed is a
+`tokio::time::Instant` from a runtime that no longer exists, and erring long
+respects an operator's pacing where erring short could hammer whatever the
+delay exists to protect. Restarting immediately is the other obvious option
+and is worse for the same reason.
+
+**But there is a third option neither considered, and it is better than
+both.** The elapsed time is unrecoverable only because it was recorded as a
+monotonic `Instant`. A `SystemTime` deadline survives the exec, so the
+predecessor could carry `now + remaining` and the successor re-arm for
+exactly what was left. That honours the operator's schedule instead of
+approximating it in either direction.
+
+The cost is that a wall clock can jump under it — NTP, a suspend — where the
+monotonic one cannot. For a restart delay that seems an acceptable trade,
+since a jump changes when a down sheep comes back rather than corrupting
+anything, but it is the maintainer's call and it is not urgent: today's
+behaviour is safe, merely blunt.
+
+Not scoped into 2c. Recorded here because it was found while auditing 2c's
+own timer-strand class, and because the class is exactly what makes it
+fixable.
+
 ## The reload drill
 
 Unchanged from 2b's, in `docs/writing-plans/plans/2026-08-30-handover-phase2b.md` under "The reload drill, exactly". Every constraint there still binds: the `awk` rate, `$SHEP_HOME` under 103 bytes, stopping the sheep before counting, seam-aware counting.

--- a/docs/writing-plans/plans/2026-08-31-handover-phase2c.md
+++ b/docs/writing-plans/plans/2026-08-31-handover-phase2c.md
@@ -299,6 +299,20 @@ child that inherits the test binary's stdout holds that pipe open, so under
 `cargo test | <anything>` a mutation run turned a failing assertion into a
 hang; the same helper now uses `Stdio::null()` and bounds its loop.
 
+**Tasks 3 and 4 are ONE unit too, corrected 2026-08-31 — the same mistake
+as 1 and 2, made twice.** `ReloadInFlight` refuses every sheep mid-swap, so
+nothing with a reload watchdog is ever carried, so a re-armed watchdog has
+nothing to fire against. Task 3 alone would be unobservable exactly the way
+task 1 alone was, and would need the same temporary bypass to show anything.
+
+They ship together. The ordering inside the task still stands and still
+matters: the watchdog re-arm is built first, because a carried swap with no
+watchdog is worse than a refused one.
+
+The error both times was splitting on structure rather than on observable
+behaviour. Two struct members, two refusal variants: neither is a seam a
+drill can stand on.
+
 ### Task 3: the reload deadline watchdog
 
 **Files:** `supervisor.rs` (`install_adopted`, `arm_reload_deadline`).

--- a/docs/writing-plans/plans/2026-08-31-handover-phase2c.md
+++ b/docs/writing-plans/plans/2026-08-31-handover-phase2c.md
@@ -335,12 +335,104 @@ D2. The predecessor already builds the blob and holds every descriptor. Before `
 
 A failure here is not an error the operator sees. It is the stop-and-start arm, which is the outcome they would have had anyway.
 
-- [ ] **Step 1: Write the failing test.** A blob naming a closed descriptor sends the reload down the stop arm instead of exec'ing.
-- [ ] **Step 2: Run it, watch it fail.**
-- [ ] **Step 3: Implement.**
-- [ ] **Step 4: Prove it non-vacuous.**
-- [ ] **Step 5: Real reload** where a descriptor is closed under the daemon, confirming the flock survives by the stop arm rather than being left unsupervised.
-- [ ] **Step 6: Commit.**
+- [x] **Step 1: Write the failing test.** A blob naming a closed descriptor sends the reload down the stop arm instead of exec'ing.
+- [x] **Step 2: Run it, watch it fail.**
+- [x] **Step 3: Implement.**
+- [x] **Step 4: Prove it non-vacuous.**
+- [x] **Step 5: Real reload** where a descriptor is closed under the daemon, confirming the flock survives by the stop arm rather than being left unsupervised.
+- [x] **Step 6: Commit.**
+
+#### The four claims above hold, checked 2026-08-31
+
+`nix::unistd::execve` at `handover/mod.rs:1120` is the only exec in the crate; every other `Command::new` is in a test. Nothing re-execs a predecessor: `hand_over` has exactly one production caller, `boot::hand_over_carrying`. `boot::rehydrate` at `:630` maps an adopt failure to `BootError::Adopt` and refuses to boot, and `adopt`'s own order leaves the pidfile descriptor open and unowned on a refusal, so the lock stays held. `BootError`'s `Display` arm at `:2141` says the flock is unsupervised and points at `shep muster`.
+
+#### Step 1's case is weaker than the plan thought, and the shipped tests are stronger
+
+**A closed descriptor was already refused before the exec.** `hand_over` clears `FD_CLOEXEC` on every number the blob names, and a closed one meets `EBADF` there. So a test built on "a closed descriptor" would have passed with no fix at all.
+
+Four cases were genuinely uncovered, and they are what the tests use:
+
+- a descriptor that is OPEN but not the kind its slot is adopted as. The sweep clears it happily, the exec happens, and the successor refuses.
+- a number below the stdio floor. Open, clears fine, refused after.
+- a blob naming one number twice. Clearing `FD_CLOEXEC` is idempotent by design, so a repeat crosses untouched and builds two owners on the far side.
+- a blob a successor could not read back off disk. For a handover this is the reachable case rather than the paranoid one, since a successor is by definition a different build: one that has moved `VERSION` refuses at `load_value`.
+
+#### What was built
+
+`handover::adopt::dry_run`, called from `boot::hand_over_carrying` between the fitness gate and `hand_over`. The two gates ask different questions: the first whether this flock is a shape a handover carries, the second whether the blob describing it is one a successor could adopt.
+
+**It runs the successor's own adoption rather than describing one.** A second implementation of "is this descriptor adoptable" is worse than none: if the successor's checks tighten and a hand-written copy does not, the rehearsal passes, the exec happens, and the boot still fails with the predecessor gone. So nothing re-states a check.
+
+| what could drift | what stops it |
+|---|---|
+| the per-kind checks | `dry_run` calls the same `adopt_listener`/`adopt_pipe`/`adopt_stdin`/`adopt_log`/`adopt_channel`/`adopt_fd` the successor calls, over an `F_DUPFD_CLOEXEC` duplicate so an adoption that takes ownership can run against a descriptor the predecessor must keep |
+| which number is which slot | one array, `CarriedFds::all_kinded`, pinned against `CarriedFds::all` (what the `FD_CLOEXEC` sweep walks) by a test; a seventh descriptor changes `all`'s return type and stops `all_kinded` compiling |
+| the repeated-number rule | `refuse_repeated_fds` itself, called rather than re-derived |
+| the floor-and-open probe | `sys::adopt_handover_fd`'s own, extracted as `sys::adoptable_fd` and shared. Checked against the BLOB's number, never the duplicate's: a duplicate is always open and always above the floor, so a rehearsal that only inspected duplicates would wave through exactly the two blobs the successor is certain to refuse |
+| the parse | `Handover::load_value`, the successor's own entry point, and the descriptors are rehearsed against the REPARSED blob |
+| a slot dispatched to the wrong adoption | `the_rehearsal_and_the_adoption_agree_on_every_slot` walks all six and compares verdicts |
+
+Two seams are named in the code rather than hidden. The successor reads bytes with `from_str` while this goes through `to_value`; and the four socket and pipe adoptions set `O_NONBLOCK`, which is a property of the open file description and so reaches the original through the duplicate — a write of the value already there, because tokio does not accept a blocking one.
+
+`VERSION` unmoved: nothing about the blob format changed.
+
+##### The measurement
+
+Fault injected identically in both builds (uncommitted, `SHEP_HANDOVER_FAULT`): one sheep's `out_pipe` replaced with an open `/dev/null`, which is open enough for the `FD_CLOEXEC` sweep and not a pipe. One quiet sheep, so the "unsupervised orphan" outcome is visible rather than being masked by `SIGPIPE` — a chatty sheep dies when the successor exits and closes the last reader, which is a different bad ending and hides this one.
+
+| | before (fix stashed) | after |
+|---|---|---|
+| `shep daemon reload` exit | 0 | 0 |
+| shepherd, before → after | 22988 → **29421** | 30605 → **66107** |
+| the sheep, before → after | 23052 → **29442** | 30680 → **66158** |
+| old sheep afterwards | **alive, `ppid` 1, orphaned** | gone |
+| `quiet.sh` processes afterwards | **2** | **1** |
+| what the shepherd supervises | 1 of the 2 | the 1 |
+| `run/handover.json` afterwards | **left behind** | gone |
+
+The blob left behind names `out_pipe: 16` — the injected number — for `quiet` at pid 23052, which is the orphan. It is on disk because the successor's `adopt` refused, and `adopt` unlinks only on success.
+
+The same fault by raw `SIGHUP`, so the two log lines can be read side by side:
+
+```
+BEFORE  error[failure]: the daemon failed to boot: this shepherd was handed a flock it could not
+        take over: sheep 'quiet' stdout pipe is not a readable pipe: not a pipe. The flock is still
+        running and nothing is supervising it. ...
+        -> sheep 84773 alive at ppid 1, no shep process anywhere, blob on disk
+
+AFTER   WARN shep_daemon::boot: SIGHUP: this flock could not be handed to a successor; stopping
+        gracefully instead ... refusal=a successor could not have adopted this flock, so none was
+        started: sheep 'quiet' stdout pipe is not a readable pipe: not a pipe. This is a shep bug
+        worth reporting: the descriptors are ones this shepherd opened itself, and the check that
+        refused them is the successor's own. ...
+        -> flock stopped by the ladder, no orphan, no blob
+```
+
+The refusal reaches the operator's log carrying the successor's own wording, so it names the sheep and the stream.
+
+**Residual, pre-existing and not touched here.** Both reloads took 10s, because `daemon::hand_over`'s `await_successor` waits out `admin::KILL_TEARDOWN_WAIT` for a successor that in the refusal case was deliberately never started. That is the CLI's behaviour for any post-signal handover failure, and shortening it would mean the CLI learning that the predecessor refused, which a signal cannot tell it.
+
+##### Mutations
+
+Ten, each applied alone against `cargo test -p shep-daemon --lib --all-features -- --skip ::slow::` and reverted afterwards. Baseline 656 passing.
+
+| # | what was broken | what failed |
+|---|---|---|
+| 1 | the `dry_run` call removed from `hand_over_carrying` | `a_sighup_over_a_blob_no_successor_could_adopt_refuses_before_it_execs` only |
+| 2 | `adoptable_fd` checks the duplicate's number, not the blob's | `a_reserved_or_closed_number_is_refused_before_the_exec`, plus the boot case at its `-1` assertion |
+| 3 | `refuse_repeated_fds` dropped from `dry_run` | `a_blob_naming_one_descriptor_twice_is_refused_before_the_exec` only |
+| 4 | the reparse skipped, rehearsing the blob as handed | `a_blob_a_successor_could_not_read_back_is_refused_before_the_exec` only |
+| 5 | `all_kinded` labels `out_pipe` as `Stdin` | seven, including `every_carried_number_is_kinded_in_the_same_order` |
+| 5b | `all_kinded` swaps the `out_pipe`/`err_pipe` fields, slots unchanged | `every_carried_number_is_kinded_in_the_same_order` at its `all()` equality |
+| 6 | the `Channel` slot dispatched to `adopt_log` | `the_rehearsal_and_the_adoption_agree_on_every_slot` only |
+| 7 | the sheep walk skipped | three, including the open-but-wrong-kind case |
+| 8 | one duplicate leaked per rehearsal | `a_rehearsal_leaks_no_descriptors` only |
+| 9 | the adoption handed the original instead of a duplicate | the test binary ABORTS: `IO Safety violation: owned file descriptor already closed`, attributed to `a_rehearsal_leaves_every_descriptor_it_checked_working` |
+| 10 | `rehearse` refuses everything | six, including `a_blob_a_successor_could_adopt_passes_the_rehearsal` |
+
+6 is the one worth keeping. It is exactly the drift this task was told not to ship — a rehearsal that grows lax while the adoption stays strict — and one test catches it, alone, with the other 655 green.
+
+9 is the second. Without the duplicate the rehearsal closes the predecessor's own descriptors, and Rust's IO-safety net turns that into an abort rather than a subtle failure.
 
 ---
 

--- a/docs/writing-plans/plans/2026-08-31-handover-phase2c.md
+++ b/docs/writing-plans/plans/2026-08-31-handover-phase2c.md
@@ -1,0 +1,149 @@
+# Daemon handover, phase 2c: the in-flight cases
+
+> **For agentic workers:** REQUIRED SUB-SKILL: use `superpowers:subagent-driven-development` to implement this task-by-task. Steps use `- [ ]` for tracking.
+
+**Goal:** Remove the last three `handover::fitness` refusals — `PendingStop`, `PendingDelete`, `ReloadInFlight` — and close the one failure mode that has no recovery today.
+
+**Spec:** `docs/brainstorming/specs/2026-08-29-daemon-handover-design.md`, H2a's "2c, the hard cases" bullet.
+
+**Base:** cut from `origin/main` at v0.1.20, which contains 2a and 2b.
+
+---
+
+## What 2b established that this phase inherits
+
+2b removed four refusals and found the same bug four times. It is one class, and naming it is most of 2c's design:
+
+**Any state whose progress depends on a `tokio::spawn`ed timer is stranded by the exec.** The task belongs to the predecessor's runtime and dies with the image, while the successor installs the *status* that timer was supposed to resolve.
+
+| found in | the stranded state | closed by |
+|---|---|---|
+| task 5 | `Starting`, waiting on readiness | re-arm from `listen_timeout` |
+| task 8 | `WaitingRestart`, owed a respawn | re-arm from `backoff::restart_delay` |
+| this phase | a reload waiting on its deadline | task 3 below |
+
+Each was invisible to the whole suite and to a pid check, and each left the flock looking healthy. **The lesson 2c must not relearn: a green suite is not evidence here. Every task drives a real reload.**
+
+## The three refusals, and what each actually is
+
+Mapped 2026-08-31 against the code, with citations, so no task starts from a guess.
+
+**`PendingStop`** is `SheepSlot::manual: Option<PendingManual>` (`supervisor.rs:2284`), a `{ kind, origin }` marker set by `claim_manual` (`:3937`) and cleared in `handle_exited` (`:6277`). It means "a stop, restart or delete owns this sheep's next exit." A client is waiting, but not on the marker: the reply goes through a `PendingReply` that aggregates several ids (`:4119`).
+
+**`PendingDelete`** is a plain `bool` (`:2296`), set on a `Delete` (`:4106`) and taken in `handle_exited` (`:6279`). It deliberately survives a respawn (`:5463`). The simplest of the three: no timer, no linked entry.
+
+**`ReloadInFlight`** is the hard one. A swap is two entries linked by id — `ReloadState::Drainee { new_id }` and `ReloadState::Replacement` (`entry.rs:170`) — plus a `ReloadJob { queue, mode, swap, deadline }` in `reloads: HashMap<String, ReloadJob>` (`supervisor.rs:2502`), a `ReloadPhase` of `DrainFirst`/`AwaitReady`/`DrainOld`/`Verify`, and **one or two** watchdog timers: `Overlap` with a probe arms a second one in `post_drain_probe` (`:5380`).
+
+## Rollback cannot exist as the spec words it
+
+The spec lists "rollback when a rehydrate fails." Checked, and there is nothing to roll back to:
+
+- the `execve` at `handover/mod.rs:1120` is the only exec and is one-way
+- no code anywhere re-execs the predecessor, and its image is gone
+- on a failed adopt, `boot.rs:630` returns `BootError::Adopt`; the daemon refuses to boot holding the pidfile lock, and the flock keeps running unsupervised
+- `boot.rs:2141` already tells the operator exactly that, and points at `shep muster`
+
+So the honest reframing, and this is the one scope change 2c makes to the spec: **the predecessor validates the blob while it still exists, and refuses the handover into the safe stop-and-start arm rather than exec'ing into a successor that cannot boot.** Rollback-after becomes do-not-exec. Task 5.
+
+---
+
+## Decisions for the maintainer
+
+Implementation proceeds on the stated assumption in each case. Say the word on any of them and the affected task changes.
+
+**D1. A carried `manual` loses its client's reply.** The connection dies at the exec, which H2 already accepts for every in-flight RPC, and task 5 ruled the same way for an in-flight `shep trigger`: the reply is dropped by the path that already drops a reply arriving after its wait ended. *Assumption: same ruling. The operator sees a dropped connection from `shep stop`, never a wrong answer, and the sheep still stops.*
+
+**D2. "Rollback" becomes pre-exec validation**, per the section above. *Assumption: accepted, because the alternative is not implementable.*
+
+**D3. A successor inherits a swap it did not start. Continue it, or abort it?** Aborting is simpler and `abort_reload` already exists. But a reload the operator asked for, silently abandoned by an unrelated daemon upgrade, is a surprise with no notice. *Assumption: CONTINUE. Carry the job and re-arm the watchdog, and let the existing deadline path be the safety net — if the swap cannot finish, `handle_reload_deadline` already abandons it and emits `ReloadAbandoned` (`:5606`, `:5630`). That adds no new failure mode, because it is the same ending the swap would have had without a handover.*
+
+---
+
+## Order
+
+1, 2 and 5 are independent. 3 and 4 are coupled and 4 depends on 3. Nothing after 2 may start before 1 and 2 are green, because all five touch `refusal()` in `handover/mod.rs` and would conflict.
+
+---
+
+### Task 1: `pending_delete`
+
+**Files:** `crates/shep-daemon/src/handover/mod.rs` (the refusal and `CarriedSheep`), `crates/shep-daemon/src/supervisor.rs` (`install_adopted`).
+
+A `bool` on the blob, restored onto the entry. No timer, no linked id, no waiter beyond D1's reply.
+
+- [ ] **Step 1: Write the failing test.** A carried sheep with `pending_delete` set is adopted with it still set, and its next exit deregisters it rather than respawning it.
+- [ ] **Step 2: Run it, watch it fail** on `Refused(PendingDelete)`.
+- [ ] **Step 3: Implement.** Field on `CarriedSheep`, `Option<bool>` so an older blob loads as `None` — do NOT move `VERSION`, per tasks 4, 5 and 6's precedent.
+- [ ] **Step 4: Prove it non-vacuous.** Drop the field from the blob; that test and only that test fails.
+- [ ] **Step 5: Real reload.** `shep delete` a sheep whose exit is slow, reload mid-delete, confirm the delete still completes and the row is gone.
+- [ ] **Step 6: Commit** with the plan section updated.
+
+### Task 2: `manual`
+
+**Files:** same two, plus `PendingManual` needs to cross the wire.
+
+`PendingManual { kind, origin }` is not `Serialize` today. Carry the `kind`; `origin` says who asked, and after the exec the answer is "a client that is gone", which D1 settles.
+
+- [ ] **Step 1: Write the failing test.** A carried sheep with a manual stop pending still stops, and does not respawn, after the exec.
+- [ ] **Step 2: Run it, watch it fail.**
+- [ ] **Step 3: Implement.** Decide what `origin` becomes on the far side and say why in the commit; do not invent a new variant without arguing for it.
+- [ ] **Step 4: Prove it non-vacuous**, including that a manual *restart* still restarts rather than being read as a stop.
+- [ ] **Step 5: Real reload.** `shep stop` a sheep with a long `kill_timeout`, reload during the ladder, confirm it still stops.
+- [ ] **Step 6: Commit.**
+
+### Task 3: the reload deadline watchdog
+
+**Files:** `supervisor.rs` (`install_adopted`, `arm_reload_deadline`).
+
+Third instance of the timer-strand class. The stamp counter is already carried (2a's `Counters::next_deadline`), so this is a re-arm, not a carry.
+
+- [ ] **Step 1: Write the failing test.** A carried swap past its deadline is abandoned, rather than sitting in its phase forever.
+- [ ] **Step 2: Run it, watch it fail.**
+- [ ] **Step 3: Implement** the re-arm, from the same `listen_timeout + graceful_timeout + RELOAD_DEADLINE_SLACK` the original used. **Note the Overlap+probe case arms twice** (`:5380`); a re-arm that handles only the first is a half fix.
+- [ ] **Step 4: Prove it non-vacuous.**
+- [ ] **Step 5: Real reload,** measured the way task 8 measured the restart strand: a control daemon that was not reloaded, and a real wall clock.
+- [ ] **Step 6: Commit.**
+
+### Task 4: a swap in flight
+
+**Files:** `handover/mod.rs`, `supervisor.rs`, `entry.rs`.
+
+The hard one, and it depends on task 3 because a carried swap with no watchdog is worse than a refused one.
+
+Carry, per D3: each entry's `ReloadState`, and the `ReloadJob` for each app mid-swap — `queue`, `mode`, `swap { old_id, new_id, phase }`. The ids are entry ids and 2a already carries `next_id`, so they stay valid across the exec.
+
+- [ ] **Step 1: Write the failing tests**, one per `ReloadPhase`. `DrainFirst`, `AwaitReady`, `DrainOld` and `Verify` fail differently and a single case will not cover them.
+- [ ] **Step 2: Run them, watch them fail.**
+- [ ] **Step 3: Implement.**
+- [ ] **Step 4: Prove each non-vacuous.** Report which mutations only the end-to-end tier catches; 2b found several that all 646 lib tests missed.
+- [ ] **Step 5: Real reload in each phase**, both `Serial` and `Overlap`, with pids checked on both halves of every swap.
+- [ ] **Step 6: Commit.**
+
+### Task 5: validate before the exec
+
+**Files:** `handover/mod.rs`, `boot.rs`.
+
+D2. The predecessor already builds the blob and holds every descriptor. Before `execve`, check the thing the successor will check: each numbered descriptor is open and of the expected kind, no number is repeated, and the blob parses as the type the successor will parse it into.
+
+A failure here is not an error the operator sees. It is the stop-and-start arm, which is the outcome they would have had anyway.
+
+- [ ] **Step 1: Write the failing test.** A blob naming a closed descriptor sends the reload down the stop arm instead of exec'ing.
+- [ ] **Step 2: Run it, watch it fail.**
+- [ ] **Step 3: Implement.**
+- [ ] **Step 4: Prove it non-vacuous.**
+- [ ] **Step 5: Real reload** where a descriptor is closed under the daemon, confirming the flock survives by the stop arm rather than being left unsupervised.
+- [ ] **Step 6: Commit.**
+
+---
+
+## The reload drill
+
+Unchanged from 2b's, in `docs/writing-plans/plans/2026-08-30-handover-phase2b.md` under "The reload drill, exactly". Every constraint there still binds: the `awk` rate, `$SHEP_HOME` under 103 bytes, stopping the sheep before counting, seam-aware counting.
+
+## Gate
+
+Per `CLAUDE.md`. Inner loop `cargo test -p shep-daemon --lib --all-features -- --skip ::slow::`. One cargo shape per task. The Windows cross-check gets its own `CARGO_TARGET_DIR`.
+
+Counts at the branch point: **647** daemon lib, roughly **2110** workspace. A shape, not a checksum.
+
+**CI's `slow` tier flaked three times on 2b's night** — a macOS `EIO` on a pidfile, and the Windows node-pipe budget test twice. Both are documented as machine-speed-sensitive. Read a `slow` failure against `main`'s own history before treating it as yours.

--- a/web/src/data/cli-reference.generated.txt
+++ b/web/src/data/cli-reference.generated.txt
@@ -1,5 +1,5 @@
 @@VERSION@@
-shep 0.1.18
+shep 0.1.20
 @@TOPLEVEL@@
 A process manager for your flock
 

--- a/web/src/pages/docs/getting-started.astro
+++ b/web/src/pages/docs/getting-started.astro
@@ -83,12 +83,11 @@ import CodeBlock from "../../components/docs/CodeBlock.astro";
       again; the note below says which flocks those are.
     </p>
     <p class="fine">
-      Not every flock can be carried yet. A dog or anything mid-reload sends
-      the reload down the older path instead: the flock is stopped and
-      started, and the reload prints which sheep held it back. Coming from
-      0.1.17 or earlier, the first reload always takes that path too: the
-      shepherd being replaced predates the handover and has nothing to hand
-      over with.
+      Not every flock can be carried yet. A dog sends the reload down the
+      older path instead: the flock is stopped and started, and the reload
+      prints which sheep held it back. Coming from 0.1.17 or earlier, the
+      first reload always takes that path too: the shepherd being replaced
+      predates the handover and has nothing to hand over with.
     </p>
     <Callout variant="careful">
       Skip <code>shep daemon reload</code> and the new binary answers


### PR DESCRIPTION
Phase 2c of the daemon handover. `shep daemon reload` now carries a sheep with a pending stop, restart or delete, and one in the middle of a reload swap. Only two refusals are left in the gate: `Dog`, descoped to phase 3, and `PumpUnresponsive`, which is permanent by design.

Also closes the failure mode that had no recovery. Before this, a blob the successor could not adopt meant the successor refused to boot while holding the pidfile, and the flock kept running with nothing supervising it. There was nothing to roll back to: the `execve` is one way and no code re-execs the predecessor. So the predecessor now rehearses the adoption before it execs, and refuses into the ordinary stop-and-start arm instead. Measured with an injected fault, same fixture both ways:

| | before | after |
|---|---|---|
| `daemon reload` exit | 0 | 0 |
| the old sheep afterwards | alive, ppid 1, orphaned | gone |
| supervised | 1 of 2 | the 1 |
| `handover.json` | left behind | gone |

The rehearsal runs the successor's real `adopt_*` functions over duplicated descriptors rather than describing them, so it cannot drift into passing something the successor would reject.

## The timer class

2b found the same bug four times without naming it. Any state whose progress depends on a spawned timer is stranded by the exec, because the task belongs to the predecessor's runtime while the successor installs the status it was meant to resolve. Six are now closed:

- readiness, and a carried replacement gets this one free
- a pending restart
- a kill ladder's escalation, found by driving a reload rather than reading code
- the reload deadline
- the `Verify` probe, which was not in the plan and would have abandoned a working deploy 16 seconds after its replacement was already serving
- the drainee's own exit

## Drills

Seven handovers, shepherd pid unmoved throughout. Every reachable phase and mode: Serial `DrainFirst` and `DrainOld`, Overlap `AwaitReady`, `DrainOld` and `Verify`. Both halves of every swap kept their pids, and every swap finished as it would have without a handover.

The watchdog bound has a control. A probe that never passes, reloaded mid-`Verify`, ended at 15.4s against 14.8s for a daemon that was never reloaded, with the same abandonment line. Candidates were 15s for the probe deadline, 25s for the watchdog, and never for nothing re-armed.

671 daemon lib tests, 2145 workspace. Ten mutations, each proven non-vacuous.

## Three things worth a second look

- an operator's `stop` that claims a drainee's marker during `AwaitReady` is re-armed under the wrong cap. The ending is `SIGKILL` either way and it is bounded by the longer of the two, but the cap the ladder actually started under is recorded nowhere
- a `wait_ready` replacement whose ready signal lands between the snapshot and the exec loses it, and the successor reads the timeout as failure. Narrow, and the operator sees `ReloadAbandoned`
- a dangling job is dropped with a warning rather than refused, because the invariants are mode and phase dependent and restating them in the rehearsal would be exactly the drift it exists to prevent


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Daemon handovers now preserve and resume in-progress reloads, pending deletions, manual commands, and readiness state.
  * Reload timers, watchdogs, and related operations continue across handover.
  * Handover validation previews adoption and safely rejects invalid state before switching.

* **Bug Fixes**
  * Invalid handover data now falls back to graceful shutdown.
  * File descriptor validation prevents adoption of closed or reserved descriptors.

* **Documentation**
  * Updated reload guidance to reflect continued support for in-progress reloads during handover.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Found in review, fixed here

`SheepSlot::ready_failed` was not carried, and losing it is worse than it sounds. That flag is what keeps a failed reload's instance reachable by the reload that rolls it back, so without it a deploy tool swaps the release directory, asks for a reload, and is told `Ok` by a shepherd that replaced nothing.

It had a second half the review did not name. `install_adopted` re-arms a readiness wait for every `Starting` sheep, and a `ready_failed` instance is `Starting` by construction, so an ungated re-arm marks it `online` one `listen_timeout` later and clears the carried flag on the way past. Carrying it alone would have held for twenty seconds and then undone itself, while reporting a release that never served as serving. The re-arm is now gated on the flag.

Measured both ways, rollback after a handover:

| | before | after |
|---|---|---|
| rollback reload | exit 0, instance untouched | exit 0, instance drained |
| the flock 6s later | old pid, `online` | new pid, `online` |
| 28s after, probe still failing | `online`, never passed a probe | `starting` |

A control with no handover replaces correctly, which pins the loss on the exec rather than on the abandonment.

Two smaller ones: every rehearsal refusal now names the sheep and the stream, since `dry_run` promised that and only delivered it on one arm; and the module header called `Dog` the only remaining refusal when `PumpUnresponsive` also stands, deferred and permanent respectively.
