### PR TITLE
chore(coderabbit): fix a stale rule count and scope two instructions

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -105,7 +105,7 @@ reviews:
     - path: "crates/**/*.rs"
       instructions: >-
         This workspace has a written Rust style, docs/idiomatic-rust.md, with
-        45 numbered rules IR-1 through IR-45. Cite the rule number when a
+        46 numbered rules IR-1 through IR-46. Cite the rule number when a
         finding matches one.
 
         Load-bearing rules, in rough order of how often they drift: no
@@ -120,6 +120,13 @@ reviews:
         The only unsafe in the workspace is shep-daemon's `sys.rs` and
         `sys_windows.rs`, and every block there needs its own `// SAFETY:`
         comment (IR-22, IR-23).
+
+        Weight a finding in test-only code lower than the same finding in
+        code an operator runs. The assertive profile is set because a missed
+        defect costs an operator their flock; a leaked descriptor in a test
+        binary that is about to exit costs nothing, so the trade that
+        justifies the volume does not apply there. Report it once, briefly,
+        and do not re-raise it on a later push.
 
         Do not suggest widening an input grammar past what the specification
         says. A parser here refusing something is usually the specified
@@ -172,10 +179,36 @@ reviews:
         drift: a claim about behaviour that the diff makes false, a command
         that no longer exists, a sample that will not parse.
 
-        Terminology is fixed by docs/terminology.md. A `sheep` is one managed
-        process and the word is singular only; the plural is `flock`, never
-        "sheeps" and never bare "sheep". `dogs` are plugin processes, `lambs`
-        are a sheep's children, and the daemon is only ever "the shepherd".
+        A residual the same diff already documents as a known limitation has
+        been considered. Raise it once if the reasoning looks wrong, and not
+        again on a later push.
+
+    - path: "docs/writing-plans/**/*.md"
+      instructions: >-
+        Working documents, not published prose. The terminology rule below
+        does not apply here: these name a feature after the verb an operator
+        types, so "daemon handover" tracks `shep daemon reload` and matches
+        the sibling plans deliberately. Flag factual drift only.
+
+    - path: "docs/brainstorming/**/*.md"
+      instructions: >-
+        Design documents under revision, held to the same standard as the
+        plans above: factual drift only, and the terminology rule does not
+        reach them.
+
+    - path: "web/**/*.md"
+      instructions: >-
+        Terminology is fixed by docs/terminology.md and this is published
+        prose, so it applies in full. A `sheep` is one managed process and
+        the word is singular only; the plural is `flock`, never "sheeps" and
+        never bare "sheep". `dogs` are plugin processes, `lambs` are a
+        sheep's children, and the daemon is only ever "the shepherd".
+
+    - path: "README.md"
+      instructions: >-
+        Published prose. Terminology is fixed by docs/terminology.md: the
+        plural of `sheep` is `flock`, and the daemon is only ever "the
+        shepherd".
 
     - path: ".github/workflows/**"
       instructions: >-

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -174,8 +174,9 @@ reviews:
 
     - path: "**/*.md"
       instructions: >-
-        Prose here is hand-written and hand-wrapped in a deliberate voice. Do
-        not suggest rewording, tightening, or rewrapping. Flag only factual
+        Except where a more-specific Markdown rule sets terminology, prose
+        here is hand-written and hand-wrapped in a deliberate voice. Do not
+        suggest rewording, tightening, or rewrapping. Flag only factual
         drift: a claim about behaviour that the diff makes false, a command
         that no longer exists, a sample that will not parse.
 


### PR DESCRIPTION
Four changes, each from something observed on #75 and #80 rather than from taste.

- the rule count was stale: 45 becomes 46. IR-46 requires every `await` in a test to have a forcing mechanism, and it exists because that failure turned up in five separate phases
- terminology is scoped to published prose. `web/**` and `README.md` keep it in full; `docs/writing-plans/**` and `docs/brainstorming/**` get factual-drift review without it
- test-only code is weighted lower, and re-raising a finding there on a later push is discouraged
- a residual the same diff already documents gets raised once, not twice

The terminology one is the change I would push back on hardest if you disagree. On #80 the rule produced a finding against a plan whose title matches its sibling plan word for word, and whose "daemon handover" tracks the verb operators type. Applying it would have made one file inconsistent with the two beside it.

The test-code lever is imperfect and worth saying out loud: path instructions are glob-scoped, so they reach `crates/*/tests/**` but not the inline `#[cfg(test)]` modules where most of the noise sits.

`profile: assertive` is deliberately unchanged. The argument already in the file holds, and #80 proved it. `ready_failed` was not carried across the handover, which would have shipped a rollback deploy that reports success and replaces nothing. Five agents, mutation testing on every task, drills in every phase and both modes, and a review pass all missed it. CodeRabbit found it by reading, which is the class this repo's own verification habits are worst at.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for writing plans, brainstorming documents, web Markdown, and README terminology.
  * Documented known limitations and residual considerations.

* **Chores**
  * Updated review configuration to better prioritize findings, including lower priority for test-only issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->