### PR TITLE
fix(handover): anchor a carried restart delay to the sheep's own exit

### DIFF
--- a/crates/shep-daemon/src/backoff.rs
+++ b/crates/shep-daemon/src/backoff.rs
@@ -211,26 +211,35 @@ exp_backoff_restart_delay = "0"
         app
     }
 
-    /// A moment `secs` from now, as a predecessor would have recorded it.
+    /// A fixed instant to measure every carried deadline against.
+    ///
+    /// Not `SystemTime::now()`, and the difference is the whole reason this
+    /// exists. `adopted_restart_delay` takes `now` as an argument, so a test
+    /// that builds a deadline from one `now()` and passes another reads the
+    /// clock twice and can only assert a RANGE. That range is a claim about
+    /// how long the test thread was descheduled between two lines, which on
+    /// a loaded runner is not a claim worth making (IR-26, IR-36).
+    const NOW: SystemTime = SystemTime::UNIX_EPOCH;
+
+    /// A moment `secs` after [`NOW`], as a predecessor would have recorded it.
     fn due_in(secs: u64) -> SystemTime {
-        SystemTime::now() + Duration::from_secs(secs)
+        NOW + Duration::from_secs(secs)
     }
 
     /// Fails if an adopted sheep's remaining wait is rounded up to the whole
     /// configured delay, which is what restarts the clock at every handover.
     ///
-    /// The assertion is a RANGE rather than an equality: `now` is read
-    /// inside the call and the fixture's `due` was built a moment earlier,
-    /// so the answer is a hair under the minute rather than exactly it. The
-    /// upper bound is what the case is really about -- anything at or above
-    /// the hour is the old behaviour.
+    /// Exact, because both sides come from [`NOW`] rather than from two
+    /// reads of the wall clock. What the case is really about is the upper
+    /// bound: anything at or above the hour is the old behaviour.
     #[test]
     fn an_adopted_sheep_waits_out_only_what_was_left() {
-        let left = adopted_restart_delay(&hourly(), Some(due_in(60)), SystemTime::now())
+        let left = adopted_restart_delay(&hourly(), Some(due_in(60)), NOW)
             .expect("a minute of an hour is still a wait");
-        assert!(
-            left <= Duration::from_secs(60) && left > Duration::from_secs(55),
-            "a minute left of an hour must come back as about a minute, not as an hour: {left:?}"
+        assert_eq!(
+            left,
+            Duration::from_secs(60),
+            "a minute left of an hour must come back as that minute, not as an hour"
         );
     }
 
@@ -241,11 +250,8 @@ exp_backoff_restart_delay = "0"
     /// respawn hiding behind a zero.
     #[test]
     fn a_deadline_already_past_respawns_immediately() {
-        let past = SystemTime::now() - Duration::from_secs(30);
-        assert_eq!(
-            adopted_restart_delay(&hourly(), Some(past), SystemTime::now()),
-            None
-        );
+        let past = NOW - Duration::from_secs(30);
+        assert_eq!(adopted_restart_delay(&hourly(), Some(past), NOW), None);
     }
 
     /// Fails if a wall clock that jumped backwards can make a sheep wait
@@ -259,7 +265,7 @@ exp_backoff_restart_delay = "0"
     #[test]
     fn a_clock_that_jumped_backwards_is_clamped_to_the_configured_delay() {
         assert_eq!(
-            adopted_restart_delay(&hourly(), Some(due_in(7200)), SystemTime::now()),
+            adopted_restart_delay(&hourly(), Some(due_in(7200)), NOW),
             Some(Duration::from_secs(3600))
         );
     }
@@ -274,12 +280,12 @@ exp_backoff_restart_delay = "0"
     #[test]
     fn no_carried_deadline_falls_back_to_a_first_unstable_exit() {
         assert_eq!(
-            adopted_restart_delay(&hourly(), None, SystemTime::now()),
+            adopted_restart_delay(&hourly(), None, NOW),
             Some(Duration::from_secs(3600))
         );
         let backing_off = AppConfig::minimal("p", "./p");
         assert_eq!(
-            adopted_restart_delay(&backing_off, None, SystemTime::now()),
+            adopted_restart_delay(&backing_off, None, NOW),
             Some(Duration::from_millis(100)),
             "an app on the default backoff gets its first step, not its current one"
         );
@@ -297,10 +303,7 @@ exp_backoff_restart_delay = "0"
     fn an_app_that_opted_out_of_backoff_is_never_delayed_by_a_deadline() {
         let mut app = AppConfig::minimal("p", "./p");
         app.exp_backoff_restart_delay = None;
-        assert_eq!(
-            adopted_restart_delay(&app, Some(due_in(3600)), SystemTime::now()),
-            None
-        );
-        assert_eq!(adopted_restart_delay(&app, None, SystemTime::now()), None);
+        assert_eq!(adopted_restart_delay(&app, Some(due_in(3600)), NOW), None);
+        assert_eq!(adopted_restart_delay(&app, None, NOW), None);
     }
 }

--- a/crates/shep-daemon/src/backoff.rs
+++ b/crates/shep-daemon/src/backoff.rs
@@ -1,6 +1,7 @@
 //! Exponential backoff with pinned integer arithmetic
 
 use core::time::Duration;
+use std::time::SystemTime;
 
 use shep_core::config::AppConfig;
 
@@ -38,6 +39,72 @@ pub fn restart_delay(app: &AppConfig, consecutive_unstable: u32) -> Option<Durat
     }
 
     None
+}
+
+/// The delay a sheep adopted across a handover still owes, given the moment
+/// its predecessor recorded the respawn as falling due.
+///
+/// The delay belongs to the sheep's own exit, not to the handover: an app
+/// with `restart_delay = "1h"` whose shepherd is reloaded at minute 59 is
+/// owed the remaining minute, not another hour. `due` is what makes that
+/// recoverable — a wall-clock moment, which survives an `execve` where the
+/// [`tokio::time::Instant`] the original timer slept against does not.
+///
+/// Returns what [`schedule_restart`](crate::supervisor) should sleep, in the
+/// spelling that function already uses: `None` means "respawn now", not "no
+/// restart".
+///
+/// # The three cases, and the ruling on each
+///
+/// - **`due` has already passed.** Respawn immediately, with no floor. The
+///   delay exists to space the respawn from the exit, and that spacing has
+///   been served in the only terms it was ever expressed in. A handover
+///   happening inside the window does not un-serve it, and a floor would
+///   invent pacing neither the operator configured nor the predecessor owed.
+///   The `None` this returns still hops through a task and a mailbox send,
+///   so "immediate" stays an observable scheduling step rather than an
+///   inline respawn.
+/// - **The wall clock jumped backwards** — NTP, a suspend — leaving `due -
+///   now` longer than the app's configured delay. Clamped to that delay.
+///   This is the cost of a clock that can move under a deadline, and the
+///   clamp bounds it by what this daemon would have waited anyway: the new
+///   behaviour can never make a sheep wait longer than the old one did. A
+///   FORWARD jump needs no rule — it shortens the wait, at worst to zero,
+///   which is the case above.
+/// - **`due` is `None`.** A predecessor from before this field existed
+///   carried a `WaitingRestart` sheep and silently dropped the deadline, so
+///   there is nothing to anchor to and the fallback is what that
+///   predecessor's successor did: the delay a FIRST unstable exit would get.
+///   Erring long, deliberately — an operator's pacing is never shortened by
+///   a reload.
+///
+/// The clamp's ceiling is `restart_delay(app, 1)`, the same value the
+/// fallback returns, because that is this image's whole belief about what
+/// this app is owed: the carried restart COUNT does not survive into the
+/// budget (`install_adopted` installs a fresh [`RestartBudget`], since the
+/// window it counts over is a run of wall-clock this image never observed).
+/// A ceiling of `None` means the app is owed no delay at all, so no carried
+/// deadline can make it wait.
+#[must_use]
+pub fn adopted_restart_delay(
+    app: &AppConfig,
+    due: Option<SystemTime>,
+    now: SystemTime,
+) -> Option<Duration> {
+    let ceiling = restart_delay(app, 1);
+    let Some(due) = due else {
+        return ceiling;
+    };
+    // `Err` is a `due` in the past, which is the first case above.
+    let remaining = due.duration_since(now).unwrap_or(Duration::ZERO);
+    let remaining = match ceiling {
+        Some(ceiling) => remaining.min(ceiling),
+        None => Duration::ZERO,
+    };
+    // Zero folds into `None` rather than being slept for: the two are the
+    // same instruction to `schedule_restart`, and `None` is the spelling
+    // every other caller uses for it.
+    (remaining > Duration::ZERO).then_some(remaining)
 }
 
 #[cfg(test)]
@@ -131,5 +198,109 @@ exp_backoff_restart_delay = "0"
             Some(shep_core::values::UpDuration::from_millis(0))
         );
         assert_eq!(restart_delay(app, 1), Some(Duration::from_millis(0)));
+    }
+
+    // --- what an adopted sheep still owes ------------------------------
+
+    /// An app whose respawn is paced by a fixed hour, which is the shape the
+    /// whole carried deadline exists for: long enough that restarting the
+    /// clock at a handover is a difference an operator would notice.
+    fn hourly() -> AppConfig {
+        let mut app = AppConfig::minimal("p", "./p");
+        app.restart_delay = Some("1h".parse().unwrap());
+        app
+    }
+
+    /// A moment `secs` from now, as a predecessor would have recorded it.
+    fn due_in(secs: u64) -> SystemTime {
+        SystemTime::now() + Duration::from_secs(secs)
+    }
+
+    /// Fails if an adopted sheep's remaining wait is rounded up to the whole
+    /// configured delay, which is what restarts the clock at every handover.
+    ///
+    /// The assertion is a RANGE rather than an equality: `now` is read
+    /// inside the call and the fixture's `due` was built a moment earlier,
+    /// so the answer is a hair under the minute rather than exactly it. The
+    /// upper bound is what the case is really about -- anything at or above
+    /// the hour is the old behaviour.
+    #[test]
+    fn an_adopted_sheep_waits_out_only_what_was_left() {
+        let left = adopted_restart_delay(&hourly(), Some(due_in(60)), SystemTime::now())
+            .expect("a minute of an hour is still a wait");
+        assert!(
+            left <= Duration::from_secs(60) && left > Duration::from_secs(55),
+            "a minute left of an hour must come back as about a minute, not as an hour: {left:?}"
+        );
+    }
+
+    /// Fails if a deadline that has already elapsed schedules another wait.
+    ///
+    /// `None` is `schedule_restart`'s own spelling for "respawn now", and it
+    /// still costs a task and a mailbox hop, so this is not a synchronous
+    /// respawn hiding behind a zero.
+    #[test]
+    fn a_deadline_already_past_respawns_immediately() {
+        let past = SystemTime::now() - Duration::from_secs(30);
+        assert_eq!(
+            adopted_restart_delay(&hourly(), Some(past), SystemTime::now()),
+            None
+        );
+    }
+
+    /// Fails if a wall clock that jumped backwards can make a sheep wait
+    /// longer than its own configuration ever asked for.
+    ///
+    /// A deadline two hours out under a one-hour delay is not a schedule
+    /// anybody wrote: it is an NTP correction, or a suspend, moving the
+    /// clock under a deadline recorded before it. The clamp bounds the new
+    /// behaviour by the old one, so the worst a jump can do is give back
+    /// exactly what shipped in v0.1.20.
+    #[test]
+    fn a_clock_that_jumped_backwards_is_clamped_to_the_configured_delay() {
+        assert_eq!(
+            adopted_restart_delay(&hourly(), Some(due_in(7200)), SystemTime::now()),
+            Some(Duration::from_secs(3600))
+        );
+    }
+
+    /// Fails if a blob written before the deadline was carried stops getting
+    /// the behaviour its own predecessor's successor gave it.
+    ///
+    /// Absent means unknown here, not "due now": that predecessor carried a
+    /// `WaitingRestart` sheep happily and simply had no field to put the
+    /// moment in. Erring long is the safe reading, and it is what v0.1.20
+    /// did for every sheep.
+    #[test]
+    fn no_carried_deadline_falls_back_to_a_first_unstable_exit() {
+        assert_eq!(
+            adopted_restart_delay(&hourly(), None, SystemTime::now()),
+            Some(Duration::from_secs(3600))
+        );
+        let backing_off = AppConfig::minimal("p", "./p");
+        assert_eq!(
+            adopted_restart_delay(&backing_off, None, SystemTime::now()),
+            Some(Duration::from_millis(100)),
+            "an app on the default backoff gets its first step, not its current one"
+        );
+    }
+
+    /// Fails if an app that opted out of every delay is made to wait by a
+    /// carried deadline.
+    ///
+    /// Its ceiling is `None`, which is this image's whole belief about what
+    /// the app is owed. A deadline in the future can only have come from a
+    /// predecessor running a different configuration, or from a clock that
+    /// moved, and neither is a reason to start throttling an app whose
+    /// operator turned throttling off.
+    #[test]
+    fn an_app_that_opted_out_of_backoff_is_never_delayed_by_a_deadline() {
+        let mut app = AppConfig::minimal("p", "./p");
+        app.exp_backoff_restart_delay = None;
+        assert_eq!(
+            adopted_restart_delay(&app, Some(due_in(3600)), SystemTime::now()),
+            None
+        );
+        assert_eq!(adopted_restart_delay(&app, None, SystemTime::now()), None);
     }
 }

--- a/crates/shep-daemon/src/handover/adopt.rs
+++ b/crates/shep-daemon/src/handover/adopt.rs
@@ -519,6 +519,7 @@ mod tests {
             manual: None,
             reload: Some(crate::entry::ReloadState::None),
             ready_failed: Some(false),
+            restart_due: None,
             app: crate::testing::app_with("web", |_| {}).into_config(),
         }
     }

--- a/crates/shep-daemon/src/handover/mod.rs
+++ b/crates/shep-daemon/src/handover/mod.rs
@@ -30,6 +30,7 @@ use std::os::unix::ffi::{OsStrExt, OsStringExt};
 use std::os::unix::fs::OpenOptionsExt;
 use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
+use std::time::SystemTime;
 
 use serde::{Deserialize, Serialize};
 use shep_core::config::AppConfig;
@@ -642,6 +643,48 @@ pub struct CarriedSheep {
     /// instance. A successor that dropped it would answer that rollback with
     /// `Ok` and replace nothing.
     ready_failed: Option<bool>,
+    /// When this instance's owed respawn falls due, in wall-clock terms, or
+    /// `None` for an instance that is not owed one at all.
+    ///
+    /// The one thing on this row that is deliberately NOT a monotonic value,
+    /// and the reason is the `execve`. A [`tokio::time::Instant`] has no
+    /// epoch and means nothing outside the runtime that read it -- which is
+    /// exactly why `started_at` cannot be carried and is re-derived from the
+    /// process table instead (see [`uptime`](super::uptime)). A wall-clock
+    /// moment has an epoch, so it crosses the exec intact, and the successor
+    /// can re-arm for what is LEFT of the delay rather than for the whole of
+    /// it. An app with `restart_delay = "1h"` reloaded at minute 59 waits the
+    /// remaining minute; a flock reloaded four times inside that hour still
+    /// comes back at the original moment, because an absolute deadline
+    /// absorbs each handover's own duration where a carried remainder would
+    /// add it back on every hop.
+    ///
+    /// The cost is a clock that can move under it, where a monotonic one
+    /// cannot: an NTP correction or a suspend changes when a down sheep
+    /// comes back. That is bounded rather than open-ended --
+    /// [`adopted_restart_delay`](crate::backoff::adopted_restart_delay)
+    /// clamps the remainder to the app's own configured delay, so a backward
+    /// jump can at worst give back the behaviour that shipped in v0.1.20 --
+    /// and it corrupts nothing: a restart delay is pacing, not state.
+    ///
+    /// `Option` for the reason [`Self::ready_failed`] gives rather than the
+    /// one the three fields above it give, and it is the same distinction.
+    /// Each of those was a gate refusal before it was a field, so an absent
+    /// key proves the fact was false. This was never a refusal: a
+    /// predecessor from before this field existed carried a
+    /// [`ProcStatus::WaitingRestart`] sheep happily and re-armed the whole
+    /// delay on the far side. So an absent key is that predecessor staying
+    /// silent, and the successor falls back to exactly what it did.
+    /// [`VERSION`] stays unmoved: nothing an older reader must understand
+    /// has changed, and a hard parse failure would leave a successor
+    /// refusing to boot after its predecessor had exec'd itself away.
+    ///
+    /// Written only for a row this blob reports as `WaitingRestart` -- see
+    /// [`Self::from_entry`], which gates it -- so it never appears on a row
+    /// an operator reading the blob would be surprised to find it on.
+    ///
+    /// Nothing on it is sensitive: one timestamp (IR-41).
+    restart_due: Option<SystemTime>,
     /// The resolved config this instance runs under, environment included.
     ///
     /// This is the `AppConfig` beneath [`ProcessEntry::spec`]'s
@@ -675,13 +718,18 @@ pub struct CarriedSheep {
 impl CarriedSheep {
     /// Describe `entry` for the successor.
     ///
-    /// `epoch`, `fds`, `pending_delete`, `manual` and `ready_failed` are
-    /// arguments rather than reads off `entry` because none of them lives
-    /// there: the respawn epoch, the pending-delete marker, the
-    /// manual-command marker and the failed-readiness verdict are on the
-    /// supervisor's private slot type, and the descriptor numbers are known
-    /// only to whichever code holds the open descriptors. This is the same
-    /// split [`Candidate`] makes, for the same reason.
+    /// `epoch`, `fds`, `pending_delete`, `manual`, `ready_failed` and
+    /// `restart_due` are arguments rather than reads off `entry` because
+    /// none of them lives there: the respawn epoch, the pending-delete
+    /// marker, the manual-command marker, the failed-readiness verdict and
+    /// the respawn deadline are on the supervisor's private slot type, and
+    /// the descriptor numbers are known only to whichever code holds the
+    /// open descriptors. This is the same split [`Candidate`] makes, for the
+    /// same reason.
+    ///
+    /// `restart_due` is the one argument this does not carry verbatim: it is
+    /// gated on the entry's status, for the reason
+    /// [`Self::restart_due`]'s own doc gives.
     #[must_use]
     pub fn from_entry(
         entry: &ProcessEntry,
@@ -690,6 +738,7 @@ impl CarriedSheep {
         pending_delete: bool,
         manual: Option<PendingManual>,
         ready_failed: bool,
+        restart_due: Option<SystemTime>,
     ) -> Self {
         Self {
             id: entry.id,
@@ -708,6 +757,18 @@ impl CarriedSheep {
             // either side of it: this one does live on `ProcessEntry`.
             reload: Some(entry.reload),
             ready_failed: Some(ready_failed),
+            // Gated on the status rather than carried verbatim, unlike every
+            // marker above. The slot's own field is written on the one
+            // transition INTO `WaitingRestart` and never cleared -- the two
+            // ways out of that status (a respawn, and an operator's `stop`
+            // on a waiting sheep) both land somewhere this value has no
+            // meaning -- so gating here is what stops a moment that expired
+            // three restarts ago riding out on an `Online` row, where the
+            // successor would ignore it and an operator reading the blob
+            // would not.
+            restart_due: (entry.status == ProcStatus::WaitingRestart)
+                .then_some(restart_due)
+                .flatten(),
             app: entry.spec.config().clone(),
         }
     }
@@ -755,6 +816,16 @@ impl CarriedSheep {
     #[must_use]
     pub const fn ready_failed(&self) -> Option<bool> {
         self.ready_failed
+    }
+
+    /// When this instance's owed respawn falls due, or `None` for one that
+    /// is not owed a respawn -- and for a blob written before this field
+    /// existed, whose predecessor re-armed the whole delay instead. See the
+    /// field's own doc for why those two read the same and what the
+    /// successor does about it.
+    #[must_use]
+    pub const fn restart_due(&self) -> Option<SystemTime> {
+        self.restart_due
     }
 
     /// The supervisor slot's respawn epoch at the moment of the handover.
@@ -1561,8 +1632,8 @@ mod tests {
 
         let blob = Handover::new(
             vec![
-                CarriedSheep::from_entry(&zero, 7, fds_at(11), false, None, false),
-                CarriedSheep::from_entry(&one, 8, fds_at(21), false, None, false),
+                CarriedSheep::from_entry(&zero, 7, fds_at(11), false, None, false, None),
+                CarriedSheep::from_entry(&one, 8, fds_at(21), false, None, false, None),
             ],
             DaemonFds {
                 listener: 3,
@@ -1662,6 +1733,7 @@ mod tests {
                 origin: CommandOrigin::Automatic,
             }),
             false,
+            None,
         );
         assert_eq!(
             marked.manual(),
@@ -1693,7 +1765,7 @@ mod tests {
     /// One carried sheep off `entry`, with the descriptor numbers a
     /// running sheep would have.
     fn carried(entry: &ProcessEntry) -> CarriedSheep {
-        CarriedSheep::from_entry(entry, 7, fds_at(11), false, None, false)
+        CarriedSheep::from_entry(entry, 7, fds_at(11), false, None, false, None)
     }
 
     fn handover_over(entry: &ProcessEntry) -> Handover {
@@ -1956,6 +2028,7 @@ mod tests {
             false,
             Some(marker),
             false,
+            None,
         );
         let value = serde_json::to_value(&blob).unwrap();
 
@@ -2081,8 +2154,15 @@ mod tests {
     #[test]
     fn a_blob_written_before_ready_failed_was_carried_still_loads() {
         let mut blob = sample_handover();
-        blob.sheep[0] =
-            CarriedSheep::from_entry(&entry_fixture(|_| {}), 7, fds_at(11), false, None, true);
+        blob.sheep[0] = CarriedSheep::from_entry(
+            &entry_fixture(|_| {}),
+            7,
+            fds_at(11),
+            false,
+            None,
+            true,
+            None,
+        );
         let value = serde_json::to_value(&blob).unwrap();
 
         assert_eq!(
@@ -2111,6 +2191,131 @@ mod tests {
             loaded.sheep[0].id(),
             blob.sheep[0].id(),
             "the rest of the row is unchanged by the one field that was absent"
+        );
+    }
+
+    /// One entry owed a respawn, which is the only status the deadline is
+    /// carried for.
+    fn owed_a_restart() -> ProcessEntry {
+        let mut entry = entry_fixture(|_| {});
+        entry.status = ProcStatus::WaitingRestart;
+        entry.pid = None;
+        entry
+    }
+
+    /// fails if a blob written before this daemon carried a respawn deadline
+    /// stops loading, or if a deadline that IS carried does not survive the
+    /// wire.
+    ///
+    /// Same shape as `ready_failed` above and the same argument: this was
+    /// never a gate refusal, so an absent key is a predecessor staying
+    /// silent rather than saying "no". What it does about that silence is
+    /// different, though, and is what makes the case worth having — it falls
+    /// back to re-arming the whole delay, which is exactly what v0.1.20 did
+    /// for every sheep. A hard parse failure instead would leave a successor
+    /// refusing to boot after its predecessor had exec'd itself away, over a
+    /// field whose absence has a correct reading.
+    ///
+    /// The current-blob half is asserted first so the removal below removes
+    /// something.
+    ///
+    /// A whole second of slack on the round trip: serde carries a
+    /// `SystemTime` as seconds plus nanoseconds, so this pins the value
+    /// rather than the precision, and an exact equality would be asserting
+    /// something about serde rather than about the blob.
+    #[test]
+    fn a_blob_written_before_a_restart_deadline_was_carried_still_loads() {
+        let due = SystemTime::now() + core::time::Duration::from_secs(600);
+        let mut blob = sample_handover();
+        blob.sheep[0] = CarriedSheep::from_entry(
+            &owed_a_restart(),
+            7,
+            fds_at(11),
+            false,
+            None,
+            false,
+            Some(due),
+        );
+        let value = serde_json::to_value(&blob).unwrap();
+
+        let carried = Handover::load_value(value.clone())
+            .expect("a current blob loads")
+            .sheep[0]
+            .restart_due()
+            .expect("a deadline on the wire must come back as one");
+        let drift = carried
+            .duration_since(due)
+            .or_else(|_| due.duration_since(carried))
+            .unwrap();
+        assert!(
+            drift < core::time::Duration::from_secs(1),
+            "a moment that does not survive the wire is a moment the successor cannot re-arm \
+             from: {drift:?} of drift"
+        );
+
+        let mut older = value;
+        let sheep = older["sheep"][0]
+            .as_object_mut()
+            .expect("a carried sheep is an object");
+        assert!(
+            sheep.remove("restart_due").is_some(),
+            "the field this case removes must be there to remove"
+        );
+
+        let loaded = Handover::load_value(older).expect("an older blob must still load");
+
+        assert_eq!(loaded.sheep[0].restart_due(), None);
+        assert_eq!(
+            loaded.sheep[0].id(),
+            blob.sheep[0].id(),
+            "the rest of the row is unchanged by the one field that was absent"
+        );
+    }
+
+    /// fails if a deadline reaches the blob on a row that is not owed a
+    /// respawn.
+    ///
+    /// The slot's own field is written on the transition into
+    /// `WaitingRestart` and never cleared, so a sheep that has since been
+    /// respawned still holds the moment its previous exit was due back at.
+    /// Nothing would act on it — `install_adopted` re-arms only for a
+    /// `WaitingRestart` row — but the blob is a file an operator may read,
+    /// and a stale deadline on an `Online` row is a claim about the flock
+    /// that is not true.
+    ///
+    /// Both halves, because a gate that dropped the field unconditionally
+    /// would pass the second assertion on its own.
+    #[test]
+    fn a_deadline_is_carried_only_for_a_sheep_owed_a_respawn() {
+        let due = SystemTime::now() + core::time::Duration::from_secs(600);
+
+        let waiting = CarriedSheep::from_entry(
+            &owed_a_restart(),
+            7,
+            fds_at(11),
+            false,
+            None,
+            false,
+            Some(due),
+        );
+        assert!(
+            waiting.restart_due().is_some(),
+            "a sheep that IS owed a respawn must carry its deadline, or there is nothing to gate"
+        );
+
+        let online = CarriedSheep::from_entry(
+            &entry_fixture(|_| {}),
+            7,
+            fds_at(11),
+            false,
+            None,
+            false,
+            Some(due),
+        );
+        assert_eq!(
+            online.restart_due(),
+            None,
+            "a running sheep must not carry a deadline left over from an earlier exit"
         );
     }
 
@@ -2200,7 +2405,9 @@ mod tests {
     ) -> Handover {
         Handover {
             version: VERSION,
-            sheep: vec![CarriedSheep::from_entry(entry, 7, fds, false, None, false)],
+            sheep: vec![CarriedSheep::from_entry(
+                entry, 7, fds, false, None, false, None,
+            )],
             listener_fd,
             pidfile_fd,
             next_id: 9,

--- a/crates/shep-daemon/src/supervisor.rs
+++ b/crates/shep-daemon/src/supervisor.rs
@@ -41,6 +41,7 @@ use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet, VecDeque};
 use std::io;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::time::SystemTime;
 
 use serde::{Deserialize, Serialize};
 use tokio::sync::{mpsc, oneshot};
@@ -2448,6 +2449,30 @@ struct SheepSlot {
     /// [`Actor::respawn`]'s success arm and [`Actor::went_online`]. Both are
     /// the moment the fact stops being true rather than a tidy-up.
     ready_failed: bool,
+    /// When this slot's owed respawn falls due, in wall-clock terms.
+    ///
+    /// Written on the one transition INTO [`ProcStatus::WaitingRestart`],
+    /// beside the [`Actor::schedule_restart`] that sleeps for the same
+    /// interval. The two are the same fact in the two clocks that can hold
+    /// it: the timer's is monotonic, which is what an interval should be
+    /// measured in and is why it stays the thing that actually fires; this
+    /// one is wall-clock, which is the only kind of moment that survives an
+    /// `execve`. A handover carries this one and re-arms a fresh timer from
+    /// it, so the respawn lands when the sheep's own exit said it would
+    /// rather than a full delay after whenever the shepherd was last
+    /// upgraded. See [`CarriedSheep::restart_due`](crate::handover::CarriedSheep)
+    /// for the argument in full, and
+    /// [`backoff::adopted_restart_delay`](crate::backoff::adopted_restart_delay)
+    /// for what a successor does with it.
+    ///
+    /// `None` on every other status, and NOT cleared on the way out of
+    /// `WaitingRestart`, which needs saying because the fields above it are.
+    /// Nothing reads it without the status: `CarriedSheep::from_entry` gates
+    /// the carry, and `install_adopted` gates the re-arm. So a moment left
+    /// behind by a respawn, or by an operator's `stop` on a waiting sheep,
+    /// is unreachable rather than wrong -- and a clear in three places would
+    /// be three chances to miss one, for a value none of them can expose.
+    restart_due: Option<SystemTime>,
 }
 
 impl SheepSlot {
@@ -3293,6 +3318,7 @@ impl<R: ProcessRunner> Actor<R> {
                 ready_tx: None,
                 actions: ActionWaits::default(),
                 ready_failed: false,
+                restart_due: None,
             },
         );
         Registration::Fresh(info)
@@ -3435,6 +3461,7 @@ impl<R: ProcessRunner> Actor<R> {
                         ready_tx,
                         actions: ActionWaits::default(),
                         ready_failed: false,
+                        restart_due: None,
                     },
                 );
                 self.emit(ProcessEventKind::Start, info.clone(), true);
@@ -3482,6 +3509,7 @@ impl<R: ProcessRunner> Actor<R> {
                         ready_tx: None,
                         actions: ActionWaits::default(),
                         ready_failed: false,
+                        restart_due: None,
                     },
                 );
                 self.emit(ProcessEventKind::Errored, info, true);
@@ -3707,6 +3735,16 @@ impl<R: ProcessRunner> Actor<R> {
                     // the verdict still standing — and `respawn` clears it
                     // at the spawn that answers it.
                     ready_failed,
+                    // Restored verbatim, and it is what makes the deadline
+                    // survive MORE THAN ONE handover. The re-arm below
+                    // computes a fresh timer from it; without the moment
+                    // itself back on the slot, a second reload during the
+                    // same wait would snapshot a sheep with no deadline and
+                    // the successor would start the delay over — which is
+                    // the whole defect, moved one exec along. An absolute
+                    // moment is what makes the chain flat: four reloads
+                    // inside the hour still respawn at the original minute.
+                    restart_due: carried.restart_due(),
                 },
             );
             // A sheep the blob reports as `WaitingRestart` is owed a respawn,
@@ -3723,17 +3761,29 @@ impl<R: ProcessRunner> Actor<R> {
             // and upgrading the shepherd is exactly what an operator does
             // about a crash-looping app.
             //
-            // Re-armed rather than carried, for the reason the readiness wait
-            // is: what elapsed is a `tokio::time::Instant` from a runtime
-            // that no longer exists. The delay is the one an app in its FIRST
-            // unstable exit would get, which is what the fresh
-            // `RestartBudget` above already says this image believes: an
-            // explicit `restart_delay` is honoured in full (an operator's
-            // pacing is never shortened by a reload), an exponential-backoff
-            // app gets its initial step, and one that opted out of both
-            // restarts at once.
+            // The timer is re-armed, but the DEADLINE is carried, and that
+            // distinction is the whole of this behaviour. What cannot cross
+            // the exec is the `tokio::time::Instant` the original timer slept
+            // against, exactly as the readiness wait's cannot; what can is a
+            // wall-clock moment, which the predecessor recorded beside that
+            // timer for this one purpose. So the successor sleeps out what is
+            // LEFT rather than starting the delay again, and an app with
+            // `restart_delay = "1h"` reloaded at minute 59 comes back in a
+            // minute rather than in another hour.
+            //
+            // This shipped as `restart_delay(config, 1)` in v0.1.20 -- the
+            // delay a FIRST unstable exit would get -- which restarted the
+            // clock at every handover. That is still the fallback, and still
+            // for its own reason: a blob from before the deadline existed
+            // carries none, and erring long is the safe reading of a
+            // predecessor's silence. `adopted_restart_delay` owns all three
+            // cases (elapsed, clock-jumped, absent) and argues each.
             if status == ProcStatus::WaitingRestart {
-                let delay = crate::backoff::restart_delay(app.config(), 1);
+                let delay = crate::backoff::adopted_restart_delay(
+                    app.config(),
+                    carried.restart_due(),
+                    SystemTime::now(),
+                );
                 self.schedule_restart(id, carried.epoch(), delay);
             }
             return Ok(());
@@ -3884,6 +3934,12 @@ impl<R: ProcessRunner> Actor<R> {
                 // would answer that rollback `Ok` and skip the only instance
                 // there was.
                 ready_failed,
+                // Restored verbatim, as the branch above does, though this
+                // one is always `None` in practice: a sheep with a pid is
+                // not `WaitingRestart`, and `CarriedSheep::from_entry` gates
+                // the field on that status. Reading it anyway keeps one rule
+                // for the field rather than a rule and an exception.
+                restart_due: carried.restart_due(),
             },
         );
         // A sheep the blob reports a `manual` marker for is one an operator
@@ -5322,6 +5378,7 @@ impl<R: ProcessRunner> Actor<R> {
                         ready_tx: Some(ready_tx),
                         actions: ActionWaits::default(),
                         ready_failed: false,
+                        restart_due: None,
                     },
                 );
                 // The instance being replaced announces itself BEFORE its
@@ -6345,6 +6402,7 @@ impl<R: ProcessRunner> Actor<R> {
                 pending_delete: slot.pending_delete,
                 epoch: slot.epoch,
                 ready_failed: slot.ready_failed,
+                restart_due: slot.restart_due,
                 log_ctl: slot.log_ctl.clone(),
                 channel_open: slot.open_channel().is_some(),
             })
@@ -6879,6 +6937,24 @@ impl<R: ProcessRunner> Actor<R> {
                 // schedules can tell, when it fires, whether it's still the
                 // authoritative one for this id (see `respawn`/`SheepSlot`).
                 let epoch = self.sheep.get(&id).expect("checked above").epoch;
+                // The same interval as the timer below, in the one clock
+                // that survives an `execve`. Recorded here rather than
+                // inside `schedule_restart` because the other caller is
+                // `install_adopted`, which is re-arming a deadline this
+                // already produced and must not stamp a new one over it.
+                //
+                // `checked_add` rather than `+`: `restart_delay` is an
+                // operator's `Duration` and `SystemTime`'s `Add` panics on
+                // overflow. The `filter` is the same refusal for the other
+                // end of the range -- serde cannot serialize a `SystemTime`
+                // before the Unix epoch, and a whole blob that fails to
+                // write would drop a live flock down the stop-and-start arm
+                // over one field. Either way the successor gets `None` and
+                // falls back to the whole delay, which is what shipped in
+                // v0.1.20.
+                self.sheep.get_mut(&id).expect("checked above").restart_due = SystemTime::now()
+                    .checked_add(delay.unwrap_or(Duration::ZERO))
+                    .filter(|due| due.duration_since(SystemTime::UNIX_EPOCH).is_ok());
                 self.schedule_restart(id, epoch, delay);
                 info
             }
@@ -8163,6 +8239,10 @@ struct HandoverDraft {
     /// Whether a reload's readiness verification has already failed against
     /// this sheep. See [`SheepSlot::ready_failed`].
     ready_failed: bool,
+    /// When this sheep's owed respawn falls due, so the successor re-arms
+    /// for what is left of the delay rather than for the whole of it. See
+    /// [`SheepSlot::restart_due`].
+    restart_due: Option<SystemTime>,
     /// This sheep's log pump, or `None` for a slot whose spawn never
     /// succeeded.
     log_ctl: Option<mpsc::Sender<LogCtl>>,
@@ -8260,6 +8340,7 @@ fn spawn_handover_task(
                 draft.pending_delete,
                 draft.manual,
                 draft.ready_failed,
+                draft.restart_due,
             );
             let candidate = OwnedCandidate {
                 entry: draft.entry,
@@ -10648,6 +10729,7 @@ mod tests {
             ready_tx: None,
             actions: ActionWaits::default(),
             ready_failed: false,
+            restart_due: None,
         };
         let mut sheep = HashMap::new();
         sheep.insert(0, slot);
@@ -11360,6 +11442,7 @@ mod tests {
                 ready_tx: None,
                 actions: ActionWaits::default(),
                 ready_failed: false,
+                restart_due: None,
             },
         );
         let (events, _events_rx) = crate::bus::test_bus(64);
@@ -11422,6 +11505,7 @@ mod tests {
                     ready_tx: None,
                     actions: ActionWaits::default(),
                     ready_failed: false,
+                    restart_due: None,
                 },
             );
         }
@@ -11618,6 +11702,7 @@ mod tests {
                     ready_tx: None,
                     actions: ActionWaits::default(),
                     ready_failed: false,
+                    restart_due: None,
                 },
             );
         }
@@ -15082,6 +15167,7 @@ mod tests {
                 ready_tx: None,
                 actions: ActionWaits::default(),
                 ready_failed: false,
+                restart_due: None,
             },
         );
         id
@@ -18490,7 +18576,49 @@ mod tests {
             pending_delete,
             manual,
             ready_failed,
+            None,
         )
+    }
+
+    /// One sheep as a blob describes it, owed a respawn at a named moment.
+    ///
+    /// Its own function rather than a seventh argument to
+    /// [`carried_marked`]: that one is already at the edge of
+    /// `clippy::too_many_arguments`, and every case there passes the same
+    /// values for the markers these cases are not about. It also needs
+    /// something `carried_marked` does not offer at all — a `restart_delay`
+    /// on the app itself, since a deadline means nothing without a
+    /// configured delay to be shorter than.
+    ///
+    /// `autorestart` is left ON, unlike [`carried_marked`]'s: these cases
+    /// are about a respawn happening, so suppressing it would suppress the
+    /// thing under test.
+    #[cfg(unix)]
+    fn carried_owed_a_restart(
+        name: &str,
+        id: u32,
+        delay: shep_core::values::UpDuration,
+        due: Option<SystemTime>,
+    ) -> CarriedSheep {
+        let mut app = AppConfig::minimal(name, "./srv");
+        app.restart_delay = Some(delay);
+        let entry = ProcessEntry {
+            id,
+            spec: normalize(app).unwrap(),
+            instance: 0,
+            status: ProcStatus::WaitingRestart,
+            pid: None,
+            restarts: 1,
+            started_at: None,
+            budget: RestartBudget::default(),
+            reload: ReloadState::None,
+            credentials: SpawnIdentity::Resolved(None),
+            out_file: PathBuf::new(),
+            err_file: PathBuf::new(),
+            dog: None,
+            last_exit: None,
+        };
+        CarriedSheep::from_entry(&entry, 0, CarriedFds::none(), false, None, false, due)
     }
 
     /// A carried sheep with no descriptors to rebuild, which is every case
@@ -19124,6 +19252,200 @@ mod tests {
             info[0].pid,
             Some(STAND_IN_SPAWN_PID),
             "the restart must be a real respawn, not a status edit: {info:?}"
+        );
+    }
+
+    /// Fails if an adopted sheep waits out its WHOLE restart delay again
+    /// instead of the part of it that was left.
+    ///
+    /// The case above proves a respawn happens at all; this one proves it
+    /// happens WHEN the sheep's own exit said it would. Both sheep here are
+    /// paced by a fixed hour and both are owed a respawn. The only
+    /// difference is that one carries the moment its predecessor recorded
+    /// the respawn as falling due, two seconds out, and the other carries
+    /// nothing — which is what a blob written before v0.1.22 looks like.
+    ///
+    /// The control is the attribution, and it is what makes the first
+    /// assertion mean something. A re-arm that ignored the deadline and
+    /// slept for a hundred milliseconds would satisfy "it came back" just as
+    /// well; only the pair can tell "it waited out what was left" from "it
+    /// did not wait at all". They share one paused clock and one advance, so
+    /// there is no second run to differ.
+    ///
+    /// Ten virtual seconds is the forcing mechanism (IR-46): it is past the
+    /// carried deadline by a factor of five and short of the configured hour
+    /// by a factor of three hundred and sixty, so each sheep's status after
+    /// it can only have come from one of the two behaviours. The paused
+    /// clock advances itself once every task is idle, so it costs the suite
+    /// nothing.
+    #[cfg(unix)]
+    #[tokio::test(start_paused = true)]
+    async fn an_adopted_sheep_waits_out_only_what_is_left_of_its_delay() {
+        let hour = "1h".parse().unwrap();
+        let anchored_dir = tempfile::tempdir().unwrap();
+        let (anchored_events, _anchored_rx) = crate::bus::test_bus(64);
+        let anchored =
+            SupervisorBuilder::new(AdoptingRunner, test_paths(&anchored_dir), anchored_events)
+                .spawn_adopted(
+                    vec![without_handles(carried_owed_a_restart(
+                        "web",
+                        7,
+                        hour,
+                        Some(SystemTime::now() + Duration::from_secs(2)),
+                    ))],
+                    counters(9),
+                    Vec::new(),
+                )
+                .expect("a carried flock installs");
+
+        let control_dir = tempfile::tempdir().unwrap();
+        let (control_events, _control_rx) = crate::bus::test_bus(64);
+        let control =
+            SupervisorBuilder::new(AdoptingRunner, test_paths(&control_dir), control_events)
+                .spawn_adopted(
+                    vec![without_handles(carried_owed_a_restart(
+                        "web", 7, hour, None,
+                    ))],
+                    counters(9),
+                    Vec::new(),
+                )
+                .expect("a carried flock installs");
+
+        tokio::time::sleep(Duration::from_secs(10)).await;
+
+        let anchored = anchored.list().await;
+        assert_eq!(
+            anchored[0].status,
+            ProcStatus::Online,
+            "a sheep two seconds from its own due time must not be made to wait another hour by \
+             the handover: {anchored:?}"
+        );
+        assert_eq!(
+            anchored[0].pid,
+            Some(STAND_IN_SPAWN_PID),
+            "the restart must be a real respawn, not a status edit: {anchored:?}"
+        );
+
+        let control = control.list().await;
+        assert_eq!(
+            control[0].status,
+            ProcStatus::WaitingRestart,
+            "with no carried deadline the whole delay is re-armed, so an hourly app must still \
+             be waiting ten seconds in — a control that respawned would mean the case above \
+             proved nothing: {control:?}"
+        );
+    }
+
+    /// Fails if a snapshot of a sheep owed a respawn does not carry the
+    /// moment that respawn falls due.
+    ///
+    /// The other end of the case above, and a separate assertion rather than
+    /// an implied one: that case hands `spawn_adopted` a blob built by hand,
+    /// so a predecessor that recorded no deadline at all would leave it
+    /// green while no live handover ever carried one. This drives a real
+    /// exit through `decide_on_exit` instead, which is the only thing that
+    /// writes the moment.
+    ///
+    /// The assertion is a window rather than an equality. The deadline is
+    /// wall-clock — that is the whole point of it, since a monotonic instant
+    /// cannot cross an `execve` — and a paused tokio clock does not pause
+    /// the wall clock, so what is pinned is that the moment is about an hour
+    /// out rather than exactly one.
+    #[cfg(unix)]
+    #[tokio::test(start_paused = true)]
+    async fn a_snapshot_of_a_waiting_sheep_carries_the_moment_its_respawn_falls_due() {
+        let (events, _rx) = crate::bus::test_bus(64);
+        let runner = ScriptedRunner::new(vec![ProcScript::const_exit(1)]);
+        let dir = tempfile::tempdir().unwrap();
+        let (fds, _held) = daemon_fds(&dir);
+        let handle = spawn_supervisor(runner, test_paths(&dir), events);
+        let mut app = AppConfig::minimal("web", "./srv");
+        // An hour, so the sheep is still waiting when the snapshot is taken
+        // rather than racing its own respawn, and so the window below is
+        // wide enough to be unambiguous.
+        app.restart_delay = Some("1h".parse().unwrap());
+        handle.start(vec![normalize(app).unwrap()]).await.unwrap();
+
+        // A transition rather than a state (IR-46): the sheep starts
+        // `Online` and the snapshot is only meaningful after the exit, so
+        // waiting for `WaitingRestart` is what stops this passing on the
+        // state before the crash under test. Bounded well past the exit,
+        // which is immediate.
+        let waits = async {
+            while handle.list().await[0].status != ProcStatus::WaitingRestart {
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        };
+        tokio::time::timeout(Duration::from_secs(30), waits)
+            .await
+            .expect("an app that exits immediately with autorestart on must reach WaitingRestart");
+
+        let (_candidates, blob, _parked) = handle.handover_snapshot(fds).await.unwrap();
+
+        let due = blob.sheep()[0]
+            .restart_due()
+            .expect("a sheep owed a respawn must carry the moment it is owed at");
+        let left = due
+            .duration_since(SystemTime::now())
+            .expect("a deadline an hour out has not passed");
+        assert!(
+            left > Duration::from_secs(3595) && left <= Duration::from_secs(3600),
+            "the carried moment must be this sheep's own exit plus its own delay: {left:?}"
+        );
+    }
+
+    /// Fails if the second handover inside one restart delay loses the
+    /// moment the first one carried.
+    ///
+    /// The deadline is only worth carrying if it survives a CHAIN of them:
+    /// an operator upgrading a shepherd twice inside an hourly delay must
+    /// still get the sheep back at the original minute. That needs the
+    /// successor to restore the moment onto its own slot, not merely to read
+    /// it once on the way past — a successor that armed a correct timer and
+    /// then forgot the moment would pass every other case here and move the
+    /// whole defect one exec along, where it is harder to see.
+    ///
+    /// An absolute moment is what makes the chain flat rather than
+    /// compounding. A carried REMAINDER would have each hop add its own
+    /// handover duration back on, so four reloads would drift by four
+    /// handovers; this drifts by none, which is what the window asserts.
+    ///
+    /// The adopt-then-snapshot pair IS the second handover: `spawn_adopted`
+    /// is what a successor runs, and `handover_snapshot` is what it hands to
+    /// its own successor.
+    #[cfg(unix)]
+    #[tokio::test(start_paused = true)]
+    async fn a_second_handover_inside_one_delay_still_names_the_original_moment() {
+        let dir = tempfile::tempdir().unwrap();
+        let (fds, _held) = daemon_fds(&dir);
+        let (events, _rx) = crate::bus::test_bus(64);
+        let due = SystemTime::now() + Duration::from_secs(3000);
+        let handle = SupervisorBuilder::new(AdoptingRunner, test_paths(&dir), events)
+            .spawn_adopted(
+                vec![without_handles(carried_owed_a_restart(
+                    "web",
+                    7,
+                    "1h".parse().unwrap(),
+                    Some(due),
+                ))],
+                counters(9),
+                Vec::new(),
+            )
+            .expect("a carried flock installs");
+
+        let (_candidates, blob, _parked) = handle.handover_snapshot(fds).await.unwrap();
+
+        let carried = blob.sheep()[0]
+            .restart_due()
+            .expect("a successor must hand its own successor the moment it was given");
+        let drift = carried
+            .duration_since(due)
+            .or_else(|_| due.duration_since(carried))
+            .unwrap();
+        assert!(
+            drift < Duration::from_secs(1),
+            "the second hop must name the same moment as the first, not a fresh one: {drift:?} \
+             of drift"
         );
     }
 

--- a/docs/specs/deferred.md
+++ b/docs/specs/deferred.md
@@ -411,6 +411,39 @@ True of the daemon's `Request::Start`, false of the `shep start` an operator
 types: the CLI sorts apps into resumed and fresh, and only fresh ones reach
 that request. The sentence describes something no terminal can produce.
 
+### The handover blob's compatibility tests never load an old blob
+
+Raised in review on #84, 2026-08-31, and agreed rather than argued away.
+
+Seven cases are named `a_blob_written_before_<field>_was_carried_still_loads`
+-- stdin, the channel, `pending_delete`, the manual marker, a swap in flight,
+`ready_failed`, and the restart deadline. Every one of them builds a blob from
+today's `Handover`, serialises it, removes one key, and loads the result.
+
+That proves the thing each field's carry actually needs: an absent key loads
+as `None` rather than refusing, so a successor boots against a predecessor
+that never wrote the field. It is not nothing.
+
+**What it cannot prove is that a blob written by an older binary still
+parses**, because it round-trips through today's serialiser. Rename a field
+and every one of these follows the rename and keeps passing, while a real
+blob on disk from v0.1.18 fails. IR-35 asks for exactly the missing half:
+"committed byte-fixtures from the previous protocol version that must still
+deserialize".
+
+**One wrinkle stops this being a straight IR-35 application, and it needs
+deciding rather than inferring.** The rule says fixtures from the PREVIOUS
+protocol version, and the blob's `VERSION` has never moved from 1. Every
+format worth pinning -- v0.1.18 through v0.1.21, and each phase's additions
+inside them -- is version 1 with fewer optional fields. So the fixture policy
+has to answer what a fixture is keyed to when the version does not move: a
+release, a phase, or every shape that ever shipped.
+
+Not done in #84 because it is not that PR's test. Covering only the newest
+field would leave one case in a different style from six siblings and barely
+reduce the risk, since the exposure is the whole blob rather than any one
+key.
+
 ## Ideas, recorded but not designed
 
 Not debt, not deferred spec surface, and not promised to anybody. Things worth

--- a/docs/writing-plans/plans/2026-08-31-handover-phase2c.md
+++ b/docs/writing-plans/plans/2026-08-31-handover-phase2c.md
@@ -841,36 +841,71 @@ it is handed, so nothing short of a hand-written refusal reddens it. It is a
 regression guard on the reparse, the same shape and the same worth as
 `a_blob_carrying_a_swap_in_flight_passes_the_rehearsal`.
 
-## Inherited from 2b, for a second look
+## Inherited from 2b — DECIDED AND CLOSED
 
-**The re-armed restart delay is a judgement call, and it shipped in v0.1.20.**
-2b's task 8 re-arms a carried `WaitingRestart` sheep with
-`backoff::restart_delay(config, 1)`, which is the delay a FIRST unstable exit
-would get. So an app with `restart_delay = "1h"` reloaded at minute 59 waits
-another full hour rather than the minute it had left.
+**The re-armed restart delay was a judgement call, it shipped in v0.1.20, and
+the maintainer's ruling has replaced it.** The delay is now anchored to the
+sheep's own exit: a sheep that exited at T comes back at T plus its delay,
+however many handovers happen in between. Built on
+`feat/handover-restart-deadline`, not in 2c itself.
 
-The reasoning is sound as far as it goes: what elapsed is a
-`tokio::time::Instant` from a runtime that no longer exists, and erring long
-respects an operator's pacing where erring short could hammer whatever the
-delay exists to protect. Restarting immediately is the other obvious option
-and is worse for the same reason.
+What this section recorded, and what came of it. 2b's task 8 re-armed a
+carried `WaitingRestart` sheep with `backoff::restart_delay(config, 1)`, the
+delay a FIRST unstable exit would get, so an app with `restart_delay = "1h"`
+reloaded at minute 59 waited another full hour. The third option this section
+named is what was built: a `SystemTime` deadline, which survives the exec
+where the monotonic `Instant` cannot. The predecessor records the moment the
+respawn falls due, carries it on `CarriedSheep::restart_due`, and the
+successor arms for what is left.
 
-**But there is a third option neither considered, and it is better than
-both.** The elapsed time is unrecoverable only because it was recorded as a
-monotonic `Instant`. A `SystemTime` deadline survives the exec, so the
-predecessor could carry `now + remaining` and the successor re-arm for
-exactly what was left. That honours the operator's schedule instead of
-approximating it in either direction.
+Two things this section did not have, settled by building it:
 
-The cost is that a wall clock can jump under it — NTP, a suspend — where the
-monotonic one cannot. For a restart delay that seems an acceptable trade,
-since a jump changes when a down sheep comes back rather than corrupting
-anything, but it is the maintainer's call and it is not urgent: today's
-behaviour is safe, merely blunt.
+- **An absolute moment, not a carried remainder.** Subtracting at snapshot
+  time and carrying a `Duration` is the other way to make a monotonic
+  deadline cross the exec, and it is immune to the clock jump this section
+  worried about. Rejected anyway, because each hop would add its own handover
+  duration back on: four reloads inside one delay would drift by four
+  handovers. An absolute moment absorbs each handover rather than
+  accumulating it, which is what "however many handovers" actually asks for.
+- **The clock jump is clamped, not simply accepted.** `adopted_restart_delay`
+  bounds the remainder by `restart_delay(config, 1)` — the value the old code
+  used — so a backward jump can at worst give back exactly v0.1.20's
+  behaviour. That turns this section's "acceptable trade" into a bounded one.
 
-Not scoped into 2c. Recorded here because it was found while auditing 2c's
-own timer-strand class, and because the class is exactly what makes it
-fixable.
+The three cases (elapsed, clock-jumped, absent) and their rulings live in that
+function's own doc and in the commit message.
+
+Measured under an isolated `$SHEP_HOME`, an app with `restart_delay = "45s"`
+that exits immediately, reloaded 15s into the wait, with a never-reloaded
+control alongside. The shepherd's pid was unchanged across every reload, so
+each one was a carry rather than a fallback stop-and-start.
+
+| binary | reloads | exit-to-respawn |
+|---|---|---|
+| v0.1.21 | none (control) | 45.0s |
+| v0.1.21 | one, at t+15s | **60.1s** |
+| v0.1.21 | one, at t+15s (repeat) | **60.1s** |
+| this branch | none (control) | 45.0s |
+| this branch | one, at t+15s | **45.0s** |
+| this branch | two, at t+15s and t+30s | **45.0s** |
+
+The 15.1s excess before is exactly the reload offset: the clock restarted. The
+two-reload row is the chain staying flat.
+
+**One residual, and it is a tradeoff rather than an oversight.** All six
+mutations are caught by the daemon lib tier, so nothing here is e2e-only --
+but that also means no permanent test drives the deadline through a REAL
+`execve`. `a_sheep_owed_a_restart_still_gets_one_after_a_daemon_reload` in
+`crates/shep-cli/tests/cli_e2e.rs` reloads a real `WaitingRestart` sheep and
+would be the place for it; it asserts that the sheep comes back, not that it
+comes back on time. Adding the timing half needs a delay long enough to
+separate "what was left" from "the whole thing" on a loaded runner, plus a
+deliberate wait before the reload, which is roughly +20s on the slowest suite
+and makes the assertion a claim about the machine's speed as much as about
+shep -- the exact shape that has already cost this project four red CI runs
+and put three test groups in `mod slow`. The drill above covers it instead,
+twice per side with a control and a shepherd-pid check. Buying the permanent
+guard is the maintainer's call.
 
 ## The reload drill
 


### PR DESCRIPTION
A sheep owed a respawn used to restart its whole delay when the shepherd was replaced. An app with `restart_delay = "1h"`, reloaded at minute 59, waited another full hour.

The delay is now anchored to the sheep's own exit, so it comes back at the moment it was always due, however many handovers land in between.

Measured under an isolated `SHEP_HOME`, `restart_delay = "45s"`, reload at t+15s. The shepherd's pid held across every reload, so each one was a carry rather than a fallback stop and start:

| binary | reloads | exit to respawn |
|---|---|---|
| v0.1.21 | none | 45.0s |
| v0.1.21 | one | 60.1s |
| this branch | none | 45.0s |
| this branch | one | 45.0s |
| this branch | two | 45.0s |

The 15.1s excess before is exactly the reload offset.

The elapsed time was only unrecoverable because it was recorded as a monotonic `Instant`, which belongs to a runtime the exec destroys. A `SystemTime` survives, so the moment the respawn falls due is carried in the blob and the successor arms for what is left.

An absolute moment rather than a carried remainder, which is the part worth reading twice. A remainder is immune to a clock jump, but each hop adds its own handover duration back on, so four reloads would drift by four handovers. Absolute absorbs them.

Three cases it had to rule on:

- deadline already passed on adoption: respawn immediately, no floor. The spacing was served in the only terms it was expressed in
- clock jumped backwards, so the remainder exceeds the configured delay: clamp to the full delay, which bounds the cost of a movable clock by what v0.1.21 already waited
- no deadline in the blob, meaning an older predecessor: fall back to the full delay

`VERSION` unmoved, no `#[serde(default)]`, legacy blob test alongside its siblings. 685 daemon lib tests, 2159 workspace, all gates green including the windows cross-check.

One residual, recorded in the plan rather than papered over. No permanent test drives the deadline through a real `execve`. The natural home is the existing reload case, but the timing half needs a longer delay and a deliberate pre-reload wait, roughly 20 seconds on the slowest suite, and it turns the assertion into a claim about the runner's speed. That is what put three groups in `mod slow` and cost four red CI runs. The drill above covers it instead.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Preserved restart timing when a service instance is handed over or reloaded.
  * Resumed waiting instances using only the remaining restart delay.
  * Added safe handling for expired, missing, or invalid restart deadlines.

* **Bug Fixes**
  * Prevented unexpected extended waits after handovers, including when the system clock moves backward.

* **Documentation**
  * Documented restart-delay behavior and timing across multiple handovers.
  * Recorded compatibility considerations for handover data across versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->