### PR TITLE
chore(coderabbit): stop the generic markdown rule weakening the specific ones

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -172,12 +172,18 @@ reviews:
         one that has already shipped broken is Callout, whose prop is
         `variant` with values "careful" or "note".
 
+    # CodeRabbit applies EVERY matching path instruction, not the most
+    # specific one, so these four blocks are additive rather than a
+    # precedence chain. That is why the generic block below carries only
+    # what is true of every markdown file in the repository: a restriction
+    # placed there would reach the published pages too, and "flag only
+    # factual drift" sitting beside the terminology rule would tell a
+    # reviewer to ignore the terminology rule. Each restriction therefore
+    # lives on the paths that want it.
     - path: "**/*.md"
       instructions: >-
         Prose here is hand-written and hand-wrapped in a deliberate voice. Do
-        not suggest rewording, tightening, or rewrapping. Flag only factual
-        drift: a claim about behaviour that the diff makes false, a command
-        that no longer exists, a sample that will not parse.
+        not suggest rewording, tightening, or rewrapping.
 
         A residual the same diff already documents as a known limitation has
         been considered. Raise it once if the reasoning looks wrong, and not
@@ -185,16 +191,19 @@ reviews:
 
     - path: "docs/writing-plans/**/*.md"
       instructions: >-
-        Working documents, not published prose. The terminology rule below
-        does not apply here: these name a feature after the verb an operator
-        types, so "daemon handover" tracks `shep daemon reload` and matches
-        the sibling plans deliberately. Flag factual drift only.
+        Working documents, not published prose. Flag factual drift only: a
+        claim about behaviour the diff makes false, a command that no longer
+        exists, a sample that will not parse.
+
+        The terminology rule does not apply here. These name a feature after
+        the verb an operator types, so "daemon handover" tracks `shep daemon
+        reload` and matches the sibling plans deliberately.
 
     - path: "docs/brainstorming/**/*.md"
       instructions: >-
         Design documents under revision, held to the same standard as the
-        plans above: factual drift only, and the terminology rule does not
-        reach them.
+        plans: factual drift only, and the terminology rule does not reach
+        them either.
 
     - path: "web/**/*.md"
       instructions: >-


### PR DESCRIPTION
Follow-up to #82, which merged before this landed.

CodeRabbit applies every matching path instruction, not the most specific one. #82 was designed on the opposite assumption, that a narrower glob overrides a wider one the way gitignore and CSS do.

So a published page under `web/` matched both the generic `**/*.md` rule and the new `web/**/*.md` one and received both. The generic said "flag only factual drift" while the specific said terminology applies in full, which is a reviewer told to enforce a rule and ignore it at once. Since the point of #82 was to keep terminology on published prose and lift it off working documents, that got the published half backwards.

- the blocks are additive now rather than a precedence chain, which is what they always were
- the generic block carries only what is true of every markdown file here
- "factual drift only" moved onto the two paths that want it, the plans and the brainstorming specs
- the mechanism is written into the file above the blocks, because the next person to add a markdown rule will reach for precedence too

Also fixes a stale cross-reference #82 introduced. The plans rule said "the terminology rule below does not apply here" when that rule had just moved into a sibling block that does not match plan files at all.

Found by CodeRabbit on #82 and rated Major, which was the right call.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Markdown review guidance to better distinguish general editing rules from factual-accuracy checks for writing plans and brainstorming documents.
  * Refined terminology-related review behavior for document-specific guidance.
  * No user-facing product functionality or public API changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->