### PR TITLE
test(cli): give the held-pipe case a budget a shared runner can meet

### DIFF
--- a/crates/shep-cli/src/commands/lifecycle.rs
+++ b/crates/shep-cli/src/commands/lifecycle.rs
@@ -3363,8 +3363,11 @@ mod tests {
     /// the coverage job) while passing every local run: node took longer than
     /// that to come up, so the run hit the deadline still running and shep
     /// reported the kill it really had performed. The tier exists for exactly
-    /// this, and the budget here is 5s because a stalled read waits out
-    /// whatever is left of it, so the budget IS what the test costs.
+    /// this, and the budget here is 20s: a stalled read waits out whatever
+    /// is left of it, so the budget IS what the test costs. Raised from 5s
+    /// on 2026-08-31 after four CI failures, and the twenty seconds it now
+    /// spends every run is the price of a red board that means something.
+    /// See `HELD_PIPE_BUDGET` below for both ends of the number.
     mod slow {
         use super::*;
 

--- a/crates/shep-cli/src/commands/lifecycle.rs
+++ b/crates/shep-cli/src/commands/lifecycle.rs
@@ -3394,7 +3394,22 @@ mod tests {
             )
             .unwrap();
 
-            let err = evaluate_js_flockfile(&path, Duration::from_secs(5)).unwrap_err();
+            // Twenty seconds, and both ends of that are load-bearing.
+            //
+            // The floor: five seconds was the budget until 2026-08-31 and it
+            // failed on CI four times, twice noted in the comment above and
+            // twice more on `slow (windows-latest)`. The slowest observed
+            // run took 11.41s. This is not a claim about shep, it is a claim
+            // about how long a shared runner takes to start a node process
+            // and notice a held pipe, so it wants headroom rather than
+            // precision.
+            //
+            // The ceiling: the pipe-holder above lives 30 seconds. A budget
+            // at or past that would let the child exit on its own, and the
+            // case would pass for the wrong reason.
+            const HELD_PIPE_BUDGET: Duration = Duration::from_secs(20);
+
+            let err = evaluate_js_flockfile(&path, HELD_PIPE_BUDGET).unwrap_err();
 
             assert_eq!(target_exit_code(&err), ExitCode::InvalidConfig);
             let message = err.to_string();


### PR DESCRIPTION
`a_js_flockfile_leaving_a_process_on_the_pipe_says_that_instead` has failed on CI four times: twice recorded in its own fixture comment, and twice more on `slow (windows-latest)` during the 2c work.

Five seconds was never a claim about shep. It is a claim about how long a shared runner takes to start a node process, spawn a detached child from it, and notice that child still holds the parent's stdout. The slowest observed run took 11.41s.

- budget raised to 20s, as a named const rather than an inline literal
- the floor is the observed worst case with headroom
- the ceiling is the fixture's own child, which lives 30 seconds. A budget at or past that would let the child exit on its own and the case would pass for the wrong reason

The cost is real and worth stating: this case now takes the full 20 seconds every run, because detecting a held pipe means waiting out the budget. That is 15 seconds added to the slow tier, which is already the slowest job.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Increased the evaluation time allowed for a slow JavaScript lifecycle test.
  * Added documentation explaining the timing adjustment for more reliable execution in slower CI environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->