### PR TITLE
feat(handover): carry a dog across the exec, and give it a connection that survives

### DIFF
--- a/crates/shep-cli/src/commands/daemon.rs
+++ b/crates/shep-cli/src/commands/daemon.rs
@@ -960,16 +960,152 @@ async fn stop_and_start(
 /// meets a daemon not yet ready to serve one. A plain `ListFlock` is what
 /// the handover arm actually wants: it reports, and asks for nothing.
 async fn report_reload(client: &Client, streams: &mut Streams<'_>, restored: bool) -> ExitCode {
+    report_reload_waiting(client, streams, restored, DOG_SETTLE_WAIT).await
+}
+
+/// As [`report_reload`], but with a caller-chosen dog wait — the same
+/// injectable-timing shape [`reload_with_wait`] carries, and for the same
+/// reason.
+async fn report_reload_waiting(
+    client: &Client,
+    streams: &mut Streams<'_>,
+    restored: bool,
+    dog_wait: std::time::Duration,
+) -> ExitCode {
     let shepherd = client.daemon();
     let message = format!(
         "the shepherd is now {} (pid {})",
         shepherd.daemon_version, shepherd.pid
     );
     streams.aside("reload", &message);
+    report_dog_staleness(client, streams, &shepherd.daemon_version, dog_wait).await;
     if restored {
         return muster::muster(client, streams).await;
     }
     crate::commands::query::flock(client, streams).await
+}
+
+/// How long a reload waits for the flock's dogs to finish reconnecting
+/// before it reports what came back.
+///
+/// Sized against the round trip it has to outlast, which is not the
+/// reconnect: a dog refused on the handshake is restarted once from the
+/// binary on disk (G8), and only the SECOND refusal — after a full kill
+/// ladder and a fresh spawn — is what makes it stale. A budget shorter
+/// than that would report every stale dog as healthy, which is the
+/// failure this whole reading exists to avoid.
+///
+/// Only ever paid when a dog has not answered. An ordinary reload finds
+/// nothing pending on its first ask and spends none of this.
+const DOG_SETTLE_WAIT: std::time::Duration = std::time::Duration::from_secs(3);
+
+/// Gap between [`report_dog_staleness`]'s asks. Coarser than
+/// [`SUCCESSOR_POLL_INTERVAL`], because what this waits on is a process
+/// being killed and respawned rather than an `execve`.
+const DOG_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_millis(50);
+
+/// Reports the dogs that could not come back, once the shepherd has heard
+/// from all of them.
+///
+/// **The waiting is the point** (spec G13). A dog's recorded crate version
+/// describes the process that was running when it connected, so before a
+/// reload it is evidence about something about to stop existing, and a
+/// report taken then is a claim rather than a finding. Afterwards the same
+/// question has a real answer — this shepherd either accepted the dog's
+/// handshake or refused it — and asking early would get the answer for the
+/// wrong daemon. So this asks, waits while anything is unsettled, and asks
+/// again.
+///
+/// **Silent unless something is wrong.** A flock whose dogs all came back
+/// prints nothing at all: the sentence an operator wants after a reload is
+/// the shepherd's version and their own flock, and a line-per-reload
+/// saying the dogs are fine would bury both.
+///
+/// **What it does not say.** That a dog is stale is a fact about two
+/// refused handshakes, not about the binary on disk — shep never reads
+/// that file's version, and cannot, until a dog answers `--version` (G11,
+/// a later phase). So the sentence reports what happened and suggests a
+/// remedy; it never promises the remedy will work.
+///
+/// A shepherd that will not answer is left alone rather than reported. The
+/// reload itself has already succeeded by the time this runs, and a dog
+/// reading that could not be taken is not a reason to say anything about
+/// the dogs.
+async fn report_dog_staleness(
+    client: &Client,
+    streams: &mut Streams<'_>,
+    daemon_version: &str,
+    wait: std::time::Duration,
+) {
+    let deadline = tokio::time::Instant::now() + wait;
+    loop {
+        let Ok(shep_core::protocol::Response::DogStaleness { stale, pending }) = client
+            .request(shep_core::protocol::Request::DogStaleness)
+            .await
+        else {
+            return;
+        };
+        let out_of_time = tokio::time::Instant::now() >= deadline;
+        if pending.is_empty() || out_of_time {
+            if !stale.is_empty() {
+                streams.aside("reload", &stale_dog_report(&stale, daemon_version));
+            }
+            if out_of_time && !pending.is_empty() {
+                streams.aside("reload", &unsettled_dog_report(&pending, wait));
+            }
+            return;
+        }
+        tokio::time::sleep(DOG_POLL_INTERVAL).await;
+    }
+}
+
+/// The sentence naming the dogs this shepherd has given up on.
+///
+/// Two whole sentences rather than one with the number interpolated
+/// through it: the singular and the plural differ in four places, and a
+/// reader checking the wording should not have to run the ternaries in
+/// their head to see what either one says.
+fn stale_dog_report(stale: &[String], daemon_version: &str) -> String {
+    match stale {
+        [only] => format!(
+            "the `{only}` dog cannot talk to this shepherd; restarting it from the binary on \
+             disk did not help, so rebuild or reinstall it against shep {daemon_version}"
+        ),
+        many => format!(
+            "these dogs cannot talk to this shepherd: {}; restarting them from the binaries on \
+             disk did not help, so rebuild or reinstall them against shep {daemon_version}",
+            quoted_names(many)
+        ),
+    }
+}
+
+/// The sentence for dogs that never finished settling inside the budget.
+///
+/// Said out loud rather than folded into silence, because silence here
+/// would mean the same thing as a clean reload and this is not one: the
+/// reading was taken before these dogs had answered, so it speaks for the
+/// rest of the flock and not for them.
+fn unsettled_dog_report(pending: &[String], wait: std::time::Duration) -> String {
+    match pending {
+        [only] => format!(
+            "the `{only}` dog had not answered this shepherd after {wait:?}, so this reload \
+             cannot say whether it came back"
+        ),
+        many => format!(
+            "these dogs had not answered this shepherd after {wait:?}, so this reload cannot say \
+             whether they came back: {}",
+            quoted_names(many)
+        ),
+    }
+}
+
+/// `` `a`, `b`, `c` `` — the list shape both sentences above end on.
+fn quoted_names(names: &[String]) -> String {
+    names
+        .iter()
+        .map(|name| format!("`{name}`"))
+        .collect::<Vec<_>>()
+        .join(", ")
 }
 
 #[cfg(test)]
@@ -1626,6 +1762,194 @@ otel = "/usr/local/bin/shep-otel"
         // No shepherd owns this home, so the stop arm it fell back to has
         // nothing to stop -- which is what proves it took that arm at all.
         assert_eq!(code, ExitCode::DaemonUnreachable, "{text}");
+    }
+
+    /// fails if the dog reading is taken before the dogs have answered —
+    /// which is the whole of G13. The shepherd here reports `metrics` as
+    /// unsettled twice and stale on the third ask, so the two answers
+    /// genuinely DIFFER: a report taken on the first ask says nothing at
+    /// all, and only one taken after the dog has finished settling names
+    /// it. Both halves are asserted, because a reload that asked once and
+    /// happened to catch the third answer would pass the output check on
+    /// its own.
+    #[tokio::test]
+    async fn a_reload_waits_for_a_pending_dog_before_it_reports_staleness() {
+        let dir = tempfile::tempdir().unwrap();
+        let addr = shep_client::testing::control_address(dir.path());
+        let asks = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let counted = std::sync::Arc::clone(&asks);
+        let (client, _envelopes) = shep_client::testing::fake_client_answering(&addr, move |req| {
+            if !matches!(req, Request::DogStaleness) {
+                return Response::Mustered(vec![]);
+            }
+            let seen = counted.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            if seen < 2 {
+                Response::DogStaleness {
+                    stale: vec![],
+                    pending: vec!["metrics".to_string()],
+                }
+            } else {
+                Response::DogStaleness {
+                    stale: vec!["metrics".to_string()],
+                    pending: vec![],
+                }
+            }
+        })
+        .await;
+
+        let mut out = Vec::new();
+        let mut err = Vec::new();
+        {
+            let mut streams = Streams {
+                out: &mut out,
+                err: &mut err,
+                style: crate::style::Presentation::BARE,
+                fmt: Format::Table,
+            };
+            report_reload_waiting(
+                &client,
+                &mut streams,
+                true,
+                std::time::Duration::from_secs(3),
+            )
+            .await;
+        }
+
+        let text = String::from_utf8(err).unwrap();
+        assert!(
+            text.contains("metrics") && text.contains("rebuild or reinstall"),
+            "the dog that could not come back must be named: {text}"
+        );
+        assert!(
+            asks.load(std::sync::atomic::Ordering::SeqCst) >= 3,
+            "an answer taken on the first ask is a claim about a dog that had not spoken"
+        );
+    }
+
+    /// fails if an ordinary reload starts talking about dogs. Every reload
+    /// on a healthy flock takes this path, so a line here is a line the
+    /// operator reads every time — and the two facts they ran the verb for,
+    /// the shepherd's version and their own flock, are the ones it would
+    /// bury.
+    #[tokio::test]
+    async fn a_reload_whose_dogs_all_answered_says_nothing_about_them() {
+        let dir = tempfile::tempdir().unwrap();
+        let addr = shep_client::testing::control_address(dir.path());
+        let (client, _envelopes) = shep_client::testing::fake_client_answering(&addr, |req| {
+            if matches!(req, Request::DogStaleness) {
+                Response::DogStaleness {
+                    stale: vec![],
+                    pending: vec![],
+                }
+            } else {
+                Response::Mustered(vec![shep_client::testing::sample_info()])
+            }
+        })
+        .await;
+
+        let mut out = Vec::new();
+        let mut err = Vec::new();
+        {
+            let mut streams = Streams {
+                out: &mut out,
+                err: &mut err,
+                style: crate::style::Presentation::BARE,
+                fmt: Format::Table,
+            };
+            report_reload_waiting(
+                &client,
+                &mut streams,
+                true,
+                std::time::Duration::from_secs(3),
+            )
+            .await;
+        }
+
+        let text = format!(
+            "{}{}",
+            String::from_utf8(out).unwrap(),
+            String::from_utf8(err).unwrap()
+        );
+        assert!(
+            !text.contains("dog"),
+            "a flock whose dogs all came back has nothing to say about them: {text}"
+        );
+    }
+
+    /// fails if a dog that never answers hangs the verb, or is silently
+    /// counted as healthy. Both outcomes are wrong in opposite directions:
+    /// the reload has already succeeded, so it must finish, and the reading
+    /// it took cannot speak for a dog that never spoke.
+    #[tokio::test]
+    async fn a_reload_stops_waiting_for_a_dog_that_never_answers() {
+        let dir = tempfile::tempdir().unwrap();
+        let addr = shep_client::testing::control_address(dir.path());
+        let (client, _envelopes) = shep_client::testing::fake_client_answering(&addr, |req| {
+            if matches!(req, Request::DogStaleness) {
+                Response::DogStaleness {
+                    stale: vec![],
+                    pending: vec!["metrics".to_string()],
+                }
+            } else {
+                Response::Mustered(vec![])
+            }
+        })
+        .await;
+
+        let mut out = Vec::new();
+        let mut err = Vec::new();
+        {
+            let mut streams = Streams {
+                out: &mut out,
+                err: &mut err,
+                style: crate::style::Presentation::BARE,
+                fmt: Format::Table,
+            };
+            // The forcing mechanism (IR-46), and the assertion at the same
+            // time: a budget that is never consulted loops forever, and a
+            // test that waited for it would hang the suite rather than
+            // report which line is wrong.
+            tokio::time::timeout(
+                std::time::Duration::from_secs(5),
+                report_reload_waiting(
+                    &client,
+                    &mut streams,
+                    true,
+                    std::time::Duration::from_millis(150),
+                ),
+            )
+            .await
+            .expect("a dog that never answers must not hold the verb open");
+        }
+
+        let text = String::from_utf8(err).unwrap();
+        assert!(
+            text.contains("metrics") && text.contains("cannot say whether it came back"),
+            "an unanswered dog is reported as unanswered, not as healthy: {text}"
+        );
+    }
+
+    /// fails if the report claims something shep did not do. It knows two
+    /// handshakes were refused and that a restart ran the binary on disk in
+    /// between; it does NOT know what version that file holds, and cannot
+    /// until a dog answers `--version` (G11, a later phase). Pinned as an
+    /// exact string in both shapes, because the singular and the plural are
+    /// written out separately and a copy-paste between them is invisible.
+    #[test]
+    fn the_stale_report_says_what_happened_and_never_reads_the_disk() {
+        let one = stale_dog_report(&["metrics".to_string()], "0.1.22");
+        assert_eq!(
+            one,
+            "the `metrics` dog cannot talk to this shepherd; restarting it from the binary on \
+             disk did not help, so rebuild or reinstall it against shep 0.1.22"
+        );
+
+        let two = stale_dog_report(&["bark".to_string(), "metrics".to_string()], "0.1.22");
+        assert_eq!(
+            two,
+            "these dogs cannot talk to this shepherd: `bark`, `metrics`; restarting them from \
+             the binaries on disk did not help, so rebuild or reinstall them against shep 0.1.22"
+        );
     }
 
     /// A [`HelloAck`] naming `version`, for the arm-selection tests.

--- a/crates/shep-cli/src/dog/bark/mod.rs
+++ b/crates/shep-cli/src/dog/bark/mod.rs
@@ -223,6 +223,28 @@ pub fn run_loop<E: EventSource, F: FlockSource>(
                 _ = sigterm.recv() => break,
                 next = events.next() => {
                     match next {
+                        // The stream belongs to one connection generation,
+                        // so this is "the shepherd this dog handshook with
+                        // is gone" -- which since phase 3 usually means it
+                        // exec'd a successor rather than that it died. The
+                        // dog exits 0 and `autorestart` replaces it, so it
+                        // comes back, at one restart per reload; the
+                        // metrics dog beside it holds its pid and its
+                        // `restarts 0` because `ReconnectingClient` dials
+                        // again underneath it.
+                        //
+                        // Deliberate and recorded, not an oversight. The
+                        // right answer is to re-subscribe here and then
+                        // `reconcile`, because a handover gap is the same
+                        // class of loss as the `Err(dropped)` arm below and
+                        // deserves the same "ask the shepherd what things
+                        // look like now" -- but it needs an
+                        // `EventSource::resubscribe`, an await-on-connected
+                        // that `ReconnectingClient` does not expose, and a
+                        // ruling on what an ORPHANED dog does, which is a
+                        // question about every dog. See "The bark dog still
+                        // restarts once per reload" in `docs/specs/
+                        // deferred.md`.
                         None => break,
                         Some(Ok(event)) => {
                             let firings = rules.on_event(&event, now_ms());

--- a/crates/shep-cli/src/dog/bark/mod.rs
+++ b/crates/shep-cli/src/dog/bark/mod.rs
@@ -242,9 +242,9 @@ pub fn run_loop<E: EventSource, F: FlockSource>(
                         // `EventSource::resubscribe`, an await-on-connected
                         // that `ReconnectingClient` does not expose, and a
                         // ruling on what an ORPHANED dog does, which is a
-                        // question about every dog. See "The bark dog still
-                        // restarts once per reload" in `docs/specs/
-                        // deferred.md`.
+                        // question about every dog. `docs/specs/deferred.md`
+                        // carries it, under "The bark dog still restarts
+                        // once per reload".
                         None => break,
                         Some(Ok(event)) => {
                             let firings = rules.on_event(&event, now_ms());

--- a/crates/shep-cli/src/dog/metrics/mod.rs
+++ b/crates/shep-cli/src/dog/metrics/mod.rs
@@ -16,7 +16,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use serde::Deserialize;
-use shep_client::Client;
+use shep_client::ReconnectingClient;
 use shep_core::protocol::{ProcessInfo, Request, Response};
 use sysinfo::{MemoryRefreshKind, ProcessRefreshKind, RefreshKind, System};
 use tokio::net::{TcpListener, TcpStream};
@@ -200,7 +200,7 @@ pub async fn run(runtime: DogRuntime) -> ExitCode {
 /// Never returns on its own — [`run`] races it against the two shutdown
 /// signals, and a test drives it directly, aborting the [`tokio::task::JoinHandle`]
 /// it comes back on rather than waiting for a return that never happens.
-async fn accept_forever(listener: TcpListener, client: Arc<Client>) {
+async fn accept_forever(listener: TcpListener, client: Arc<ReconnectingClient>) {
     loop {
         match listener.accept().await {
             Ok((stream, _peer)) => {
@@ -219,7 +219,7 @@ async fn accept_forever(listener: TcpListener, client: Arc<Client>) {
 /// who curls `/` is told where to look rather than handed the exposition
 /// from the wrong path, which is how a scrape config ends up depending on a
 /// path the next version does not serve.
-async fn handle_connection(mut stream: TcpStream, client: Arc<Client>) {
+async fn handle_connection(mut stream: TcpStream, client: Arc<ReconnectingClient>) {
     let request = match http::read_request(&mut stream, READ_TIMEOUT).await {
         Ok(request) => request,
         // A peer that never finished a request (timed out, sent garbage,
@@ -263,10 +263,15 @@ async fn handle_connection(mut stream: TcpStream, client: Arc<Client>) {
         }
     };
 
+    // Read once, from the generation that just answered `ListFlock`.
+    // `ReconnectingClient::daemon` reports the daemon answering RIGHT NOW,
+    // so two separate reads either side of a handover could publish one
+    // daemon's version beside another's pid.
+    let ack = client.daemon();
     let reading = Reading {
         flock,
-        daemon_version: client.daemon().daemon_version.clone(),
-        daemon_pid: client.daemon().pid,
+        daemon_version: ack.daemon_version,
+        daemon_pid: ack.pid,
         host: sample_host(),
     };
     let body = exposition::render(&reading);
@@ -283,8 +288,10 @@ async fn handle_connection(mut stream: TcpStream, client: Arc<Client>) {
 mod tests {
     use std::time::Duration;
 
-    use shep_client::testing::{fake_client_on, fake_client_that_dies_mid_request};
-    use shep_core::protocol::ProcessInfo;
+    use shep_client::testing::{
+        Handshake, fake_daemon_across_handovers, fake_reconnecting_client_on, sample_ack,
+    };
+    use shep_core::protocol::{HelloAck, PROTOCOL_VERSION, ProcessInfo};
     use shep_core::status::ProcStatus;
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
     use tokio::task::JoinHandle;
@@ -328,7 +335,7 @@ mod tests {
     /// port, which is how a test suite starts failing on a developer's
     /// machine for reasons unrelated to the change), reads back the
     /// OS-assigned address, and serves `client` on it in the background.
-    async fn serve_on_free_port(client: Client, config: MetricsConfig) -> RunningDog {
+    async fn serve_on_free_port(client: ReconnectingClient, config: MetricsConfig) -> RunningDog {
         let listener = TcpListener::bind(config.bind).await.unwrap();
         let addr = listener.local_addr().unwrap();
         let handle = tokio::spawn(accept_forever(listener, Arc::new(client)));
@@ -369,7 +376,7 @@ mod tests {
     async fn every_scrape_asks_the_shepherd_again() {
         let dir = tempfile::tempdir().unwrap();
         let socket = shep_client::testing::control_address(dir.path());
-        let (client, daemon) = fake_client_on(&socket).await;
+        let (client, daemon) = fake_reconnecting_client_on(&socket).await;
         daemon.reply_to_list_sequence(vec![
             vec![sample_info("web")],
             vec![sample_info("web"), sample_info("api")],
@@ -409,19 +416,89 @@ mod tests {
     /// indistinguishable from a real one; a 503 is `up == 0`, which is what
     /// happened.
     ///
-    /// `fake_client_that_dies_mid_request` reads exactly one envelope (this
-    /// dog's own `ListFlock`) and drops the connection without a reply —
-    /// the shepherd accepted the request and then never answered it, which
-    /// is "will not answer" without needing a real timeout to prove it.
+    /// `cut_on_next_request` makes the shepherd read exactly one envelope
+    /// (this dog's own `ListFlock`) and drop the connection without a reply
+    /// — the shepherd accepted the request and then never answered it,
+    /// which is "will not answer" without needing a real timeout to prove
+    /// it. It is also the exact shape a daemon handover produces, so this
+    /// pins the OTHER half of the reconnect contract: the request that was
+    /// in flight still fails. Only the connection is re-established, never
+    /// the request (the design's H2).
     #[tokio::test]
     async fn a_shepherd_that_will_not_answer_produces_a_503() {
         let dir = tempfile::tempdir().unwrap();
         let socket = shep_client::testing::control_address(dir.path());
-        let (client, _task) = fake_client_that_dies_mid_request(&socket).await;
+        let shepherds =
+            fake_daemon_across_handovers(&socket, vec![Handshake::Accept(sample_ack())]);
+        let client = ReconnectingClient::connect(&socket).await.unwrap();
         let dog = serve_on_free_port(client, MetricsConfig::default_on_port(0)).await;
+        shepherds.cut_on_next_request();
 
         let response = scrape(dog.addr(), "/metrics").await;
         assert!(response.starts_with("HTTP/1.1 503 "), "{response}");
+    }
+
+    /// fails if a reload leaves the dog mute. THE measured defect: a dog's
+    /// process crosses the shepherd's `execve` for free, but only the
+    /// listening socket crosses with it, so the accepted connection this
+    /// dog holds dies. Over six real reloads before this was supervised,
+    /// the metrics dog kept its pid, reported zero restarts, stayed
+    /// `online`, wrote nothing to stderr, and answered 503 to every scrape
+    /// for 6m 22s. A pid check cannot see any of that, which is why the
+    /// assertion here is a scrape and not a liveness probe.
+    #[tokio::test]
+    async fn a_scrape_after_a_handover_serves_the_successors_flock() {
+        let dir = tempfile::tempdir().unwrap();
+        let socket = shep_client::testing::control_address(dir.path());
+        let successor = HelloAck {
+            daemon_version: "0.2.0".into(),
+            protocol: PROTOCOL_VERSION,
+            pid: 5150,
+        };
+        let shepherds = fake_daemon_across_handovers(
+            &socket,
+            vec![
+                Handshake::Accept(sample_ack()),
+                Handshake::Accept(successor),
+            ],
+        );
+        shepherds.reply_to_list(vec![sample_info("web")]);
+        let client = ReconnectingClient::connect(&socket).await.unwrap();
+        let dog = serve_on_free_port(client, MetricsConfig::default_on_port(0)).await;
+
+        let before = scrape(dog.addr(), "/metrics").await;
+        assert!(before.starts_with("HTTP/1.1 200 "), "{before}");
+        assert!(
+            before.contains(r#"shep_daemon_up{version="9.9.9"}"#),
+            "{before}"
+        );
+
+        shepherds.cut().await;
+
+        // The dog is scraped until the successor answers, bounded — a
+        // scrape landing inside the reconnect window legitimately 503s, and
+        // the contract is that the dog RECOVERS, not that it never misses a
+        // beat. Before this task that loop ran out every time.
+        let recovered = tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                let body = scrape(dog.addr(), "/metrics").await;
+                if body.starts_with("HTTP/1.1 200 ") {
+                    return body;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("the dog must answer 200 again after its shepherd is replaced");
+
+        assert!(
+            recovered.contains(r#"sheep="web""#),
+            "the exposition must carry the successor's flock: {recovered}"
+        );
+        assert!(
+            recovered.contains(r#"shep_daemon_up{version="0.2.0"}"#),
+            "the exposition must name the daemon now running, not the one              that was replaced: {recovered}"
+        );
     }
 
     /// fails if any path serves the exposition. A scrape config that
@@ -431,7 +508,7 @@ mod tests {
     async fn only_the_metrics_path_serves_metrics() {
         let dir = tempfile::tempdir().unwrap();
         let socket = shep_client::testing::control_address(dir.path());
-        let (client, _daemon) = fake_client_on(&socket).await;
+        let (client, _daemon) = fake_reconnecting_client_on(&socket).await;
         let dog = serve_on_free_port(client, MetricsConfig::default_on_port(0)).await;
 
         let root = scrape(dog.addr(), "/").await;

--- a/crates/shep-cli/src/dog/mod.rs
+++ b/crates/shep-cli/src/dog/mod.rs
@@ -201,6 +201,10 @@ impl DogRuntime {
     /// # Errors
     /// - [`DogRunError::Connect`] — no shepherd answered at the socket.
     /// - [`DogRunError::Request`] — the shepherd refused the config request.
+    /// - [`DogRunError::UnexpectedReply`] — the shepherd answered
+    ///   `Request::DogConfig` with something other than
+    ///   `Response::DogSection`. Its own doc explains why a same-version
+    ///   shepherd never sends it.
     pub async fn start(name: &str, paths: ShepPaths) -> Result<Self, DogRunError> {
         let client = ReconnectingClient::connect_as_dog(&paths.socket, name).await?;
         let response = client

--- a/crates/shep-cli/src/dog/mod.rs
+++ b/crates/shep-cli/src/dog/mod.rs
@@ -22,15 +22,15 @@
 //! same connection. [`ClientFlockSource`] and the [`bark::EventSource`]
 //! impl for [`shep_client::EventStream`] both live here rather than in
 //! `bark::mod` itself, because both are thin adapters over
-//! [`shep_client::Client`], the type this module already owns through
-//! [`DogRuntime`].
+//! [`shep_client::ReconnectingClient`], the type this module already owns
+//! through [`DogRuntime`].
 
 pub mod bark;
 pub mod metrics;
 
 use core::fmt;
 
-use shep_client::{Client, ConnectError, EventStream, RequestError};
+use shep_client::{ConnectError, EventStream, ReconnectingClient, RequestError};
 use shep_core::paths::ShepPaths;
 use shep_core::protocol::{BusEvent, ProcessInfo, Request, Response, RpcError, RpcErrorCode};
 
@@ -56,7 +56,20 @@ const BUILT_IN_DOGS: [&str; 2] = ["metrics", "bark"];
 /// here is deferred or made optional.
 pub struct DogRuntime {
     /// The connected client. A dog IS a client; there is no second protocol.
-    pub client: Client,
+    ///
+    /// A [`ReconnectingClient`] rather than a bare
+    /// [`Client`](shep_client::Client), and that is the difference between
+    /// a dog that crosses a daemon handover and one that does not. A dog's
+    /// process survives the shepherd's `execve` for free — it is a child of
+    /// a daemon whose pid does not change — but only the LISTENING socket
+    /// crosses that exec, so the accepted connection underneath this field
+    /// dies every time an operator reloads. Measured over six real reloads
+    /// before this was supervised: the metrics dog kept its pid, reported
+    /// zero restarts, stayed `online`, wrote nothing to stderr, and
+    /// answered HTTP 503 to every scrape. The CLI keeps the bare `Client`
+    /// deliberately; see `shep_client`'s own `reconnect` module docs for
+    /// why one-shot verbs must not gain this.
+    pub client: ReconnectingClient,
     /// This dog's `[dog.<name>]` section, exactly as the shepherd rendered
     /// it, for the dog to parse into its own shape. Empty when the file has
     /// no such section.
@@ -183,7 +196,7 @@ impl DogRuntime {
     /// - [`DogRunError::Connect`] — no shepherd answered at the socket.
     /// - [`DogRunError::Request`] — the shepherd refused the config request.
     pub async fn start(name: &str, paths: ShepPaths) -> Result<Self, DogRunError> {
-        let client = Client::connect(&paths.socket).await?;
+        let client = ReconnectingClient::connect(&paths.socket).await?;
         let response = client
             .request(Request::DogConfig {
                 name: name.to_string(),
@@ -350,11 +363,11 @@ impl bark::EventSource for EventStream {
     }
 }
 
-/// Wraps [`Client`] as [`bark::FlockSource`]: `Request::ListFlock`, mapped
+/// Wraps [`ReconnectingClient`] as [`bark::FlockSource`]: `Request::ListFlock`, mapped
 /// into the shape [`bark::run_loop`] can poll without a socket of its own —
 /// the same reason [`bark::EventSource`] exists for the subscription side.
 struct ClientFlockSource {
-    client: Client,
+    client: ReconnectingClient,
 }
 
 impl bark::FlockSource for ClientFlockSource {
@@ -381,7 +394,7 @@ mod tests {
     use std::path::{Path, PathBuf};
     use std::time::Duration;
 
-    use shep_client::testing::{fake_client_on, sample_ack, serve_one_request};
+    use shep_client::testing::{fake_reconnecting_client_on, sample_ack, serve_one_request};
 
     use super::*;
 
@@ -407,7 +420,7 @@ mod tests {
     /// Builds a [`DogRuntime`] carrying `section`, backed by a real (if
     /// otherwise unused) connection — [`DogRuntime::config`] never touches
     /// `client`, but the field has to hold a real one, so this reaches for
-    /// the lightest fixture that produces one ([`fake_client_on`]) rather
+    /// the lightest fixture that produces one ([`fake_reconnecting_client_on`]) rather
     /// than growing a second connection double. Bridges into its own fresh
     /// Tokio runtime rather than being `async` itself, so call sites stay
     /// plain `#[test]`s — matching `config`, which is sync.
@@ -415,7 +428,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let socket = shep_client::testing::control_address(dir.path());
         tokio::runtime::Runtime::new().unwrap().block_on(async {
-            let (client, _daemon) = fake_client_on(&socket).await;
+            let (client, _daemon) = fake_reconnecting_client_on(&socket).await;
             DogRuntime {
                 client,
                 section: section.to_string(),

--- a/crates/shep-cli/src/dog/mod.rs
+++ b/crates/shep-cli/src/dog/mod.rs
@@ -192,11 +192,17 @@ impl From<RequestError> for DogRunError {
 impl DogRuntime {
     /// Connects and fetches `name`'s section.
     ///
+    /// Announces itself as the dog registered under `name`, so a daemon
+    /// that refuses this handshake on protocol skew knows which dog it just
+    /// refused and can restart it once from disk (the handover design's
+    /// G8). A refused handshake never reaches the `DogConfig` request
+    /// below, which is the only other place this name would have travelled.
+    ///
     /// # Errors
     /// - [`DogRunError::Connect`] — no shepherd answered at the socket.
     /// - [`DogRunError::Request`] — the shepherd refused the config request.
     pub async fn start(name: &str, paths: ShepPaths) -> Result<Self, DogRunError> {
-        let client = ReconnectingClient::connect(&paths.socket).await?;
+        let client = ReconnectingClient::connect_as_dog(&paths.socket, name).await?;
         let response = client
             .request(Request::DogConfig {
                 name: name.to_string(),
@@ -488,6 +494,37 @@ mod tests {
         assert_eq!(
             runtime.section,
             "webhook = \"https://example.invalid/hook\"\n"
+        );
+    }
+
+    /// fails if a dog connects anonymously. The name in the `Hello` is the
+    /// only thing a daemon that REFUSES this handshake has to work with —
+    /// the `DogConfig` request below never happens on that path — so a dog
+    /// that named itself in the request and not in the handshake would
+    /// leave the shepherd unable to say which dog went stale, or to restart
+    /// it from disk (the handover design's G8).
+    ///
+    /// The fake closes right after acking, so the `DogConfig` request that
+    /// follows fails and `start` returns an error. That is not what this
+    /// asserts on: the handshake has already happened by then, and it is
+    /// the frame under test.
+    #[tokio::test]
+    async fn a_dog_announces_its_own_name_at_the_handshake() {
+        let dir = tempfile::tempdir().unwrap();
+        let socket = shep_client::testing::control_address(dir.path());
+        let served = shep_client::testing::fake_daemon(&socket, Ok(sample_ack())).await;
+        let paths = test_paths(dir.path(), socket);
+
+        let _started = DogRuntime::start("bark", paths).await;
+
+        let hello = tokio::time::timeout(Duration::from_secs(5), served)
+            .await
+            .expect("DogRuntime::start must reach the wire; it hung instead of connecting")
+            .unwrap();
+        assert_eq!(
+            hello.dog_name.as_deref(),
+            Some("bark"),
+            "a dog must announce the name it was registered under"
         );
     }
 

--- a/crates/shep-cli/tests/cli_e2e.rs
+++ b/crates/shep-cli/tests/cli_e2e.rs
@@ -4731,6 +4731,231 @@ fn a_real_shepherd_runs_a_real_metrics_dog_that_answers_a_scrape() {
 }
 
 #[cfg(unix)]
+/// [`poll_metrics`], retried until the exposition CONTAINS `needle` rather
+/// than merely until it answers.
+///
+/// The distinction is the whole of what a carried dog needs proving about
+/// it. A dog that survived the exec holding a dead socket answers 503
+/// forever, so "it answered" is already worth asserting -- but a dog that
+/// answered from a cached reading, or from a connection to a shepherd that
+/// no longer exists, would answer 200 too. Only content the predecessor
+/// never saw can tell those apart.
+///
+/// Bounded exactly as [`poll_metrics`] is, and for the same reason: a dog
+/// that never comes back must fail as a named assertion on the last body
+/// it did produce, never hang the case.
+fn poll_metrics_containing(addr: std::net::SocketAddr, needle: &str) -> String {
+    let start = Instant::now();
+    let mut last = String::new();
+    loop {
+        if let Ok(body) = scrape_metrics(addr) {
+            if body.contains(needle) {
+                return body;
+            }
+            last = body;
+        }
+        if start.elapsed() >= METRICS_SCRAPE_DEADLINE {
+            return last;
+        }
+        std::thread::sleep(METRICS_SCRAPE_POLL_INTERVAL);
+    }
+}
+
+#[cfg(unix)]
+/// The whole of phase 3, at the only tier that can see it: a real dog
+/// PROCESS, carried across a real `execve`, still able to talk to the
+/// shepherd that replaced the one it handshook with.
+///
+/// **A pid check cannot see this defect, which is why every assertion below
+/// the pids is here.** Carrying a dog's process is free -- it is a child of
+/// a daemon whose pid does not change -- and carrying its accepted
+/// connection is impossible, so a carried dog was a live process holding a
+/// dead socket: pid unmoved, restarts 0, status `online`, stderr empty, and
+/// HTTP 503 to every scrape, for as long as the daemon lived. Six real
+/// reloads read exactly like a healthy dog on every column a listing has.
+///
+/// So the decisive assertion is CONTENT: a sheep started AFTER the reload
+/// has to appear in the exposition. No cached reading, no replayed body and
+/// no connection to the predecessor could produce that row.
+///
+/// Three more things this case pins, each of which was broken at some point
+/// in the phase and none of which a scrape would notice:
+///
+/// - the dog keeps its `dog` marker across the blob, so `shep dogs` still
+///   lists it and `shep flock`'s table does not (`CarriedSheep::dog`);
+/// - neither restart count moves, which is what G7 asks for and what
+///   separates a carry from the stop-and-start arm;
+/// - the reload says nothing about the dogs, because it waited for them and
+///   found nothing stale (`report_dog_staleness`).
+#[test]
+fn a_carried_dog_answers_a_scrape_after_a_real_reload() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path();
+    let port = free_port();
+    write_shep_toml(
+        &dir,
+        &format!("[dog.metrics]\nbind = \"127.0.0.1:{port}\"\n"),
+    );
+    let script = write_test_script(&dir);
+    let mut guard = DaemonGuard::default();
+
+    let started = shep(home)
+        .arg("start")
+        .arg(&script)
+        .arg("--name")
+        .arg("web")
+        .output()
+        .unwrap();
+    guard.adopt_home(home);
+    assert_success(&started);
+    let online = poll_flock(home, |info| info["status"] == "online");
+    let sheep_pid = online["pid"].as_u64().expect("an online sheep has a pid");
+
+    let enabled = shep(home).arg("enable").arg("metrics").output().unwrap();
+    assert_success(&enabled);
+    let dog_pid = wait_for_dog_pid(home, "metrics");
+    guard.adopt_dog_pid(dog_pid);
+
+    let addr = std::net::SocketAddr::from(([127, 0, 0, 1], port));
+    let before = poll_metrics(addr);
+    assert!(
+        before.contains("HTTP/1.1 200"),
+        "the dog must be answering BEFORE the reload, or this case proves nothing: {before}"
+    );
+
+    let reloaded = shep(home).arg("daemon").arg("reload").output().unwrap();
+    assert_success(&reloaded);
+    let text = format!(
+        "{}{}",
+        String::from_utf8_lossy(&reloaded.stdout),
+        String::from_utf8_lossy(&reloaded.stderr)
+    );
+    // The exact sentence `handover::RefusedReason`'s `Display` ends with. A
+    // looser probe would pass whether or not the reload was refused, which
+    // is precisely the failure this assertion exists to catch: the stop arm
+    // restarts every dog from disk and satisfies "the scrape works".
+    assert!(
+        !text.contains("falls back to a stop-and-start"),
+        "a flock with a dog in it is carried now, not refused: {text}"
+    );
+    assert!(
+        !text.contains("cannot talk to this shepherd"),
+        "the carried dog must reconnect rather than be reported stale: {text}"
+    );
+    assert!(
+        !text.contains("cannot say whether it came back"),
+        "the carried dog must answer inside the reload's own wait: {text}"
+    );
+
+    let after = poll_flock_data(home, FLOCK_DEADLINE, |data| {
+        data.as_array()
+            .is_some_and(|rows| rows.len() == 2 && rows.iter().all(|row| !row["pid"].is_null()))
+    });
+    let rows = after.as_array().expect("flock data is an array");
+    let dog_row = rows
+        .iter()
+        .find(|row| row["name"] == "metrics")
+        .unwrap_or_else(|| panic!("the dog must still be registered: {after}"));
+    let sheep_row = rows
+        .iter()
+        .find(|row| row["name"] == "web")
+        .unwrap_or_else(|| panic!("the sheep must still be registered: {after}"));
+
+    assert_eq!(
+        dog_row["pid"].as_u64(),
+        Some(u64::try_from(dog_pid.as_raw()).unwrap()),
+        "the dog was restarted rather than carried: {after}"
+    );
+    assert_eq!(
+        sheep_row["pid"].as_u64(),
+        Some(sheep_pid),
+        "the sheep was restarted rather than carried: {after}"
+    );
+    assert_eq!(
+        dog_row["restarts"], 0,
+        "the dog's restart count moved: {after}"
+    );
+    assert_eq!(
+        sheep_row["restarts"], 0,
+        "the sheep's restart count moved: {after}"
+    );
+    // The marker, which is what keeps the two populations apart. JSON
+    // carries both in one undivided array (`emit_flock`'s own doc), so this
+    // is where the marker is readable; the two TABLES below are what an
+    // operator actually sees it through.
+    assert_eq!(
+        dog_row["dog"]["kind"], "built_in",
+        "a carried dog that lost its marker is one `shep dogs` has lost: {after}"
+    );
+    assert!(
+        sheep_row["dog"].is_null(),
+        "a sheep must not pick a marker up on the way across: {after}"
+    );
+
+    let dogs = shep(home).arg("dogs").output().unwrap();
+    assert_success(&dogs);
+    assert!(
+        String::from_utf8_lossy(&dogs.stdout).contains("metrics"),
+        "`shep dogs` must still list the carried dog: {}",
+        String::from_utf8_lossy(&dogs.stdout)
+    );
+    let flock = shep(home).arg("flock").output().unwrap();
+    assert_success(&flock);
+    let flock_text = String::from_utf8_lossy(&flock.stdout);
+    let (sheep_table, _dogs_table) = flock_text
+        .split_once("Dogs")
+        .unwrap_or_else(|| panic!("`shep flock` prints a dogs section: {flock_text}"));
+    assert!(
+        !sheep_table.contains("metrics"),
+        "a carried dog must not be listed beside the operator's own apps: {flock_text}"
+    );
+
+    // The decisive one. A sheep that did not exist when the predecessor was
+    // running, named by the dog that is answering now.
+    let fresh = shep(home)
+        .arg("start")
+        .arg(&script)
+        .arg("--name")
+        .arg("freshsheep")
+        .output()
+        .unwrap();
+    assert_success(&fresh);
+    let body = poll_metrics_containing(addr, r#"sheep="freshsheep""#);
+    assert!(
+        body.contains("HTTP/1.1 200"),
+        "the carried dog must still answer a scrape after the exec: {body}"
+    );
+    assert!(
+        body.contains(r#"sheep="freshsheep""#),
+        "the exposition must name a sheep started AFTER the reload, which no cached reading \
+         and no connection to the predecessor could produce: {body}"
+    );
+
+    // The muster roll, which a successor rebuilds from the blob rather than
+    // from disk. A dog has never been in it -- `spawn_enabled_dogs`
+    // registers dogs straight through the supervisor and never touches
+    // `FlockRegistry` -- so carrying one would put it there for the first
+    // time, and permanently: the roll outlives the daemon, so a later cold
+    // boot would restore `metrics` as an ordinary unmarked sheep before
+    // `spawn_enabled_dogs` ran. `boot::apps_for_the_roll` has a unit case of
+    // its own; this is the only tier that reaches `boot`'s USE of it.
+    let saved = shep(home)
+        .arg("--format")
+        .arg("json")
+        .arg("save")
+        .output()
+        .unwrap();
+    assert_success(&saved);
+    let roll: serde_json::Value = serde_json::from_slice(&saved.stdout).unwrap();
+    assert_eq!(
+        roll["data"]["apps"], 2,
+        "the roll holds the two sheep and no dog: {roll}"
+    );
+
+    graceful_kill(home);
+}
+
+#[cfg(unix)]
 /// Fails if `shep dogs` renders the sheep, or `shep flock` renders the dogs
 /// into the sheep table. The two-table split (`FlockRows`/`DogRows`, and
 /// `emit_flock`'s partition between them) has unit coverage of its own;
@@ -7363,9 +7588,9 @@ fn a_clustered_flock_keeps_every_pid_and_every_slot_across_a_daemon_reload() {
         String::from_utf8_lossy(&reloaded.stderr)
     );
     // The exact sentence the gate prints when it refuses -- see
-    // `handover::RefusedReason`'s `Display`, which every feature variant
-    // ends with. A looser probe would pass whether or not the reload was
-    // refused, which is the failure this assertion is here to catch.
+    // `handover::RefusedReason`'s `Display`, which ends on it. A looser
+    // probe would pass whether or not the reload was refused, which is the
+    // failure this assertion is here to catch.
     assert!(
         !text.contains("falls back to a stop-and-start"),
         "a clustered flock is carried now, not refused: {text}"
@@ -8159,9 +8384,9 @@ fn a_flock_of_every_carried_kind_survives_a_daemon_reload() {
         String::from_utf8_lossy(&reloaded.stdout),
         String::from_utf8_lossy(&reloaded.stderr)
     );
-    // The exact sentence every feature variant of `handover::RefusedReason`
-    // ends with. Without this the case would pass on a stop-and-start, which
-    // restarts the flock and satisfies "everything still works".
+    // The exact sentence `handover::RefusedReason`'s `Display` ends with.
+    // Without this the case would pass on a stop-and-start, which restarts
+    // the flock and satisfies "everything still works".
     assert!(
         !text.contains("falls back to a stop-and-start"),
         "every kind in this flock is carried now, not refused: {text}"

--- a/crates/shep-client/src/client.rs
+++ b/crates/shep-client/src/client.rs
@@ -176,6 +176,25 @@ impl Client {
         &self.ack
     }
 
+    /// Resolves once this connection has ended — daemon exit, crash,
+    /// `execve`, a write failure, or a prior [`Self::close`].
+    ///
+    /// The actor task owns the receiving half of this client's command
+    /// channel and drops it when its loop ends, which is exactly the set of
+    /// conditions above, so awaiting the sender's own closure reports the
+    /// connection's death without a poll, a timer, or a probe request.
+    ///
+    /// Resolves immediately, not once, if the connection is already gone: a
+    /// caller may await it as many times as it likes.
+    ///
+    /// This is a *query*, not a recovery. Nothing here reconnects, and
+    /// [`Self::request`] does not retry — see
+    /// [`ReconnectingClient`](crate::ReconnectingClient) for the supervised
+    /// wrapper dogs use and the CLI deliberately does not.
+    pub async fn closed(&self) {
+        self.commands.closed().await;
+    }
+
     /// The path this client is connected through.
     ///
     /// `HelloAck` carries `daemon_version`, `protocol` and `pid` and

--- a/crates/shep-client/src/client.rs
+++ b/crates/shep-client/src/client.rs
@@ -160,7 +160,31 @@ impl Client {
         socket: &Path,
         timeout: Duration,
     ) -> Result<Self, ConnectError> {
-        let connection = Connection::open(socket, timeout).await?;
+        Self::connect_as(socket, timeout, None).await
+    }
+
+    /// As [`Self::connect_with_timeout`], but announcing this client as the
+    /// dog registered under `dog_name`.
+    ///
+    /// Crate-private on purpose, and that is the whole reason the CLI is
+    /// safe here. A `Hello` naming a dog is what lets the daemon restart
+    /// that dog when it refuses the handshake (the handover design's G8),
+    /// so a client that can claim a name it was not spawned as can have a
+    /// dog restarted on its say-so. No `shep` verb can: the public
+    /// constructors above pass `None` and there is no other door.
+    /// [`ReconnectingClient`](crate::ReconnectingClient), the type dogs
+    /// name and the CLI does not, is this function's only caller.
+    ///
+    /// # Errors
+    ///
+    /// See [`Self::connect_with_timeout`] — every error variant it can
+    /// return, this returns unchanged.
+    pub(crate) async fn connect_as(
+        socket: &Path,
+        timeout: Duration,
+        dog_name: Option<&str>,
+    ) -> Result<Self, ConnectError> {
+        let connection = Connection::open(socket, timeout, dog_name).await?;
         let (frames, ack) = connection.into_parts();
         let commands = actor::spawn(frames);
         Ok(Self {

--- a/crates/shep-client/src/connection.rs
+++ b/crates/shep-client/src/connection.rs
@@ -151,6 +151,12 @@ impl Connection {
     /// the whole attempt — connect, send [`Hello`], read the reply — by
     /// `timeout`.
     ///
+    /// `dog_name` is the name this client was registered under as a dog, or
+    /// `None` for every client that is not one. It travels in the `Hello`
+    /// so a daemon that REFUSES this handshake knows which dog it just
+    /// refused: a refused handshake never reaches a request, so nothing
+    /// later on the connection could tell it (the handover design's G8).
+    ///
     /// # Errors
     ///
     /// - [`ConnectError::Connect`] — `connect(2)` failed; nothing is
@@ -164,18 +170,22 @@ impl Connection {
     ///   `HelloReply` (or close) arrived within `timeout`.
     /// - [`ConnectError::ProtocolMismatch`] — the daemon refused the
     ///   handshake on protocol-version skew.
-    pub(crate) async fn open(socket: &Path, timeout: Duration) -> Result<Self, ConnectError> {
+    pub(crate) async fn open(
+        socket: &Path,
+        timeout: Duration,
+        dog_name: Option<&str>,
+    ) -> Result<Self, ConnectError> {
         // `timeout` bounds `connect(2)` and the handshake together, not just
         // the handshake — intentional, but barely testable over AF_UNIX (a
         // mutant moving `connect` outside this timeout still passes all
         // five tests below). Not directly covered; don't contort a test to
         // chase it.
-        tokio::time::timeout(timeout, Self::open_inner(socket))
+        tokio::time::timeout(timeout, Self::open_inner(socket, dog_name))
             .await
             .map_err(|_elapsed| ConnectError::HandshakeTimeout { after: timeout })?
     }
 
-    async fn open_inner(socket: &Path) -> Result<Self, ConnectError> {
+    async fn open_inner(socket: &Path, dog_name: Option<&str>) -> Result<Self, ConnectError> {
         let stream = transport::connect(socket)
             .await
             .map_err(|source| ConnectError::Connect {
@@ -187,6 +197,7 @@ impl Connection {
         let hello = Hello {
             client_version: env!("CARGO_PKG_VERSION").to_string(),
             protocol: PROTOCOL_VERSION,
+            dog_name: dog_name.map(str::to_owned),
         };
         let payload = encode_frame(&hello).map_err(ConnectError::Wire)?;
         frames.send(payload).await.map_err(ConnectError::Io)?;
@@ -238,7 +249,9 @@ mod tests {
         };
         let served = fake_daemon(&path, Ok(ack.clone())).await;
 
-        let conn = Connection::open(&path, HANDSHAKE_TIMEOUT).await.unwrap();
+        let conn = Connection::open(&path, HANDSHAKE_TIMEOUT, None)
+            .await
+            .unwrap();
 
         let (_frames, actual_ack) = conn.into_parts();
         assert_eq!(actual_ack, ack);
@@ -252,6 +265,34 @@ mod tests {
             env!("CARGO_PKG_VERSION"),
             "the client must identify its own version"
         );
+        assert_eq!(
+            hello.dog_name, None,
+            "a client that is not a dog must not claim to be one"
+        );
+    }
+
+    /// fails if a dog's name is dropped between [`Connection::open`]'s
+    /// argument and the frame that goes out. It is the whole of what the
+    /// daemon has to work with when it REFUSES this handshake, and a
+    /// refused handshake never reaches a request, so nothing later on the
+    /// connection could supply it (the handover design's G8).
+    #[tokio::test]
+    async fn a_dogs_hello_carries_the_name_it_was_registered_under() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = crate::testing::control_address(dir.path());
+        let ack = HelloAck {
+            daemon_version: "9.9.9".into(),
+            protocol: PROTOCOL_VERSION,
+            pid: 4242,
+        };
+        let served = fake_daemon(&path, Ok(ack)).await;
+
+        let _conn = Connection::open(&path, HANDSHAKE_TIMEOUT, Some("metrics"))
+            .await
+            .unwrap();
+
+        let hello = served.await.unwrap();
+        assert_eq!(hello.dog_name.as_deref(), Some("metrics"));
     }
 
     #[tokio::test]
@@ -265,7 +306,7 @@ mod tests {
         };
         let _served = fake_daemon(&path, Err(refusal)).await;
 
-        let err = Connection::open(&path, HANDSHAKE_TIMEOUT)
+        let err = Connection::open(&path, HANDSHAKE_TIMEOUT, None)
             .await
             .unwrap_err();
 
@@ -299,7 +340,7 @@ mod tests {
         };
         let _served = fake_daemon(&path, Err(refusal)).await;
 
-        let err = Connection::open(&path, HANDSHAKE_TIMEOUT)
+        let err = Connection::open(&path, HANDSHAKE_TIMEOUT, None)
             .await
             .unwrap_err();
 
@@ -329,7 +370,7 @@ mod tests {
         // `serde_json` to assert it with and does not need one.
         let _served = fake_daemon(&path, Err(refusal)).await;
 
-        let err = Connection::open(&path, HANDSHAKE_TIMEOUT)
+        let err = Connection::open(&path, HANDSHAKE_TIMEOUT, None)
             .await
             .unwrap_err();
 
@@ -378,7 +419,7 @@ mod tests {
             drop(stream);
         });
 
-        let err = Connection::open(&path, HANDSHAKE_TIMEOUT)
+        let err = Connection::open(&path, HANDSHAKE_TIMEOUT, None)
             .await
             .expect_err("a peer that closed without a HelloReply is not a connection");
 
@@ -393,7 +434,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = crate::testing::control_address(dir.path());
         let ConnectError::Connect { path: reported, .. } =
-            Connection::open(&path, HANDSHAKE_TIMEOUT)
+            Connection::open(&path, HANDSHAKE_TIMEOUT, None)
                 .await
                 .unwrap_err()
         else {
@@ -419,7 +460,7 @@ mod tests {
         // timeout ends the attempt.
         let _listener = Listener::bind(&path).unwrap();
 
-        let err = Connection::open(&path, Duration::from_millis(150))
+        let err = Connection::open(&path, Duration::from_millis(150), None)
             .await
             .unwrap_err();
 

--- a/crates/shep-client/src/lib.rs
+++ b/crates/shep-client/src/lib.rs
@@ -26,6 +26,7 @@ mod actor;
 mod client;
 mod connection;
 mod events;
+mod reconnect;
 // `spawn` stays a public module rather than a flattened re-export: the
 // exit-code contract (`spawn::DAEMON_ALREADY_RUNNING`) reads better
 // qualified, a cross-crate agreement rather than a convenience import.
@@ -71,6 +72,7 @@ pub use events::{EventStream, Lagged};
 /// ```
 #[doc(inline)]
 pub use futures_util::Stream;
+pub use reconnect::{LinkState, RECONNECT_MAX_DELAY, RECONNECT_MIN_DELAY, ReconnectingClient};
 
 // Portable for the same reason as `connection` above: every fake here binds
 // a `shep_core::transport::Listener` rather than a `UnixListener`.

--- a/crates/shep-client/src/reconnect.rs
+++ b/crates/shep-client/src/reconnect.rs
@@ -1,0 +1,747 @@
+//! [`ReconnectingClient`]: a connection that re-establishes itself when the
+//! daemon on the other end is replaced.
+//!
+//! # Why this is a separate type and not a mode on [`Client`]
+//!
+//! A daemon handover carries the listening socket across an `execve` but
+//! cannot carry an accepted one, so every connection to the shepherd dies
+//! at a reload. A dog's *process* survives that for free — it is a child of
+//! a daemon whose pid does not change — so what a carried dog becomes is a
+//! live process holding a dead socket. Measured over six real reloads: the
+//! metrics dog kept its pid, reported zero restarts, stayed `online`, wrote
+//! nothing to stderr, and answered HTTP 503 to every scrape for 6m 22s.
+//!
+//! The CLI has the opposite requirement. `shep stop` is one-shot: a request
+//! that dropped mid-flight must fail, because a silently re-issued `Stop`
+//! could stop a sheep twice — the second time after an operator's own
+//! `start` put it back. So the reconnect could not go on [`Client`] itself,
+//! nor behind a flag on it: a type whose retry behaviour depends on how it
+//! was built is a type every CLI call site has to be read carefully to
+//! trust. Making it a *distinct type* means the CLI is unaffected by
+//! construction rather than by convention — it never names
+//! `ReconnectingClient`, so no `shep` verb can acquire this behaviour by
+//! accident or by a later edit to a shared constructor.
+//!
+//! # What it does and does not retry
+//!
+//! **In-flight requests fail, never retry.** A request already handed to
+//! the connection when it died comes back [`RequestError::Closed`], exactly
+//! as it does on a bare [`Client`]. The client cannot tell a request the
+//! daemon never received from one it received and acted on before the image
+//! swapped, so retrying would be a guess about a side effect. What
+//! reconnects is the *connection*, so the caller's NEXT request is served.
+//!
+//! # Why the reconnect is supervised rather than lazy
+//!
+//! A background task waits on the current connection's death and
+//! re-establishes it immediately, rather than the cheaper design of
+//! reconnecting on the next use. Two reasons, both about the daemon's side
+//! of the reload:
+//!
+//! - A dog nobody is talking to still has to re-handshake. A metrics dog
+//!   scraped once a minute would otherwise spend that minute unreconnected,
+//!   and a refusal the daemon needs to act on (the design's G8) would not
+//!   surface until something happened to ask.
+//! - `daemon reload` reports dog staleness *after* the dogs have
+//!   reconnected (G13), which is only immediate if the reconnect is driven
+//!   by the disconnection rather than by the next request.
+//!
+//! A request issued during the reconnect window still fails with
+//! [`RequestError::Closed`]: the window is one connect plus one handshake
+//! on a local socket, and waiting inside `request` would turn a fast
+//! failure into a long hang for no correctness gain.
+//!
+//! # A refused reconnect stops
+//!
+//! A successor that refuses the handshake on protocol skew has said
+//! something a retry cannot change: this dog's running image speaks a
+//! protocol this daemon does not. The supervisor stops, and
+//! [`ReconnectingClient::link`] reports [`LinkState::Refused`]. Restarting
+//! that dog from disk is the daemon's job, not this client's — retrying
+//! here would be the spin the design's G8 exists to forbid.
+
+use core::fmt;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, PoisonError, RwLock, RwLockReadGuard, RwLockWriteGuard};
+use std::time::Duration;
+
+use tokio::task::JoinHandle;
+
+use shep_core::protocol::{HelloAck, Request, Response};
+
+use crate::client::{Client, RequestError};
+use crate::connection::{ConnectError, HANDSHAKE_TIMEOUT};
+use crate::events::EventStream;
+
+/// How long the supervisor waits after its FIRST failed reconnect attempt
+/// before trying again.
+///
+/// The first attempt carries no delay at all, which is the case that
+/// matters: across a handover the listening socket never stops being bound,
+/// so `connect(2)` succeeds into the backlog and only the handshake waits
+/// for the successor to start accepting. 50ms is the pause before a second
+/// attempt, short enough that a successor a few milliseconds late costs one
+/// of these rather than a visible outage (IR-26: named, with the reason).
+pub const RECONNECT_MIN_DELAY: Duration = Duration::from_millis(50);
+
+/// The ceiling [`RECONNECT_MIN_DELAY`] doubles up to.
+///
+/// Same order as [`HANDSHAKE_TIMEOUT`] deliberately: once a daemon has been
+/// unreachable long enough to reach this ceiling, one further attempt costs
+/// about as much as the wait between attempts, so the loop is bounded noise
+/// rather than a spin. A dog whose daemon is genuinely gone sits here
+/// indefinitely, which is correct — the daemon that would have reaped it is
+/// the one that vanished.
+pub const RECONNECT_MAX_DELAY: Duration = Duration::from_secs(5);
+
+/// What a [`ReconnectingClient`]'s supervisor is currently doing.
+///
+/// Growth is expected — library-crate public type (IR-20).
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum LinkState {
+    /// Connected. Requests go out on this generation of the connection.
+    Connected,
+    /// The connection dropped and the supervisor is re-establishing it.
+    /// Requests issued now fail with [`RequestError::Closed`]; they are not
+    /// queued and not retried.
+    Reconnecting,
+    /// A successor refused the handshake on protocol-version skew. The
+    /// supervisor has stopped and every later request fails with
+    /// [`RequestError::Closed`] — a refusal is not something a retry can
+    /// fix, and the daemon that refused is the party that can.
+    Refused {
+        /// The daemon's own crate version, when it named one. `None` from a
+        /// daemon built before the refusal carried it.
+        daemon_version: Option<String>,
+        /// The daemon's refusal message, verbatim.
+        message: String,
+    },
+}
+
+/// A [`Client`] that re-establishes its own connection when the daemon it
+/// was talking to is replaced.
+///
+/// Built for dogs, which outlive the shepherd they connected to: a dog's
+/// process crosses a daemon handover as an ordinary child, so it is still
+/// running when its socket dies. The CLI deliberately uses a bare
+/// [`Client`] instead — see this module's own docs for why that is a
+/// separate type rather than a flag.
+///
+/// # Example
+///
+/// ```no_run
+/// use shep_client::{ReconnectingClient, shep_core::protocol::Request};
+///
+/// # async fn dog(socket: &std::path::Path) -> Result<(), Box<dyn core::error::Error>> {
+/// let client = ReconnectingClient::connect(socket).await?;
+/// // Survives the daemon being replaced underneath it; a request that was
+/// // in flight at the moment it happened still fails rather than retrying.
+/// let _flock = client.request(Request::ListFlock).await?;
+/// # Ok(())
+/// # }
+/// # let _ = dog;
+/// ```
+pub struct ReconnectingClient {
+    shared: Arc<Shared>,
+    supervisor: JoinHandle<()>,
+}
+
+/// Manual, not derived (IR-41). The socket path and the [`HelloAck`] are
+/// both already printed by [`Client`]'s own `Debug`, and neither carries a
+/// secret — a control-socket path is an operator-visible filename, and an
+/// ack is a version, a protocol number and a pid. [`LinkState`] is printed
+/// in full for the same reason: its one payload is the daemon's own
+/// refusal sentence. Manual only because [`RwLock`] and [`JoinHandle`]
+/// derive into noise, and because a derived impl would print the *inner*
+/// [`Client`] on every line where the link state is the useful fact.
+impl fmt::Debug for ReconnectingClient {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ReconnectingClient")
+            .field("socket", &self.shared.socket)
+            .field("link", &self.link())
+            .field("ack", &self.daemon())
+            .finish_non_exhaustive()
+    }
+}
+
+/// Everything the handle and its supervisor both reach: the address to
+/// reconnect to, the budget to do it under, and the current generation.
+struct Shared {
+    socket: PathBuf,
+    handshake_timeout: Duration,
+    state: RwLock<State>,
+}
+
+/// The generation of the connection in force right now, and what the
+/// supervisor last reported about it.
+struct State {
+    client: Arc<Client>,
+    link: LinkState,
+}
+
+impl Shared {
+    /// A read guard, treating a poisoned lock as ordinary data.
+    ///
+    /// Nothing inside a critical section here can panic — every one is a
+    /// clone or an assignment of a plain struct — so poisoning cannot
+    /// signal a torn value, and `unwrap()` would turn an impossible
+    /// condition into a panic in a library.
+    fn read(&self) -> RwLockReadGuard<'_, State> {
+        self.state.read().unwrap_or_else(PoisonError::into_inner)
+    }
+
+    /// A write guard. See [`Self::read`] for the poisoning argument.
+    fn write(&self) -> RwLockWriteGuard<'_, State> {
+        self.state.write().unwrap_or_else(PoisonError::into_inner)
+    }
+
+    /// The current generation, cloned out so the guard is dropped before
+    /// any caller awaits on it — no lock is ever held across an `await`.
+    fn client(&self) -> Arc<Client> {
+        Arc::clone(&self.read().client)
+    }
+
+    fn set_link(&self, link: LinkState) {
+        self.write().link = link;
+    }
+
+    /// Swaps in a freshly handshaken generation, dropping the dead one.
+    fn install(&self, client: Client) {
+        let mut state = self.write();
+        state.client = Arc::new(client);
+        state.link = LinkState::Connected;
+    }
+}
+
+impl ReconnectingClient {
+    /// Connects to `socket`, performs the version handshake bounded by
+    /// [`HANDSHAKE_TIMEOUT`], and starts the supervisor that will
+    /// re-establish this connection whenever it dies.
+    ///
+    /// The FIRST connection is not supervised: a socket nobody is listening
+    /// on is a caller's error, not a handover, so this reports it rather
+    /// than retrying behind the caller's back.
+    ///
+    /// # Errors
+    ///
+    /// See [`Self::connect_with_timeout`] — every error variant it can
+    /// return, this returns unchanged.
+    pub async fn connect(socket: &Path) -> Result<Self, ConnectError> {
+        Self::connect_with_timeout(socket, HANDSHAKE_TIMEOUT).await
+    }
+
+    /// As [`Self::connect`], but with a caller-supplied handshake timeout,
+    /// used for the first connection and for every reconnect after it.
+    ///
+    /// # Errors
+    ///
+    /// - [`ConnectError::Connect`] — `connect(2)` failed; nothing is
+    ///   listening at `socket`.
+    /// - [`ConnectError::Wire`] — the `Hello` failed to encode, or the
+    ///   reply frame failed to decode.
+    /// - [`ConnectError::Io`] — a framed read or write failed after connect.
+    /// - [`ConnectError::HandshakeClosed`] — the peer closed the connection
+    ///   before sending a `HelloReply`.
+    /// - [`ConnectError::HandshakeTimeout`] — connect succeeded but no
+    ///   `HelloReply` (or close) arrived within `timeout`.
+    /// - [`ConnectError::ProtocolMismatch`] — the daemon refused the
+    ///   handshake on protocol-version skew.
+    pub async fn connect_with_timeout(
+        socket: &Path,
+        timeout: Duration,
+    ) -> Result<Self, ConnectError> {
+        let client = Client::connect_with_timeout(socket, timeout).await?;
+        let shared = Arc::new(Shared {
+            socket: socket.to_path_buf(),
+            handshake_timeout: timeout,
+            state: RwLock::new(State {
+                client: Arc::new(client),
+                link: LinkState::Connected,
+            }),
+        });
+        let supervisor = tokio::spawn(supervise(Arc::clone(&shared)));
+        Ok(Self { shared, supervisor })
+    }
+
+    /// The handshake acknowledgement of the daemon this client is talking
+    /// to **right now**.
+    ///
+    /// Owned rather than borrowed, unlike [`Client::daemon`]: the ack
+    /// belongs to a generation that a reconnect can replace at any moment,
+    /// so handing out a reference would either pin a stale one or need a
+    /// guard in the caller's hands. Reading it through the current
+    /// generation is also the only correct answer — a cached ack would
+    /// describe the predecessor, which is exactly what a dog publishing
+    /// `daemon_version` must not do.
+    #[must_use]
+    pub fn daemon(&self) -> HelloAck {
+        self.shared.read().client.daemon().clone()
+    }
+
+    /// The path this client connects (and reconnects) through.
+    #[must_use]
+    pub fn socket(&self) -> &Path {
+        &self.shared.socket
+    }
+
+    /// What the supervisor is doing right now.
+    #[must_use]
+    pub fn link(&self) -> LinkState {
+        self.shared.read().link.clone()
+    }
+
+    /// Sends `body` with [`DEFAULT_DEADLINE`](crate::DEFAULT_DEADLINE) on
+    /// the current generation of the connection.
+    ///
+    /// # Errors
+    ///
+    /// See [`Self::request_with_deadline`].
+    pub async fn request(&self, body: Request) -> Result<Response, RequestError> {
+        self.request_with_deadline(body, None).await
+    }
+
+    /// Sends `body` with `deadline` on the current generation of the
+    /// connection.
+    ///
+    /// **Never retried.** A request that was on the wire when the daemon
+    /// was replaced fails, and a request issued while the supervisor is
+    /// still reconnecting fails too. Only the connection is re-established;
+    /// the caller decides what to do about the request, because only the
+    /// caller knows whether sending it twice is safe.
+    ///
+    /// # Errors
+    ///
+    /// - [`RequestError::Rpc`] — the daemon answered with a structured error.
+    /// - [`RequestError::Timeout`] — no reply within the request's budget.
+    /// - [`RequestError::Closed`] — the connection closed before a reply
+    ///   arrived, or had already closed when this was issued.
+    /// - [`RequestError::Wire`] — `body` failed to encode.
+    pub async fn request_with_deadline(
+        &self,
+        body: Request,
+        deadline: Option<Duration>,
+    ) -> Result<Response, RequestError> {
+        self.shared
+            .client()
+            .request_with_deadline(body, deadline)
+            .await
+    }
+
+    /// Subscribes the current generation of the connection to `topics`.
+    ///
+    /// **The returned stream belongs to one generation and is not re-armed
+    /// across a reconnect**: it ends when that connection dies, the same as
+    /// [`Client::subscribe`]'s would. A consumer that wants events past a
+    /// handover subscribes again after the stream ends. Re-arming it inside
+    /// this type would silently swallow the gap between the connection
+    /// dying and the successor accepting a new `Subscribe`, and an event
+    /// stream that hides a gap is worse than one that ends.
+    ///
+    /// # Errors
+    ///
+    /// Same as [`Self::request`]: a daemon-side error, a client-side
+    /// timeout, a closed connection, or a wire encode failure.
+    pub async fn subscribe(&self, topics: Vec<String>) -> Result<EventStream, RequestError> {
+        self.shared.client().subscribe(topics).await
+    }
+}
+
+/// Stops the supervisor when the handle goes away.
+///
+/// Without this, a dropped `ReconnectingClient` whose daemon is gone leaves
+/// a task reconnecting forever against an address nobody will answer,
+/// holding the last generation's socket open with it. `abort` rather than a
+/// cooperative signal because the supervisor spends its life parked on
+/// either a connection's death or a connect attempt, neither of which would
+/// notice a flag until it woke.
+impl Drop for ReconnectingClient {
+    fn drop(&mut self) {
+        self.supervisor.abort();
+    }
+}
+
+/// The supervisor loop: wait for the current generation to die, then
+/// re-establish it, forever.
+///
+/// Ends only on a protocol refusal (see [`LinkState::Refused`]) or when the
+/// handle is dropped and this task is aborted.
+async fn supervise(shared: Arc<Shared>) {
+    loop {
+        // Held only for the await on this generation's death — dropped
+        // before the reconnect, so the dead client's socket goes away as
+        // soon as `install` replaces it rather than being pinned here.
+        let generation = shared.client();
+        generation.closed().await;
+        drop(generation);
+        shared.set_link(LinkState::Reconnecting);
+
+        let mut delay = RECONNECT_MIN_DELAY;
+        loop {
+            match Client::connect_with_timeout(&shared.socket, shared.handshake_timeout).await {
+                Ok(fresh) => {
+                    shared.install(fresh);
+                    break;
+                }
+                Err(ConnectError::ProtocolMismatch {
+                    daemon_version,
+                    message,
+                    ..
+                }) => {
+                    shared.set_link(LinkState::Refused {
+                        daemon_version,
+                        message,
+                    });
+                    return;
+                }
+                // Everything else is a daemon that is not ready yet: the
+                // successor has not started accepting, or the socket is
+                // momentarily unbound. Those resolve on their own, so the
+                // only question is how often to ask.
+                Err(_transient) => {
+                    tokio::time::sleep(delay).await;
+                    delay = (delay * 2).min(RECONNECT_MAX_DELAY);
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use shep_core::protocol::{PROTOCOL_VERSION, RpcError, RpcErrorCode};
+
+    use super::*;
+    use crate::testing::{Handovers, Handshake, control_address, fake_daemon_across_handovers};
+
+    /// Every bounded wait in this module uses one budget. Generous against
+    /// a loaded CI runner, and small enough that a genuinely stuck test
+    /// fails rather than hanging the suite (IR-46: every `await` here has a
+    /// forcing mechanism, and this is it).
+    const BOUND: Duration = Duration::from_secs(5);
+
+    /// The window a test watches for something that must NOT happen.
+    ///
+    /// Eight times [`RECONNECT_MIN_DELAY`], so a supervisor that were still
+    /// looping would have made several further attempts inside it — the
+    /// first of them after 50ms. A negative assertion is only as good as
+    /// its window, so this is stated against the delay it has to outrun
+    /// rather than picked as a round number.
+    const NEGATIVE_WINDOW: Duration = Duration::from_millis(400);
+
+    /// An ack distinguishable per generation, so a test can tell WHICH
+    /// daemon answered rather than only that one did.
+    fn ack_from(pid: u32) -> HelloAck {
+        HelloAck {
+            daemon_version: format!("0.0.{pid}"),
+            protocol: PROTOCOL_VERSION,
+            pid,
+        }
+    }
+
+    /// Waits until the fake has accepted `accepts` connections AND the
+    /// client has installed the newest of them, or fails inside [`BOUND`].
+    /// The reconnect is driven by a background task, so there is no handle
+    /// to await; polling against a real condition with a hard ceiling is
+    /// the forcing mechanism.
+    ///
+    /// Both halves are needed and neither alone would do. The accept count
+    /// alone rises before the handshake completes, so a request issued on
+    /// it could still meet the dead generation; the link alone still reads
+    /// `Connected` in the instant after a cut, before the supervisor has
+    /// noticed. Together they are unambiguous, because the supervisor sets
+    /// `Reconnecting` BEFORE it dials — so an accept count that has moved
+    /// and a link back at `Connected` can only mean the fresh generation is
+    /// installed.
+    ///
+    /// Deliberately does NOT observe [`ReconnectingClient::daemon`]: the
+    /// ack is what one of these tests is asserting about, and a helper that
+    /// waited on it would make every other test fail for that test's
+    /// reason.
+    async fn await_reconnect(client: &ReconnectingClient, shepherds: &Handovers, accepts: u32) {
+        let seen = tokio::time::timeout(BOUND, async {
+            loop {
+                if shepherds.accepted() >= accepts && client.link() == LinkState::Connected {
+                    return;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await;
+        assert!(
+            seen.is_ok(),
+            "no reconnect within {BOUND:?}: {} accepts, link {:?}",
+            shepherds.accepted(),
+            client.link()
+        );
+    }
+
+    /// Waits until `client`'s link reaches a refusal, or fails inside
+    /// [`BOUND`].
+    async fn await_refusal(client: &ReconnectingClient) -> LinkState {
+        let seen = tokio::time::timeout(BOUND, async {
+            loop {
+                let link = client.link();
+                if matches!(link, LinkState::Refused { .. }) {
+                    return link;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await;
+        seen.unwrap_or_else(|_| panic!("the link never reached a refusal within {BOUND:?}"))
+    }
+
+    /// fails if a dog is left holding a dead socket after its daemon is
+    /// replaced. This is the measured defect: over six real reloads the
+    /// metrics dog kept its pid, reported zero restarts and answered 503 to
+    /// every scrape, because only the LISTENING socket crosses the exec and
+    /// an accepted one dies with the image.
+    #[tokio::test]
+    async fn a_dropped_connection_is_re_established_and_the_next_request_is_served() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = control_address(dir.path());
+        let shepherds = fake_daemon_across_handovers(
+            &path,
+            vec![
+                Handshake::Accept(ack_from(11)),
+                Handshake::Accept(ack_from(22)),
+            ],
+        );
+        let client = ReconnectingClient::connect(&path).await.unwrap();
+
+        let before = tokio::time::timeout(BOUND, client.request(Request::Ping))
+            .await
+            .expect("the first request must not hang");
+        assert!(before.is_ok(), "before the handover: {before:?}");
+
+        // The handover, exactly: the accepted connection dies under the
+        // client while the listener stays bound.
+        shepherds.cut().await;
+        await_reconnect(&client, &shepherds, 2).await;
+
+        let after = tokio::time::timeout(BOUND, client.request(Request::Ping))
+            .await
+            .expect("the request after a handover must not hang");
+        assert!(
+            after.is_ok(),
+            "a request after the handover must be served, got {after:?}"
+        );
+    }
+
+    /// fails if the ack keeps describing the predecessor after a
+    /// reconnect. A dog publishing `daemon_version` from a cached ack —
+    /// which the metrics dog does — would report a daemon that is no longer
+    /// running.
+    #[tokio::test]
+    async fn the_ack_follows_the_successor_rather_than_the_predecessor() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = control_address(dir.path());
+        let shepherds = fake_daemon_across_handovers(
+            &path,
+            vec![
+                Handshake::Accept(ack_from(11)),
+                Handshake::Accept(ack_from(22)),
+            ],
+        );
+        let client = ReconnectingClient::connect(&path).await.unwrap();
+        assert_eq!(client.daemon().pid, 11);
+        assert_eq!(client.daemon().daemon_version, "0.0.11");
+
+        shepherds.cut().await;
+        await_reconnect(&client, &shepherds, 2).await;
+
+        assert_eq!(
+            client.daemon().daemon_version,
+            "0.0.22",
+            "the version must come from the daemon now answering"
+        );
+    }
+
+    /// fails if a request that was in flight when the daemon was replaced
+    /// is re-sent to the successor. A re-issued `Stop` stops a sheep twice,
+    /// and the client cannot tell a request the daemon never saw from one
+    /// it received and acted on before the image swapped — so the rule is
+    /// the whole of the design's H2: in-flight requests fail, never retry.
+    ///
+    /// The proof is positional rather than a count: the successor's FIRST
+    /// envelope must be the request issued after the reconnect. A retry
+    /// would put the abandoned `Ping` there instead.
+    #[tokio::test]
+    async fn an_in_flight_request_fails_and_is_never_re_sent_to_the_successor() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = control_address(dir.path());
+        let shepherds = fake_daemon_across_handovers(
+            &path,
+            vec![
+                Handshake::Accept(ack_from(11)),
+                Handshake::Accept(ack_from(22)),
+            ],
+        );
+        let client = ReconnectingClient::connect(&path).await.unwrap();
+
+        // The predecessor reads this envelope and dies without answering
+        // it — a request the daemon may or may not have acted on.
+        shepherds.cut_on_next_request();
+        let lost = tokio::time::timeout(BOUND, client.request(Request::Ping))
+            .await
+            .expect("an abandoned request must fail, not hang");
+        assert_eq!(
+            lost,
+            Err(RequestError::Closed),
+            "an in-flight request must fail when the daemon is replaced"
+        );
+
+        await_reconnect(&client, &shepherds, 2).await;
+        let served = tokio::time::timeout(BOUND, client.request(Request::ListFlock))
+            .await
+            .expect("the request after a handover must not hang");
+        assert!(served.is_ok(), "after the handover: {served:?}");
+
+        let successor: Vec<Request> = shepherds
+            .envelopes()
+            .into_iter()
+            .filter(|(generation, _)| *generation == 2)
+            .map(|(_, envelope)| envelope.body)
+            .collect();
+        assert_eq!(
+            successor,
+            vec![Request::ListFlock],
+            "the successor must see only the request issued after the reconnect"
+        );
+    }
+
+    /// fails if a refused reconnect is retried. A successor that refuses on
+    /// protocol skew has said something no retry can change; the design's
+    /// G8 puts the fix on the daemon (restart that dog once, from disk) and
+    /// forbids the client spinning against it in the meantime.
+    #[tokio::test]
+    async fn a_refused_reconnect_stops_rather_than_spinning() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = control_address(dir.path());
+        let shepherds = fake_daemon_across_handovers(
+            &path,
+            vec![
+                Handshake::Accept(ack_from(11)),
+                Handshake::Refuse(RpcError {
+                    code: RpcErrorCode::ProtocolMismatch,
+                    message: "daemon speaks protocol 3, client speaks 2".into(),
+                    daemon_version: Some("0.9.9".into()),
+                }),
+            ],
+        );
+        let client = ReconnectingClient::connect(&path).await.unwrap();
+
+        shepherds.cut().await;
+        let link = await_refusal(&client).await;
+
+        let LinkState::Refused {
+            daemon_version,
+            message,
+        } = link
+        else {
+            unreachable!("await_refusal only returns a refusal");
+        };
+        assert_eq!(daemon_version.as_deref(), Some("0.9.9"));
+        assert!(message.contains("protocol 3"), "{message}");
+        assert_eq!(
+            shepherds.accepted(),
+            2,
+            "one initial connection plus exactly one refused reconnect"
+        );
+        // And it must STAY at two. Reaching `Refused` only proves the
+        // supervisor got there; a supervisor that recorded the refusal and
+        // then went round again would satisfy every assertion above and
+        // still be the spin G8 forbids, so the window is the assertion.
+        let spun = tokio::time::timeout(NEGATIVE_WINDOW, async {
+            while shepherds.accepted() < 3 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await;
+        assert!(
+            spun.is_err(),
+            "the supervisor retried a refusal: {} accepts",
+            shepherds.accepted()
+        );
+    }
+
+    /// fails if a reconnect gives up on a daemon that is merely not ready
+    /// yet. Across a real handover the listening socket stays bound while
+    /// the successor replays its blob, so a connect that completes and a
+    /// handshake that is not yet answered is the ordinary case, not a
+    /// failure.
+    #[tokio::test]
+    async fn a_reconnect_retries_past_a_successor_that_is_not_accepting_yet() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = control_address(dir.path());
+        let shepherds = fake_daemon_across_handovers(
+            &path,
+            vec![
+                Handshake::Accept(ack_from(11)),
+                Handshake::Drop,
+                Handshake::Drop,
+                Handshake::Accept(ack_from(44)),
+            ],
+        );
+        let client = ReconnectingClient::connect(&path).await.unwrap();
+
+        shepherds.cut().await;
+        await_reconnect(&client, &shepherds, 4).await;
+
+        assert_eq!(
+            shepherds.accepted(),
+            4,
+            "two unanswered handshakes must be retried past, not given up on"
+        );
+        let served = tokio::time::timeout(BOUND, client.request(Request::Ping))
+            .await
+            .expect("the request after the retries must not hang");
+        assert!(served.is_ok(), "after the retries: {served:?}");
+    }
+
+    /// fails if dropping the handle leaves the supervisor reconnecting
+    /// forever. A dog that exits, or a test that finishes, must not leave a
+    /// task dialling an address nobody will answer and pinning the last
+    /// generation's socket open with it.
+    ///
+    /// Asserts a NEGATIVE, so the bound is the assertion: the accept count
+    /// must NOT grow within it.
+    #[tokio::test]
+    async fn dropping_the_handle_stops_the_supervisor() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = control_address(dir.path());
+        let shepherds = fake_daemon_across_handovers(
+            &path,
+            vec![Handshake::Accept(ack_from(11)), Handshake::Drop],
+        );
+        let client = ReconnectingClient::connect(&path).await.unwrap();
+
+        shepherds.cut().await;
+        // Let the supervisor get as far as its first (dropped) reconnect,
+        // so it is provably still running at the moment the handle goes.
+        let reached = tokio::time::timeout(BOUND, async {
+            while shepherds.accepted() < 2 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await;
+        assert!(reached.is_ok(), "the supervisor never retried at all");
+
+        drop(client);
+
+        let grew = tokio::time::timeout(NEGATIVE_WINDOW, async {
+            while shepherds.accepted() < 3 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await;
+        assert!(
+            grew.is_err(),
+            "the supervisor kept reconnecting after its handle was dropped: {} accepts",
+            shepherds.accepted()
+        );
+    }
+}

--- a/crates/shep-client/src/reconnect.rs
+++ b/crates/shep-client/src/reconnect.rs
@@ -59,6 +59,12 @@
 //! [`ReconnectingClient::link`] reports [`LinkState::Refused`]. Restarting
 //! that dog from disk is the daemon's job, not this client's — retrying
 //! here would be the spin the design's G8 exists to forbid.
+//!
+//! The daemon can only do that job if it knows WHICH dog it refused, and a
+//! refused handshake never reaches a request. So a dog connects with
+//! [`ReconnectingClient::connect_as_dog`], which carries the name the
+//! daemon spawned it under in the `Hello` itself — on the first connection
+//! and on every reconnect after it.
 
 use core::fmt;
 use std::path::{Path, PathBuf};
@@ -134,7 +140,9 @@ pub enum LinkState {
 /// use shep_client::{ReconnectingClient, shep_core::protocol::Request};
 ///
 /// # async fn dog(socket: &std::path::Path) -> Result<(), Box<dyn core::error::Error>> {
-/// let client = ReconnectingClient::connect(socket).await?;
+/// // `name` is what the daemon put in `$SHEP_DOG_NAME` when it spawned
+/// // this process; it lets the daemon act on a refusal (G8).
+/// let client = ReconnectingClient::connect_as_dog(socket, "metrics").await?;
 /// // Survives the daemon being replaced underneath it; a request that was
 /// // in flight at the moment it happened still fails rather than retrying.
 /// let _flock = client.request(Request::ListFlock).await?;
@@ -159,6 +167,7 @@ impl fmt::Debug for ReconnectingClient {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("ReconnectingClient")
             .field("socket", &self.shared.socket)
+            .field("dog_name", &self.shared.dog_name)
             .field("link", &self.link())
             .field("ack", &self.daemon())
             .finish_non_exhaustive()
@@ -170,6 +179,9 @@ impl fmt::Debug for ReconnectingClient {
 struct Shared {
     socket: PathBuf,
     handshake_timeout: Duration,
+    /// The name this client announces itself as a dog under, re-sent on
+    /// every reconnect — see [`ReconnectingClient::connect_as_dog`].
+    dog_name: Option<String>,
     state: RwLock<State>,
 }
 
@@ -251,10 +263,56 @@ impl ReconnectingClient {
         socket: &Path,
         timeout: Duration,
     ) -> Result<Self, ConnectError> {
-        let client = Client::connect_with_timeout(socket, timeout).await?;
+        Self::connect_inner(socket, timeout, None).await
+    }
+
+    /// As [`Self::connect`], but announcing this client as the dog
+    /// registered under `name` — the value the daemon put in
+    /// `$SHEP_DOG_NAME` when it spawned this process.
+    ///
+    /// **A dog should use this rather than [`Self::connect`].** The name is
+    /// what makes a refused handshake actionable: it never reaches a
+    /// request, so `Request::DogConfig`'s name is unreachable on exactly
+    /// the path where the daemon needs to know which dog to restart (the
+    /// handover design's G8). A dog that connects without it still
+    /// reconnects across a handover, and still stops rather than spinning
+    /// when a successor refuses it — but the daemon is left unable to say
+    /// which dog went stale, or to restart it from disk.
+    ///
+    /// # Errors
+    ///
+    /// See [`Self::connect_with_timeout`] — every error variant it can
+    /// return, this returns unchanged.
+    pub async fn connect_as_dog(socket: &Path, name: &str) -> Result<Self, ConnectError> {
+        Self::connect_as_dog_with_timeout(socket, HANDSHAKE_TIMEOUT, name).await
+    }
+
+    /// As [`Self::connect_as_dog`], but with a caller-supplied handshake
+    /// timeout, used for the first connection and for every reconnect after
+    /// it.
+    ///
+    /// # Errors
+    ///
+    /// See [`Self::connect_with_timeout`] — every error variant it can
+    /// return, this returns unchanged.
+    pub async fn connect_as_dog_with_timeout(
+        socket: &Path,
+        timeout: Duration,
+        name: &str,
+    ) -> Result<Self, ConnectError> {
+        Self::connect_inner(socket, timeout, Some(name)).await
+    }
+
+    async fn connect_inner(
+        socket: &Path,
+        timeout: Duration,
+        dog_name: Option<&str>,
+    ) -> Result<Self, ConnectError> {
+        let client = Client::connect_as(socket, timeout, dog_name).await?;
         let shared = Arc::new(Shared {
             socket: socket.to_path_buf(),
             handshake_timeout: timeout,
+            dog_name: dog_name.map(str::to_owned),
             state: RwLock::new(State {
                 client: Arc::new(client),
                 link: LinkState::Connected,
@@ -262,6 +320,13 @@ impl ReconnectingClient {
         });
         let supervisor = tokio::spawn(supervise(Arc::clone(&shared)));
         Ok(Self { shared, supervisor })
+    }
+
+    /// The name this client announces itself as a dog under, or `None` for
+    /// a caller that is not one.
+    #[must_use]
+    pub fn dog_name(&self) -> Option<&str> {
+        self.shared.dog_name.as_deref()
     }
 
     /// The handshake acknowledgement of the daemon this client is talking
@@ -378,7 +443,13 @@ async fn supervise(shared: Arc<Shared>) {
 
         let mut delay = RECONNECT_MIN_DELAY;
         loop {
-            match Client::connect_with_timeout(&shared.socket, shared.handshake_timeout).await {
+            match Client::connect_as(
+                &shared.socket,
+                shared.handshake_timeout,
+                shared.dog_name.as_deref(),
+            )
+            .await
+            {
                 Ok(fresh) => {
                     shared.install(fresh);
                     break;
@@ -557,6 +628,72 @@ mod tests {
             client.daemon().daemon_version,
             "0.0.22",
             "the version must come from the daemon now answering"
+        );
+    }
+
+    /// fails if a dog's name reaches the FIRST daemon and not its
+    /// successor. The refusal is the one that matters and it is the second
+    /// one here: a dog that named itself at boot and then reconnected
+    /// anonymously would leave the successor unable to say which dog it
+    /// just refused, which is precisely the case G8 exists for. A daemon's
+    /// predecessor is not around to be asked.
+    #[tokio::test]
+    async fn a_dogs_name_rides_every_handshake_including_the_refused_one() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = control_address(dir.path());
+        let shepherds = fake_daemon_across_handovers(
+            &path,
+            vec![
+                Handshake::Accept(ack_from(11)),
+                Handshake::Refuse(RpcError {
+                    code: RpcErrorCode::ProtocolMismatch,
+                    message: "daemon speaks protocol 3, client sent 2".to_string(),
+                    daemon_version: Some("0.2.0".to_string()),
+                }),
+            ],
+        );
+        let client = ReconnectingClient::connect_as_dog(&path, "metrics")
+            .await
+            .unwrap();
+        assert_eq!(client.dog_name(), Some("metrics"));
+
+        shepherds.cut().await;
+        await_refusal(&client).await;
+
+        let named: Vec<Option<String>> = shepherds
+            .hellos()
+            .into_iter()
+            .map(|hello| hello.dog_name)
+            .collect();
+        assert_eq!(
+            named,
+            vec![Some("metrics".to_string()), Some("metrics".to_string())],
+            "every generation must be told which dog is talking to it"
+        );
+    }
+
+    /// fails if a client that is not a dog claims to be one. The name is
+    /// what lets a daemon restart a dog on a refused handshake, so a
+    /// `ReconnectingClient` built without one must stay anonymous rather
+    /// than inventing a name from its environment or its path.
+    #[tokio::test]
+    async fn a_client_that_is_not_a_dog_names_none() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = control_address(dir.path());
+        let shepherds = fake_daemon_across_handovers(&path, vec![Handshake::Accept(ack_from(11))]);
+        let client = ReconnectingClient::connect(&path).await.unwrap();
+        assert_eq!(client.dog_name(), None);
+
+        shepherds.cut().await;
+        await_reconnect(&client, &shepherds, 2).await;
+
+        assert!(
+            shepherds
+                .hellos()
+                .iter()
+                .all(|hello| hello.dog_name.is_none()),
+            "an unnamed client must stay unnamed across a reconnect: {:?}",
+            shepherds.hellos()
         );
     }
 

--- a/crates/shep-client/src/testing.rs
+++ b/crates/shep-client/src/testing.rs
@@ -142,7 +142,7 @@ pub async fn serve_one_request(
     tokio::spawn(async move {
         let stream = listener.accept().await.unwrap();
         let mut frames = Framed::new(stream, codec());
-        handshake(&mut frames, ack).await;
+        let _hello = handshake(&mut frames, ack).await;
         let envelope = read_envelope(&mut frames).await;
         write_reply(&mut frames, envelope.id, response).await;
         envelope
@@ -193,7 +193,7 @@ pub fn fake_daemon_accepting_repeatedly_with_ack(
     let handle = tokio::spawn(async move {
         while let Ok(stream) = listener.accept().await {
             let mut frames = Framed::new(stream, codec());
-            handshake(&mut frames, ack.clone()).await;
+            let _hello = handshake(&mut frames, ack.clone()).await;
             let envelope = read_envelope(&mut frames).await;
             // `write_reply` wraps the value in `Ok` itself — its signature is
             // `(&mut Frames, u64, Response)`, testing.rs:155 — so passing an
@@ -248,6 +248,7 @@ pub struct Handovers {
     cut: mpsc::Sender<()>,
     cut_on_next_request: Arc<AtomicBool>,
     accepted: Arc<AtomicU32>,
+    hellos: Arc<Mutex<Vec<Hello>>>,
     envelopes: Arc<Mutex<Vec<(u32, Envelope)>>>,
     armed_list: Arc<Mutex<Vec<ProcessInfo>>>,
     task: JoinHandle<()>,
@@ -279,6 +280,14 @@ impl Handovers {
     #[must_use]
     pub fn accepted(&self) -> u32 {
         self.accepted.load(Ordering::SeqCst)
+    }
+
+    /// Every `Hello` this fake has read, in the order its generations read
+    /// them — including the ones it went on to REFUSE, which is the only
+    /// path where a real daemon can learn which dog it just turned away.
+    #[must_use]
+    pub fn hellos(&self) -> Vec<Hello> {
+        self.hellos.lock().unwrap().clone()
     }
 
     /// Every request envelope received so far, each paired with the 1-based
@@ -320,12 +329,14 @@ pub fn fake_daemon_across_handovers(path: &Path, handshakes: Vec<Handshake>) -> 
     let (cut_tx, mut cut_rx) = mpsc::channel(SCRIPT_CHANNEL_CAPACITY);
     let cut_on_next_request = Arc::new(AtomicBool::new(false));
     let accepted = Arc::new(AtomicU32::new(0));
+    let hellos: Arc<Mutex<Vec<Hello>>> = Arc::new(Mutex::new(Vec::new()));
     let envelopes: Arc<Mutex<Vec<(u32, Envelope)>>> = Arc::new(Mutex::new(Vec::new()));
     let armed_list: Arc<Mutex<Vec<ProcessInfo>>> = Arc::new(Mutex::new(Vec::new()));
 
     let task = tokio::spawn({
         let cut_on_next_request = Arc::clone(&cut_on_next_request);
         let accepted = Arc::clone(&accepted);
+        let hellos = Arc::clone(&hellos);
         let envelopes = Arc::clone(&envelopes);
         let armed_list = Arc::clone(&armed_list);
         async move {
@@ -344,12 +355,21 @@ pub fn fake_daemon_across_handovers(path: &Path, handshakes: Vec<Handshake>) -> 
                     Handshake::Refuse(err) => {
                         // The client's `Hello` is read first so the refusal
                         // is an answer rather than a race with its own write.
-                        let _first = frames.next().await;
+                        // Recorded before the refusal, not after: a real
+                        // daemon has to read the name off a `Hello` it is
+                        // about to refuse, and that is the only path where
+                        // it can learn which dog it just refused.
+                        if let Some(Ok(first)) = frames.next().await {
+                            hellos.lock().unwrap().push(decode_frame(&first).unwrap());
+                        }
                         let reply: HelloReply = Err(err);
                         let _ = frames.send(encode_frame(&reply).unwrap()).await;
                         continue;
                     }
-                    Handshake::Accept(ack) => handshake(&mut frames, ack).await,
+                    Handshake::Accept(ack) => {
+                        let hello = handshake(&mut frames, ack).await;
+                        hellos.lock().unwrap().push(hello);
+                    }
                 }
                 loop {
                     tokio::select! {
@@ -382,6 +402,7 @@ pub fn fake_daemon_across_handovers(path: &Path, handshakes: Vec<Handshake>) -> 
         cut: cut_tx,
         cut_on_next_request,
         accepted,
+        hellos,
         envelopes,
         armed_list,
         task,
@@ -436,16 +457,17 @@ pub fn sample_info() -> ProcessInfo {
 const SCRIPT_CHANNEL_CAPACITY: usize = 8;
 
 /// Completes the handshake side of the protocol: reads the client's
-/// `Hello` (and discards it — callers that need to assert on it use
-/// [`fake_daemon`] instead) and answers with `ack`.
+/// `Hello`, answers with `ack`, and hands the `Hello` back for a caller
+/// that wants to assert on it.
 ///
 /// Panics on any accept/read/decode/write failure — test scaffolding, see
 /// [`fake_daemon`]'s own doc for why that is the right failure mode here.
-async fn handshake(frames: &mut Frames, ack: HelloAck) {
+async fn handshake(frames: &mut Frames, ack: HelloAck) -> Hello {
     let first = frames.next().await.unwrap().unwrap();
-    let _hello: Hello = decode_frame(&first).unwrap();
+    let hello: Hello = decode_frame(&first).unwrap();
     let reply: HelloReply = Ok(ack);
     frames.send(encode_frame(&reply).unwrap()).await.unwrap();
+    hello
 }
 
 /// Reads and decodes the next envelope. Panics on failure or a closed
@@ -805,7 +827,7 @@ async fn serve_scripted(
 ) {
     let stream = listener.accept().await.unwrap();
     let mut frames = Framed::new(stream, codec());
-    handshake(&mut frames, ack).await;
+    let _hello = handshake(&mut frames, ack).await;
 
     let mut armed_err: Option<(RpcErrorCode, String)> = None;
     let mut armed_event_then_reply = false;
@@ -1059,7 +1081,7 @@ pub async fn fake_daemon_answering_with_ack(
             let answer = answer.clone();
             tokio::spawn(async move {
                 let mut frames = Framed::new(stream, codec());
-                handshake(&mut frames, ack).await;
+                let _hello = handshake(&mut frames, ack).await;
                 while let Some(Ok(frame)) = frames.next().await {
                     let Ok(envelope) = decode_frame::<Envelope>(&frame) else {
                         break;
@@ -1120,7 +1142,7 @@ pub async fn fake_client_answering(
     tokio::spawn(async move {
         let stream = listener.accept().await.unwrap();
         let mut frames = Framed::new(stream, codec());
-        handshake(&mut frames, sample_ack()).await;
+        let _hello = handshake(&mut frames, sample_ack()).await;
         while let Some(Ok(frame)) = frames.next().await {
             let Ok(envelope) = decode_frame::<Envelope>(&frame) else {
                 break;
@@ -1148,7 +1170,7 @@ pub async fn fake_client_capturing_envelopes(path: &Path) -> (Client, mpsc::Rece
     tokio::spawn(async move {
         let stream = listener.accept().await.unwrap();
         let mut frames = Framed::new(stream, codec());
-        handshake(&mut frames, sample_ack()).await;
+        let _hello = handshake(&mut frames, sample_ack()).await;
         loop {
             let envelope = read_envelope(&mut frames).await;
             let id = envelope.id;
@@ -1233,7 +1255,7 @@ pub async fn fake_client_that_closes_after_handshake(path: &Path) -> (Client, Jo
     let task = tokio::spawn(async move {
         let stream = listener.accept().await.unwrap();
         let mut frames = Framed::new(stream, codec());
-        handshake(&mut frames, sample_ack()).await;
+        let _hello = handshake(&mut frames, sample_ack()).await;
         // Dropping `frames` (and the `UnixStream` it owns) here closes the
         // connection from this side.
     });
@@ -1253,7 +1275,7 @@ pub async fn fake_client_that_dies_mid_request(path: &Path) -> (Client, JoinHand
     let task = tokio::spawn(async move {
         let stream = listener.accept().await.unwrap();
         let mut frames = Framed::new(stream, codec());
-        handshake(&mut frames, sample_ack()).await;
+        let _hello = handshake(&mut frames, sample_ack()).await;
         let _envelope = read_envelope(&mut frames).await;
         // Dropping `frames` here — after reading, not before — closes the
         // connection only once the actor has already written the request
@@ -1279,7 +1301,7 @@ pub async fn fake_client_that_never_replies(path: &Path) -> (Client, JoinHandle<
     let task = tokio::spawn(async move {
         let stream = listener.accept().await.unwrap();
         let mut frames = Framed::new(stream, codec());
-        handshake(&mut frames, sample_ack()).await;
+        let _hello = handshake(&mut frames, sample_ack()).await;
         core::future::pending::<()>().await;
     });
     let client = Client::connect(path).await.unwrap();
@@ -1330,7 +1352,7 @@ pub fn start_fake_daemon_answering_on(path: &Path) {
     tokio::spawn(async move {
         let stream = listener.accept().await.unwrap();
         let mut frames = Framed::new(stream, codec());
-        handshake(&mut frames, sample_ack()).await;
+        let _hello = handshake(&mut frames, sample_ack()).await;
         core::future::pending::<()>().await;
     });
 }

--- a/crates/shep-client/src/testing.rs
+++ b/crates/shep-client/src/testing.rs
@@ -19,7 +19,7 @@
 
 use std::collections::VecDeque;
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
@@ -36,7 +36,7 @@ use shep_core::protocol::{
 };
 use shep_core::status::ProcStatus;
 
-use crate::Client;
+use crate::{Client, ReconnectingClient};
 
 /// A control address valid on the platform running the test, unique to
 /// `dir`.
@@ -203,6 +203,189 @@ pub fn fake_daemon_accepting_repeatedly_with_ack(
         }
     });
     (handle, served)
+}
+
+/// What one generation of [`fake_daemon_across_handovers`] does with the
+/// `Hello` a client sends it.
+///
+/// The three shapes a reconnecting client has to survive, and no others:
+/// a daemon that answers, one that refuses on version skew, and one that is
+/// bound but not yet able to answer at all.
+#[derive(Debug, Clone)]
+pub enum Handshake {
+    /// Answer the `Hello` with this ack, then serve requests until the
+    /// connection is cut.
+    Accept(HelloAck),
+    /// Refuse the `Hello` with this error and close — the successor a dog
+    /// compiled against an older protocol meets.
+    Refuse(RpcError),
+    /// Close without answering the `Hello` at all — a successor that is
+    /// accepting but has not finished coming up.
+    Drop,
+}
+
+/// A fake shepherd that survives a handover: ONE listener, one accepted
+/// connection at a time, and a [`Self::cut`] that drops the accepted
+/// connection out from under the client.
+///
+/// That asymmetry is the whole fixture. A real daemon handover passes the
+/// LISTENING socket across its `execve` and cannot pass an accepted one, so
+/// the address never stops being connectable while every established
+/// connection dies — which is precisely why a carried dog ends up a live
+/// process holding a dead socket. A fake that dropped its listener too
+/// would exercise "the daemon went away", a different situation with a
+/// different answer.
+///
+/// Each connection is served by the next [`Handshake`] in the list; once
+/// they run out the last one repeats, so a test sizes the list to what it
+/// means to assert and not to how many attempts the client makes.
+///
+/// Panics if `path` cannot be bound, and on any accept/decode/encode
+/// failure — test scaffolding, the same failure mode [`fake_daemon`]
+/// documents.
+#[derive(Debug)]
+pub struct Handovers {
+    cut: mpsc::Sender<()>,
+    cut_on_next_request: Arc<AtomicBool>,
+    accepted: Arc<AtomicU32>,
+    envelopes: Arc<Mutex<Vec<(u32, Envelope)>>>,
+    armed_list: Arc<Mutex<Vec<ProcessInfo>>>,
+    task: JoinHandle<()>,
+}
+
+impl Handovers {
+    /// Drops the currently accepted connection, leaving the listener bound.
+    ///
+    /// The handover, compressed: what the client sees is exactly what an
+    /// `execve` in the daemon produces for it.
+    pub async fn cut(&self) {
+        let _ = self.cut.send(()).await;
+    }
+
+    /// Arms the current connection to read its next request envelope and
+    /// then die WITHOUT answering it — a request the daemon may or may not
+    /// have acted on before the image swapped.
+    ///
+    /// Synchronous rather than `async`, so a test can arm it on the line
+    /// before the request it means to lose (an `await` here would give the
+    /// serving task a chance to run first).
+    pub fn cut_on_next_request(&self) {
+        self.cut_on_next_request.store(true, Ordering::SeqCst);
+    }
+
+    /// How many connections this fake has accepted so far, across every
+    /// generation. The number that says whether a client retried, gave up,
+    /// or spun.
+    #[must_use]
+    pub fn accepted(&self) -> u32 {
+        self.accepted.load(Ordering::SeqCst)
+    }
+
+    /// Every request envelope received so far, each paired with the 1-based
+    /// generation that received it — so a test can ask what the SUCCESSOR
+    /// saw rather than only what the fake saw in total.
+    #[must_use]
+    pub fn envelopes(&self) -> Vec<(u32, Envelope)> {
+        self.envelopes.lock().unwrap().clone()
+    }
+
+    /// Arms the answer every generation gives to `Request::ListFlock`.
+    /// Unlike [`FakeDaemon::reply_to_list`] this is not consumed, because a
+    /// test that reloads under a dog asks the same question of both
+    /// generations.
+    pub fn reply_to_list(&self, flock: Vec<ProcessInfo>) {
+        *self.armed_list.lock().unwrap() = flock;
+    }
+}
+
+impl Drop for Handovers {
+    fn drop(&mut self) {
+        self.task.abort();
+    }
+}
+
+/// Binds `path` and serves one connection per entry in `handshakes`, in
+/// order. See [`Handovers`] for what this fixture models and why the
+/// listener outlives every connection.
+///
+/// Panics if `path` cannot be bound — test scaffolding, the same failure
+/// mode [`fake_daemon`] documents.
+#[must_use]
+pub fn fake_daemon_across_handovers(path: &Path, handshakes: Vec<Handshake>) -> Handovers {
+    assert!(
+        !handshakes.is_empty(),
+        "a handover fixture needs at least one generation"
+    );
+    let mut listener = Listener::bind(path).unwrap();
+    let (cut_tx, mut cut_rx) = mpsc::channel(SCRIPT_CHANNEL_CAPACITY);
+    let cut_on_next_request = Arc::new(AtomicBool::new(false));
+    let accepted = Arc::new(AtomicU32::new(0));
+    let envelopes: Arc<Mutex<Vec<(u32, Envelope)>>> = Arc::new(Mutex::new(Vec::new()));
+    let armed_list: Arc<Mutex<Vec<ProcessInfo>>> = Arc::new(Mutex::new(Vec::new()));
+
+    let task = tokio::spawn({
+        let cut_on_next_request = Arc::clone(&cut_on_next_request);
+        let accepted = Arc::clone(&accepted);
+        let envelopes = Arc::clone(&envelopes);
+        let armed_list = Arc::clone(&armed_list);
+        async move {
+            let mut generation: u32 = 0;
+            while let Ok(stream) = listener.accept().await {
+                generation += 1;
+                accepted.fetch_add(1, Ordering::SeqCst);
+                let index = usize::try_from(generation - 1).unwrap_or(usize::MAX);
+                let script = handshakes
+                    .get(index)
+                    .unwrap_or_else(|| handshakes.last().expect("non-empty, asserted above"))
+                    .clone();
+                let mut frames = Framed::new(stream, codec());
+                match script {
+                    Handshake::Drop => continue,
+                    Handshake::Refuse(err) => {
+                        // The client's `Hello` is read first so the refusal
+                        // is an answer rather than a race with its own write.
+                        let _first = frames.next().await;
+                        let reply: HelloReply = Err(err);
+                        let _ = frames.send(encode_frame(&reply).unwrap()).await;
+                        continue;
+                    }
+                    Handshake::Accept(ack) => handshake(&mut frames, ack).await,
+                }
+                loop {
+                    tokio::select! {
+                        frame = frames.next() => {
+                            let Some(Ok(bytes)) = frame else { break };
+                            let envelope: Envelope = decode_frame(&bytes).unwrap();
+                            let id = envelope.id;
+                            let body = envelope.body.clone();
+                            envelopes.lock().unwrap().push((generation, envelope));
+                            if cut_on_next_request.swap(false, Ordering::SeqCst) {
+                                break;
+                            }
+                            let response = match body {
+                                Request::ListFlock => {
+                                    Response::Flock(armed_list.lock().unwrap().clone())
+                                }
+                                Request::Subscribe { .. } => Response::Subscribed,
+                                _ => Response::Pong,
+                            };
+                            write_reply(&mut frames, id, response).await;
+                        }
+                        _ = cut_rx.recv() => break,
+                    }
+                }
+            }
+        }
+    });
+
+    Handovers {
+        cut: cut_tx,
+        cut_on_next_request,
+        accepted,
+        envelopes,
+        armed_list,
+        task,
+    }
 }
 
 /// A `HelloAck` with a distinctive version and pid, so a test that asserts
@@ -769,6 +952,37 @@ pub async fn fake_client_on(path: &Path) -> (Client, FakeDaemon) {
 /// As [`fake_client_on`], but with a caller-chosen [`HelloAck`] — for a
 /// test asserting on the ack a `Client` receives.
 pub async fn fake_client_with_ack(path: &Path, ack: HelloAck) -> (Client, FakeDaemon) {
+    let daemon = fake_daemon_scripted_on(path, ack);
+    let client = Client::connect(path).await.unwrap();
+    (client, daemon)
+}
+
+/// As [`fake_client_on`], but hands back a [`ReconnectingClient`] — the
+/// supervised wrapper a dog uses — instead of a bare [`Client`].
+///
+/// The [`FakeDaemon`] behind it still serves exactly ONE connection, so a
+/// test that cuts this connection leaves the supervisor retrying against a
+/// listener that is gone. That is the right fixture for a test about what
+/// the dog does over a live connection, and the wrong one for a test about
+/// the reconnect itself — use [`fake_daemon_across_handovers`] for that.
+pub async fn fake_reconnecting_client_on(path: &Path) -> (ReconnectingClient, FakeDaemon) {
+    let daemon = fake_daemon_scripted_on(path, sample_ack());
+    let client = ReconnectingClient::connect(path).await.unwrap();
+    (client, daemon)
+}
+
+/// Binds `path` and starts the scripted fake WITHOUT connecting a client of
+/// its own, for a caller that performs its own connect — which is what
+/// separates a [`Client`] fixture from a [`ReconnectingClient`] one.
+///
+/// Synchronous: binding and spawning are both immediate, and the listener is
+/// bound before this returns, so a caller can connect straight away without
+/// a sleep.
+///
+/// Panics if `path` cannot be bound — test scaffolding, the same failure
+/// mode [`fake_daemon`] documents.
+#[must_use]
+pub fn fake_daemon_scripted_on(path: &Path, ack: HelloAck) -> FakeDaemon {
     let listener = Listener::bind(path).unwrap();
     let (script_tx, script_rx) = mpsc::channel(SCRIPT_CHANNEL_CAPACITY);
     let armed_list = Arc::new(Mutex::new(None));
@@ -791,21 +1005,17 @@ pub async fn fake_client_with_ack(path: &Path, ack: HelloAck) -> (Client, FakeDa
         Arc::clone(&armed_shutdown_never_unlink),
         Arc::clone(&list_flock_count),
     ));
-    let client = Client::connect(path).await.unwrap();
-    (
-        client,
-        FakeDaemon {
-            script: script_tx,
-            armed_list,
-            armed_list_sequence,
-            armed_describe,
-            armed_reply_then_event,
-            armed_shutdown_then_unlink,
-            armed_shutdown_never_unlink,
-            list_flock_count,
-            task,
-        },
-    )
+    FakeDaemon {
+        script: script_tx,
+        armed_list,
+        armed_list_sequence,
+        armed_describe,
+        armed_reply_then_event,
+        armed_shutdown_then_unlink,
+        armed_shutdown_never_unlink,
+        list_flock_count,
+        task,
+    }
 }
 
 /// Binds `path`, handshakes with [`sample_ack`], and hands back a connected

--- a/crates/shep-core/src/protocol/request.rs
+++ b/crates/shep-core/src/protocol/request.rs
@@ -451,6 +451,27 @@ pub enum Request {
         /// The dog's name
         name: String,
     },
+    /// Ask which dogs this daemon has given up on, and which it is still
+    /// waiting to hear from (`shep daemon reload`, the handover design's
+    /// G13).
+    ///
+    /// Read-only, and about THIS daemon's own handshakes. A dog's recorded
+    /// crate version describes the process that was running when it
+    /// connected, so it says nothing about a dog that has since been
+    /// replaced; the only thing that knows whether a dog can talk to this
+    /// daemon is whether this daemon accepted its handshake. That is what
+    /// this answers, which is why the reading is worth taking AFTER a
+    /// reload rather than before one.
+    ///
+    /// Answers [`Response::DogStaleness`].
+    ///
+    /// # Why this variant does not move `PROTOCOL_VERSION`
+    ///
+    /// The same argument [`Self::HandoverFitness`] makes above, and the
+    /// same gate enforces it: its only caller is `shep daemon reload`, which
+    /// asks it of the successor it has just proven is running this binary's
+    /// own version. An older daemon is never sent it.
+    DogStaleness,
     /// Ask whether this daemon could hand its flock to a successor in place,
     /// rather than stopping it and starting it again (`shep daemon reload`).
     ///
@@ -1342,6 +1363,30 @@ pub enum Response {
     },
     /// Answer to `EnableDog` — the dog as it stands now
     DogStarted(ProcessInfo),
+    /// Answer to `DogStaleness` — this daemon's own handshake record, split
+    /// into the dogs it has given up on and the dogs it is still waiting on.
+    ///
+    /// Two lists rather than one because they are answers to two different
+    /// questions, and only one of them is reportable. `stale` is a
+    /// finding: those dogs were refused, restarted from the binary on disk,
+    /// and refused again. `pending` is a reason to ask again: those
+    /// dogs have not finished settling, so a reading taken now would be a
+    /// guess about them rather than a fact.
+    ///
+    /// Names only. What a stale dog's crate version is does not answer the
+    /// question a caller is asking — two builds differing only in the
+    /// protocol they speak report the same version — so carrying one here
+    /// would invite exactly the inference it cannot support.
+    DogStaleness {
+        /// Dogs this daemon has refused twice: once on the handshake that
+        /// bought them a restart from disk, and again after it. It will not
+        /// restart them a third time (the handover design's G8).
+        stale: Vec<String>,
+        /// Dogs this daemon is still waiting to hear a final answer from —
+        /// one whose restart is in flight, or one it supervises that has
+        /// not handshook yet. Neither stale nor known healthy.
+        pending: Vec<String>,
+    },
     /// Answer to `HandoverFitness`: `None` when the whole flock can be
     /// carried across a daemon handover, and otherwise the sentence saying
     /// which sheep cannot be and why.
@@ -2106,6 +2151,16 @@ mod tests {
                 deadline_ms: None,
                 body: Request::HandoverFitness,
             },
+            // The second request gated on the daemon's crate version, and
+            // pinned beside the first for that reason: the two are asked by
+            // the same verb, of the two daemons either side of the same
+            // handover, and a rename of either is a variant nothing on
+            // either side recognises.
+            Envelope {
+                id: 25,
+                deadline_ms: None,
+                body: Request::DogStaleness,
+            },
         ];
         insta::assert_json_snapshot!("request_wire_v2", requests);
     }
@@ -2393,6 +2448,18 @@ mod tests {
                 id: 29,
                 result: Ok(Response::HandoverFitness {
                     refusal: Some("sheep 'web' has a shepherd channel".to_string()),
+                }),
+            },
+            // Both lists non-empty and DIFFERENT, because the two carry the
+            // same wire shape and a reply that filled one from the other
+            // would be invisible in a fixture that used the same names
+            // twice. Empty is the shape an ordinary reload sees, and it is
+            // already proven by every `Vec`-carrying row above.
+            Reply {
+                id: 30,
+                result: Ok(Response::DogStaleness {
+                    stale: vec!["metrics".to_string()],
+                    pending: vec!["bark".to_string()],
                 }),
             },
         ];

--- a/crates/shep-core/src/protocol/request.rs
+++ b/crates/shep-core/src/protocol/request.rs
@@ -15,6 +15,32 @@ pub struct Hello {
     pub client_version: String,
     /// [`crate::protocol::PROTOCOL_VERSION`] the client speaks
     pub protocol: u32,
+    /// The name this client was registered under as a dog, when it is one.
+    ///
+    /// `None` is what every other client truthfully is, and what a dog built
+    /// before this field existed sends. The CLI never sets it: a bare
+    /// `Client` has no way to, by construction, so `shep stop` cannot
+    /// impersonate a dog however its environment is set.
+    ///
+    /// The daemon needs it on exactly one path, and it is the path where
+    /// nothing else can supply it. A handshake refused for protocol skew
+    /// never reaches a request, so `Request::DogConfig`'s name — the one
+    /// place a dog otherwise identifies itself — is unreachable precisely
+    /// when the daemon has to know WHICH dog it just refused in order to
+    /// restart it (the handover design's G8). A dog already knows its own
+    /// name: the daemon put it in `$SHEP_DOG_NAME` when it spawned it.
+    ///
+    /// Additive by construction: absent on the wire rather than `null`, and
+    /// ignored by a daemon too old to know it, so
+    /// [`crate::protocol::PROTOCOL_VERSION`] does not move for it. That
+    /// argument deserves more care here than anywhere else, because `Hello`
+    /// IS the version-negotiation frame: a daemon that rejected unknown
+    /// fields would refuse a newer client BEFORE reading `protocol`, and
+    /// that would be a hard break rather than an additive change. It does
+    /// not — this type carries no `#[serde(deny_unknown_fields)]`, and
+    /// `a_hello_without_a_dog_name_still_parses` pins both directions.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub dog_name: Option<String>,
 }
 
 /// Daemon's handshake answer
@@ -2463,9 +2489,57 @@ mod tests {
         let hello = Hello {
             client_version: "0.1.0".to_string(),
             protocol: PROTOCOL_VERSION,
+            dog_name: None,
         };
         let json = serde_json::to_string(&hello).unwrap();
         assert_eq!(json, r#"{"client_version":"0.1.0","protocol":2}"#);
+    }
+
+    /// fails if a non-dog client's `Hello` grows a key. The CLI is the
+    /// overwhelming majority of handshakes and sends `dog_name: None`, so
+    /// `skip_serializing_if` is what keeps this addition free on the wire
+    /// for every client that is not a dog — and what makes the bytes above
+    /// byte-identical to the ones protocol 2 shipped with.
+    #[test]
+    fn a_dogs_hello_names_the_dog_and_nothing_elses_does() {
+        let dog = Hello {
+            client_version: "0.1.0".to_string(),
+            protocol: PROTOCOL_VERSION,
+            dog_name: Some("metrics".to_string()),
+        };
+        let json = serde_json::to_string(&dog).unwrap();
+        assert_eq!(
+            json,
+            r#"{"client_version":"0.1.0","protocol":2,"dog_name":"metrics"}"#
+        );
+        assert_eq!(serde_json::from_str::<Hello>(&json).unwrap(), dog);
+    }
+
+    /// fails if `Hello` gains `#[serde(deny_unknown_fields)]`, or if
+    /// `dog_name` stops being optional — the two ways this addition could
+    /// become a wire break after the fact.
+    ///
+    /// `Hello` is the version-negotiation frame, which makes it the one
+    /// place where rejecting an unknown field would be unrecoverable: the
+    /// daemon would refuse a newer client BEFORE reading `protocol`, so
+    /// neither peer could report the skew that caused it. The fixture below
+    /// is the committed bytes a client built before this field sends
+    /// (IR-35), and the second half is the same rule in the other
+    /// direction — an older daemon parsing a newer client's frame.
+    #[test]
+    fn a_hello_without_a_dog_name_still_parses() {
+        let fixture = r#"{"client_version":"0.1.14","protocol":2}"#;
+        let hello: Hello = serde_json::from_str(fixture).unwrap();
+        assert_eq!(hello.protocol, 2);
+        assert_eq!(hello.dog_name, None);
+
+        // The other direction: whatever an older daemon does not know, it
+        // must ignore rather than refuse. `unknown_to_an_older_daemon`
+        // stands in for `dog_name` as that daemon would see it.
+        let newer = r#"{"client_version":"9.9.9","protocol":2,"dog_name":"metrics","unknown_to_an_older_daemon":true}"#;
+        let hello: Hello = serde_json::from_str(newer).unwrap();
+        assert_eq!(hello.protocol, 2);
+        assert_eq!(hello.dog_name.as_deref(), Some("metrics"));
     }
 
     #[test]

--- a/crates/shep-core/src/protocol/snapshots/shep_core__protocol__request__tests__reply_wire_v2.snap
+++ b/crates/shep-core/src/protocol/snapshots/shep_core__protocol__request__tests__reply_wire_v2.snap
@@ -521,5 +521,21 @@ expression: replies
         }
       }
     }
+  },
+  {
+    "id": 30,
+    "result": {
+      "Ok": {
+        "kind": "dog_staleness",
+        "data": {
+          "stale": [
+            "metrics"
+          ],
+          "pending": [
+            "bark"
+          ]
+        }
+      }
+    }
   }
 ]

--- a/crates/shep-core/src/protocol/snapshots/shep_core__protocol__request__tests__request_wire_v2.snap
+++ b/crates/shep-core/src/protocol/snapshots/shep_core__protocol__request__tests__request_wire_v2.snap
@@ -275,5 +275,12 @@ expression: requests
     "body": {
       "kind": "handover_fitness"
     }
+  },
+  {
+    "id": 25,
+    "deadline_ms": null,
+    "body": {
+      "kind": "dog_staleness"
+    }
   }
 ]

--- a/crates/shep-daemon/src/boot.rs
+++ b/crates/shep-daemon/src/boot.rs
@@ -1319,6 +1319,10 @@ pub async fn boot<R: ProcessRunner>(
         daemon_config: paths.daemon_config.clone(),
         paths: paths.clone(),
         daemon_version: env!("CARGO_PKG_VERSION").to_string(),
+        // Empty, and deliberately not carried across a handover: a
+        // successor has refused nobody yet, and a dog it can talk to is not
+        // stale by any definition it could apply.
+        dog_refusals: crate::dogs::DogRefusals::new(),
         pid,
         shutdown,
         stats,

--- a/crates/shep-daemon/src/boot.rs
+++ b/crates/shep-daemon/src/boot.rs
@@ -4101,9 +4101,6 @@ mod tests {
             .unwrap();
     }
 
-    /// A blob written by hand rather than by `Handover::write`, so this
-    /// module's tests pin the on-disk shape a successor has to read rather
-    /// than round-tripping whatever the writer happens to emit.
     /// One carried sheep, named, with `dog` set or not.
     #[cfg(unix)]
     fn carried_for_the_roll(
@@ -4188,6 +4185,9 @@ mod tests {
         );
     }
 
+    /// A blob written by hand rather than by `Handover::write`, so this
+    /// module's tests pin the on-disk shape a successor has to read rather
+    /// than round-tripping whatever the writer happens to emit.
     fn write_blob(path: &Path, version: u32) {
         std::fs::write(
             path,

--- a/crates/shep-daemon/src/boot.rs
+++ b/crates/shep-daemon/src/boot.rs
@@ -558,6 +558,33 @@ impl PidfileLock {
     }
 }
 
+/// The apps a successor records in its own registry, which is what the
+/// muster roll on disk is written from.
+///
+/// Every carried sheep's, and **no dog's**. A dog is registered by
+/// `dogs::spawn_enabled_dogs` at every boot, from `shep.toml`'s own
+/// `enabled_dogs`/`adopted_dogs` lists, and it has never been in the roll:
+/// nothing on the dog path ever touches [`FlockRegistry::record`]. Writing
+/// one in here would put it there for the first time, and the roll outlives
+/// the daemon -- so a later cold boot would restore `metrics` as an
+/// ordinary sheep, with no marker, before `spawn_enabled_dogs` got to it,
+/// and `shep disable metrics` would not be able to take it back out.
+///
+/// The filter belongs here rather than at the `record_config` call because
+/// this is the one place that still holds the blob's own rows: the registry
+/// takes bare [`AppConfig`](shep_core::config::AppConfig)s, which carry no
+/// marker to filter on afterwards.
+#[cfg(unix)]
+fn apps_for_the_roll(
+    flock: &[crate::handover::adopt::AdoptedSheep],
+) -> Vec<shep_core::config::AppConfig> {
+    flock
+        .iter()
+        .filter(|sheep| sheep.carried.dog().is_none())
+        .map(|sheep| sheep.carried.app().clone())
+        .collect()
+}
+
 /// The handover blob this process was handed, if it is a successor.
 ///
 /// A successor is a shep image an outgoing daemon `execve`d in its own
@@ -1220,7 +1247,7 @@ pub async fn boot<R: ProcessRunner>(
         Some((flock, counters, reloads)) => {
             // Read before the flock is moved: the registry below is rebuilt
             // from these, and the roll would otherwise be written empty.
-            carried_apps.extend(flock.iter().map(|sheep| sheep.carried.app().clone()));
+            carried_apps.extend(apps_for_the_roll(&flock));
             builder
                 .spawn_adopted(flock, counters, reloads)
                 .map_err(|source| BootError::Adopt(source.to_string()))?
@@ -3469,40 +3496,45 @@ mod tests {
     /// them, meet `EBADF`, and return, rather than exec'ing this test binary
     /// into an endless re-run of the whole suite. The assertion on
     /// the message is what tells the two failures apart.
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn a_sighup_over_a_flock_it_cannot_carry_refuses_before_it_execs() {
-        // Real time + real signal listeners. This case raises nothing
-        // itself, but `SIGNAL_TEST_LOCK`'s rule is "calls `boot()`
+        // Real signal listeners, and a PAUSED clock. This case raises
+        // nothing itself, but `SIGNAL_TEST_LOCK`'s rule is "calls `boot()`
         // successfully", not "calls `raise()`": a successful `boot()`
         // installs SIGTERM, SIGHUP and SIGUSR2 listeners that run for this
         // test's whole duration, and a concurrent `raise()` in one of the
         // shutdown cases reaches them too. This daemon would then shut down
         // ahead of its own `ctx.shutdown()` while absorbing a delivery the
         // other test needed, which is the way a real regression there gets
-        // masked.
+        // masked. The lock is about the signals; the clock is a separate
+        // question, and pausing it is what stops the refusal this case
+        // needs -- a log pump missing `REPORT_DEADLINE` -- costing the
+        // suite two real seconds. Measured: 2.0s awake, 0.03s paused.
         let _guard = SIGNAL_TEST_LOCK.lock().await;
         let dir = tempfile::tempdir().unwrap();
         let paths = test_paths(&dir);
         init_dirs(&paths).unwrap();
-        // A dog: the sheep the gate still refuses. This was a shepherd
-        // channel until 2b task 5 carried one and two instances until task
-        // 6 carried those, and the case is about the gate firing at all
-        // rather than about which feature fires it. Task 7 carries dogs, so
-        // it moves again.
+        // A wedged log pump: the one thing the gate still refuses, and the
+        // only one it ever will. The case is about the gate firing at all
+        // rather than about what fires it, so its fixture has moved every
+        // time a phase carried the feature it was reaching for -- a
+        // shepherd channel in 2b task 5, two instances in task 6, a dog in
+        // phase 3 task 4. There is nothing left for it to move to.
         let daemon = boot(
-            ScriptedRunner::new(vec![ProcScript::never_exits()]),
+            ScriptedRunner::new(vec![ProcScript::never_exits()])
+                .with_a_pump_that_never_reports(&["wedged"]),
             paths.clone(),
-            BootOptions {
-                dogs: vec![DogSpec {
-                    name: "metrics".to_string(),
-                    source: DogSource::BuiltIn,
-                }],
-                ..BootOptions::default()
-            },
+            BootOptions::default(),
         )
         .await
         .unwrap();
         let ctx = daemon.context();
+        ctx.supervisor
+            .start(vec![
+                normalize(AppConfig::minimal("wedged", "./srv")).unwrap(),
+            ])
+            .await
+            .unwrap();
 
         let seam = HandoverSeam {
             supervisor: ctx.supervisor.clone(),
@@ -3514,10 +3546,14 @@ mod tests {
         };
         let refusal = hand_over_now(&seam)
             .await
-            .expect_err("a flock with a dog in it cannot be carried");
+            .expect_err("a flock with a wedged log pump cannot be carried");
         assert!(
-            refusal.contains("being a dog"),
+            refusal.contains("did not report its descriptors in time"),
             "the gate must refuse before anything is exec'd: {refusal}"
+        );
+        assert!(
+            refusal.contains("wedged"),
+            "the refusal must name the sheep that held the flock back: {refusal}"
         );
 
         ctx.shutdown();
@@ -3618,33 +3654,29 @@ mod tests {
     /// Two sheep, because the resume has to reach every pump that was
     /// reported to rather than the one the refusal named.
     #[cfg(unix)]
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn an_abandoned_handover_starts_every_pump_reading_again() {
         // As the sibling above: a successful `boot()` installs real signal
-        // listeners for this test's whole duration.
+        // listeners for this test's whole duration, and the clock is paused
+        // so the missed `REPORT_DEADLINE` this refusal needs costs the
+        // suite nothing to wait out.
         let _guard = SIGNAL_TEST_LOCK.lock().await;
         let dir = tempfile::tempdir().unwrap();
         let paths = test_paths(&dir);
         init_dirs(&paths).unwrap();
-        let runner = Arc::new(ScriptedRunner::new(vec![ProcScript::never_exits(); 3]));
-        // The refusal: a dog is a sheep this daemon still cannot carry, and
-        // the gate reads it AFTER every pump has already been reported to,
-        // which is what makes the resume owed. It was a shepherd channel
-        // until 2b task 5 carried one and two instances until task 6
-        // carried those; what the case needs is any refusal at all.
-        //
-        // Spawned by `boot` rather than by the `start` below, so the dog is
-        // script 0 and the two sheep are 1 and 2.
+        let runner = Arc::new(
+            ScriptedRunner::new(vec![ProcScript::never_exits(); 3])
+                .with_a_pump_that_never_reports(&["wedged"]),
+        );
+        // The refusal: a wedged log pump, read AFTER every pump that
+        // answered has already been reported to and parked, which is what
+        // makes the resume owed. It was a dog until phase 3 task 4 carried
+        // one, a shepherd channel until 2b task 5 and two instances until
+        // task 6; what the case needs is any refusal at all.
         let daemon = boot(
             SharedRunner(Arc::clone(&runner)),
             paths.clone(),
-            BootOptions {
-                dogs: vec![DogSpec {
-                    name: "metrics".to_string(),
-                    source: DogSource::BuiltIn,
-                }],
-                ..BootOptions::default()
-            },
+            BootOptions::default(),
         )
         .await
         .unwrap();
@@ -3653,6 +3685,7 @@ mod tests {
             .start(vec![
                 normalize(AppConfig::minimal("quiet", "./srv")).unwrap(),
                 normalize(AppConfig::minimal("chatty", "./srv")).unwrap(),
+                normalize(AppConfig::minimal("wedged", "./srv")).unwrap(),
             ])
             .await
             .unwrap();
@@ -3673,31 +3706,45 @@ mod tests {
         };
         let refusal = hand_over_now(&seam)
             .await
-            .expect_err("a flock with a dog in it cannot be carried");
+            .expect_err("a flock with a wedged log pump cannot be carried");
         assert!(
-            refusal.contains("being a dog"),
+            refusal.contains("did not report its descriptors in time"),
             "the gate must refuse before anything is exec'd: {refusal}"
         );
 
+        let answered: Vec<usize> = ["quiet", "chatty"]
+            .iter()
+            .map(|name| runner.spawn_index_of(name).expect("started above"))
+            .collect();
+        let wedged = runner.spawn_index_of("wedged").expect("started above");
         // Polled rather than read once: a resume carries no acknowledgement
         // (see `LogCtl::Resume`), so a send that has returned has been
         // queued rather than served. Bounded, so a pump that is never told
         // fails here instead of hanging.
         let all_resumed = async {
-            while (0..3).any(|sheep| runner.resumes(sheep) == 0) {
+            while answered.iter().any(|sheep| runner.resumes(*sheep) == 0) {
                 tokio::time::sleep(Duration::from_millis(10)).await;
             }
         };
         tokio::time::timeout(Duration::from_secs(10), all_resumed)
             .await
             .expect("every pump a refused handover reported to must be reading again");
-        for sheep in 0..3 {
+        for sheep in &answered {
             assert_eq!(
-                runner.resumes(sheep),
+                runner.resumes(*sheep),
                 1,
                 "sheep {sheep} must be resumed once rather than repeatedly"
             );
         }
+        // The plural is what this case adds over its sibling, which has one
+        // answering pump: a resume that reached only the first sheep
+        // reported to would satisfy that one and fail here.
+        assert_eq!(answered.len(), 2, "two pumps must have answered the report");
+        assert_eq!(
+            runner.resumes(wedged),
+            0,
+            "a pump that never answered never parked, so nothing may resume it"
+        );
 
         ctx.shutdown();
         tokio::time::timeout(Duration::from_secs(5), daemon.run())
@@ -4057,6 +4104,90 @@ mod tests {
     /// A blob written by hand rather than by `Handover::write`, so this
     /// module's tests pin the on-disk shape a successor has to read rather
     /// than round-tripping whatever the writer happens to emit.
+    /// One carried sheep, named, with `dog` set or not.
+    #[cfg(unix)]
+    fn carried_for_the_roll(
+        name: &str,
+        dog: Option<DogSource>,
+    ) -> crate::handover::adopt::AdoptedSheep {
+        let mut entry = crate::entry::ProcessEntry {
+            id: 1,
+            spec: normalize(AppConfig::minimal(name, "./srv")).unwrap(),
+            instance: 0,
+            status: shep_core::status::ProcStatus::Online,
+            pid: Some(4242),
+            restarts: 0,
+            started_at: None,
+            budget: crate::entry::RestartBudget::default(),
+            reload: crate::entry::ReloadState::None,
+            credentials: crate::privilege::SpawnIdentity::Resolved(None),
+            out_file: PathBuf::new(),
+            err_file: PathBuf::new(),
+            dog: None,
+            last_exit: None,
+        };
+        entry.dog = dog;
+        crate::handover::adopt::AdoptedSheep {
+            carried: crate::handover::CarriedSheep::from_entry(
+                &entry,
+                0,
+                crate::handover::CarriedFds::none(),
+                false,
+                None,
+                false,
+                None,
+            ),
+            out_pipe: None,
+            err_pipe: None,
+            out_log: None,
+            err_log: None,
+            stdin_pipe: None,
+            channel: None,
+        }
+    }
+
+    /// fails if a carried dog reaches the muster roll.
+    ///
+    /// A successor rebuilds its registry from the blob rather than from the
+    /// roll, and the registry is what the roll on disk is written from
+    /// within seconds. A dog has never been in it -- `spawn_enabled_dogs`
+    /// registers dogs straight through the supervisor and never touches
+    /// `FlockRegistry` -- so a successor that recorded one would put it
+    /// there for the first time, and permanently: the roll outlives the
+    /// daemon, so a later cold boot would restore `metrics` as an ordinary
+    /// unmarked sheep BEFORE `spawn_enabled_dogs` ran, and `shep disable
+    /// metrics` could not take it back out.
+    ///
+    /// Both rows, because a filter that dropped everything would satisfy
+    /// the negative half on its own -- and an empty registry is the failure
+    /// this whole `record_config` path exists to prevent, since it would
+    /// overwrite a good roll with an empty one.
+    #[cfg(unix)]
+    #[test]
+    fn a_carried_dog_does_not_reach_the_muster_roll() {
+        let flock = vec![
+            carried_for_the_roll("web", None),
+            carried_for_the_roll("metrics", Some(DogSource::BuiltIn)),
+            carried_for_the_roll(
+                "log-rotate",
+                Some(DogSource::Adopted {
+                    path: "/opt/bin/shep-log-rotate".to_string(),
+                }),
+            ),
+        ];
+
+        let names: Vec<String> = apps_for_the_roll(&flock)
+            .into_iter()
+            .map(|app| app.name)
+            .collect();
+
+        assert_eq!(
+            names,
+            vec!["web".to_string()],
+            "the roll is the operator's flock; a dog belongs to `shep.toml`"
+        );
+    }
+
     fn write_blob(path: &Path, version: u32) {
         std::fs::write(
             path,

--- a/crates/shep-daemon/src/dogs.rs
+++ b/crates/shep-daemon/src/dogs.rs
@@ -33,7 +33,7 @@
 //! that exposure to a second surface.
 
 use core::fmt;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex, PoisonError};
 
@@ -321,9 +321,30 @@ pub enum Refusal {
 /// VALUES, and no value ever reaches this type.
 #[derive(Debug, Clone, Default)]
 pub struct DogRefusals {
+    /// Both halves under one lock, because every caller that changes one
+    /// changes the other in the same breath and a dog seen as refused and
+    /// handshook at once is a state no reader should be able to observe.
+    seen: Arc<Mutex<Links>>,
+}
+
+/// What [`DogRefusals`] holds: how often each dog has been refused, and
+/// which dogs have ever got in.
+///
+/// Private, and only ever reached under the one lock above.
+#[derive(Debug, Default)]
+struct Links {
     /// Refusals per dog name since that dog last handshook. A name absent
     /// from the map has not been refused since it last got in.
-    seen: Arc<Mutex<BTreeMap<String, u32>>>,
+    refusals: BTreeMap<String, u32>,
+    /// Dogs whose handshake this daemon has accepted and not refused
+    /// since.
+    ///
+    /// Not derivable from the absence of a refusal, which is why it is
+    /// kept: a dog that has never connected at all and a dog that is
+    /// talking happily both have no entry in [`Self::refusals`], and
+    /// telling those two apart is the whole of what G13's reporting waits
+    /// on.
+    handshook: BTreeSet<String>,
 }
 
 impl DogRefusals {
@@ -342,7 +363,11 @@ impl DogRefusals {
     /// [`Refusal::AlreadyStale`]. There is no fourth case and no dial.
     pub fn refused(&self, name: &str) -> Refusal {
         let mut seen = self.lock();
-        let count = seen.entry(name.to_string()).or_insert(0);
+        // A dog this daemon was talking to a moment ago is no longer one it
+        // can vouch for. The connection that earned the mark is gone, and
+        // the process behind the name may not be the one that made it.
+        seen.handshook.remove(name);
+        let count = seen.refusals.entry(name.to_string()).or_insert(0);
         *count = count.saturating_add(1);
         match *count {
             1 => Refusal::Restart,
@@ -357,7 +382,35 @@ impl DogRefusals {
     /// A dog that is talking to this daemon is not stale by any definition
     /// this daemon can apply, whatever happened before.
     pub fn handshook(&self, name: &str) {
-        self.lock().remove(name);
+        let mut seen = self.lock();
+        seen.refusals.remove(name);
+        seen.handshook.insert(name.to_string());
+    }
+
+    /// Whether `name` has handshook with this daemon and not been refused
+    /// since.
+    ///
+    /// The question G13's reporting asks of every dog before it reports
+    /// anything: a dog that has answered is one whose state is a fact, and
+    /// a dog that has not is one the answer would be a guess about.
+    #[must_use]
+    pub fn has_handshook(&self, name: &str) -> bool {
+        self.lock().handshook.contains(name)
+    }
+
+    /// Every dog whose one restart from disk is in flight, sorted.
+    ///
+    /// Exactly the dogs refused ONCE. The restart G8 owes them has been
+    /// asked for and its outcome has not arrived, so neither answer is
+    /// available yet: they are not stale, and they are not talking.
+    #[must_use]
+    pub fn restarting(&self) -> Vec<String> {
+        self.lock()
+            .refusals
+            .iter()
+            .filter(|(_, count)| **count == 1)
+            .map(|(name, _)| name.clone())
+            .collect()
     }
 
     /// Every dog this daemon has given up on, sorted.
@@ -370,20 +423,21 @@ impl DogRefusals {
     #[must_use]
     pub fn stale(&self) -> Vec<String> {
         self.lock()
+            .refusals
             .iter()
             .filter(|(_, count)| **count >= 2)
             .map(|(name, _)| name.clone())
             .collect()
     }
 
-    /// The map, treating a poisoned lock as ordinary data.
+    /// The record, treating a poisoned lock as ordinary data.
     ///
     /// Every critical section here is a lookup or an increment on a plain
-    /// `BTreeMap`, so a panic elsewhere cannot leave a torn value, and
-    /// taking down a daemon whose whole job is staying up would be the
-    /// worse failure — the same argument
+    /// `BTreeMap` and a `BTreeSet`, so a panic elsewhere cannot leave a torn
+    /// value, and taking down a daemon whose whole job is staying up would
+    /// be the worse failure — the same argument
     /// [`FlockRegistry`](crate::snapshot) already makes for its own map.
-    fn lock(&self) -> std::sync::MutexGuard<'_, BTreeMap<String, u32>> {
+    fn lock(&self) -> std::sync::MutexGuard<'_, Links> {
         self.seen.lock().unwrap_or_else(PoisonError::into_inner)
     }
 }
@@ -901,6 +955,57 @@ mod tests {
             refusals.stale(),
             vec!["bark".to_string()],
             "one dog getting in says nothing about another"
+        );
+    }
+
+    /// fails if a dog mid-restart reads as an answer. G13's report is taken
+    /// once every dog has settled, and a dog refused ONCE has not: the
+    /// restart G8 owes it has been asked for and its verdict has not come
+    /// back. Reading that as "not stale" is exactly the early report the
+    /// whole rule exists to prevent — it is the state a stale dog passes
+    /// through on its way to being stale.
+    #[test]
+    fn a_dog_mid_restart_is_neither_stale_nor_settled() {
+        let refusals = DogRefusals::new();
+        assert!(refusals.restarting().is_empty());
+
+        refusals.refused("metrics");
+        assert_eq!(refusals.restarting(), vec!["metrics".to_string()]);
+        assert!(refusals.stale().is_empty());
+
+        refusals.refused("metrics");
+        assert!(
+            refusals.restarting().is_empty(),
+            "a dog that has been given up on is settled, not still being restarted"
+        );
+        assert_eq!(refusals.stale(), vec!["metrics".to_string()]);
+    }
+
+    /// fails if "this daemon has heard from that dog" is inferred from the
+    /// absence of a refusal. A dog that has never connected and a dog
+    /// talking happily both have no refusal recorded, and telling those two
+    /// apart is the whole of what G13's report waits on: the first is a
+    /// carried dog that has not dialled back yet.
+    ///
+    /// The refusal half is the other direction. A dog this daemon accepted
+    /// and has since refused is not one it can vouch for any more — the
+    /// connection that earned the mark is gone.
+    #[test]
+    fn only_an_accepted_handshake_says_a_dog_has_answered() {
+        let refusals = DogRefusals::new();
+        assert!(
+            !refusals.has_handshook("metrics"),
+            "a dog nobody has heard from has not answered"
+        );
+
+        refusals.handshook("metrics");
+        assert!(refusals.has_handshook("metrics"));
+        assert!(!refusals.has_handshook("bark"), "one dog answers for one");
+
+        refusals.refused("metrics");
+        assert!(
+            !refusals.has_handshook("metrics"),
+            "the handshake that earned the mark is the one that just died"
         );
     }
 }

--- a/crates/shep-daemon/src/dogs.rs
+++ b/crates/shep-daemon/src/dogs.rs
@@ -33,12 +33,15 @@
 //! that exposure to a second surface.
 
 use core::fmt;
+use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex, PoisonError};
 
 use shep_core::barks::{self, Bark};
 use shep_core::config::{AppConfig, DaemonConfig, ResolvedApp, normalize};
 use shep_core::paths::ShepPaths;
 use shep_core::protocol::{BusEvent, DogSource, ProcessEventKind};
+use shep_core::selector::ProcessSelector;
 use tokio::sync::broadcast::{self, error::RecvError};
 
 use crate::bus::SharedEvent;
@@ -258,6 +261,223 @@ pub fn dog_section(path: &Path, name: &str) -> Result<String, DogError> {
     match config.dog.get(name) {
         None => Ok(String::new()),
         Some(table) => toml::to_string(table).map_err(|err| DogError::Config(err.to_string())),
+    }
+}
+
+/// What a refused handshake costs the dog that sent it.
+///
+/// Derived from how many times that dog has been refused since it last
+/// handshook successfully, rather than being a tuning choice — see
+/// [`DogRefusals::refused`], which is the only thing that produces one.
+///
+/// `#[non_exhaustive]`: `shep-daemon` is a published library, and a fourth
+/// verdict (a dog refused for something other than protocol skew, say)
+/// would otherwise be a breaking change for an out-of-tree matcher (IR-20).
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Refusal {
+    /// The first refusal since this dog last handshook. Restart it once,
+    /// from disk: the running image is stale, and the binary on disk is
+    /// very often already the right one — that is the ordinary shape of an
+    /// upgrade, where the package replaced the file and the running process
+    /// is simply the old one.
+    Restart,
+    /// The second. The restart already happened and produced a dog that
+    /// speaks the same protocol the last one did, which PROVES the binary
+    /// on disk cannot satisfy this daemon either. Restarting again would be
+    /// a spin, not optimism. Report it stale and stop.
+    Stale,
+    /// Already stale, already reported. Say nothing further: a stale dog
+    /// that its own `autorestart` keeps respawning would otherwise write
+    /// one error line per respawn, and the operator has already been told
+    /// the one thing there is to tell.
+    AlreadyStale,
+}
+
+/// Which dogs this daemon has refused at the handshake, and how often since
+/// each last got in.
+///
+/// The handover design's G8, held as state: a refused dog is restarted
+/// ONCE and then reported stale, and the difference between those two is
+/// nothing more than whether this daemon has refused it before. Cheap to
+/// clone (one `Arc`), and shared by every connection through
+/// [`RpcContext`](crate::rpc::RpcContext).
+///
+/// **A count per dog, cleared by a successful handshake.** Clearing on the
+/// handshake rather than on the restart is what bounds the whole thing: a
+/// dog that keeps being refused never clears, so it never earns a second
+/// restart, while a dog that gets in is back to a clean slate and would be
+/// restarted once again by a LATER daemon that refuses it. One restart per
+/// episode, and an episode ends when the dog is talking again.
+///
+/// Nothing here survives a handover, and that is correct rather than a
+/// gap: a successor is a different daemon that has refused nobody yet, and
+/// a dog it can talk to is not stale by any definition it could apply.
+///
+/// `Debug` is derived and needs no redaction (IR-41): the map holds dog
+/// names and counts. A dog's name is the `[dog.<name>]` key an operator
+/// typed, which `dogs.rs` already places in the child's environment for the
+/// reason its module doc gives — the section's KEY is not one of its
+/// VALUES, and no value ever reaches this type.
+#[derive(Debug, Clone, Default)]
+pub struct DogRefusals {
+    /// Refusals per dog name since that dog last handshook. A name absent
+    /// from the map has not been refused since it last got in.
+    seen: Arc<Mutex<BTreeMap<String, u32>>>,
+}
+
+impl DogRefusals {
+    /// Builds an empty record — a daemon that has refused nobody.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Records one refused handshake from the dog named `name`, and says
+    /// what the daemon should do about it.
+    ///
+    /// The rule is G8's, and it falls out of the count rather than being
+    /// configured: the first refusal earns [`Refusal::Restart`], the second
+    /// [`Refusal::Stale`], and every one after that
+    /// [`Refusal::AlreadyStale`]. There is no fourth case and no dial.
+    pub fn refused(&self, name: &str) -> Refusal {
+        let mut seen = self.lock();
+        let count = seen.entry(name.to_string()).or_insert(0);
+        *count = count.saturating_add(1);
+        match *count {
+            1 => Refusal::Restart,
+            2 => Refusal::Stale,
+            _ => Refusal::AlreadyStale,
+        }
+    }
+
+    /// Records that `name` handshook successfully, clearing whatever this
+    /// daemon held against it.
+    ///
+    /// A dog that is talking to this daemon is not stale by any definition
+    /// this daemon can apply, whatever happened before.
+    pub fn handshook(&self, name: &str) {
+        self.lock().remove(name);
+    }
+
+    /// Every dog this daemon has given up on, sorted.
+    ///
+    /// A dog is stale once it has been refused twice: the first refusal
+    /// bought it a restart from disk, and the second proved the disk binary
+    /// is no better. This is the daemon's own answer to "which dogs cannot
+    /// talk to me", and the reading G13's `daemon reload` reporting is
+    /// meant to take.
+    #[must_use]
+    pub fn stale(&self) -> Vec<String> {
+        self.lock()
+            .iter()
+            .filter(|(_, count)| **count >= 2)
+            .map(|(name, _)| name.clone())
+            .collect()
+    }
+
+    /// The map, treating a poisoned lock as ordinary data.
+    ///
+    /// Every critical section here is a lookup or an increment on a plain
+    /// `BTreeMap`, so a panic elsewhere cannot leave a torn value, and
+    /// taking down a daemon whose whole job is staying up would be the
+    /// worse failure — the same argument
+    /// [`FlockRegistry`](crate::snapshot) already makes for its own map.
+    fn lock(&self) -> std::sync::MutexGuard<'_, BTreeMap<String, u32>> {
+        self.seen.lock().unwrap_or_else(PoisonError::into_inner)
+    }
+}
+
+/// Records a dog's refused handshake and acts on it — the whole of the
+/// handover design's G8, from the one place that knows a refusal happened.
+///
+/// Three steps and one prohibition:
+///
+/// 1. **Record it.** Every refusal is logged, at a level that says what the
+///    daemon is doing about it. Before this existed the refusal was logged
+///    at no level at all, which is half of what G8 calls a defect: a dog
+///    could go mute and neither side would write a line.
+/// 2. **Restart it once, from disk.** A restart re-spawns the binary the
+///    dog's stored config names, which is the file on disk now and not the
+///    image the running process was started from. That is the entire
+///    automatic fix, and it is enough for the ordinary case: the package
+///    already replaced the binary and the running process is merely old.
+/// 3. **Then stop.** A second refusal proves the disk binary cannot satisfy
+///    this daemon either, so a third restart would be a spin rather than
+///    optimism. The dog is reported stale and left alone.
+///
+/// **Never loops**, and that is a property of the state rather than a
+/// budget: [`DogRefusals`] only clears a dog's count when that dog
+/// handshakes successfully, so a dog that cannot get in cannot earn a
+/// second restart however many times it is refused.
+///
+/// The restart runs on its own task rather than inline. A restart is a full
+/// kill ladder, which can take as long as the dog's `kill_timeout`, and the
+/// caller is a connection handler holding a socket this daemon has already
+/// refused — there is nothing left on that connection worth delaying for.
+///
+/// **What this does NOT do is stop a stale dog's own `autorestart`.** A dog
+/// whose process EXITS on a refused handshake — which is what a dog does
+/// when its very first connection is refused, rather than one it lost to a
+/// handover — is respawned by the supervisor exactly as any sheep would be,
+/// and goes on being refused until its restart budget runs out and
+/// [`spawn_dog_watch`] records the exhaustion. That loop is bounded, it is
+/// the supervisor's existing mechanism, and G8 is about not ADDING daemon
+/// restarts on top of it.
+pub fn record_refused_dog(
+    name: &str,
+    client_version: &str,
+    refusals: &DogRefusals,
+    supervisor: &SupervisorHandle,
+) -> Refusal {
+    let verdict = refusals.refused(name);
+    match verdict {
+        Refusal::Restart => {
+            tracing::warn!(
+                dog = %name,
+                dog_version = %client_version,
+                "refused a dog on protocol skew; restarting it once from the binary on disk"
+            );
+            let supervisor = supervisor.clone();
+            let name = name.to_string();
+            tokio::spawn(async move { restart_refused_dog(&supervisor, &name).await });
+        }
+        Refusal::Stale => tracing::error!(
+            dog = %name,
+            dog_version = %client_version,
+            "refused a dog on protocol skew again after restarting it: the binary on disk speaks the same protocol the running one did, so this dog is stale and will not be restarted again. Rebuild or reinstall it against this shep"
+        ),
+        Refusal::AlreadyStale => tracing::debug!(
+            dog = %name,
+            dog_version = %client_version,
+            "refused a dog already reported stale"
+        ),
+    }
+    verdict
+}
+
+/// Restarts the dog named `name`, logging either outcome.
+///
+/// [`SupervisorHandle::restart_automatic`] rather than the operator door:
+/// nobody typed this, so an operator's own `stop` or `delete` landing
+/// mid-ladder must take the dog off it rather than being silently converted
+/// into the restart it raced.
+///
+/// An exact-name selector, which is also the only kind that reaches a dog
+/// at all — the supervisor deliberately keeps dogs out of `all` and out of
+/// pattern matches, so an operator's `shep restart all` never touches one.
+async fn restart_refused_dog(supervisor: &SupervisorHandle, name: &str) {
+    match supervisor
+        .restart_automatic(ProcessSelector::Name(name.to_string()))
+        .await
+    {
+        Ok(_) => tracing::info!(dog = %name, "restarted a refused dog from the binary on disk"),
+        // Not an error the daemon can act on: the dog may have been
+        // disabled between the refusal and this restart, or the engine may
+        // be shutting down. Either way the dog is not coming back on this
+        // daemon's initiative, and saying so once is the whole of what is
+        // left to do.
+        Err(err) => tracing::warn!(dog = %name, %err, "a refused dog could not be restarted"),
     }
 }
 
@@ -614,5 +834,73 @@ mod tests {
         );
 
         watch.abort();
+    }
+
+    /// fails if a refused dog is restarted more than once. The one-restart
+    /// rule is the whole difference between an automatic fix and a crash
+    /// loop, and it is derived from the count rather than configured: a
+    /// second refusal PROVES the binary on disk cannot satisfy this daemon,
+    /// because the restart already ran it.
+    #[test]
+    fn a_refused_dog_earns_one_restart_and_is_then_stale_forever() {
+        let refusals = DogRefusals::new();
+        assert!(refusals.stale().is_empty());
+
+        assert_eq!(refusals.refused("metrics"), Refusal::Restart);
+        assert!(
+            refusals.stale().is_empty(),
+            "one refusal is a dog to restart, not a dog to give up on"
+        );
+
+        assert_eq!(refusals.refused("metrics"), Refusal::Stale);
+        assert_eq!(refusals.stale(), vec!["metrics".to_string()]);
+
+        // The refusals a stale dog's own autorestart goes on producing must
+        // not each buy another restart, and must not each be reported.
+        for _ in 0..5 {
+            assert_eq!(refusals.refused("metrics"), Refusal::AlreadyStale);
+        }
+        assert_eq!(refusals.stale(), vec!["metrics".to_string()]);
+    }
+
+    /// fails if a dog that got back in stays marked. The count is cleared
+    /// by a successful handshake and by nothing else, which is what makes
+    /// "one restart" mean one restart per episode rather than one per
+    /// daemon: a dog talking to this daemon is not stale by any definition
+    /// it could apply, and a LATER refusal is a new episode with its own
+    /// restart.
+    #[test]
+    fn a_dog_that_gets_in_is_owed_a_fresh_restart_if_it_is_ever_refused_again() {
+        let refusals = DogRefusals::new();
+        assert_eq!(refusals.refused("metrics"), Refusal::Restart);
+        refusals.handshook("metrics");
+        assert!(refusals.stale().is_empty());
+        assert_eq!(
+            refusals.refused("metrics"),
+            Refusal::Restart,
+            "the restart that fixed it must not be charged against the next episode"
+        );
+    }
+
+    /// fails if the record is per-daemon rather than per-dog. A stale
+    /// `bark` must not spend `metrics`'s one restart, and a healthy
+    /// `metrics` handshake must not clear `bark`'s stale mark.
+    #[test]
+    fn each_dog_carries_its_own_count() {
+        let refusals = DogRefusals::new();
+        assert_eq!(refusals.refused("bark"), Refusal::Restart);
+        assert_eq!(refusals.refused("bark"), Refusal::Stale);
+
+        assert_eq!(
+            refusals.refused("metrics"),
+            Refusal::Restart,
+            "bark's two refusals are bark's"
+        );
+        refusals.handshook("metrics");
+        assert_eq!(
+            refusals.stale(),
+            vec!["bark".to_string()],
+            "one dog getting in says nothing about another"
+        );
     }
 }

--- a/crates/shep-daemon/src/handover/adopt.rs
+++ b/crates/shep-daemon/src/handover/adopt.rs
@@ -518,6 +518,7 @@ mod tests {
             pending_delete: Some(false),
             manual: None,
             reload: Some(crate::entry::ReloadState::None),
+            dog: None,
             ready_failed: Some(false),
             restart_due: None,
             app: crate::testing::app_with("web", |_| {}).into_config(),

--- a/crates/shep-daemon/src/handover/mod.rs
+++ b/crates/shep-daemon/src/handover/mod.rs
@@ -2,11 +2,14 @@
 //! place, the [`Handover`] blob that describes it, and (in a later task) the
 //! exec that carries it.
 //!
-//! Two things are still refused, and they are not the same kind of thing. A
-//! DOG is deferred: phase 3 carries it, and the refusal goes when it does. An
-//! unresponsive log pump is PERMANENT, because it is a live sheep whose
-//! descriptors this daemon does not know, and carrying it would hand the
-//! successor a sheep it cannot read. A
+//! One thing is still refused, and it is permanent rather than deferred: a
+//! live sheep whose log pump did not report its descriptors in time is a
+//! sheep whose descriptors this daemon does not know, and carrying it would
+//! hand the successor a sheep it cannot read. Every refusal that named a
+//! FEATURE has gone -- a dog was the last of them, and phase 3 carries one
+//! by giving it a connection that re-establishes itself after the exec -- so
+//! the gate no longer says anything about how much of the handover has
+//! shipped. A
 //! sheep's stdout, stderr, log files, stdin pipe and shepherd channel all
 //! cross the exec, and every one of those is per SHEEP rather than per app,
 //! so an app running several instances crosses as several sets and needs
@@ -35,7 +38,7 @@ use std::time::SystemTime;
 use serde::{Deserialize, Serialize};
 use shep_core::config::AppConfig;
 use shep_core::paths::ShepPaths;
-use shep_core::protocol::ExitInfo;
+use shep_core::protocol::{DogSource, ExitInfo};
 use shep_core::status::ProcStatus;
 
 use crate::entry::{ProcessEntry, ReloadState};
@@ -54,39 +57,30 @@ pub enum Fitness {
 
 /// Why a flock cannot be handed over in place, and what happens instead.
 ///
-/// Almost every variant is a feature this daemon does not yet carry rather
-/// than an error, and the caller falls back to the stop arm, which is correct
-/// behaviour rather than a degraded one. [`Self::PumpUnresponsive`] is the
-/// exception and is a fault: it says a sheep's log pump did not answer in
-/// time, so nothing here knows which descriptors that sheep holds. The
-/// answer is still to refuse and stop, which is why it lives with the rest.
+/// One variant, and it is a fault rather than a feature this daemon has not
+/// shipped yet: a sheep's log pump did not answer in time, so nothing here
+/// knows which descriptors that sheep holds. The caller still falls back to
+/// the stop arm, which is correct behaviour rather than a degraded one.
+///
+/// **Every other variant this enum has ever had is gone**, each one turned
+/// into something the daemon carries -- a shepherd channel, a stdin pipe, a
+/// pending delete or stop, a swap in flight, more than one instance, and now
+/// a dog. That is why the wording is written as a fault: an operator who
+/// reads "cannot yet" about a stuck filesystem waits for a version that is
+/// never coming.
 ///
 /// `#[non_exhaustive]`, unlike [`crate::boot::Shepherd`]: that enum is
 /// closed by its mechanism (a pidfile lock is either free, held-with-pid or
-/// held-without, and there is no fourth state). This one is closed by
-/// nothing but how much of the handover has shipped. Every phase so far has
-/// turned one of these into something the daemon carries, and a dog is still
-/// to go, so a match here must keep tolerating a variant this module has not
-/// named yet. [`RefusedReason::PumpUnresponsive`] is the exception that will
-/// not go: it answers a question about THIS daemon's knowledge rather than
-/// about the handover's coverage.
+/// held-without, and there is no fourth state). This one is not closed by
+/// anything. A second way for a live sheep's descriptors to be unknowable
+/// would join it, and shep-daemon is a published library an out-of-tree
+/// matcher should not break for (IR-20).
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum RefusedReason {
     /// The sheep's log pump did not report its descriptors before the
     /// snapshot's deadline, so nothing knows which descriptors it holds.
-    ///
-    /// First in this enum and first in [`refusal`]'s order, because it is
-    /// the only variant that is not a statement about the sheep's config: a
-    /// sheep can be both wedged and a dog, and the wedge is the fact an
-    /// operator needs, since it will still be true after every feature
-    /// below has shipped.
     PumpUnresponsive {
-        /// The sheep's name.
-        sheep: String,
-    },
-    /// The sheep is a dog, whose descriptor inventory is not covered yet.
-    Dog {
         /// The sheep's name.
         sheep: String,
     },
@@ -94,25 +88,17 @@ pub enum RefusedReason {
 
 impl core::fmt::Display for RefusedReason {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        let (sheep, feature) = match self {
-            // Its own sentence rather than a `feature` for the one below:
-            // "has a wedged log pump, which this daemon cannot yet hand
-            // over" would read as a gap a later phase closes, and this one
-            // will still be a fault when every other variant has gone.
-            Self::PumpUnresponsive { sheep } => {
-                return write!(
-                    f,
-                    "sheep '{sheep}' has a log pump that did not report its descriptors in \
-                     time; reload falls back to a stop-and-start instead"
-                );
-            }
-            Self::Dog { sheep } => (sheep, "being a dog"),
-        };
-        write!(
-            f,
-            "sheep '{sheep}' has {feature}, which this daemon cannot yet hand \
-             over; reload falls back to a stop-and-start instead"
-        )
+        // The tail is what `shep daemon reload`'s own end-to-end cases probe
+        // for to tell a carried flock from a stopped-and-started one, so it
+        // is load-bearing text rather than punctuation: see `cli_e2e`'s
+        // assertions on "falls back to a stop-and-start".
+        match self {
+            Self::PumpUnresponsive { sheep } => write!(
+                f,
+                "sheep '{sheep}' has a log pump that did not report its descriptors in \
+                 time; reload falls back to a stop-and-start instead"
+            ),
+        }
     }
 }
 
@@ -197,9 +183,6 @@ fn refusal(candidate: &Candidate<'_>) -> Option<RefusedReason> {
 
     if candidate.pump_unresponsive {
         return Some(RefusedReason::PumpUnresponsive { sheep: name() });
-    }
-    if entry.dog.is_some() {
-        return Some(RefusedReason::Dog { sheep: name() });
     }
     None
 }
@@ -685,6 +668,37 @@ pub struct CarriedSheep {
     ///
     /// Nothing on it is sensitive: one timestamp (IR-41).
     restart_due: Option<SystemTime>,
+    /// Where this instance's binary came from, for an instance that is a
+    /// dog, or `None` for an ordinary sheep.
+    ///
+    /// `Option` for the reason [`Self::pending_delete`] gives: a
+    /// predecessor from before this field existed refused to carry a dog at
+    /// all, so a blob it wrote never has the key, and `None` is what that
+    /// blob truthfully means -- "not a dog" -- rather than "unknown".
+    /// [`VERSION`] stays unmoved: nothing an older reader must understand
+    /// has changed. Serde's derive already lets an `Option` field be
+    /// absent, so there is no `#[serde(default)]`, for the reason
+    /// [`CarriedFds::stdin`] gives at length.
+    ///
+    /// **The whole [`DogSource`], not a boolean**, because `shep dogs`
+    /// reports where each dog's binary came from and a successor holding
+    /// only "yes" would have to guess that column.
+    ///
+    /// Losing it is not cosmetic, and none of what it costs is visible to a
+    /// pid check. `Actor::matching_ids` keeps a dog out of every selector
+    /// but an exact one, so an unmarked dog joins `shep flock` beside the
+    /// operator's own apps, leaves `shep dogs`, and starts answering to
+    /// `shep restart all`. `dogs::spawn_dog_watch` records an exhausted
+    /// restart budget only for a marked entry, so an unmarked dog that
+    /// burned its whole budget writes nothing to `barks.jsonl` -- the alert
+    /// an operator reads after an outage. And `rpc::dog_staleness` builds
+    /// its roster from the marker, so a reload could not tell a dog that had
+    /// not dialled back yet from one that had.
+    ///
+    /// Nothing on it is sensitive: a closed enum naming this binary or a
+    /// path the operator typed into `shep adopt`, which the blob's own
+    /// `AppConfig` already carries as the program to run (IR-41).
+    dog: Option<DogSource>,
     /// The resolved config this instance runs under, environment included.
     ///
     /// This is the `AppConfig` beneath [`ProcessEntry::spec`]'s
@@ -725,7 +739,8 @@ impl CarriedSheep {
     /// the respawn deadline are on the supervisor's private slot type, and
     /// the descriptor numbers are known only to whichever code holds the
     /// open descriptors. This is the same split [`Candidate`] makes, for the
-    /// same reason.
+    /// same reason. [`Self::reload`] and [`Self::dog`] are the two that do
+    /// live on `entry`, so they are read rather than passed.
     ///
     /// `restart_due` is the one argument this does not carry verbatim: it is
     /// gated on the entry's status, for the reason
@@ -754,8 +769,9 @@ impl CarriedSheep {
             pending_delete: Some(pending_delete),
             manual,
             // Read off the entry rather than passed in, unlike the markers
-            // either side of it: this one does live on `ProcessEntry`.
+            // either side of it: these two do live on `ProcessEntry`.
             reload: Some(entry.reload),
+            dog: entry.dog.clone(),
             ready_failed: Some(ready_failed),
             // Gated on the status rather than carried verbatim, unlike every
             // marker above. The slot's own field is written on the one
@@ -806,6 +822,18 @@ impl CarriedSheep {
     #[must_use]
     pub const fn reload(&self) -> Option<ReloadState> {
         self.reload
+    }
+
+    /// Where this instance's binary came from if it is a dog, or `None` for
+    /// an ordinary sheep — which is also what a blob written before this
+    /// field existed says, and truthfully, since that predecessor refused to
+    /// carry a dog at all. See the field's own doc for what losing it costs.
+    ///
+    /// Borrowed rather than cloned: [`DogSource::Adopted`] owns a path, and
+    /// every caller either reads it or clones it for an entry of its own.
+    #[must_use]
+    pub const fn dog(&self) -> Option<&DogSource> {
+        self.dog.as_ref()
     }
 
     /// Whether a reload's readiness verification has already failed against
@@ -1462,6 +1490,23 @@ mod tests {
         }
     }
 
+    /// The same entry as a candidate whose log pump missed the snapshot's
+    /// deadline, which is the one thing left that refuses a flock.
+    ///
+    /// Every case below that needs A refusal rather than a particular one
+    /// goes through here. Three of them used to reach for a feature the
+    /// daemon had not shipped yet -- a shepherd channel, then two instances,
+    /// then a dog -- and moved each time that feature landed. There is
+    /// nothing left for them to move to, which is the point: a wedged pump
+    /// is a fault about this daemon's own knowledge and will still refuse
+    /// when every feature has shipped.
+    fn wedged(entry: &ProcessEntry) -> Candidate<'_> {
+        Candidate {
+            entry,
+            pump_unresponsive: true,
+        }
+    }
+
     #[test]
     fn a_plain_sheep_is_carryable() {
         let e = entry_fixture(|_| {});
@@ -1472,11 +1517,10 @@ mod tests {
     fn one_unsupported_sheep_refuses_the_whole_flock() {
         // Not per-sheep. The blob describes one process image, so a flock is
         // carried whole or not at all.
-        let plain_entry = entry_fixture(|_| {});
-        let mut unsupported = entry_fixture(|_| {});
-        unsupported.dog = Some(shep_core::protocol::DogSource::BuiltIn);
+        let carryable = entry_fixture(|_| {});
+        let unsupported = entry_fixture(|_| {});
         assert!(matches!(
-            fitness(&[plain(&plain_entry), plain(&unsupported)]),
+            fitness(&[plain(&carryable), wedged(&unsupported)]),
             Fitness::Refused(_)
         ));
     }
@@ -1485,14 +1529,17 @@ mod tests {
     fn the_refusal_names_which_sheep_and_why() {
         // The operator sees this in `shep daemon reload`'s output, so it has
         // to say what to do about it, not just that it declined.
-        let mut unsupported = entry_fixture(|_| {});
-        unsupported.dog = Some(shep_core::protocol::DogSource::BuiltIn);
-        let Fitness::Refused(r) = fitness(&[plain(&unsupported)]) else {
+        let unsupported = entry_fixture(|_| {});
+        let Fitness::Refused(r) = fitness(&[wedged(&unsupported)]) else {
             panic!("expected a refusal")
         };
         let text = r.to_string();
-        assert!(text.contains("being a dog"), "{text}");
+        assert!(text.contains("did not report its descriptors"), "{text}");
         assert!(text.contains("web"), "{text}");
+        assert!(
+            text.contains("falls back to a stop-and-start"),
+            "the refusal must say what happens instead, not only that it declined: {text}"
+        );
     }
 
     /// A wedged pump refuses, and says so as a fault rather than as a
@@ -1576,14 +1623,30 @@ mod tests {
         assert_eq!(fitness(&[plain(&e)]), Fitness::Carryable);
     }
 
+    /// fails if the gate still refuses a flock because one of its sheep is
+    /// a dog.
+    ///
+    /// The last FEATURE refusal, and the one this phase exists to remove. A
+    /// dog's process crosses the exec for free, exactly as every sheep's
+    /// does; what it needed was a connection that re-establishes itself
+    /// afterwards (`shep_client::ReconnectingClient`, task 1) and a daemon
+    /// that knows what to do when a successor refuses that handshake
+    /// (`dogs::record_refused_dog`, task 2).
+    ///
+    /// Both sources, because a dog is the MARKER rather than the binary: a
+    /// gate that read `DogSource::BuiltIn` alone would pass this half and go
+    /// on refusing every flock an operator had adopted a dog into.
     #[test]
-    fn a_dog_refuses() {
-        let mut e = entry_fixture(|_| {});
-        e.dog = Some(shep_core::protocol::DogSource::BuiltIn);
-        assert!(matches!(
-            fitness(&[plain(&e)]),
-            Fitness::Refused(RefusedReason::Dog { .. })
-        ));
+    fn a_dog_is_carried_rather_than_refused() {
+        let mut built_in = entry_fixture(|_| {});
+        built_in.dog = Some(DogSource::BuiltIn);
+        assert_eq!(fitness(&[plain(&built_in)]), Fitness::Carryable);
+
+        let mut adopted = entry_fixture(|_| {});
+        adopted.dog = Some(DogSource::Adopted {
+            path: "/opt/bin/shep-log-rotate".to_string(),
+        });
+        assert_eq!(fitness(&[plain(&adopted)]), Fitness::Carryable);
     }
 
     /// fails if the gate still refuses an app running more than one
@@ -2187,6 +2250,117 @@ mod tests {
         let loaded = Handover::load_value(older).expect("an older blob must still load");
 
         assert_eq!(loaded.sheep[0].ready_failed(), None);
+        assert_eq!(
+            loaded.sheep[0].id(),
+            blob.sheep[0].id(),
+            "the rest of the row is unchanged by the one field that was absent"
+        );
+    }
+
+    /// fails if a dog crosses the blob as an ordinary sheep.
+    ///
+    /// The marker is not decoration. `Actor::matching_ids` keeps a dog out
+    /// of every selector but an exact one, so a carried dog that lost it
+    /// leaves `shep dogs` and turns up in `shep flock` beside the
+    /// operator's own apps -- and `shep restart all` reaches it.
+    /// `dogs::spawn_dog_watch` records an exhausted restart budget only for
+    /// an entry carrying it, so a dog that burned its whole budget after a
+    /// reload would write nothing to `barks.jsonl`. And `rpc::dog_staleness`
+    /// builds its roster from it, so a reload could not tell a dog that had
+    /// not dialled back yet from one that had.
+    ///
+    /// The whole `DogSource`, not a boolean: `shep dogs` reports where a
+    /// dog's binary came from, and a successor that knew only THAT a sheep
+    /// was a dog would answer that column with a guess.
+    #[test]
+    fn a_dogs_marker_crosses_the_blob() {
+        let mut entry = entry_fixture(|_| {});
+        entry.dog = Some(DogSource::Adopted {
+            path: "/opt/bin/shep-log-rotate".to_string(),
+        });
+        let mut blob = sample_handover();
+        blob.sheep[0] = CarriedSheep::from_entry(&entry, 7, fds_at(11), false, None, false, None);
+
+        let loaded = Handover::load_value(serde_json::to_value(&blob).unwrap())
+            .expect("a current blob loads");
+
+        assert_eq!(
+            loaded.sheep[0].dog(),
+            Some(&DogSource::Adopted {
+                path: "/opt/bin/shep-log-rotate".to_string(),
+            }),
+            "a dog that crossed the exec as an ordinary sheep is one `shep dogs` has lost"
+        );
+    }
+
+    /// fails if a plain sheep picks a dog marker up on the way across.
+    ///
+    /// The other direction, and it is not implied by the case above: a
+    /// `from_entry` that hardcoded a source would pass that one and turn
+    /// every carried app into a dog, which takes the whole flock out of
+    /// `shep flock` and out of `shep restart all` at once.
+    #[test]
+    fn a_plain_sheep_crosses_the_blob_without_one() {
+        let mut blob = sample_handover();
+        blob.sheep[0] = CarriedSheep::from_entry(
+            &entry_fixture(|_| {}),
+            7,
+            fds_at(11),
+            false,
+            None,
+            false,
+            None,
+        );
+
+        let loaded = Handover::load_value(serde_json::to_value(&blob).unwrap())
+            .expect("a current blob loads");
+
+        assert_eq!(loaded.sheep[0].dog(), None);
+    }
+
+    /// fails if a blob written before this daemon carried a dog stops
+    /// loading.
+    ///
+    /// Same stakes and the same argument as the four fields above it: a
+    /// predecessor from before this field existed refused to carry a dog at
+    /// ALL, so a blob it wrote never has the key and never describes one.
+    /// `None` is what that blob truthfully means rather than "unknown", so
+    /// [`VERSION`] stays unmoved -- and a hard parse failure would leave a
+    /// successor refusing to boot after its predecessor had exec'd itself
+    /// away, over a field whose absence has a correct reading.
+    ///
+    /// The current-blob half is asserted first so the removal below removes
+    /// something: a blob whose sheep was never a dog could not tell an
+    /// absent key from a present one.
+    #[test]
+    fn a_blob_written_before_a_dog_was_carried_still_loads() {
+        let mut entry = entry_fixture(|_| {});
+        entry.dog = Some(DogSource::BuiltIn);
+        let mut blob = sample_handover();
+        blob.sheep[0] = CarriedSheep::from_entry(&entry, 7, fds_at(11), false, None, false, None);
+        let value = serde_json::to_value(&blob).unwrap();
+
+        assert_eq!(
+            Handover::load_value(value.clone())
+                .expect("a current blob loads")
+                .sheep[0]
+                .dog(),
+            Some(&DogSource::BuiltIn),
+            "a marker on the wire must come back as one"
+        );
+
+        let mut older = value;
+        let sheep = older["sheep"][0]
+            .as_object_mut()
+            .expect("a carried sheep is an object");
+        assert!(
+            sheep.remove("dog").is_some(),
+            "the field this case removes must be there to remove"
+        );
+
+        let loaded = Handover::load_value(older).expect("an older blob must still load");
+
+        assert_eq!(loaded.sheep[0].dog(), None);
         assert_eq!(
             loaded.sheep[0].id(),
             blob.sheep[0].id(),

--- a/crates/shep-daemon/src/lib.rs
+++ b/crates/shep-daemon/src/lib.rs
@@ -183,6 +183,8 @@
 //!     .send(encode_frame(&Hello {
 //!         client_version: "0.1.0".to_string(),
 //!         protocol: PROTOCOL_VERSION,
+//!         // Only a dog names one; see `Hello::dog_name`.
+//!         dog_name: None,
 //!     })?)
 //!     .await?;
 //! let ack: HelloReply = decode_frame(&frames.next().await.unwrap()?)?;

--- a/crates/shep-daemon/src/rpc.rs
+++ b/crates/shep-daemon/src/rpc.rs
@@ -75,6 +75,13 @@ pub struct RpcContext {
     pub(crate) paths: ShepPaths,
     /// This daemon's crate version, echoed in the handshake.
     pub(crate) daemon_version: String,
+    /// Which dogs this daemon has refused at the handshake, and how often.
+    ///
+    /// Written by the connection layer's handshake — the one place that
+    /// knows a refusal happened — and read by it to decide whether a
+    /// refused dog earns its one restart from disk or has already had it
+    /// (the handover design's G8; [`crate::dogs::DogRefusals`]).
+    pub(crate) dog_refusals: crate::dogs::DogRefusals,
     /// This daemon's OS pid, echoed in the handshake.
     pub(crate) pid: u32,
     /// Flips to `true` to start graceful daemon shutdown; see [`Self::shutdown`].

--- a/crates/shep-daemon/src/rpc.rs
+++ b/crates/shep-daemon/src/rpc.rs
@@ -31,6 +31,7 @@ use shep_core::protocol::{
 };
 use shep_core::selector::ProcessSelector;
 use shep_core::signals::OperatorSignal;
+use shep_core::status::ProcStatus;
 
 use crate::bus::{Bus, TopicFilter};
 use crate::dogs::DogSpec;
@@ -529,6 +530,10 @@ async fn run(id: u64, conn: ConnId, request: Request, ctx: &RpcContext) -> Outco
                 daemon_version: None,
             })),
         },
+        Request::DogStaleness => {
+            let (stale, pending) = dog_staleness(ctx).await;
+            reply(Ok(Response::DogStaleness { stale, pending }))
+        }
         Request::HandoverFitness => reply(Ok(Response::HandoverFitness {
             refusal: handover_refusal(ctx).await,
         })),
@@ -544,6 +549,63 @@ async fn run(id: u64, conn: ConnId, request: Request, ctx: &RpcContext) -> Outco
             daemon_version: None,
         })),
     }
+}
+
+/// The dogs this daemon has given up on, and the dogs it is still waiting
+/// to hear from — the handover design's G13, as a reading rather than a
+/// prediction.
+///
+/// **Stale** is [`DogRefusals::stale`](crate::dogs::DogRefusals::stale):
+/// refused, restarted from the binary on disk, refused again. It is the
+/// only thing here a caller may report, and it is a fact about handshakes
+/// this daemon performed rather than about a version anybody recorded.
+/// G9's point, which task 2 measured: two dog builds differing only in the
+/// protocol they speak report the same crate version, so a version cannot
+/// answer this question and a handshake can.
+///
+/// **Pending** is what stops a caller reporting too early, and it has two
+/// sources because a dog can be unheard-from in two ways. A dog refused
+/// ONCE is mid-restart, so its verdict has been asked for and has not
+/// arrived. A dog this daemon supervises that has never handshook has not
+/// been asked yet — a carried dog whose connection died with the
+/// predecessor's image is exactly that, for the whole gap between the exec
+/// and its reconnect.
+///
+/// **Why the supervisor's own rows are a sound roster.** A dog is
+/// registered before this daemon accepts anything: `boot` restores the
+/// flock, runs `spawn_enabled_dogs`, and only then hands the listener to
+/// `serve`. So a caller that can ask this question is talking to a daemon
+/// that already knows which dogs it has, and there is no window where an
+/// empty roster reads as "every dog has answered".
+///
+/// Only a dog with a PROCESS counts. A dog that has errored out of its
+/// restart budget is not going to handshake, and one parked in a backoff
+/// cannot until it is respawned — waiting on either would make an operator
+/// pay a whole timeout for a dog that is already broken in a way every
+/// other listing reports. Nothing is lost by leaving them out: a dog whose
+/// restart this daemon ASKED for is in `restarting` above whatever the
+/// supervisor's row says about it, and a carried dog that has not dialled
+/// back yet is `Online` — its process never died, only its socket did.
+async fn dog_staleness(ctx: &RpcContext) -> (Vec<String>, Vec<String>) {
+    let stale = ctx.dog_refusals.stale();
+    let mut pending = ctx.dog_refusals.restarting();
+    // A stopped engine has no dogs left to wait on, so its rows are not
+    // worth an error: the refusal record above is still the honest answer.
+    if let Ok(infos) = ctx.supervisor.list_checked().await {
+        for info in infos {
+            let running = matches!(info.status, ProcStatus::Starting | ProcStatus::Online);
+            if info.dog.is_some()
+                && running
+                && !ctx.dog_refusals.has_handshook(&info.name)
+                && !stale.contains(&info.name)
+            {
+                pending.push(info.name);
+            }
+        }
+    }
+    pending.sort();
+    pending.dedup();
+    (stale, pending)
 }
 
 /// Why this shepherd cannot hand its flock to a successor in place, or
@@ -2258,6 +2320,136 @@ mod tests {
         assert_eq!(
             rows[0].lambs,
             Some(vec![Lamb::new(FIRST_SCRIPTED_PID + 1, "node")])
+        );
+    }
+
+    /// Registers one built-in dog on `ctx`'s supervisor, the same way
+    /// `spawn_enabled_dogs` does at boot.
+    async fn start_dog(ctx: &RpcContext, name: &str) -> ProcessInfo {
+        let spec = DogSpec {
+            name: name.to_string(),
+            source: DogSource::BuiltIn,
+        };
+        let app = crate::dogs::dog_app(&spec, &ctx.paths).expect("the dog fixture must assemble");
+        ctx.supervisor
+            .start_dog(app, DogSource::BuiltIn)
+            .await
+            .expect("the dog fixture must start")
+    }
+
+    /// The two lists `Request::DogStaleness` answers with.
+    async fn staleness(ctx: &RpcContext) -> (Vec<String>, Vec<String>) {
+        let reply = reply_of(dispatch(envelope(1, Request::DogStaleness), ctx).await);
+        let Ok(Response::DogStaleness { stale, pending }) = reply.result else {
+            panic!("expected a dog staleness answer");
+        };
+        (stale, pending)
+    }
+
+    /// fails if a flock with no dogs at all is reported as having something
+    /// unsettled. This is what an ordinary reload asks, and the answer it
+    /// gets is what decides whether the operator reads a line about dogs
+    /// they do not run.
+    ///
+    /// The sheep is the point, not scenery: a reader that walked every row
+    /// instead of every DOG row would hold an operator's reload open
+    /// waiting for `web` to handshake, which it is never going to do — a
+    /// sheep is an arbitrary executable and does not speak this protocol at
+    /// all (spec, part 4).
+    #[tokio::test]
+    async fn a_flock_of_ordinary_sheep_has_nothing_stale_and_nothing_pending() {
+        let h = harness(vec![ProcScript::never_exits()]);
+        let started = reply_of(
+            dispatch(
+                envelope(
+                    1,
+                    Request::Start {
+                        apps: vec![AppConfig::minimal("web", "./srv")],
+                    },
+                ),
+                &h.ctx,
+            )
+            .await,
+        );
+        started.result.expect("the sheep must start");
+
+        assert_eq!(staleness(&h.ctx).await, (Vec::new(), Vec::new()));
+    }
+
+    /// fails if a registered dog that has never handshaken reads as an
+    /// answer. That state is exactly what a carried dog is for the whole
+    /// gap between the exec and its reconnect, so a report taken while it
+    /// holds would be the early report G13 forbids: the dog has said
+    /// nothing, and "nothing stale" would be read as "every dog came back".
+    #[tokio::test]
+    async fn a_dog_that_has_not_handshaken_is_pending() {
+        let h = harness(vec![ProcScript::never_exits()]);
+        start_dog(&h.ctx, "metrics").await;
+
+        assert_eq!(
+            staleness(&h.ctx).await,
+            (Vec::new(), vec!["metrics".to_string()])
+        );
+
+        h.ctx.dog_refusals.handshook("metrics");
+        assert_eq!(
+            staleness(&h.ctx).await,
+            (Vec::new(), Vec::new()),
+            "a dog talking to this shepherd is settled and is not worth reporting"
+        );
+    }
+
+    /// fails if the report can be taken while a dog's one restart is still
+    /// in flight. A refused dog passes THROUGH this state on its way to
+    /// being stale, so a reader that treated it as settled would report
+    /// every stale dog as healthy — the exact failure the waiting exists
+    /// for. Drives the ladder rather than asserting on the record, because
+    /// the claim is about what a caller over the wire sees.
+    #[tokio::test]
+    async fn a_dog_being_restarted_is_pending_and_then_stale() {
+        let h = harness(vec![ProcScript::never_exits()]);
+        start_dog(&h.ctx, "metrics").await;
+        h.ctx.dog_refusals.handshook("metrics");
+
+        h.ctx.dog_refusals.refused("metrics");
+        assert_eq!(
+            staleness(&h.ctx).await,
+            (Vec::new(), vec!["metrics".to_string()]),
+            "one refusal buys a restart; it does not condemn the dog"
+        );
+
+        h.ctx.dog_refusals.refused("metrics");
+        assert_eq!(
+            staleness(&h.ctx).await,
+            (vec!["metrics".to_string()], Vec::new()),
+            "a stale dog is a finding, not something still to wait on"
+        );
+    }
+
+    /// fails if a dog nobody is going to hear from holds the report open. A
+    /// dog with no process — out of its restart budget, parked in a
+    /// backoff, or stopped by an operator — cannot handshake, so waiting on
+    /// one would make every later reload pay the whole budget for a dog
+    /// already reported broken everywhere else. Measured under an isolated
+    /// `SHEP_HOME`: a `bark` looping on a bad config is `waiting-restart`
+    /// most of the time, and every reload during that loop would have paid
+    /// for it.
+    #[tokio::test]
+    async fn a_dog_that_has_stopped_running_is_not_waited_on() {
+        let h = harness(vec![ProcScript::never_exits()]);
+        start_dog(&h.ctx, "metrics").await;
+        assert_eq!(staleness(&h.ctx).await.1, vec!["metrics".to_string()]);
+
+        h.ctx
+            .supervisor
+            .stop(ProcessSelector::Name("metrics".to_string()))
+            .await
+            .expect("the dog must stop");
+
+        assert_eq!(
+            staleness(&h.ctx).await,
+            (Vec::new(), Vec::new()),
+            "a dog that is not running has nothing to answer with"
         );
     }
 }

--- a/crates/shep-daemon/src/server.rs
+++ b/crates/shep-daemon/src/server.rs
@@ -592,6 +592,7 @@ mod tests {
             .send(&Hello {
                 client_version: "0.1.0".to_string(),
                 protocol: PROTOCOL_VERSION,
+                dog_name: None,
             })
             .await;
         let ack: HelloReply = client.recv().await;
@@ -609,6 +610,7 @@ mod tests {
             .send(&Hello {
                 client_version: "9.9.9".to_string(),
                 protocol: PROTOCOL_VERSION + 1,
+                dog_name: None,
             })
             .await;
         let refusal: HelloReply = client.recv().await;
@@ -632,6 +634,7 @@ mod tests {
             .send(&Hello {
                 client_version: "9.9.9".to_string(),
                 protocol: PROTOCOL_VERSION + 1,
+                dog_name: None,
             })
             .await;
         let refusal: HelloReply = client.recv().await;
@@ -665,6 +668,7 @@ mod tests {
             .send(&Hello {
                 client_version: "0.1.0".to_string(),
                 protocol: PROTOCOL_VERSION,
+                dog_name: None,
             })
             .await;
         let _: HelloReply = client.recv().await;
@@ -691,6 +695,7 @@ mod tests {
             .send(&Hello {
                 client_version: "0.1.0".to_string(),
                 protocol: PROTOCOL_VERSION,
+                dog_name: None,
             })
             .await;
         let _: HelloReply = client.recv().await;
@@ -759,6 +764,7 @@ mod tests {
             .send(&Hello {
                 client_version: "0.1.0".to_string(),
                 protocol: PROTOCOL_VERSION,
+                dog_name: None,
             })
             .await;
         let _: HelloReply = client.recv().await;
@@ -788,6 +794,7 @@ mod tests {
             .send(&Hello {
                 client_version: "0.1.0".to_string(),
                 protocol: PROTOCOL_VERSION,
+                dog_name: None,
             })
             .await;
         let _: HelloReply = client.recv().await;
@@ -861,6 +868,7 @@ mod tests {
             .send(&Hello {
                 client_version: "0.1.0".to_string(),
                 protocol: PROTOCOL_VERSION,
+                dog_name: None,
             })
             .await;
         let _: HelloReply = client.recv().await;

--- a/crates/shep-daemon/src/server.rs
+++ b/crates/shep-daemon/src/server.rs
@@ -488,9 +488,50 @@ async fn handshake(
             daemon_version: Some(ctx.daemon_version.clone()),
         });
         send(out, &refusal).await?;
+        // The refusal is on the writer's queue before anything else
+        // happens, so a peer that is about to be restarted still learns
+        // why. Then: which dog was that, and what does this daemon owe it?
+        //
+        // `None` is every client that is not a dog, and the CLI is nearly
+        // all of them. A `shep` verb has no way to name a dog here — the
+        // name travels only on `ReconnectingClient`, the type dogs use and
+        // no verb does — so the branch below cannot be reached by an
+        // operator with a stray `$SHEP_DOG_NAME` in their environment.
+        match &hello.dog_name {
+            Some(dog) => {
+                crate::dogs::record_refused_dog(
+                    dog,
+                    &hello.client_version,
+                    &ctx.dog_refusals,
+                    &ctx.supervisor,
+                );
+            }
+            // A refused client this daemon cannot restart and would not
+            // want to: an operator running an older `shep` against a newer
+            // daemon, who is already reading the skew in plain English from
+            // their own CLI. `debug!` rather than `warn!`, which this was
+            // until a real reload across a protocol bump measured it: the
+            // CLI polls the socket while it waits for a successor, so ONE
+            // `shep daemon reload` produced 442 of these in 9.8 seconds,
+            // and the daemon's default level is `warn`. The only fact this
+            // adds over `handle_conn`'s own "connection ended" line is the
+            // client's crate version, which is worth carrying and is not
+            // worth waking anybody for.
+            None => tracing::debug!(
+                client_protocol = hello.protocol,
+                client_version = %hello.client_version,
+                "refused a client on protocol skew"
+            ),
+        }
         return Err(ConnError::ProtocolMismatch {
             client: hello.protocol,
         });
+    }
+    // A dog that got in is not stale, whatever this daemon held against it
+    // before — including the restart it was just given, which is exactly
+    // the case that has to clear.
+    if let Some(dog) = &hello.dog_name {
+        ctx.dog_refusals.handshook(dog);
     }
     let ack: HelloReply = Ok(HelloAck {
         daemon_version: ctx.daemon_version.clone(),
@@ -523,14 +564,17 @@ mod tests {
     // HANDSHAKE_TIMEOUT_MS before the peer's bytes are delivered.
     use super::*;
     use crate::bus::SharedEvent;
+    use crate::fake::{FIRST_SCRIPTED_PID, ProcScript};
     use crate::testing::harness;
     use futures_util::{SinkExt, StreamExt};
     use serde::Serialize;
     use serde::de::DeserializeOwned;
     use shep_core::protocol::{
-        BusEvent, Envelope, Hello, HelloReply, PROTOCOL_VERSION, ProcessEventKind, ProcessInfo,
-        Request, Response, RpcErrorCode, ServerFrame, codec, decode_frame, encode_frame,
+        BusEvent, DogSource, Envelope, Hello, HelloReply, PROTOCOL_VERSION, ProcessEventKind,
+        ProcessInfo, Request, Response, RpcErrorCode, ServerFrame, codec, decode_frame,
+        encode_frame,
     };
+    use shep_core::status::ProcStatus;
     use tokio_util::codec::Framed;
 
     const RECV_TIMEOUT: Duration = Duration::from_secs(5);
@@ -915,5 +959,217 @@ mod tests {
             dropped > 0,
             "a flood past CONN_QUEUE + BUS_CAPACITY must report a real lag"
         );
+    }
+
+    // --- G8: what a refused DOG's handshake costs it ------------------
+    //
+    // A refused handshake never reaches a request, so `Request::DogConfig`'s
+    // name — the one place a dog otherwise identifies itself — is
+    // unreachable on exactly the path where the daemon has to know which
+    // dog it just refused. `Hello.dog_name` is what closes that, and these
+    // four tests are what the daemon does with it.
+
+    /// Registers `name` as a built-in dog and returns the row it produced.
+    ///
+    /// Straight through [`crate::supervisor::SupervisorHandle::start_dog`]
+    /// rather than through `Request::EnableDog`, because the request path
+    /// would need a handshaken connection of its own and the point here is
+    /// what a REFUSED one does.
+    async fn start_dog(ctx: &RpcContext, name: &str) -> ProcessInfo {
+        let spec = crate::dogs::DogSpec {
+            name: name.to_string(),
+            source: DogSource::BuiltIn,
+        };
+        let app = crate::dogs::dog_app(&spec, &ctx.paths).expect("the dog fixture must assemble");
+        ctx.supervisor
+            .start_dog(app, DogSource::BuiltIn)
+            .await
+            .expect("the dog fixture must start")
+    }
+
+    /// One refused handshake, announcing `dog` (or nothing, for a client
+    /// that is not a dog), returning once the daemon has closed on it.
+    ///
+    /// The close is the forcing mechanism for everything synchronous
+    /// (IR-46): the daemon records the refusal and decides what it owes the
+    /// dog BEFORE it returns the error that closes the socket, so a caller
+    /// that has seen the close can read the verdict without racing it. The
+    /// restart itself runs on its own task and needs [`await_dog`].
+    async fn refuse_as(ctx: &RpcContext, dog: Option<&str>) {
+        let mut client = connected(ctx.clone()).await;
+        client
+            .send(&Hello {
+                client_version: "0.1.14".to_string(),
+                protocol: PROTOCOL_VERSION + 1,
+                dog_name: dog.map(str::to_owned),
+            })
+            .await;
+        let refusal: HelloReply = client.recv().await;
+        refusal.expect_err("a skewed protocol must be refused");
+        assert!(
+            client.closed().await,
+            "the daemon must close after refusing"
+        );
+    }
+
+    /// The flock row named `name`, or a panic naming what was there.
+    async fn dog_row(ctx: &RpcContext, name: &str) -> ProcessInfo {
+        ctx.supervisor
+            .list()
+            .await
+            .into_iter()
+            .find(|info| info.name == name)
+            .unwrap_or_else(|| panic!("no row named {name}"))
+    }
+
+    /// Waits until `name` is running as `pid`, or fails inside
+    /// [`RECV_TIMEOUT`], returning how long it took.
+    ///
+    /// The restart a refusal triggers runs on its own task, so there is no
+    /// handle to await; polling a real condition against a hard ceiling is
+    /// the forcing mechanism (IR-46). The elapsed time is returned because
+    /// the never-restart-twice test below sizes its negative window against
+    /// it rather than against a guess.
+    async fn await_dog(ctx: &RpcContext, name: &str, pid: u32) -> Duration {
+        let began = tokio::time::Instant::now();
+        let seen = tokio::time::timeout(RECV_TIMEOUT, async {
+            loop {
+                if dog_row(ctx, name).await.pid == Some(pid) {
+                    return;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await;
+        assert!(
+            seen.is_ok(),
+            "{name} never reached pid {pid} within {RECV_TIMEOUT:?}: {:?}",
+            ctx.supervisor.list().await
+        );
+        began.elapsed()
+    }
+
+    /// fails if a refused dog is left mute. This is G8's step 2, and the
+    /// daemon is the only party that can take it: the dog's own client has
+    /// stopped rather than spinning (that is `ReconnectingClient`'s half),
+    /// and a dog carried across a handover is a live process holding a dead
+    /// socket that nothing else will replace.
+    ///
+    /// The pid moving is the assertion, not the restart count: a restart
+    /// that re-registered the row without re-spawning would leave a dog
+    /// exactly as mute as it was.
+    #[tokio::test]
+    async fn a_refused_dog_is_restarted_once_from_the_binary_on_disk() {
+        let h = harness(vec![ProcScript::never_exits(), ProcScript::never_exits()]);
+        let started = start_dog(&h.ctx, "metrics").await;
+        assert_eq!(started.pid, Some(FIRST_SCRIPTED_PID));
+
+        refuse_as(&h.ctx, Some("metrics")).await;
+
+        await_dog(&h.ctx, "metrics", FIRST_SCRIPTED_PID + 1).await;
+        assert!(
+            h.ctx.dog_refusals.stale().is_empty(),
+            "one refusal buys a restart; it does not condemn the dog"
+        );
+    }
+
+    /// fails if the daemon restarts a dog it has already restarted — the
+    /// spin G8 exists to forbid. A second refusal proves the binary on disk
+    /// cannot satisfy this daemon either, because the restart already ran
+    /// it, so a third attempt is not optimism.
+    ///
+    /// Three independent things have to hold, and each catches a different
+    /// mutation. The dog must be REPORTED stale, which a daemon that
+    /// silently stopped restarting would fail. Its pid must not move inside
+    /// a window sized against the restart that really happened earlier in
+    /// this same test — a negative assertion is only as good as its window,
+    /// and a measured one scales with a loaded runner where a fixed number
+    /// would not. And the harness is scripted with exactly the two spawns
+    /// G8 permits, so a third would fail to spawn and take the dog out of
+    /// `Online` even if it somehow beat the window.
+    #[tokio::test]
+    async fn a_twice_refused_dog_is_reported_stale_and_never_restarted_again() {
+        let h = harness(vec![ProcScript::never_exits(), ProcScript::never_exits()]);
+        start_dog(&h.ctx, "metrics").await;
+
+        refuse_as(&h.ctx, Some("metrics")).await;
+        let restart_took = await_dog(&h.ctx, "metrics", FIRST_SCRIPTED_PID + 1).await;
+
+        refuse_as(&h.ctx, Some("metrics")).await;
+        assert_eq!(
+            h.ctx.dog_refusals.stale(),
+            vec!["metrics".to_string()],
+            "the second refusal must be reported, not swallowed"
+        );
+
+        // Ten times the restart that DID happen, floored so a machine fast
+        // enough to make the measurement meaningless still watches for a
+        // real interval.
+        let window = (restart_took * 10).max(Duration::from_millis(200));
+        tokio::time::sleep(window).await;
+
+        let after = dog_row(&h.ctx, "metrics").await;
+        assert_eq!(
+            after.pid,
+            Some(FIRST_SCRIPTED_PID + 1),
+            "a second restart within {window:?} is the spin G8 forbids"
+        );
+        assert_eq!(
+            after.status,
+            ProcStatus::Online,
+            "a third spawn would exhaust the script and error the dog"
+        );
+    }
+
+    /// fails if a dog that got back in stays condemned. The restart G8 owes
+    /// a refused dog is worth nothing if the successful handshake it
+    /// produces does not clear the mark: the dog would be reported stale
+    /// forever while answering perfectly, and a LATER daemon that refused
+    /// it would skip straight past its one restart.
+    #[tokio::test]
+    async fn a_dog_that_handshakes_is_no_longer_stale() {
+        let h = harness(vec![]);
+        refuse_as(&h.ctx, Some("metrics")).await;
+        refuse_as(&h.ctx, Some("metrics")).await;
+        assert_eq!(h.ctx.dog_refusals.stale(), vec!["metrics".to_string()]);
+
+        let mut client = connected(h.ctx.clone()).await;
+        client
+            .send(&Hello {
+                client_version: "0.1.22".to_string(),
+                protocol: PROTOCOL_VERSION,
+                dog_name: Some("metrics".to_string()),
+            })
+            .await;
+        let ack: HelloReply = client.recv().await;
+        ack.expect("a matching protocol must be acked");
+
+        assert!(
+            h.ctx.dog_refusals.stale().is_empty(),
+            "a dog talking to this daemon is not stale by any definition it can apply"
+        );
+    }
+
+    /// fails if an operator running an older `shep` has a dog restarted
+    /// under them. The CLI cannot name a dog — the name travels only on
+    /// `ReconnectingClient`, which no verb uses — so a refusal carrying no
+    /// name must leave the flock exactly as it was, however many of them
+    /// arrive.
+    #[tokio::test]
+    async fn a_refused_client_that_is_not_a_dog_touches_nothing() {
+        let h = harness(vec![ProcScript::never_exits()]);
+        let started = start_dog(&h.ctx, "metrics").await;
+
+        for _ in 0..3 {
+            refuse_as(&h.ctx, None).await;
+        }
+
+        assert!(h.ctx.dog_refusals.stale().is_empty());
+        let after = dog_row(&h.ctx, "metrics").await;
+        assert_eq!(
+            after.pid, started.pid,
+            "a nameless refusal must not restart anything"
+        );
+        assert_eq!(after.status, ProcStatus::Online);
     }
 }

--- a/crates/shep-daemon/src/supervisor.rs
+++ b/crates/shep-daemon/src/supervisor.rs
@@ -3689,9 +3689,20 @@ impl<R: ProcessRunner> Actor<R> {
             credentials: carried.credentials(),
             out_file: spec.out_file.clone(),
             err_file: spec.err_file.clone(),
-            // The gate refuses any flock carrying a dog, so a carried sheep
-            // is never one, and the blob has no field for it to lose.
-            dog: None,
+            // Restored, and it is the marker that keeps a dog OUT of the
+            // flock rather than in it: `matching_ids` passes a marked entry
+            // over for every selector but an exact one, so an adoption that
+            // dropped it would put the dog in `shep flock` beside the
+            // operator's own apps, take it out of `shep dogs`, and let
+            // `shep restart all` reach it. `spawn_dog_watch` and
+            // `rpc::dog_staleness` read the same field, so it also decides
+            // whether an exhausted dog reaches `barks.jsonl` and whether a
+            // reload waits for this dog to dial back in.
+            //
+            // `None` for a blob written before this daemon carried a dog at
+            // all, which said the same thing by refusing to carry one; see
+            // `CarriedSheep::dog`.
+            dog: carried.dog().cloned(),
             last_exit: carried.last_exit(),
         };
 
@@ -18687,6 +18698,73 @@ mod tests {
             info.iter().map(|row| row.pid).collect::<Vec<_>>(),
             vec![Some(4242), Some(4243)],
             "a sheep whose pid moved was respawned"
+        );
+    }
+
+    /// Fails if an adopted dog comes back as an ordinary sheep.
+    ///
+    /// The marker is what tells the two populations apart everywhere it
+    /// matters, and losing it is invisible to a pid check: the dog is still
+    /// running, still `Online`, still on its own pid. What changes is that
+    /// `matching_ids` stops passing it by, so `shep restart all` reaches
+    /// it, `shep flock` lists it beside the operator's own apps and `shep
+    /// dogs` loses it entirely; `dogs::spawn_dog_watch` stops recording its
+    /// exhausted restart budget, so an outage writes nothing to
+    /// `barks.jsonl`; and `rpc::dog_staleness` loses it off the roster a
+    /// reload waits on.
+    ///
+    /// Two assertions, and the second is what an operator actually feels.
+    /// The listing proves the marker survived the blob and the install; the
+    /// wildcard proves the marker is DOING its job on the far side, which a
+    /// field asserted in isolation cannot. `a_wildcard_passes_a_dog_by_and_
+    /// its_own_name_still_reaches_it` pins the same rule against an actor
+    /// built by hand, so this one is about the adoption reaching it rather
+    /// than about the rule.
+    ///
+    /// A `stop` rather than a `restart`, and a kennel with no sheep in it,
+    /// so nothing here waits on a kill ladder: `NotFound` is the answer to
+    /// a wildcard that matched nothing, and it is returned without any
+    /// process being signalled. The timeout is the forcing mechanism
+    /// (IR-46) -- with the marker dropped the wildcard matches the dog and
+    /// the stop parks on an exit `StandInProc` never delivers, so without it
+    /// the mutation hangs the suite instead of failing this case.
+    #[cfg(unix)]
+    #[tokio::test(start_paused = true)]
+    async fn an_adopted_dog_keeps_its_marker_and_stays_out_of_a_wildcard() {
+        let dir = tempfile::tempdir().unwrap();
+        let (events, _rx) = crate::bus::test_bus(64);
+        let sup = SupervisorBuilder::new(AdoptingRunner, test_paths(&dir), events)
+            .spawn_adopted(
+                vec![without_handles(carried(
+                    "log-rotate",
+                    7,
+                    Some(4242),
+                    |entry| {
+                        entry.dog = Some(DogSource::Adopted {
+                            path: "/opt/bin/shep-log-rotate".to_string(),
+                        });
+                    },
+                ))],
+                counters(9),
+                Vec::new(),
+            )
+            .expect("a carried flock installs");
+
+        let info = sup.list().await;
+        assert_eq!(
+            info[0].dog,
+            Some(DogSource::Adopted {
+                path: "/opt/bin/shep-log-rotate".to_string(),
+            }),
+            "a dog adopted as an ordinary sheep is one `shep dogs` has lost"
+        );
+
+        let swept = tokio::time::timeout(Duration::from_secs(5), sup.stop(ProcessSelector::All))
+            .await
+            .expect("a wildcard over a flock of nothing but dogs must answer rather than hang");
+        assert!(
+            matches!(swept, Err(SupervisorError::NotFound)),
+            "`all` is the flock, not the kennel: {swept:?}"
         );
     }
 

--- a/crates/shep-daemon/src/testing.rs
+++ b/crates/shep-daemon/src/testing.rs
@@ -512,6 +512,7 @@ pub(crate) fn harness_with_extras(
             daemon_config: paths.daemon_config.clone(),
             paths: paths.clone(),
             daemon_version: "0.1.0".to_string(),
+            dog_refusals: crate::dogs::DogRefusals::new(),
             pid: 4242,
             shutdown: Arc::new(shutdown),
             stats: Arc::clone(&stats),

--- a/crates/shep-daemon/tests/daemon_e2e.rs
+++ b/crates/shep-daemon/tests/daemon_e2e.rs
@@ -126,6 +126,7 @@ impl Fixture {
             .send(&Hello {
                 client_version: env!("CARGO_PKG_VERSION").to_string(),
                 protocol: PROTOCOL_VERSION,
+                dog_name: None,
             })
             .await;
         let ack: HelloReply = client.recv_as().await;
@@ -1463,6 +1464,7 @@ async fn protocol_skew_is_refused_over_the_real_socket() {
             encode_frame(&Hello {
                 client_version: "9.9.9".to_string(),
                 protocol: PROTOCOL_VERSION + 1,
+                dog_name: None,
             })
             .unwrap(),
         )

--- a/docs/dogs.md
+++ b/docs/dogs.md
@@ -245,6 +245,22 @@ socket in the first place, and `$SHEP_DOG_NAME`, which is the `name` to put
 in that request. No `[dog.<name>]` value ever rides along beside them, for
 the reason given above. A section's key is not one of its values.
 
+**Put that name in the `Hello` too, as `dog_name`.** Optional, and nothing
+breaks without it right up until the shepherd is replaced by one your binary
+is too old to speak to. A refused handshake never reaches a request, so the
+`name` in `DogConfig` is unreadable at exactly the moment it is needed:
+which dog to restart. With it, the shepherd restarts you once from the
+binary on disk — which fixes the ordinary case, where the package already
+replaced your file and the running process is merely old — and reports you
+stale rather than looping if that restart is refused too. Without it you go
+quiet and nothing on either side says why.
+
+A dog written against `shep-client` gets both halves from
+`ReconnectingClient::connect_as_dog`, which fills the name in and also
+re-establishes the connection when the shepherd is replaced. `Client` does
+neither, deliberately: the CLI uses it, and a `shep stop` that silently
+retried could stop a sheep twice.
+
 Those two are what shep ADDS, not the whole environment. A dog is a
 supervised process like any other, so it also starts from the small base
 every sheep gets: `PATH`, plus whichever of `HOME`, `USER`, `LANG` and `TZ`

--- a/docs/dogs.md
+++ b/docs/dogs.md
@@ -252,8 +252,11 @@ is too old to speak to. A refused handshake never reaches a request, so the
 which dog to restart. With it, the shepherd restarts you once from the
 binary on disk — which fixes the ordinary case, where the package already
 replaced your file and the running process is merely old — and reports you
-stale rather than looping if that restart is refused too. Without it you go
-quiet and nothing on either side says why.
+stale rather than looping if that restart is refused too. `shep daemon
+reload` prints that report to the operator, after your reconnect rather
+than before it: what the old image knew about you described a process that
+was about to stop existing. Without it you go quiet and nothing on either
+side says why.
 
 A dog written against `shep-client` gets both halves from
 `ReconnectingClient::connect_as_dog`, which fills the name in and also

--- a/docs/dogs.md
+++ b/docs/dogs.md
@@ -264,6 +264,22 @@ re-establishes the connection when the shepherd is replaced. `Client` does
 neither, deliberately: the CLI uses it, and a `shep stop` that silently
 retried could stop a sheep twice.
 
+That is what `shep daemon reload` asks of a dog. A dog is carried across the
+reload the way a sheep is: the process is a child of a shepherd whose pid
+does not change, so it keeps its own pid and its restart count stays where it
+was. What does not survive is the accepted connection, which dies with the
+old image — so a dog that does not dial again is a live process holding a
+dead socket, alive on every column a listing has and answering nothing. The
+metrics dog is measured holding its pid and `restarts 0` across six reloads
+while still serving a scrape.
+
+The bark dog is the exception, and it is on the list to fix. Its subscription
+belongs to one connection, so the stream ends when that connection does and
+the dog exits; autorestart replaces it, which costs one restart per reload on
+a dog that is otherwise healthy. It comes back on its own every time, and its
+restart budget starts a fresh window with each shepherd, so this is a count
+that reads wrong rather than an outage.
+
 Those two are what shep ADDS, not the whole environment. A dog is a
 supervised process like any other, so it also starts from the small base
 every sheep gets: `PATH`, plus whichever of `HOME`, `USER`, `LANG` and `TZ`

--- a/docs/specs/deferred.md
+++ b/docs/specs/deferred.md
@@ -415,10 +415,11 @@ that request. The sentence describes something no terminal can produce.
 
 Raised in review on #84, 2026-08-31, and agreed rather than argued away.
 
-Seven cases are named `a_blob_written_before_<field>_was_carried_still_loads`
+Eight cases are named `a_blob_written_before_<field>_was_carried_still_loads`
 -- stdin, the channel, `pending_delete`, the manual marker, a swap in flight,
-`ready_failed`, and the restart deadline. Every one of them builds a blob from
-today's `Handover`, serialises it, removes one key, and loads the result.
+`ready_failed`, the restart deadline, and (since phase 3 task 4) the dog
+marker. Every one of them builds a blob from today's `Handover`, serialises
+it, removes one key, and loads the result.
 
 That proves the thing each field's carry actually needs: an absent key loads
 as `None` rather than refusing, so a successor boots against a predecessor
@@ -443,6 +444,67 @@ Not done in #84 because it is not that PR's test. Covering only the newest
 field would leave one case in a different style from six siblings and barely
 reduce the risk, since the exposure is the whole blob rather than any one
 key.
+
+### The bark dog still restarts once per reload -- open, 2026-08-31
+
+Phase 3 carries every dog across the handover with no restart, and the
+metrics dog is measured doing exactly that. **Bark is not**, and it is the
+one thing G7 asks for that phase 3 did not deliver.
+
+The mechanism, from task 1's measurement: bark's `EventStream` belongs to one
+connection generation, so when that connection dies the stream ends,
+`run_loop`'s `None` arm breaks the select loop, the dog exits 0, and
+`autorestart` replaces it. Measured across two reloads: pid moving each time,
+`restarts` 25 -> 26 -> 27, `online` after every one, while metrics held its
+pid at `restarts 0`.
+
+**What it costs, and what it does not.** The count is a false reading on the
+one column an operator uses to decide whether a dog is unhealthy: twenty
+reloads leave a perfectly healthy dog reporting `restarts 20`. It does NOT
+risk an outage -- `install_adopted` gives every adopted entry a fresh
+`RestartBudget`, so reloads cannot exhaust one -- and it is loud rather than
+silent, which is the whole difference from the defect this phase was built
+to fix. Bark also loses `rules::Rules`' per-subject debounce state across the
+restart, so a sheep already alerted on can be alerted on twice.
+
+**The fix is not "re-arm the stream inside the client".** Task 1 declined
+that and the argument still holds: `ReconnectingClient::subscribe` re-arming
+its own stream would silently swallow the gap between a connection dying and
+the successor accepting a fresh `Subscribe`, and an event stream that hides a
+gap is worse than one that ends.
+
+**The fix belongs in bark, where the gap already has an answer.**
+`run_loop`'s `Some(Err(dropped))` arm reconciles against `ListFlock` the
+moment the bus reports a lag, on the reasoning that a drop carries no
+information about what was lost and the only way to know is to ask the
+shepherd what things look like now. A handover gap is the same class of loss
+and deserves the same answer: re-subscribe, then reconcile. Nothing new is
+invented; the state-based rules and the per-subject debounce are already
+built for a subject seen twice by two routes.
+
+**What stops it being small, and why it is its own task rather than a line
+in phase 3 task 4:**
+
+- `EventSource` needs a `resubscribe`, which means a production adapter
+  holding the `ReconnectingClient` alongside the stream and its topics.
+  `run_bark` moves that client into `ClientFlockSource` today.
+- The adapter has to WAIT for the link to come back before it can subscribe:
+  a `Subscribe` issued against a dead generation fails immediately with
+  `Closed`. `ReconnectingClient` exposes `link()` as a reading, not a future
+  to await, so this needs an API the type does not have.
+- `LinkState::Refused` has to exit rather than retry, so G8's one restart
+  from disk still applies to a bark dog that cannot speak this protocol.
+- **And it needs a ruling on the ORPHANED dog, which is about every dog and
+  not about bark.** Today bark exits when its shepherd goes away for any
+  reason; a dog that re-subscribed instead would linger, and would attach
+  itself to whatever daemon next binds that socket -- beside that daemon's
+  own bark dog, double-alerting quietly. The metrics dog already has that
+  hazard through `ReconnectingClient`'s own supervisor, which retries
+  forever, and nobody has ruled on it.
+
+The last of those is the reason this is deferred rather than squeezed in: the
+question is what a dog does when its shepherd is gone, and answering it for
+bark alone would leave two dogs answering it differently for the third time.
 
 ## Ideas, recorded but not designed
 

--- a/docs/specs/deferred.md
+++ b/docs/specs/deferred.md
@@ -441,7 +441,7 @@ has to answer what a fixture is keyed to when the version does not move: a
 release, a phase, or every shape that ever shipped.
 
 Not done in #84 because it is not that PR's test. Covering only the newest
-field would leave one case in a different style from six siblings and barely
+field would leave one case in a different style from seven siblings and barely
 reduce the risk, since the exposure is the whole blob rather than any one
 key.
 
@@ -497,7 +497,8 @@ in phase 3 task 4:**
 - **And it needs a ruling on the ORPHANED dog, which is about every dog and
   not about bark.** Today bark exits when its shepherd goes away for any
   reason; a dog that re-subscribed instead would linger, and would attach
-  itself to whatever daemon next binds that socket -- beside that daemon's
+  itself to whatever shepherd next binds that socket -- beside that
+  shepherd's
   own bark dog, double-alerting quietly. The metrics dog already has that
   hazard through `ReconnectingClient`'s own supervisor, which retries
   forever, and nobody has ruled on it.

--- a/docs/writing-plans/plans/2026-08-31-handover-phase3.md
+++ b/docs/writing-plans/plans/2026-08-31-handover-phase3.md
@@ -48,7 +48,19 @@ shep-client            the code, written once, in shep
 each dog's process     where the behaviour executes
 ```
 
-Shep implements the reconnect. A dog gets it by being rebuilt. No dog author writes reconnect logic, and the dog contract does not change. Confirmed: the built-ins already `use shep_client::{Client, ConnectError, EventStream, RequestError}`, and G9 establishes that a plain `cargo install <dog>` picks up a new `shep-client`.
+Shep implements the reconnect. A dog gets it by being rebuilt, and no dog
+author writes reconnect logic.
+
+**The last clause of that was "and the dog contract does not change", and
+task 1 made it false.** The shape chosen is a distinct
+`ReconnectingClient` type rather than a mode on `Client`, because that is
+what makes the CLI unaffected BY CONSTRUCTION rather than by every call
+site being read carefully. The price is that a dog rebuilt against the new
+`shep-client` still constructs a `Client` and still goes mute: its author
+has to swap one type name. One line per dog, and both dogs in the registry
+are the maintainer's, so it rides along with the two releases the carry
+already needed. But it is a line, not a rebuild, and the plan claimed
+otherwise. Confirmed: the built-ins already `use shep_client::{Client, ConnectError, EventStream, RequestError}`, and G9 establishes that a plain `cargo install <dog>` picks up a new `shep-client`.
 
 ---
 

--- a/docs/writing-plans/plans/2026-08-31-handover-phase3.md
+++ b/docs/writing-plans/plans/2026-08-31-handover-phase3.md
@@ -1,0 +1,158 @@
+# Daemon handover, phase 3: dogs
+
+> **For agentic workers:** REQUIRED SUB-SKILL: use `superpowers:subagent-driven-development` to implement this task-by-task. Steps use `- [ ]` for tracking.
+
+**Goal:** Carry every dog across the handover with no restart, which means giving a dog a connection that survives its daemon being replaced.
+
+**Spec:** `docs/brainstorming/specs/2026-08-29-daemon-handover-design.md`, sections G6 through G13.
+
+**Base:** cut from `origin/main` at v0.1.21, which contains 2a, 2b and 2c.
+
+---
+
+## The decision this phase is built on
+
+Taken 2026-08-31: **carry every dog, and put the reconnect in `shep-client`.** The alternative, carrying only the two built-in dogs and continuing to refuse adopted ones, was rejected because dogs should be treated alike.
+
+What that buys and costs is recorded in 2b's task 7 section. The cost worth restating: an adopted dog compiled against an older `shep-client` has no reconnect, so it is mute after a reload until rebuilt. Both dogs in `web/public/dogs.json` are the maintainer's own (`shep-log-rotate`, `shep-deploy`), so "until rebuilt" means until she cuts two releases she controls.
+
+## What is actually broken
+
+Verified by driving six real reloads in 2b, not by reading:
+
+```
+metrics dog after 6 handovers:  pid unmoved, restarts 0, status online, stderr 0 bytes
+curl /metrics:                  HTTP 503, every scrape, for 6m 22s
+```
+
+A dog's PROCESS crosses the exec for free, because it is a child of a daemon whose pid does not change. Its CONNECTION does not: only the listener is in the blob, and accepted sockets die with the image. So a carried dog is a live process holding a dead socket.
+
+Neither built-in dog handles this, and their different outcomes are an accident rather than two designs:
+
+| dog | what it does when the connection dies | outcome |
+|---|---|---|
+| `bark` | its `EventStream` ends, `run_loop`'s `None` arm breaks, it exits 0, autorestart replaces it | survives by accident, at one restart per reload |
+| `metrics` | holds an `Arc<Client>` across `accept_forever`, never re-examines it | mute, 503 forever, silent on both sides |
+
+Nor could a dog have needed a reconnect before now. Every path that removed a shepherd also removed its dogs. A dog outliving the daemon it is connected to is a situation the handover invented.
+
+## Where the code lives, and where it runs
+
+This distinction caused real confusion and is worth stating once:
+
+```
+shep-client            the code, written once, in shep
+   |
+   | linked by
+   v
+each dog's process     where the behaviour executes
+```
+
+Shep implements the reconnect. A dog gets it by being rebuilt. No dog author writes reconnect logic, and the dog contract does not change. Confirmed: the built-ins already `use shep_client::{Client, ConnectError, EventStream, RequestError}`, and G9 establishes that a plain `cargo install <dog>` picks up a new `shep-client`.
+
+---
+
+## The problem the spec does not solve
+
+**G8 requires the daemon to restart a refused dog once. The daemon cannot tell which dog was refused.**
+
+`server.rs` refuses a mismatched handshake by reading `hello.protocol` and replying `ProtocolMismatch`. `Hello` carries `client_version` and `protocol` and no dog identity. A refused handshake never gets as far as a request, so `Request::DogConfig`'s name, the one place a dog does identify itself, is unreachable on exactly the path that needs it.
+
+So G8's step 2 is not implementable as written. Three ways out:
+
+1. **Carry the dog's name in `Hello`.** It already knows it: `dogs.rs` gives every dog `$SHEP_DOG_NAME` in its environment. An `Option<String>` on `Hello` is additive, and a client that omits it reads as `None`, which is what every non-dog client truthfully is.
+2. **Infer from peer credentials.** `SO_PEERCRED` on Linux, `LOCAL_PEERCRED` on macOS, neither on Windows. Platform-specific work in a layer that `shep_core::transport` deliberately keeps platform-free.
+3. **Infer from absence.** Track which dogs hold a connection; after a handover, treat a dog that has not re-established inside a deadline as refused. Conflates refused with slow and with crashed, and needs a deadline nobody has a principled value for.
+
+**Recommendation: option 1.** It is the only one that makes the refusal itself informative rather than inferred, it costs one optional field, and it is the same additive-`Option` shape the handover blob has used five times without moving a version. Option 2 puts a platform gate above the transport, which CLAUDE.md calls a design decision rather than a shrug. Option 3 answers a different question than the one asked.
+
+**Open for the maintainer: does `Hello` gaining an optional field move `PROTOCOL_VERSION`?** My reading is no, on the blob's own precedent: an absent optional field is not a wire break, and a daemon reading `None` from an older client is correct rather than degraded. But `Hello` IS the version-negotiation frame, so this is the one place that argument deserves a second look before it is relied on.
+
+---
+
+## Order
+
+1 is the spine and everything depends on it. 2 cannot be built before 1, because it is the answer to a question only a reconnecting client asks. 3 and 4 are independent of each other once 2 is in.
+
+---
+
+### Task 1: a reconnecting client
+
+**Files:** `crates/shep-client/src/`, `crates/shep-cli/src/dog/mod.rs`.
+
+A dog's connection has to re-establish itself when the daemon it was talking to is replaced.
+
+**Not on `Client` itself.** The CLI is the other consumer and must NOT gain transparent reconnect: a `shep stop` whose connection dropped mid-request and silently retried could stop a sheep twice. H2 already rules that in-flight requests fail rather than retry, and that ruling is what keeps the CLI's one-shot semantics intact. So this is a wrapper, or a mode, that dogs opt into and the CLI does not.
+
+- [ ] **Step 1: Write the failing test.** A client whose connection is closed under it re-establishes and serves the next request.
+- [ ] **Step 2: Run it, watch it fail.**
+- [ ] **Step 3: Implement.** In-flight requests fail, never retry. Say in the commit why the CLI is not affected.
+- [ ] **Step 4: Prove it non-vacuous.**
+- [ ] **Step 5: Point `DogRuntime::start` at it** (`crates/shep-cli/src/dog/mod.rs:186` connects once today).
+- [ ] **Step 6: Commit.**
+
+### Task 2: what a refused reconnect does (G8)
+
+**Files:** `crates/shep-core/src/protocol/` (`Hello`), `crates/shep-daemon/src/server.rs`, `crates/shep-daemon/src/dogs.rs`.
+
+Per the section above, and per G8: record the refusal, restart that dog ONCE from disk, and if the restart is refused too, stop and report it stale. A second refusal proves the disk binary cannot satisfy this daemon, so retrying is a spin rather than optimism.
+
+- [ ] **Step 1: Write the failing tests**, including that a twice-refused dog is NOT restarted a third time.
+- [ ] **Step 2: Run them, watch them fail.**
+- [ ] **Step 3: Implement.** `server.rs` currently drops everything but `hello.protocol` and logs the refusal at no level; that is half the defect.
+- [ ] **Step 4: Prove each non-vacuous**, especially the never-loop case.
+- [ ] **Step 5: Real reload** with a deliberately stale dog, proving one restart and no loop.
+- [ ] **Step 6: Commit.**
+
+### Task 3: a reconnected dog's version is fresh (G13)
+
+**Files:** `crates/shep-client/src/`, `crates/shep-daemon/src/`.
+
+`Client::ack` is taken once at connect and handed out by `daemon()`. After a reconnect it would still describe the predecessor. `metrics` prints `daemon_version` from it, so it would publish a version that is no longer running.
+
+G13's rule: `daemon reload` reports dog staleness AFTER the dogs have reconnected, when the answer is a fact rather than a claim about a process being replaced.
+
+- [ ] **Step 1: Write the failing test.** After a reconnect, `daemon()` reports the successor.
+- [ ] **Step 2: Run it, watch it fail.**
+- [ ] **Step 3: Implement.**
+- [ ] **Step 4: Prove it non-vacuous.**
+- [ ] **Step 5: Real reload**, scraping `metrics` afterwards and reading `daemon_version` back.
+- [ ] **Step 6: Commit.**
+
+### Task 4: strike the refusal
+
+**Files:** `crates/shep-daemon/src/handover/mod.rs`, `crates/shep-daemon/src/supervisor.rs`, `web/src/pages/docs/getting-started.astro`.
+
+Last one, and it is four lines plus the fixtures. 2b built and measured this carry already, so the mechanism is known: strike `entry.dog.is_some()` in `refusal`, give `CarriedSheep` a `dog: Option<DogSource>`, restore it in `install_adopted`.
+
+Two things 2b recorded for whoever does this:
+
+- **Losing the `dog` field is not cosmetic.** `matching_ids` includes a dog only for an exact selector, so a carried dog without its marker leaves `shep dogs` and appears in `shep flock` beside the operator's own apps.
+- **Four tests use `RefusedReason::Dog` as their refusal fixture.** The two in `handover/mod.rs` are one line each (`e.reload = ReloadState::Replacement`). The two in `boot.rs` boot a real daemon, and a reload parked in `AwaitReady` is the one to build: a pending stop needs a script that ignores signals, which then blocks the test's own 5s teardown on `kill_timeout`.
+
+- [ ] **Step 1: Write the failing tests.**
+- [ ] **Step 2: Run them, watch them fail.**
+- [ ] **Step 3: Implement, and move the four fixtures.**
+- [ ] **Step 4: Prove each non-vacuous.**
+- [ ] **Step 5: Real reload** with both built-in dogs, proving `curl /metrics` still answers 200 afterwards and neither dog's restart count moved. That measurement is the whole phase.
+- [ ] **Step 6: `web/` and commit.** `getting-started.astro` says "A dog or anything mid-reload sends the reload down the older path instead"; the first half stops being true here.
+
+---
+
+## Out of scope, deliberately
+
+**G11 and G12's row 5.** A dog answering `--version` so `adopt` can check the binary ON DISK, and the trap where upgrading only a dog leaves a system that breaks at its next restart, days later, for an unrelated reason. Real, and not needed to carry a dog. Worth its own phase once this one has shipped, and G12's matrix is already written.
+
+## The reload drill
+
+Unchanged, in `docs/writing-plans/plans/2026-08-30-handover-phase2b.md` under "The reload drill, exactly". Every constraint still binds: the `awk` rate, `$SHEP_HOME` under 103 bytes, stopping the sheep before counting, seam-aware counting.
+
+**A green suite is not evidence in this phase.** Six bugs in the timer-strand class were each found by driving a real reload and none by reading code, and this phase's own defect was found the same way. Every task drives a real reload, and for a dog that means proving it still WORKS afterwards, not that its process is still there. A live dog holding a dead socket looks perfect to a pid check.
+
+## Gate
+
+Per `CLAUDE.md`. Inner loop `cargo test -p shep-daemon --lib --all-features -- --skip ::slow::`, one cargo shape per task, Windows cross-check with its own `CARGO_TARGET_DIR`. Note that this phase touches `shep-client` and `shep-cli` as well, so a shep-scoped run needs `cargo test -p shep --lib --bins --all-features`.
+
+Counts at the branch point: about **675** daemon lib, **2149** workspace. A shape, not a checksum.
+
+**CI's process-spawning tiers flaked five times during 2b and 2c.** A `slow`, `musl` or e2e failure gets read against `main`'s own history before it is treated as the branch's fault.

--- a/docs/writing-plans/plans/2026-08-31-handover-phase3.md
+++ b/docs/writing-plans/plans/2026-08-31-handover-phase3.md
@@ -70,7 +70,29 @@ for whoever implements task 2.
 
 **Recommendation: option 1.** It is the only one that makes the refusal itself informative rather than inferred, it costs one optional field, and it is the same additive-`Option` shape the handover blob has used five times without moving a version. Option 2 puts a platform gate above the transport, which CLAUDE.md calls a design decision rather than a shrug. Option 3 answers a different question than the one asked.
 
-**Open for the maintainer: does `Hello` gaining an optional field move `PROTOCOL_VERSION`?** My reading is no, on the blob's own precedent: an absent optional field is not a wire break, and a daemon reading `None` from an older client is correct rather than degraded. But `Hello` IS the version-negotiation frame, so this is the one place that argument deserves a second look before it is relied on.
+**ANSWERED 2026-08-31: no bump.** `Hello` carries no
+`#[serde(deny_unknown_fields)]`, so serde ignores fields it does not know
+and an older daemon parses a newer client's `Hello` cleanly. That was the
+whole worry: `Hello` IS the version-negotiation frame, so a daemon that
+rejected unknown fields would refuse a newer client BEFORE reading
+`protocol`, and that would be a hard break. It does not.
+
+The change is additive in both directions and meets none of this project's
+own bar for a bump, which is a change an older peer cannot deserialize
+(`PROTOCOL_VERSION` moved 1 to 2 because `SelectorSpec` gained a variant an
+older daemon could not parse). Bumping would refuse every CLI invocation
+and every dog until upgraded, which is worse here than anywhere: it forces
+a mass dog refusal at exactly the moment G8's graceful handling does not
+exist yet.
+
+**Task 2 must pin this**, with a case proving an older-shaped `Hello`
+still parses, so nobody adds `deny_unknown_fields` later without seeing
+what it breaks.
+
+The reasoning that led there, kept because the question is worth being able
+to re-ask:
+
+**Was open for the maintainer: does `Hello` gaining an optional field move `PROTOCOL_VERSION`?** My reading is no, on the blob's own precedent: an absent optional field is not a wire break, and a daemon reading `None` from an older client is correct rather than degraded. But `Hello` IS the version-negotiation frame, so this is the one place that argument deserves a second look before it is relied on.
 
 ---
 

--- a/docs/writing-plans/plans/2026-08-31-handover-phase3.md
+++ b/docs/writing-plans/plans/2026-08-31-handover-phase3.md
@@ -575,12 +575,357 @@ Two things 2b recorded for whoever does this:
 - **Losing the `dog` field is not cosmetic.** `matching_ids` includes a dog only for an exact selector, so a carried dog without its marker leaves `shep dogs` and appears in `shep flock` beside the operator's own apps.
 - **Four tests use `RefusedReason::Dog` as their refusal fixture.** The two in `handover/mod.rs` are one line each (`e.reload = ReloadState::Replacement`). The two in `boot.rs` boot a real daemon, and a reload parked in `AwaitReady` is the one to build: a pending stop needs a script that ignores signals, which then blocks the test's own 5s teardown on `kill_timeout`.
 
-- [ ] **Step 1: Write the failing tests.**
-- [ ] **Step 2: Run them, watch them fail.**
-- [ ] **Step 3: Implement, and move the four fixtures.**
-- [ ] **Step 4: Prove each non-vacuous.**
-- [ ] **Step 5: Real reload** with both built-in dogs, proving `curl /metrics` still answers 200 afterwards and neither dog's restart count moved. That measurement is the whole phase.
-- [ ] **Step 6: `web/` and commit.** `getting-started.astro` says "A dog or anything mid-reload sends the reload down the older path instead"; the first half stops being true here.
+- [x] **Step 1: Write the failing tests.**
+- [x] **Step 2: Run them, watch them fail.**
+- [x] **Step 3: Implement, and move the four fixtures.**
+- [x] **Step 4: Prove each non-vacuous.**
+- [x] **Step 5: Real reload** with both built-in dogs, proving `curl /metrics` still answers 200 afterwards and neither dog's restart count moved. Half met and half ruled on: metrics holds its pid and `restarts 0` across six reloads while serving 200; bark still restarts once per reload, and the ruling is below.
+- [x] **Step 6: `web/` and commit.**
+
+#### Outcome
+
+**Four lines, as 2b measured, and four more that 2b could not have seen.**
+The carry itself was exactly what that section promised: strike
+`entry.dog.is_some()` in `refusal`, give `CarriedSheep` a `dog:
+Option<DogSource>`, read it off the entry in `from_entry` the way `reload`
+already is, restore it in `install_adopted`. `VERSION` unmoved, no
+`#[serde(default)]`, a legacy-blob test beside its seven siblings. What was
+not in the estimate: the four lines put a dog into the muster roll for the
+first time, and the fix for that is its own line with its own argument. See
+"Found in passing" below.
+
+**`PumpUnresponsive` is the only refusal left, and `Display` changed shape
+because of it.** The `(sheep, feature)` template existed for the variants
+that read "which this daemon cannot yet hand over"; `Dog` was the last of
+them, and a wedged pump has always had its own sentence because it is a
+fault rather than a gap a later phase closes. The template went with the
+variant. The tail — "reload falls back to a stop-and-start instead" — is
+unchanged and load-bearing: two `cli_e2e` cases probe for exactly that
+string to tell a carried flock from a stopped-and-started one, and a third
+does now.
+
+**The enum stays `#[non_exhaustive]` on a different argument than before.**
+It used to be justified by how much of the handover had shipped — every
+phase turned one variant into something the daemon carries, so a matcher had
+to tolerate variants going away. There is nothing left to remove. It stays
+because shep-daemon is a published library and a second way for a live
+sheep's descriptors to be unknowable would otherwise be a breaking change
+for an out-of-tree matcher (IR-20).
+
+**The whole `DogSource` rides the blob, not a boolean.** `shep dogs` prints
+a SOURCE column, so a successor holding only "this is a dog" would answer it
+with a guess. The adopted variant's path is the operator's own `shep adopt`
+argument, which the blob's `AppConfig` already carries as the program to
+run, so this adds nothing a reader of that file could not already see
+(IR-41).
+
+##### What the marker turns back on, measured rather than assumed
+
+Four readers, and this task strengthens three of them with no change to
+their code:
+
+| reader | what it does with the marker | measured |
+|---|---|---|
+| `matching_ids` | passes a dog over for every selector but an exact one | `shep flock`'s sheep table lists `web` and `freshsheep` only; both dogs are in their own section |
+| `dogs::spawn_dog_watch` | records an exhausted restart budget, but only for a marked entry | a CARRIED dog exhausted after a real reload wrote its line to `barks.jsonl` — drill B |
+| `rpc::dog_staleness` | builds its roster from it | both dogs are waited on now; task 3's measured gap on the handover arm is closed |
+| `dogs::spawn_enabled_dogs` | matches by name and inspects the reply's marker | the successor's "a sheep is already registered under this name" line is gone: **0 daemon log lines across six reloads**, against 1 in task 3's drill C |
+
+##### Found in passing, and it is not cosmetic: a carried dog would have entered the muster roll
+
+A successor rebuilds its registry from the blob — `record_config` per carried
+app — and the snapshot writer turns that registry into `flock.json` within
+seconds. **A dog has never been in the roll**: `spawn_enabled_dogs`
+registers dogs straight through the supervisor and nothing on that path ever
+touches `FlockRegistry`. Carrying one would have put it there for the first
+time, and permanently, because the roll outlives the daemon: a later cold
+boot would `restore_flock` `metrics` as an ordinary UNMARKED sheep before
+`spawn_enabled_dogs` ran, and `shep disable metrics` could not take it back
+out.
+
+`boot::apps_for_the_roll` is the filter. It is a named function rather than
+an inline `.filter()` because the registry takes bare `AppConfig`s, which
+carry no marker: this is the last place that still holds the blob's own
+rows, and that is the argument the function's doc makes.
+
+**Only the end-to-end tier reaches the call site**, which is the mutation
+worth recording — see below.
+
+##### The ruling on bark: deferred, with the design written down
+
+**Bark still restarts once per reload.** Measured here across three spaced
+reloads: pid moving every time, `restarts` 2 → 3 → 4, `online` after each,
+while metrics held pid 13096 at `restarts 0` throughout. Reproduces task 1
+exactly.
+
+**Three reloads inside 50ms produce ONE bark restart, not three**, and that
+is worth knowing before reading any restart count: bark exits when the
+connection it holds dies, so a reload it was not connected for costs it
+nothing. The count is per reload bark is actually up for.
+
+**The fix is not "re-arm the stream inside the client".** Task 1's argument
+still holds: `ReconnectingClient::subscribe` re-arming its own stream would
+silently swallow the gap between a connection dying and the successor
+accepting a fresh `Subscribe`, and an event stream that hides a gap is worse
+than one that ends.
+
+**The fix belongs in bark, where the gap already has an answer.**
+`run_loop`'s `Some(Err(dropped))` arm reconciles against `ListFlock` the
+moment the bus reports a lag, on the reasoning that a drop carries no
+information about what was lost and the only way to know is to ask the
+shepherd what things look like now. A handover gap is the same class of loss
+and deserves the same answer: re-subscribe, then reconcile. The state-based
+rules and the per-subject debounce are already built for a subject seen
+twice by two routes, so nothing new is invented.
+
+**Four things stop it being small, and the fourth is why it is its own task
+rather than a line here:**
+
+1. `EventSource` needs a `resubscribe`, which means a production adapter
+   holding the `ReconnectingClient` beside the stream and its topics.
+   `run_bark` moves that client into `ClientFlockSource` today.
+2. The adapter has to WAIT for the link before it can subscribe — a
+   `Subscribe` against a dead generation fails immediately with `Closed` —
+   and `ReconnectingClient` exposes `link()` as a reading, not a future.
+3. `LinkState::Refused` has to exit rather than retry, so G8's one restart
+   from disk still applies to a bark dog that cannot speak this protocol.
+4. **It needs a ruling on the ORPHANED dog, which is about every dog rather
+   than about bark.** Today bark exits when its shepherd goes away for any
+   reason; one that re-subscribed instead would linger, and would attach
+   itself to whatever daemon next binds that socket, beside that daemon's
+   own bark dog. The metrics dog already has that hazard through
+   `ReconnectingClient`'s supervisor, which retries forever, and nobody has
+   ruled on it. **Observed live during this task's mutation pass**: an
+   orphaned `shep dog metrics` from a killed test daemon was still resident
+   nine minutes later.
+
+Answering it for bark alone would leave the two dogs answering the same
+question differently for the third time. Recorded in
+`docs/specs/deferred.md` under "The bark dog still restarts once per
+reload", with `run_loop`'s `None` arm pointing at it so the next reader
+finds the ruling instead of rediscovering the question.
+
+**Why the phase is still complete without it.** The defect phase 3 was built
+for was a live process holding a dead socket: silent on both sides, 503 to
+every scrape, and indistinguishable from health on every column a listing
+has. Bark's is the opposite in every respect — it is a pid change and a
+counter an operator can read, it self-heals every time, and
+`install_adopted` gives each successor a fresh `RestartBudget` so reloads
+cannot exhaust one. What it costs is a false reading on one column and a
+lost debounce window, not an outage.
+
+##### The four fixtures moved, and there is nowhere left for them to move to
+
+All four needed A refusal rather than that one, and all four now use a
+wedged log pump. Their fixture has moved every time a phase carried the
+feature it was reaching for — a shepherd channel in 2b task 5, two instances
+in task 6, a dog here — and this is the last move available.
+
+| test | where | how it moved |
+|---|---|---|
+| `one_unsupported_sheep_refuses_the_whole_flock` | `handover/mod.rs` | a new `wedged(&entry)` helper beside `plain` |
+| `the_refusal_names_which_sheep_and_why` | `handover/mod.rs` | same, plus an assertion on the "falls back to" tail that the old version did not make |
+| `a_sighup_over_a_flock_it_cannot_carry_refuses_before_it_execs` | `boot.rs` | a `with_a_pump_that_never_reports` sheep started through the booted daemon |
+| `an_abandoned_handover_starts_every_pump_reading_again` | `boot.rs` | a third sheep, wedged, beside the two that answer |
+
+**2b's advice on the boot pair is stale and was not followed.** It said to
+build a reload parked in `AwaitReady`, because a pending stop needs a script
+that ignores signals and would then block the test's own 5s teardown on
+`kill_timeout`. Both of those were refusals in 2b and neither is one now:
+`refusal` reads `pump_unresponsive` and nothing else. A wedged pump is the
+only fixture available, and it needs no choreography at all.
+
+**Both boot cases moved to a paused clock, and that is not incidental.** The
+refusal is a missed `REPORT_DEADLINE`, which is two real seconds each.
+Measured: the daemon lib suite went **1.9s → 5.46s awake, and back to 2.35s
+paused**; the two cases run in 0.03s, stable over ten consecutive runs. The
+`SIGNAL_TEST_LOCK` guard is unrelated and stays — it is about concurrent
+`raise()` reaching this daemon's real listeners, not about the clock — and
+both comments now say which is which.
+
+**`an_abandoned_handover_starts_every_pump_reading_again` kept its own job
+rather than collapsing into its sibling.** With one wedged sheep it would
+have been `a_handover_abandoned_on_a_wedged_pump_resumes_the_pumps_that_
+parked` with a `boot()` in front. It has three sheep instead, two answering
+and one wedged, so it still proves the resume reaches EVERY pump reported to
+where the sibling has only one to reach — and it asserts `answered.len() ==
+2` so a future edit cannot quietly reduce it to the sibling's shape.
+
+##### Drill, measured
+
+**No bypass, for the first time in this phase.** Tasks 1, 2 and 3 each
+needed a temporary `if false && entry.dog.is_some()` to see anything. This
+is a plain release build of the committed tree, driving `shep daemon reload`
+against a real flock with both built-in dogs. Isolated `$SHEP_HOME` at
+`/tmp/p3d/home` (13 bytes) and `/tmp/p3e/home`.
+
+**A. Six reloads, both built-in dogs, one `sh` sheep.** Reloads 1-3 were
+back to back; 4-6 were spaced four seconds apart so bark was connected for
+each.
+
+| | before | after 6 |
+|---|---|---|
+| shepherd pid | 13052 | **13052** |
+| `web` pid / restarts | 13073 / 0 | **13073 / 0**, uptime 1m 49s unbroken |
+| `metrics` pid / restarts | 13096 / 0 | **13096 / 0**, uptime 1m 49s |
+| `bark` pid / restarts | 13871 / 1 | 14268 / **4** |
+| `curl /metrics` | HTTP 200 | **HTTP 200, six of six** |
+| reload wall clock | — | **0.043s, 0.049s, 0.050s** (spaced runs) |
+| daemon log lines | 0 | **0** |
+| `metrics-0-err.log` | 0 bytes | **0 bytes** |
+| lines about dogs in the reload | — | **0** |
+
+Reload wall clock is worth reading against task 3's, which measured 0.055s
+for a handover arm whose dog roster was EMPTY because the marker was lost.
+The roster is populated now, both dogs are waited on, and the verb is no
+slower: the reconnect lands before the first ask.
+
+**The decisive check is content, not status**, for the reason task 1 gave: a
+pid check cannot tell a live connection from a dead one. A sheep started
+after all six reloads appears in the exposition:
+
+```
+shep_sheep_status{sheep="freshsheep",id="4",fold="",status="online"} 1
+```
+
+**The two populations, after six reloads:**
+
+```
+$ shep dogs
+ID  NAME     STATUS  PID    RESTARTS  EXIT  CPU   MEM    UPTIME  SOURCE
+3   bark     online  14268  4         -     0.0%  11.0M  16s     built-in
+1   metrics  online  13096  0         -     0.5%  12.3M  1m 49s  built-in
+
+$ shep flock
+ID  NAME        STATUS  PID    RESTARTS  EXIT  CPU   MEM   UPTIME  FOLD  SMIT
+4   freshsheep  online  14378  0         -     0.2%  3.0M  2s      -     -
+0   web         online  13073  0         -     0.1%  3.1M  1m 49s  -     -
+
+Dogs
+...
+```
+
+Task 3's drill C had `shep dogs` **empty** and `metrics` listed beside the
+operator's own app. That is the marker loss, and it is closed.
+
+**The muster roll, read back through `shep save`:** `{'file':
+'/tmp/p3d/home/flock.json', 'apps': 2}`, holding `['freshsheep', 'web']`.
+No dog, after six real handovers.
+
+**B. `barks.jsonl`, which is task 2's finding and needs a dog that dies.**
+An adopted shim dog (`shep adopt`, exits 1 once a sentinel file appears),
+carried across a real reload — pid 14637 unmoved — then made to burn its
+whole budget:
+
+```
+1   shimdog  errored  -  16  1  -  -  0s  adopted
+
+$ shep barks
+WHEN                 RULE    SUBJECT  MESSAGE
+2026-08-31 13:56:26  daemon  shimdog  dog shimdog exhausted its restart budget: 16 restarts against a budget of 16
+```
+
+Task 2 measured a carried dog erupting through its whole budget and writing
+**nothing**. One line now, and it is the alert an operator reads after an
+outage.
+
+**C. A dog that never handshakes costs every reload the full wait, and says
+so.** The same shim, which does not speak the protocol at all:
+
+```
+wall=3.066s exit=0
+notice[reload]: the shepherd is now 0.1.22 (pid 14591)
+notice[reload]: the `shimdog` dog had not answered this shepherd after 3s, so this reload cannot say whether it came back
+```
+
+Reported rather than buried, because it is a real cost this task introduces
+and it will reach a real operator: **a third-party dog built against a
+`shep-client` older than task 2 sends an anonymous `Hello`, so nothing ever
+records a handshake for it and every reload pays `DOG_SETTLE_WAIT` and
+prints that line.** It is the phase decision's already-accepted cost
+("mute after a reload until rebuilt") arriving as a sentence instead of as
+silence, and the trade is three seconds against the stop arm restarting the
+entire flock. Exit stays 0 and the flock is carried either way.
+
+##### Mutations
+
+Eight, each applied to the committed tree, run, and restored from a saved
+copy rather than through git.
+
+| mutation | fails |
+|---|---|
+| the gate refuses a dog again | `a_dog_is_carried_rather_than_refused`, alone |
+| `from_entry` drops the marker | the two blob cases, the adopt case, the roll case — 4 |
+| `from_entry` invents one on every sheep | those, plus three carried-reload cases — 7 |
+| the blob field stops being optional on the wire | `a_blob_written_before_a_dog_was_carried_still_loads`, alone |
+| `install_adopted` drops the marker | `an_adopted_dog_keeps_its_marker_and_stays_out_of_a_wildcard`, alone |
+| `apps_for_the_roll` stops filtering | `a_carried_dog_does_not_reach_the_muster_roll`, alone |
+| **`boot` stops CALLING `apps_for_the_roll`** | **the end-to-end case, alone in the workspace** |
+| the reconnect supervisor never observes the death | 8 `reconnect` cases, the metrics dog case, and the end-to-end one |
+
+Three worth recording:
+
+- **The call-site mutation is the one only an end-to-end test catches, and it
+  was not covered until this drill went looking for it.** Restoring the old
+  `carried_apps.extend(...)` line leaves the helper, its unit case and all
+  **703** daemon lib tests green, because nothing but a booted daemon drives
+  `boot`'s use of it. The end-to-end case now reads the roll back through
+  `shep save` and fails at 3 apps against 2. Every task in this phase found
+  one of these; this is task 4's, and it is a `flock.json` that silently
+  acquires a dog forever.
+- **Inventing a marker has a blast radius of 7, and the three extra failures
+  are the right alarm.** `a_carried_ready_failed_instance_is_still_
+  replaceable`, `a_carried_reload_naming_no_registered_instance_is_dropped`
+  and `a_carried_swap_that_cannot_finish_is_still_abandoned_on_time` all
+  fail, because every carried sheep becomes a dog and wildcards stop
+  reaching any of them. A change that turned the whole flock into a kennel
+  would take `shep restart all` down with it, and three cases say so
+  without being about dogs at all.
+- **`a_dog_is_carried_rather_than_refused` is the only unit test guarding the
+  strike itself**, and its radius is 1. Nothing else in the lib suite goes
+  through `fitness` with a dog in it. The end-to-end case is the second
+  guard, and it catches the same mutation through the real verb: the reload
+  prints "falls back to a stop-and-start" and the assertion names it.
+
+##### Gate
+
+`cargo fmt --all --check` EXIT=0. `cargo clippy --workspace --all-targets
+--all-features -- -D warnings` EXIT=0. `cargo test --workspace
+--all-features` EXIT=0, **2196 passed**, 0 failed across 32 binaries — task
+3's 2190 plus seven added and one removed. `RUSTDOCFLAGS="-D warnings" cargo
+doc --workspace --no-deps --all-features` EXIT=0. Windows cross-check with
+its own `CARGO_TARGET_DIR` EXIT=0 (the same `cfg(unix)` dead-code warnings
+`CLAUDE.md` documents; `apps_for_the_roll` is `#[cfg(unix)]` and adds none).
+
+Daemon lib: **703**, up from 698, and back to **2.35s** with the two boot
+cases on a paused clock.
+
+**`web/` needed the hand-written half only.** `cargo build --release` then
+`./web/scripts/generate-cli-reference.sh` leaves the generated reference
+byte-identical — 2510 lines, 40 verbs — because no verb, flag, exit code or
+config key moved. Three pages carried claims this task makes false:
+`getting-started.astro` said a dog sends the reload down the older path,
+which is now a wedged log pump and nothing else; and `docs/dogs.md` and
+`web/src/pages/docs/dogs.astro` documented the reconnect without ever saying
+what a reload does to a dog, which is the question a dog author reading that
+section actually has. Both now say it, including bark's exception, because a
+page that claimed every dog keeps its pid would be wrong about one of the
+two shipped dogs. `astro build` EXIT=0, `astro check` EXIT=0, 0 errors and 0
+warnings.
+
+##### Is the phase complete?
+
+**Yes, with one residual named above and recorded in `deferred.md`.** Every
+task's steps are ticked, `RefusedReason` has no feature variant left, and a
+real `shep daemon reload` carries a dog for the first time. The residual is
+bark's restart, which is G7's "no process restart at all" met for one of the
+two built-in dogs and not the other. It is written down rather than left
+implicit, in three places: this section, `docs/specs/deferred.md`, and the
+`None` arm of `run_loop` itself.
+
+What the phase does NOT close, deliberately and as the plan said at the
+outset: G11 and G12's row 5 — a dog answering `--version` so `adopt` can
+check the binary on disk.
 
 ---
 

--- a/docs/writing-plans/plans/2026-08-31-handover-phase3.md
+++ b/docs/writing-plans/plans/2026-08-31-handover-phase3.md
@@ -110,12 +110,91 @@ A dog's connection has to re-establish itself when the daemon it was talking to 
 
 **Not on `Client` itself.** The CLI is the other consumer and must NOT gain transparent reconnect: a `shep stop` whose connection dropped mid-request and silently retried could stop a sheep twice. H2 already rules that in-flight requests fail rather than retry, and that ruling is what keeps the CLI's one-shot semantics intact. So this is a wrapper, or a mode, that dogs opt into and the CLI does not.
 
-- [ ] **Step 1: Write the failing test.** A client whose connection is closed under it re-establishes and serves the next request.
-- [ ] **Step 2: Run it, watch it fail.**
-- [ ] **Step 3: Implement.** In-flight requests fail, never retry. Say in the commit why the CLI is not affected.
-- [ ] **Step 4: Prove it non-vacuous.**
-- [ ] **Step 5: Point `DogRuntime::start` at it** (`crates/shep-cli/src/dog/mod.rs:186` connects once today).
-- [ ] **Step 6: Commit.**
+- [x] **Step 1: Write the failing test.** A client whose connection is closed under it re-establishes and serves the next request.
+- [x] **Step 2: Run it, watch it fail.**
+- [x] **Step 3: Implement.** In-flight requests fail, never retry. Say in the commit why the CLI is not affected.
+- [x] **Step 4: Prove it non-vacuous.**
+- [x] **Step 5: Point `DogRuntime::start` at it** (`crates/shep-cli/src/dog/mod.rs:186` connects once today).
+- [x] **Step 6: Commit.**
+
+#### Outcome
+
+**A distinct type, `shep_client::ReconnectingClient`, not a mode on `Client`.** Three shapes were available: a wrapper dogs name and the CLI does not; a flag on `Client::connect`; or inferring dog-ness from `$SHEP_DOG_NAME`, which `dogs.rs` already puts in every dog's environment. The CLI decides it. A flag makes "does this client retry?" a property of a CALL SITE rather than of a type, so every verb has to be read carefully to trust. Env-sniffing makes it a property of ambient state, so `SHEP_DOG_NAME=x shep stop web` would quietly acquire it and the question stops being provable at all. A distinct type makes the CLI unaffected BY CONSTRUCTION: no `shep` verb names it, so none can acquire the behaviour by accident or by a later edit to a shared constructor. `Client` gains one method — `closed()`, a query that resolves when the actor's command channel drops — and loses nothing.
+
+**One claim in this plan is now false, and it is the wrapper's price.** Line 51 says a dog gets the reconnect by being rebuilt and the dog contract does not change. That is true of the two shapes that were rejected and not of the one that shipped: an adopted dog rebuilt against a newer `shep-client` still constructs a `Client` and still goes mute. Its author has to swap one type name. Both dogs in `web/public/dogs.json` are the maintainer's own, so the cost is one line in each on top of the two releases the decision section already accepted — but it is a line, not a rebuild.
+
+**Supervised, not lazy, and that was forced by tasks 2 and 3 rather than chosen for elegance.** A background task waits on the current connection's death and dials again immediately. Reconnecting on next use would have been cheaper and is wrong twice over: a metrics dog scraped once a minute would spend that minute unreconnected, so G8's refusal would not surface until something happened to ask; and G13 wants `daemon reload` reporting staleness AFTER the dogs have reconnected, which is only immediate if the reconnect is driven by the disconnection. Measured below: the first scrape after `daemon reload` returned was already 200, six times out of six.
+
+**A refused reconnect stops, and that is the seam task 2 hooks into.** `ConnectError::ProtocolMismatch` ends the supervisor and sets `LinkState::Refused`, carrying the daemon's own version and message. Everything else is treated as a successor that is not ready yet and retried with backoff (50ms doubling to a 5s ceiling), because across a handover the listening socket never stops being bound — `connect(2)` succeeds into the backlog and only the handshake waits.
+
+**G13's client half falls out for free; its daemon half does not.** `ReconnectingClient::daemon()` reads the ack off the generation answering right now, returned owned rather than borrowed. That is the only correct answer for a type whose generation changes underneath it — a cached ack would describe the predecessor, which is exactly what the metrics dog must not publish. Task 3 still owns the reporting side.
+
+**Bark is unchanged and this is the gap task 4 will meet.** Its `EventStream` belongs to one generation and ends when that connection dies, so `run_loop`'s `None` arm breaks, the dog exits 0, and autorestart replaces it — survival by accident, at one restart per reload, exactly as 2b recorded. Re-arming the subscription inside `ReconnectingClient` would silently swallow the gap between the connection dying and the successor accepting a new `Subscribe`, and an event stream that hides a gap is worse than one that ends, so `subscribe` documents the boundary instead. **Task 4's step 5 asks that neither dog's restart count move. That is a decision about the gap, not a line of plumbing, and it is not in this task's commit.**
+
+##### Drill, measured
+
+Route 2 of the two the brief offered: a temporary local bypass of `RefusedReason::Dog` (`if false && entry.dog.is_some()`), reverted before the gate and proven reverted — `git diff --stat crates/shep-daemon/` is empty and the branch's only daemon change is none at all. Release build, isolated `$SHEP_HOME` at `/tmp/p3/home`, one `awk` sheep plus the metrics dog, `curl 127.0.0.1:9615/metrics`.
+
+The before-state was re-measured on this machine rather than quoted from 2b, by neutering the supervisor's wake-up (`core::future::pending()` in place of `closed().await`) and rebuilding:
+
+| | before (no reconnect) | after (this task) |
+|---|---|---|
+| pre-reload scrape | HTTP 200 | HTTP 200 |
+| scrapes after 1 reload | **503, 503, 503, 503, 503, 503** | 200 |
+| six reloads, three scrapes each | — | **18 of 18 HTTP 200** |
+| dog pid | 83876 unmoved | 85698 unmoved |
+| dog restarts | 0 | 0 |
+| dog status | online | online |
+| dog stderr | 0 bytes | 0 bytes |
+| `shep daemon reload` exit | 0 | 0 every time |
+
+Every column except the scrape reads identically in both builds, which is the whole point of this defect: **a pid check cannot see it.** Restarts 0, status online, stderr 0 bytes and an unmoved pid describe a dog that has been answering 503 to everything for six reloads just as well as they describe a healthy one.
+
+**The decisive check is content, not status.** A `freshsheep` started AFTER the six reloads appears in the exposition:
+
+```
+shep_sheep_status{sheep="freshsheep",id="2",fold="",status="online"} 1
+```
+
+A cached reading, a replayed exposition, or a connection to a predecessor could not produce that row. The dog is holding a live connection to the daemon that is running now.
+
+**Bark, same drill, with a valid `[dog.bark.sinks]` entry:**
+
+| | before reload | after 1 | after 2 |
+|---|---|---|---|
+| bark pid / restarts | 86973 / 25 | 87096 / **26** | 87191 / **27** |
+| metrics pid / restarts | 85698 / 0 | 85698 / 0 | 85698 / 0 |
+
+One restart per reload, pid moving each time. 2b's measurement, reproduced.
+
+**Found in passing, unrelated and not fixed.** `shep enable bark` with no `[dog.bark.sinks]` at all produces a crash loop, not a refusal: `shep dog bark: rule 0 routes to no sink at all`, once per restart, restarts climbing about 6 per 2s. The default rule set is built from a sinks map that is empty, so the dog cannot start on the configuration `enable` leaves behind. Sibling of the `[[dog.bark.rules]]` parse defect 2b recorded, and like it, not the handover.
+
+##### Mutations
+
+Each test broken deliberately, run, restored. The blast radius is per-mutation and stated because two of them started out over-broad:
+
+| mutation | fails |
+|---|---|
+| supervisor never spawned | all six `reconnect` tests + the metrics end-to-end |
+| ack cached at construction | the two ack tests, and only those |
+| in-flight request retried against the successor | `an_in_flight_request_fails_and_is_never_re_sent_to_the_successor` |
+| retry after a refusal instead of returning | `a_refused_reconnect_stops_rather_than_spinning` |
+| give up on a transient failure | `a_reconnect_retries_past_a_successor_that_is_not_accepting_yet` |
+| `Drop` no longer aborts the supervisor | `dropping_the_handle_stops_the_supervisor` |
+| supervisor never observes the death | the metrics end-to-end, alone among the dog tests |
+
+Two of those needed the tests strengthening before they died, and both are worth recording because the first attempt looked green:
+
+- **The refusal test passed the spin mutation.** It asserted `accepted() == 2` immediately after `link()` reached `Refused`, and a supervisor that recorded the refusal and then slept 50ms before going round again satisfies that. Fixed by adding a bounded negative — the count must NOT reach 3 within 8x `RECONNECT_MIN_DELAY`. A negative assertion is only as good as its window, so the window is stated against the delay it has to outrun.
+- **The wait helper conflated the reconnect with the ack.** It polled `daemon().pid`, so caching the ack killed four tests instead of the two that are about the ack. Rewritten to poll the fake's accept count AND `link() == Connected`; neither alone is sound (the count rises before the handshake completes, and the link still reads `Connected` in the instant after a cut), and together they are, because the supervisor sets `Reconnecting` before it dials.
+
+**One mutation survives and is reported rather than chased.** Retrying an in-flight `Closed` against the SAME dead generation passes every test. It is equivalent in effect — both attempts meet the same closed channel and return `Closed` — and killing it would need a test asserting how many times `request` consults the current generation, which is implementation shape rather than behaviour. The dangerous version, waiting for the fresh generation and then re-sending, is caught.
+
+##### Gate
+
+`cargo fmt --all --check` EXIT=0. `cargo clippy --workspace --all-targets --all-features -- -D warnings` EXIT=0. `cargo test --workspace --all-features` EXIT=0, **2167 passed**, 0 failed. `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features` EXIT=0. Windows cross-check with its own `CARGO_TARGET_DIR` EXIT=0.
+
+`web/` needs nothing and this was checked rather than assumed: `cargo build --release` then `./web/scripts/generate-cli-reference.sh` leaves `git status --porcelain web/` empty, 2510 lines and 40 verbs, unchanged.
 
 ### Task 2: what a refused reconnect does (G8)
 

--- a/docs/writing-plans/plans/2026-08-31-handover-phase3.md
+++ b/docs/writing-plans/plans/2026-08-31-handover-phase3.md
@@ -2,7 +2,15 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: use `superpowers:subagent-driven-development` to implement this task-by-task. Steps use `- [ ]` for tracking.
 
-**Goal:** Carry every dog across the handover with no restart, which means giving a dog a connection that survives its daemon being replaced.
+**Goal:** Carry every dog across the handover, giving it a connection that
+survives the shepherd it was talking to being replaced.
+
+**Amended after task 4**, which measured what shipped rather than what was
+planned. This said "with no restart", and that holds for `metrics` and not
+for `bark`: bark's event stream belongs to one connection generation, so it
+still exits and is replaced once per reload. Closing that needs a ruling on
+what an orphaned dog does, which is a question about every dog rather than
+about bark, and is recorded rather than left as a quietly unmet step.
 
 **Spec:** `docs/brainstorming/specs/2026-08-29-daemon-handover-design.md`, sections G6 through G13.
 

--- a/docs/writing-plans/plans/2026-08-31-handover-phase3.md
+++ b/docs/writing-plans/plans/2026-08-31-handover-phase3.md
@@ -64,6 +64,10 @@ So G8's step 2 is not implementable as written. Three ways out:
 2. **Infer from peer credentials.** `SO_PEERCRED` on Linux, `LOCAL_PEERCRED` on macOS, neither on Windows. Platform-specific work in a layer that `shep_core::transport` deliberately keeps platform-free.
 3. **Infer from absence.** Track which dogs hold a connection; after a handover, treat a dog that has not re-established inside a deadline as refused. Conflates refused with slow and with crashed, and needs a deadline nobody has a principled value for.
 
+**DECIDED 2026-08-31 by the maintainer: option 1, carry the dog's name in
+`Hello`.** The reasoning below is what the decision was taken on and is kept
+for whoever implements task 2.
+
 **Recommendation: option 1.** It is the only one that makes the refusal itself informative rather than inferred, it costs one optional field, and it is the same additive-`Option` shape the handover blob has used five times without moving a version. Option 2 puts a platform gate above the transport, which CLAUDE.md calls a design decision rather than a shrug. Option 3 answers a different question than the one asked.
 
 **Open for the maintainer: does `Hello` gaining an optional field move `PROTOCOL_VERSION`?** My reading is no, on the blob's own precedent: an absent optional field is not a wire break, and a daemon reading `None` from an older client is correct rather than degraded. But `Hello` IS the version-negotiation frame, so this is the one place that argument deserves a second look before it is relied on.

--- a/docs/writing-plans/plans/2026-08-31-handover-phase3.md
+++ b/docs/writing-plans/plans/2026-08-31-handover-phase3.md
@@ -78,7 +78,9 @@ So G8's step 2 is not implementable as written. Three ways out:
 
 **DECIDED 2026-08-31 by the maintainer: option 1, carry the dog's name in
 `Hello`.** The reasoning below is what the decision was taken on and is kept
-for whoever implements task 2.
+for whoever implements task 2. **Built in task 2 as `Hello.dog_name`, with
+`PROTOCOL_VERSION` unmoved and that reading pinned by a test** — see that
+task's outcome section.
 
 **Recommendation: option 1.** It is the only one that makes the refusal itself informative rather than inferred, it costs one optional field, and it is the same additive-`Option` shape the handover blob has used five times without moving a version. Option 2 puts a platform gate above the transport, which CLAUDE.md calls a design decision rather than a shrug. Option 3 answers a different question than the one asked.
 
@@ -214,12 +216,100 @@ Two of those needed the tests strengthening before they died, and both are worth
 
 Per the section above, and per G8: record the refusal, restart that dog ONCE from disk, and if the restart is refused too, stop and report it stale. A second refusal proves the disk binary cannot satisfy this daemon, so retrying is a spin rather than optimism.
 
-- [ ] **Step 1: Write the failing tests**, including that a twice-refused dog is NOT restarted a third time.
-- [ ] **Step 2: Run them, watch them fail.**
-- [ ] **Step 3: Implement.** `server.rs` currently drops everything but `hello.protocol` and logs the refusal at no level; that is half the defect.
-- [ ] **Step 4: Prove each non-vacuous**, especially the never-loop case.
-- [ ] **Step 5: Real reload** with a deliberately stale dog, proving one restart and no loop.
-- [ ] **Step 6: Commit.**
+- [x] **Step 1: Write the failing tests**, including that a twice-refused dog is NOT restarted a third time.
+- [x] **Step 2: Run them, watch them fail.**
+- [x] **Step 3: Implement.** `server.rs` currently drops everything but `hello.protocol` and logs the refusal at no level; that is half the defect.
+- [x] **Step 4: Prove each non-vacuous**, especially the never-loop case.
+- [x] **Step 5: Real reload** with a deliberately stale dog, proving one restart and no loop.
+- [x] **Step 6: Commit.**
+
+#### Outcome
+
+**`Hello.dog_name`, an `Option<String>`, and `PROTOCOL_VERSION` did not move.** The decision above was taken on the reading that `Hello` carries no `#[serde(deny_unknown_fields)]`; that reading is now pinned by `a_hello_without_a_dog_name_still_parses`, which asserts both directions — a committed byte fixture from before the field, and a frame carrying a key an older daemon would not know. Nobody can add `deny_unknown_fields` later without seeing what it breaks. `#[serde(skip_serializing_if)]` follows `RpcError::daemon_version`, which was added under the same argument, so a non-dog client's `Hello` is byte-identical to the one protocol 2 shipped with and `hello_handshake_shape` needed no change.
+
+**The CLI cannot name a dog, by construction, and that is the same shape task 1 chose for the same reason.** A `Hello` naming a dog is what lets the daemon restart that dog, so a client able to claim a name it was not spawned as could have a dog restarted on its say-so. `Client`'s public constructors pass `None`; its dog-naming constructor is `pub(crate)` and its only caller is `ReconnectingClient::connect_as_dog`, the type dogs name and no `shep` verb does. Nothing in `shep-client` reads `$SHEP_DOG_NAME` — `DogRuntime::start` takes the name from its own caller's argv — so `SHEP_DOG_NAME=x shep stop web` cannot reach the branch.
+
+**The name rides every handshake, not just the first.** The refusal that matters is a successor's, and a dog that named itself at boot and then reconnected anonymously would leave that successor exactly as unable to act as it was before.
+
+**One restart falls out of the state, not a budget.** `DogRefusals` is a count per dog, cleared by a SUCCESSFUL handshake and by nothing else. A dog that cannot get in never clears, so it can never earn a second restart however many times it is refused; a dog that does get in is back to a clean slate, so a later daemon that refuses it gets its own one restart. One restart per episode, and an episode ends when the dog is talking again. The count does not survive a handover, deliberately: a successor has refused nobody, and a dog it can talk to is not stale by any definition it could apply.
+
+**In `dogs.rs`, not the supervisor**, for the reason `spawn_dog_watch` already gives: this answers *who should see this*, from outside, and the supervisor stays a machine that knows only how to supervise. The connection layer supplies the one fact only it has — a handshake was refused, by this name — and asks `dogs.rs` what that costs. The restart itself runs on its own task, because a restart is a full kill ladder and the caller is a connection handler holding a socket this daemon has already refused.
+
+**What it does NOT do is stop a stale dog's own `autorestart`, and that is worth stating because the drill makes it visible.** A dog whose process EXITS on a refused handshake — a FIRST connection refused, rather than one lost to a handover — is respawned by the supervisor as any sheep is, and goes on being refused until its restart budget (16) runs out. That loop is bounded and it is the supervisor's existing mechanism. G8 is about not adding daemon restarts on top of it. The third refusal onward is `AlreadyStale`: no restart, and no second error line.
+
+**A refusal carrying no dog name is `debug!`, and a real reload decided that.** It was `warn!` until it was measured. The daemon's default level IS `warn`, and `shep daemon reload` across a protocol bump leaves the CLI polling for a successor it cannot speak to: one reload wrote **442 of those lines in 9.8 seconds**. The operator is already reading the skew in plain English from their own CLI and `handle_conn` has always logged the closed connection at `debug!`, so the only fact the line adds is the client's crate version. A dog's refusal is the opposite case in every respect and keeps its level.
+
+##### Drill, measured
+
+Route 2 of the two the brief offered, plus a genuinely stale dog. Under an isolated `$SHEP_HOME` at `/tmp/p3b/home`, release builds, and three binaries: `shep-old` (this tree, protocol 2), `shep-new` (this tree with `PROTOCOL_VERSION` bumped to 3), and a predecessor built with `if false && entry.dog.is_some()` so the reload really hands a dog over. Both source edits reverted and proven reverted — `git diff` empty — before the gate. The dog is a shim that `exec`s `shep-old dog metrics`, adopted under the name `metrics`, so the running image and the disk binary are both protocol 2 while the daemon speaks 3.
+
+**A. A dog that stays alive when refused, which is what a carried dog is.** The shim holds the process open after the refusal rather than exiting, so every restart in this run is one the daemon chose.
+
+| | value |
+|---|---|
+| refusals the daemon logged | 3 lines, total, ever |
+| G8 restarts issued | **1** (pid 22658 → 22703, restarts 0 → 1) |
+| second refusal | 11 ms later, `ERROR ... stale and will not be restarted again` |
+| pid at T+74s | **22703, unmoved** |
+| restarts at T+74s | **1, frozen** |
+| further daemon log lines | **0** |
+
+**B. The ordinary case G8 exists for: stale running image, correct binary on disk.** The shim runs `shep-old` once and `shep-new` on every exec after it, which is exactly what a package manager leaves behind.
+
+| | value |
+|---|---|
+| G8 restarts issued | 1 |
+| error lines | **0** — no second refusal happened |
+| `curl 127.0.0.1:9615/metrics` | **HTTP 200** |
+| decisive check | a sheep started AFTER the restart appears in the exposition |
+
+That last row is the one that matters, for the reason task 1 gave: a pid check cannot tell a live connection from a dead one, and only content can.
+
+**C. Through a real `shep daemon reload`.** Predecessor at protocol 2 with the dog carry un-refused, the binary on disk replaced by an atomic rename as a package manager would, then `daemon reload`.
+
+| | value |
+|---|---|
+| daemon pid across the reload | 25677, unchanged — the exec happened |
+| successor's boot | `a sheep is already registered under this name` — the carry happened |
+| G8 restarts issued | **1** |
+| further refusals, from the dog's own autorestart | 15 |
+| further G8 action | **none** |
+| whole daemon log, default level | **3 lines** (445 before the `debug!` fix) |
+| operator's end state | `metrics errored`, restarts 16 (the budget), exit 6; `web` untouched |
+
+G8's restarts and `autorestart`'s are separable only in the log, which is why the log is the assertion: one `restarting it once` line against 15 later refusals.
+
+**Found in passing, and it is task 4's, not a defect here.** A carried dog loses its `dog` marker, which the plan already records for task 4 — but the consequence runs further than `shep dogs` and `shep flock`. `spawn_dog_watch` records an exhausted restart budget only when `info.dog.is_some()`, so the carried dog that erupted through its whole budget above wrote **nothing** to `barks.jsonl`. The bark an operator would read after the outage depends on the marker the carry drops.
+
+**Also found in passing.** `dog_version` in every G8 line reads `0.1.22` for both the protocol-2 and the protocol-3 build, because they differ only in `PROTOCOL_VERSION`. That is G9's point made concrete: `Hello.client_version` is the only thing that knows, and it does not know either.
+
+##### Mutations
+
+Ten, each applied, run against the full four-crate lib suite with `--no-fail-fast`, and reverted:
+
+| mutation | fails |
+|---|---|
+| `Hello` gains `deny_unknown_fields` | the no-dog-name fixture, alone |
+| `skip_serializing_if` dropped from `dog_name` | `hello_handshake_shape`, alone |
+| the reconnect supervisor dials without the name | `a_dogs_name_rides_every_handshake_including_the_refused_one` |
+| `Client::connect_as` drops the name before the frame | that test, plus the dog-runtime one |
+| `DogRuntime::start` calls `connect` instead of `connect_as_dog` | `a_dog_announces_its_own_name_at_the_handshake`, alone |
+| a stale dog is restarted too | `a_twice_refused_dog_is_reported_stale_and_never_restarted_again`, alone |
+| the second refusal never reads `Stale` | that test, plus the two ladder tests |
+| `handshook` becomes a no-op | the two clearing tests, and only those |
+| the refusal path ignores `hello.dog_name` | all three wiring tests |
+| `AlreadyStale` collapses into `Stale` | the ladder test, alone |
+
+Two are worth recording:
+
+- **`DogRuntime::start` calling `connect` was the one only an end-to-end run would have caught**, before a test was written at that seam. It is one line, it makes every real dog announce itself, and the whole of the rest of the suite is blind to it. `a_dog_announces_its_own_name_at_the_handshake` is what closes that, and it needed `fake_daemon`'s returned `Hello` rather than `serve_one_request`'s envelope.
+- **The never-loop test was checked against its own window.** Task 1 found its refusal test initially passed a spin, so this one asserts three independent things: the dog is REPORTED stale, its pid does not move inside a window sized at ten times the restart that really happened earlier in the same test, and the harness is scripted with exactly the two spawns G8 permits so a third would fail to spawn and take the dog out of `Online`. The window was then verified alone — with spare scripts added so the exhaustion tripwire could not fire, the spin mutation still failed it, at pid 1002 inside 200 ms. The two mechanisms agree rather than one propping up the other.
+
+##### Gate
+
+`cargo fmt --all --check` EXIT=0. `cargo clippy --workspace --all-targets --all-features -- -D warnings` EXIT=0. `cargo test --workspace --all-features` EXIT=0, **2180 passed**, 0 failed — task 1's 2167 plus the thirteen this task adds. `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features` EXIT=0. Windows cross-check with its own `CARGO_TARGET_DIR` EXIT=0.
+
+**`web/` needed something this time, and the generator is not what found it.** `cargo build --release` then `./web/scripts/generate-cli-reference.sh` leaves the generated reference byte-identical — 2510 lines, 40 verbs — because no verb, flag or exit code moved. The hand-written pages are the ones that went stale: both `docs/dogs.md` and `web/src/pages/docs/dogs.astro` state the third-party dog wire contract, and both told an author to read `$SHEP_DOG_NAME`, put it in `Request::DogConfig`, and stopped there. A dog following either page exactly sends an anonymous `Hello` and cannot be restarted. Both now name `dog_name`, and both name `ReconnectingClient::connect_as_dog` — which was already missing from task 1, since the reconnect lives on that type and not on `Client`. `astro build` EXIT=0, `astro check` EXIT=0, 0 errors and 0 warnings.
 
 ### Task 3: a reconnected dog's version is fresh (G13)
 

--- a/docs/writing-plans/plans/2026-08-31-handover-phase3.md
+++ b/docs/writing-plans/plans/2026-08-31-handover-phase3.md
@@ -319,12 +319,250 @@ Two are worth recording:
 
 G13's rule: `daemon reload` reports dog staleness AFTER the dogs have reconnected, when the answer is a fact rather than a claim about a process being replaced.
 
-- [ ] **Step 1: Write the failing test.** After a reconnect, `daemon()` reports the successor.
-- [ ] **Step 2: Run it, watch it fail.**
-- [ ] **Step 3: Implement.**
-- [ ] **Step 4: Prove it non-vacuous.**
-- [ ] **Step 5: Real reload**, scraping `metrics` afterwards and reading `daemon_version` back.
-- [ ] **Step 6: Commit.**
+- [x] **Step 1: Write the failing test.** After a reconnect, `daemon()` reports the successor.
+- [x] **Step 2: Run it, watch it fail.**
+- [x] **Step 3: Implement.**
+- [x] **Step 4: Prove it non-vacuous.**
+- [x] **Step 5: Real reload**, scraping `metrics` afterwards and reading `daemon_version` back.
+- [x] **Step 6: Commit.**
+
+#### Outcome
+
+**Steps 1 to 4 were task 1's, and were verified rather than trusted.**
+`ReconnectingClient::daemon` reads the ack off the generation answering
+right now and returns it owned (`reconnect.rs`), the reading is pinned by
+`the_ack_follows_the_successor_rather_than_the_predecessor`, and the
+metrics dog takes it per scrape from the generation that just answered
+`ListFlock` (`dog/metrics/mod.rs`, with a comment saying why two reads
+either side of a handover would publish one daemon's version beside
+another's pid). Nothing was rebuilt. The client half of G13 is done.
+
+**The daemon half is a reading the operator asks for, not a line the
+daemon logs.** `Request::DogStaleness` answers with two lists: `stale`,
+which is `DogRefusals::stale()` and the only thing reportable, and
+`pending`, which is why the caller must ask again. `PROTOCOL_VERSION` did
+not move: both are `#[non_exhaustive]` enums gaining a variant, which is
+what the evolution rule on that constant already calls additive, and the
+one caller is `daemon reload` asking a successor it has just proven runs
+this binary's own version.
+
+**`pending` has two sources because a dog can be unheard-from in two
+ways.** A dog refused ONCE is mid-restart, so G8 has asked for its verdict
+and the verdict has not arrived. A dog the daemon supervises that has never
+handshaken has not been asked yet, which is exactly what a carried dog is
+for the whole gap between the exec and its reconnect. The second needed
+`DogRefusals` to record accepted handshakes as well as refused ones:
+"nobody has heard from that dog" and "that dog is talking happily" both
+have no refusal recorded, and telling them apart is the whole of what the
+waiting is for.
+
+**The supervisor's own rows are a sound roster, and that is a property of
+`boot` rather than an assumption.** A dog is registered before this daemon
+accepts anything: restore the flock, `spawn_enabled_dogs`, and only then
+hand the listener to `serve`. So a caller that can ask the question is
+talking to a daemon that already knows which dogs it has, and there is no
+window where an empty roster reads as "every dog answered".
+
+**One gap, measured, and task 4 closes it for free.** A CARRIED dog loses
+its `dog` marker today, so on the handover arm the roster is empty and the
+wait rests on the refused-once half alone. Confirmed under an isolated
+`SHEP_HOME` in drill C below: after a carried reload `shep dogs` prints
+nothing at all and `metrics` sits in `shep flock` beside the operator's own
+app. Nothing here can say anything FALSE as a result, because silence is
+what a clean reload prints anyway, but it can be silent about a dog that
+had not dialled back yet. Restoring the marker in `CarriedSheep` populates
+the roster and the wait covers a carried dog too, with no change to this
+task's code.
+
+**Only a dog with a PROCESS is waited on, and a real crash loop is what
+decided that.** `Starting` and `Online`, not `WaitingRestart` or `Errored`:
+a dog with no process cannot handshake, so waiting on one would make an
+operator pay a whole timeout for a dog every other listing already reports
+as broken. `shep enable bark` with no `[dog.bark.sinks]` produces exactly
+that state today (task 1 found the crash loop), and it is `waiting-restart`
+most of the time. Nothing is lost by leaving those out: a dog whose restart
+this daemon ASKED for is in the refused-once half whatever its row says.
+
+**Silent unless something is wrong, and the wait is not paid unless there
+is something to wait for.** A flock whose dogs all came back prints nothing
+about them and finds nothing pending on its first ask. Three ordinary
+reloads measured at 0.154s, 0.156s and 0.155s, against 0.935s for the one
+with a dog to wait for.
+
+**The report says what happened and never what shep did not check.** Two
+handshakes were refused with a restart from the binary on disk in between;
+what version that file holds is unread, and unreadable until a dog answers
+`--version` (G11, a later phase). So the sentence is "restarting it from
+the binary on disk did not help, so rebuild or reinstall it", never a claim
+about the file. `dog_version` is deliberately not on the wire either: task
+2 measured two builds differing only in `PROTOCOL_VERSION` both reporting
+`0.1.22`, so carrying a version here would invite the one inference it
+cannot support.
+
+**Nothing new reaches the daemon log.** Task 2's 442-line incident is the
+cautionary one, and this was checked rather than assumed: three ordinary
+reloads with a healthy dog wrote **0 lines**, and the one with a stale dog
+wrote the same **2** G8 already wrote.
+
+##### What the operator sees
+
+Ordinary reload, healthy dogs, verbatim and complete:
+
+```
+notice[reload]: sheep 'metrics' has being a dog, which this daemon cannot yet hand over; reload falls back to a stop-and-start instead
+notice[reload]: the shepherd is now 0.1.22 (pid 97375)
+ID  NAME  STATUS  PID    RESTARTS  EXIT  CPU  MEM  UPTIME  FOLD  SMIT
+0   fast  online  97396  0         -     -    -    0s      -     -
+```
+
+Both notices predate this task. A stale dog adds exactly one line:
+
+```
+notice[reload]: the `metrics` dog cannot talk to this shepherd; restarting it from the binary on disk did not help, so rebuild or reinstall it against shep 0.1.22
+```
+
+And a dog that never answers inside the budget adds a different one, so
+that silence never has to mean two things:
+
+```
+notice[reload]: the `metrics` dog had not answered this shepherd after 3s, so this reload cannot say whether it came back
+```
+
+##### Drill, measured
+
+Under an isolated `SHEP_HOME` at `/tmp/p3c/home`, release builds, one `awk`
+sheep plus a dog. Three binaries from this tree: `shep-old` (protocol 2),
+`shep-new` (protocol 3), and `shep-carry` (protocol 2 with `if false &&
+entry.dog.is_some()` in `handover::refusal`, route 2 of the two the brief
+offered). Both source edits reverted and proven reverted before the gate:
+`git diff --stat crates/shep-core/src/protocol/mod.rs
+crates/shep-daemon/src/handover/mod.rs` is empty.
+
+The stale dog is an adopted shim that `exec`s `shep-old dog metrics`, so
+its running image AND its binary on disk are both protocol 2 while the
+daemon speaks 3 — G12's row 4, the one a restart cannot fix.
+
+**A. The decisive one: the two answers DIFFER.** The shim sleeps 400ms
+before exec'ing, which is what a dog with work to do at startup looks like.
+One `shep daemon reload`, CLI stderr timestamped, against the daemon's own
+log:
+
+| time (UTC) | what happened | what a report taken then would say |
+|---|---|---|
+| 16:42:44.600 | CLI prints the shepherd line; the reading loop starts | **nothing — the successor had refused nobody** |
+| 16:42:44.930 | first refusal, G8 restart issued (+330ms) | nothing |
+| 16:42:45.351 | second refusal; `stale` becomes `["metrics"]` (+751ms) | `metrics` |
+| 16:42:45.380 | CLI prints the stale report (+780ms) | `metrics` |
+
+**A report taken when the loop started would have said nothing at all.**
+That is the whole of G13, measured: the answer did not exist yet at the
+moment a naive report would have been taken, and it took a restart round
+trip to come into existence. Whole verb: 0.935s, exit 0, daemon log 2
+lines.
+
+**A'. The same drill with a shim that does not sleep**, kept because it
+shows how narrow the window is without one: first refusal 16:35:21.989,
+second 16:35:22.001 (**12ms** for a whole kill ladder, spawn, connect and
+refusal), and the CLI's shepherd line at 16:35:22.067 — the answer was
+already a fact before the loop started. Correct report either way, and 12ms
+is not a margin to design a report around.
+
+**B. The ordinary case, three times, with a healthy built-in dog:**
+
+| | reload 1 | reload 2 | reload 3 |
+|---|---|---|---|
+| wall clock | 0.154s | 0.156s | 0.155s |
+| lines about dogs | **0** | **0** | **0** |
+| daemon log lines | **0** | **0** | **0** |
+| `curl /metrics` after | 200 | 200 | 200 |
+
+**C. The handover arm, dogs carried** (`shep-carry` both sides, no protocol
+skew):
+
+| | value |
+|---|---|
+| daemon pid / dog pid | 98455 / 98501 **unmoved** |
+| `curl /metrics` after | **200** — the reconnect works |
+| lines about dogs | **0**, correctly: nothing was stale |
+| wall clock | 0.055s |
+| `shep dogs` after | **empty** |
+| `shep flock` after | `metrics` listed beside `fast` |
+| daemon log | 1 line, the carry's own "already registered under this name" |
+
+The last two rows are the marker loss, reproduced. They are what bounds
+this task's guarantee on the handover arm, and what task 4 restores.
+
+**D. A handover ACROSS a protocol bump cannot be reported, and that is the
+fixture rather than the code.** The handover arm needs a CLI that can talk
+to the PREDECESSOR, and after the exec that same CLI cannot talk to the
+successor: `await_successor` ran its whole 10s budget, fell back to
+"starting one instead", and the reading never ran. The daemon did its half
+regardless (refusal 16:46:21.458, stale 16:46:21.879). Worth recording so
+nobody reads the silence as a defect: an operator upgrading shep replaces
+CLI and daemon together, which is drill A's arm.
+
+##### Mutations
+
+Fourteen, each applied, run against the three-crate lib suite with
+`--no-fail-fast`, and restored byte-for-byte from a saved copy. **No
+survivors.**
+
+| mutation | fails |
+|---|---|
+| the supervisor half never contributes | the not-handshaken test and the not-running one |
+| a handshake no longer settles a dog | `a_dog_that_has_not_handshaken_is_pending` |
+| a stale dog is also reported pending | `a_dog_being_restarted_is_pending_and_then_stale` |
+| a dog with no process is waited on | `a_dog_that_has_stopped_running_is_not_waited_on` |
+| every sheep is waited on, not only dogs | `a_flock_of_ordinary_sheep_has_nothing_stale_and_nothing_pending` |
+| a stale dog still reads as mid-restart | the `restarting` test, and the rpc ladder |
+| a refusal no longer forgets the handshake | `only_an_accepted_handshake_says_a_dog_has_answered` |
+| a handshake is never recorded | that test, plus the rpc pending one |
+| the report is taken on the first ask | both waiting tests |
+| an unanswered dog is never mentioned | `a_reload_stops_waiting_for_a_dog_that_never_answers` |
+| the report fires with nothing stale | `a_reload_whose_dogs_all_answered_says_nothing_about_them` |
+| the reload never asks about dogs | both waiting tests |
+| the report claims it read the disk | `the_stale_report_says_what_happened_and_never_reads_the_disk` |
+| the wait has no deadline | `a_reload_stops_waiting_for_a_dog_that_never_answers` |
+
+Three worth recording:
+
+- **The sheep in the no-dogs test is the point, not scenery.** The first
+  version of that case had an empty flock, and the mutation that walked
+  every row instead of every DOG row passed it. A sheep does not speak this
+  protocol at all (spec, part 4), so a reader that waited for `web` to
+  handshake would hold an operator's reload open forever. The test starts a
+  real sheep now and the mutation dies.
+- **The never-answers test hung rather than failed** when the deadline
+  mutation was applied, which is a signal nobody can read. It wraps the
+  call in a `tokio::time::timeout` now, so the same mutation fails in 5.01s
+  naming the line (IR-46: the timeout is both the forcing mechanism and the
+  assertion).
+- **The disk-claim mutation is the one only a wording test catches.**
+  Rewriting the sentence to say the binary on disk is the wrong version
+  compiles, reads plausibly, passes every behavioural test, and asserts
+  something shep cannot know until G11. Pinned as an exact string in both
+  the singular and the plural shape, because the two are written out
+  separately and a copy-paste between them is invisible.
+
+##### Gate
+
+`cargo fmt --all --check` EXIT=0. `cargo clippy --workspace --all-targets
+--all-features -- -D warnings` EXIT=0. `cargo test --workspace
+--all-features` EXIT=0, **2190 passed**, 0 failed across 32 binaries — task
+2's 2180 plus the ten this task adds. `RUSTDOCFLAGS="-D warnings" cargo doc
+--workspace --no-deps --all-features` EXIT=0. Windows cross-check with its
+own `CARGO_TARGET_DIR` EXIT=0 (the four dead-code warnings are the
+`cfg(unix)` ones `CLAUDE.md` documents).
+
+**`web/` needed the hand-written half only.** `cargo build --release` then
+`./web/scripts/generate-cli-reference.sh` leaves the generated reference
+byte-identical — 2510 lines, 40 verbs — because no verb, flag or exit code
+moved, and a stale dog does not change the exit code either. Three prose
+pages did go stale: `getting-started.astro` documents the reload and said
+nothing about what it reports, and `docs/dogs.md` and
+`web/src/pages/docs/dogs.astro` both told a dog author that a `dog_name`
+gets them "reported stale" without saying where that report goes. `astro
+build` EXIT=0, `astro check` EXIT=0, 0 errors and 0 warnings.
 
 ### Task 4: strike the refusal
 

--- a/web/src/pages/docs/dogs.astro
+++ b/web/src/pages/docs/dogs.astro
@@ -344,7 +344,10 @@ watchdog  adopted  true      stopped`}</CodeBlock>
       from the binary on disk, which fixes the ordinary case where the
       package already replaced your file and the running process is merely
       old, and reports you stale rather than looping if that restart is
-      refused too. Without it you go quiet and nothing on either side says
+      refused too. <code>shep daemon reload</code> prints that report to the
+      operator, after your reconnect rather than before it: what the old
+      image knew about you described a process that was about to stop
+      existing. Without it you go quiet and nothing on either side says
       why.
     </p>
     <p>

--- a/web/src/pages/docs/dogs.astro
+++ b/web/src/pages/docs/dogs.astro
@@ -335,6 +335,27 @@ watchdog  adopted  true      stopped`}</CodeBlock>
       beside them.
     </p>
     <p>
+      Put that name in the <code>Hello</code> too, as{" "}
+      <code>dog_name</code>. It is optional, and nothing breaks without it
+      right up until the shepherd is replaced by one your binary is too old
+      to speak to. A refused handshake never reaches a request, so the name
+      in <code>DogConfig</code> is unreadable at exactly the moment it is
+      needed: which dog to restart. With it, the shepherd restarts you once
+      from the binary on disk, which fixes the ordinary case where the
+      package already replaced your file and the running process is merely
+      old, and reports you stale rather than looping if that restart is
+      refused too. Without it you go quiet and nothing on either side says
+      why.
+    </p>
+    <p>
+      A dog written against <code>shep-client</code> gets both halves from{" "}
+      <code>ReconnectingClient::connect_as_dog</code>, which fills the name
+      in and also re-establishes the connection when the shepherd is
+      replaced. <code>Client</code> does neither, deliberately: the CLI uses
+      it, and a <code>shep stop</code> that silently retried could stop a
+      sheep twice.
+    </p>
+    <p>
       Those two are what shep adds, not the whole environment. A dog is a
       supervised process like any other, so it also starts from the small
       base every sheep gets: <code>PATH</code>, plus whichever of{" "}

--- a/web/src/pages/docs/dogs.astro
+++ b/web/src/pages/docs/dogs.astro
@@ -359,6 +359,26 @@ watchdog  adopted  true      stopped`}</CodeBlock>
       sheep twice.
     </p>
     <p>
+      That is what <code>shep daemon reload</code> asks of a dog. A dog is
+      carried across the reload the way a sheep is: the process is a child
+      of a shepherd whose pid does not change, so it keeps its own pid and
+      its restart count stays where it was. What does not survive is the
+      accepted connection, which dies with the old image — so a dog that
+      does not dial again is a live process holding a dead socket, alive on
+      every column a listing has and answering nothing. The metrics dog is
+      measured holding its pid and <code>restarts 0</code> across six
+      reloads while still serving a scrape.
+    </p>
+    <p class="fine">
+      The bark dog is the exception, and it is on the list to fix. Its
+      subscription belongs to one connection, so the stream ends when that
+      connection does and the dog exits; autorestart replaces it, which
+      costs one restart per reload on a dog that is otherwise healthy. It
+      comes back on its own every time, and its restart budget starts a
+      fresh window with each shepherd, so this is a count that reads wrong
+      rather than an outage.
+    </p>
+    <p>
       Those two are what shep adds, not the whole environment. A dog is a
       supervised process like any other, so it also starts from the small
       base every sheep gets: <code>PATH</code>, plus whichever of{" "}

--- a/web/src/pages/docs/getting-started.astro
+++ b/web/src/pages/docs/getting-started.astro
@@ -78,7 +78,10 @@ import CodeBlock from "../../components/docs/CodeBlock.astro";
     <p>
       A flock that can be carried keeps running through the reload. The
       shepherd replaces its own image in place, so every sheep keeps the pid
-      it already had and its log carries on where it was. One that cannot is
+      it already had and its log carries on where it was. The dogs cross
+      with it rather than being stopped and started alongside the flock; the
+      dogs page says what each one does on the far side. One that cannot be
+      carried is
       stopped and started instead, which moves every pid and starts every log
       again; the note below says which flocks those are.
     </p>
@@ -88,9 +91,10 @@ import CodeBlock from "../../components/docs/CodeBlock.astro";
       now running, not the one it replaced.
     </p>
     <p class="fine">
-      Not every flock can be carried yet. A dog sends the reload down the
-      older path instead: the flock is stopped and started, and the reload
-      prints which sheep held it back. Coming from 0.1.17 or earlier, the
+      One thing still sends a reload down the older path: a sheep whose log
+      pump has stopped answering. The shepherd cannot say which files that
+      sheep is writing to, so it stops and starts the flock instead and
+      names the sheep that held it back. Coming from 0.1.17 or earlier, the
       first reload always takes that path too: the shepherd being replaced
       predates the handover and has nothing to hand over with.
     </p>

--- a/web/src/pages/docs/getting-started.astro
+++ b/web/src/pages/docs/getting-started.astro
@@ -82,6 +82,11 @@ import CodeBlock from "../../components/docs/CodeBlock.astro";
       stopped and started instead, which moves every pid and starts every log
       again; the note below says which flocks those are.
     </p>
+    <p>
+      If a dog cannot talk to the new shepherd, the reload names it. It waits
+      for the dogs to reconnect first, so the answer is about the shepherd
+      now running, not the one it replaced.
+    </p>
     <p class="fine">
       Not every flock can be carried yet. A dog sends the reload down the
       older path instead: the flock is stopped and started, and the reload


### PR DESCRIPTION
Phase 3 of the daemon handover. A dog now crosses the exec like any other child, keeps its pid, and reconnects to the shepherd that replaced the one it was talking to. `RefusedReason::Dog` is gone, and the gate has one refusal left: `PumpUnresponsive`, which is permanent by design.

Six reloads on a real flock, no bypass, both built-in dogs:

| | before | after six |
|---|---|---|
| shepherd pid | 13052 | 13052 |
| sheep pid, restarts | 13073, 0 | 13073, 0, uptime unbroken |
| `metrics` pid, restarts | 13096, 0 | 13096, 0 |
| `curl /metrics` | 200 | 200, six of six |
| daemon log lines | 0 | 0 |
| reload wall clock | | 0.043s, 0.049s, 0.050s |

The decisive check is content rather than status, because a pid cannot see a dead socket: a sheep started after all six reloads appears in the exposition, which no cached reading could produce. `shep dogs` lists both dogs and `shep flock` does not, where before the carry `shep dogs` was empty and `metrics` sat beside the operator's own app.

## What was actually broken

A dog's process crossed the exec for free, since it is a child of a daemon whose pid does not change. Its connection did not. So a carried dog was a live process holding a dead socket: pid unmoved, restarts 0, status `online`, stderr empty, and `curl /metrics` answering 503 for as long as you cared to watch. Silent on both sides.

Neither built-in dog handled it, and their different outcomes were an accident rather than two designs. `bark` exited because its event stream ended and autorestart replaced it; `metrics` held its client across an accept loop and never looked again.

## The four pieces

- a `ReconnectingClient` in `shep-client`, a distinct type rather than a mode, so the CLI is unaffected by construction. A `shep stop` that silently retried a dropped request could stop a sheep twice
- a dog names itself in `Hello`, so a refused handshake can be attributed. `PROTOCOL_VERSION` does not move: `Hello` has no `deny_unknown_fields`, the field is skipped when absent, and a non-dog handshake is byte-identical to protocol 2's
- a refused dog is restarted once from disk, then reported stale, never looped. A second refusal proves the disk binary cannot satisfy this daemon, so retrying is a spin
- staleness is reported after the dogs reconnect, not before, because before the reload the recorded version describes a process about to be replaced

## Two costs, both deliberate

A dog that never names itself, meaning any third-party dog built before this, makes every reload wait the full 3s settle budget and print one line. Bounded and honest, and the alternative is the stop arm restarting the whole flock.

`bark` still restarts once per reload. Closing it needs a ruling on what an orphaned dog does, which is a question about every dog rather than about bark, so it is recorded in `deferred.md`, the plan, and the code rather than left as a quietly unmet step.

## Notes

`RefusedReason` loses a public variant, which is a breaking change to shep-daemon's API. Prior phases removed variants from the same enum, so the precedent is established, but it is worth a deliberate nod.

2196 tests. One pre-existing flake, `a_report_after_a_stream_ends_names_no_descriptor_for_it`, fails about once in twelve runs; this branch does not touch that file and 2b's task 6 reported the same test at the same rate.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dogs reconnect automatically after shepherd reloads while preserving their PID and metadata.
  * Reload reporting distinguishes recovered, pending, and stale dogs.
  * Metrics continue serving through daemon handovers.
  * Failed reconnections are retried once before being reported as stale.

* **Bug Fixes**
  * Carried dogs are no longer incorrectly restarted or included in muster rolls during handover.

* **Documentation**
  * Added guidance on dog identification, reconnection, reload behavior, and bark restart limitations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->