### PR TITLE
feat(dogs): stop reporting a silent dog as online

### DIFF
--- a/.claude/skills/shep-idiomatic-rust/SKILL.md
+++ b/.claude/skills/shep-idiomatic-rust/SKILL.md
@@ -5,7 +5,7 @@ description: Use when writing, reviewing, or refactoring ANY Rust code in the sh
 
 # shep Idiomatic Rust
 
-**REQUIRED READING before writing code: [docs/idiomatic-rust.md](../../../docs/idiomatic-rust.md)** — 45 numbered rules (IR-1..IR-45) distilled from rand 0.10.2, the project's quality bar. Cite rules by number in reviews. Full evidence: `docs/idiomatic-rust/lenses/`.
+**REQUIRED READING before writing code: [docs/idiomatic-rust.md](../../../docs/idiomatic-rust.md)** — 46 numbered rules (IR-1..IR-46) distilled from rand 0.10.2, the project's quality bar. Cite rules by number in reviews. Full evidence: `docs/idiomatic-rust/lenses/`.
 
 ## Baseline-failure checklist
 

--- a/crates/shep-cli/src/commands/daemon.rs
+++ b/crates/shep-cli/src/commands/daemon.rs
@@ -1065,35 +1065,66 @@ async fn report_dog_staleness(
 /// through it: the singular and the plural differ in four places, and a
 /// reader checking the wording should not have to run the ternaries in
 /// their head to see what either one says.
+///
+/// **Names the restart, not just the reinstall.** The production incident
+/// this whole phase traces to turned on exactly this gap: `cargo install`
+/// alone left the old code running, because a rename leaves the running
+/// inode mapped (G10) and the process that inode belongs to is never
+/// touched by installing a new one over it. The spec's own fix is two
+/// commands (`docs/brainstorming/specs/2026-08-29-daemon-handover-design.md`
+/// line 504); a sentence naming only the first leaves an operator one step
+/// short of it, exactly as this one did before this phase.
 fn stale_dog_report(stale: &[String], daemon_version: &str) -> String {
     match stale {
         [only] => format!(
             "the `{only}` dog cannot talk to this shepherd; restarting it from the binary on \
-             disk did not help, so rebuild or reinstall it against shep {daemon_version}"
+             disk did not help, so rebuild or reinstall it against shep {daemon_version}, then \
+             restart it"
         ),
         many => format!(
             "these dogs cannot talk to this shepherd: {}; restarting them from the binaries on \
-             disk did not help, so rebuild or reinstall them against shep {daemon_version}",
+             disk did not help, so rebuild or reinstall them against shep {daemon_version}, then \
+             restart them",
             quoted_names(many)
         ),
     }
 }
 
-/// The sentence for dogs that never finished settling inside the budget.
+/// The sentence for dogs that had not answered within the reload's settle
+/// wait.
 ///
 /// Said out loud rather than folded into silence, because silence here
 /// would mean the same thing as a clean reload and this is not one: the
 /// reading was taken before these dogs had answered, so it speaks for the
 /// rest of the flock and not for them.
+///
+/// **This population is not who it was expected to be.** G8's ladder
+/// (`shep_daemon::dogs::DogRefusals`) restarts a silent dog at
+/// [`shep_daemon::dogs::DOG_SILENCE_BUDGET`] and marks it stale five seconds
+/// after that, both later than this reload's own wait — so a dog stuck on a
+/// protocol it cannot speak lands HERE, not in [`stale_dog_report`], every
+/// time. Written for that population rather than for the fast, transient
+/// remnant a shorter ladder would have left behind.
+///
+/// **Names what the shepherd actually knows, not a verdict it does not
+/// have.** It cannot yet say whether this dog will come back — that
+/// question belongs to [`stale_dog_report`], later, if the restart does not
+/// help — but it does know a restart is coming and when, and it knows where
+/// the dog's own account of the silence lives. `shep bleats <dog>` is where
+/// the answer actually was in production, so this sentence points there
+/// instead of shrugging.
 fn unsettled_dog_report(pending: &[String], wait: std::time::Duration) -> String {
+    let budget = shep_daemon::dogs::DOG_SILENCE_BUDGET;
     match pending {
         [only] => format!(
-            "the `{only}` dog had not answered this shepherd after {wait:?}, so this reload \
-             cannot say whether it came back"
+            "the `{only}` dog has not answered this shepherd after {wait:?}; if it is still \
+             silent at {budget:?} it will be restarted from the binary on disk, and `shep \
+             bleats {only}` shows why"
         ),
         many => format!(
-            "these dogs had not answered this shepherd after {wait:?}, so this reload cannot say \
-             whether they came back: {}",
+            "these dogs have not answered this shepherd after {wait:?}: {}; if they are still \
+             silent at {budget:?} they will be restarted from the binaries on disk, and `shep \
+             bleats <dog>` shows why for each",
             quoted_names(many)
         ),
     }
@@ -1924,7 +1955,7 @@ otel = "/usr/local/bin/shep-otel"
 
         let text = String::from_utf8(err).unwrap();
         assert!(
-            text.contains("metrics") && text.contains("cannot say whether it came back"),
+            text.contains("metrics") && text.contains("shep bleats metrics"),
             "an unanswered dog is reported as unanswered, not as healthy: {text}"
         );
     }
@@ -1941,14 +1972,42 @@ otel = "/usr/local/bin/shep-otel"
         assert_eq!(
             one,
             "the `metrics` dog cannot talk to this shepherd; restarting it from the binary on \
-             disk did not help, so rebuild or reinstall it against shep 0.1.22"
+             disk did not help, so rebuild or reinstall it against shep 0.1.22, then restart it"
         );
 
         let two = stale_dog_report(&["bark".to_string(), "metrics".to_string()], "0.1.22");
         assert_eq!(
             two,
             "these dogs cannot talk to this shepherd: `bark`, `metrics`; restarting them from \
-             the binaries on disk did not help, so rebuild or reinstall them against shep 0.1.22"
+             the binaries on disk did not help, so rebuild or reinstall them against shep \
+             0.1.22, then restart them"
+        );
+    }
+
+    /// Pinned as an exact string in both shapes for the same reason as the
+    /// stale report above: a message naming the fix is the feature. Fails
+    /// if the sentence claims a verdict the shepherd does not have yet, or
+    /// if it stops pointing at `shep bleats` — that command is where the
+    /// answer actually was in the production incident this phase traces to.
+    #[test]
+    fn the_unsettled_report_says_what_to_check_and_never_claims_a_verdict() {
+        let one = unsettled_dog_report(&["metrics".to_string()], std::time::Duration::from_secs(3));
+        assert_eq!(
+            one,
+            "the `metrics` dog has not answered this shepherd after 3s; if it is still silent \
+             at 5s it will be restarted from the binary on disk, and `shep bleats metrics` \
+             shows why"
+        );
+
+        let two = unsettled_dog_report(
+            &["bark".to_string(), "metrics".to_string()],
+            std::time::Duration::from_secs(3),
+        );
+        assert_eq!(
+            two,
+            "these dogs have not answered this shepherd after 3s: `bark`, `metrics`; if they \
+             are still silent at 5s they will be restarted from the binaries on disk, and \
+             `shep bleats <dog>` shows why for each"
         );
     }
 

--- a/crates/shep-cli/src/commands/daemon.rs
+++ b/crates/shep-cli/src/commands/daemon.rs
@@ -1117,14 +1117,14 @@ fn unsettled_dog_report(pending: &[String], wait: std::time::Duration) -> String
     let budget = shep_daemon::dogs::DOG_SILENCE_BUDGET;
     match pending {
         [only] => format!(
-            "the `{only}` dog has not answered this shepherd after {wait:?}; if it is still \
-             silent at {budget:?} it will be restarted from the binary on disk, and `shep \
-             bleats {only}` shows why"
+            "the `{only}` dog has not answered this shepherd after {wait:?}; a dog silent \
+             past {budget:?} is restarted once from the binary on disk and then reported \
+             stale, and `shep bleats {only}` shows why"
         ),
         many => format!(
-            "these dogs have not answered this shepherd after {wait:?}: {}; if they are still \
-             silent at {budget:?} they will be restarted from the binaries on disk, and `shep \
-             bleats <dog>` shows why for each",
+            "these dogs have not answered this shepherd after {wait:?}: {}; a dog silent past \
+             {budget:?} is restarted once from the binary on disk and then reported stale, and \
+             `shep bleats <dog>` shows why for each",
             quoted_names(many)
         ),
     }
@@ -1994,9 +1994,9 @@ otel = "/usr/local/bin/shep-otel"
         let one = unsettled_dog_report(&["metrics".to_string()], std::time::Duration::from_secs(3));
         assert_eq!(
             one,
-            "the `metrics` dog has not answered this shepherd after 3s; if it is still silent \
-             at 5s it will be restarted from the binary on disk, and `shep bleats metrics` \
-             shows why"
+            "the `metrics` dog has not answered this shepherd after 3s; a dog silent past 5s \
+             is restarted once from the binary on disk and then reported stale, and `shep \
+             bleats metrics` shows why"
         );
 
         let two = unsettled_dog_report(
@@ -2005,9 +2005,9 @@ otel = "/usr/local/bin/shep-otel"
         );
         assert_eq!(
             two,
-            "these dogs have not answered this shepherd after 3s: `bark`, `metrics`; if they \
-             are still silent at 5s they will be restarted from the binaries on disk, and \
-             `shep bleats <dog>` shows why for each"
+            "these dogs have not answered this shepherd after 3s: `bark`, `metrics`; a dog \
+             silent past 5s is restarted once from the binary on disk and then reported \
+             stale, and `shep bleats <dog>` shows why for each"
         );
     }
 

--- a/crates/shep-cli/src/lib.rs
+++ b/crates/shep-cli/src/lib.rs
@@ -1672,6 +1672,31 @@ const VERSION_SKEW_CAUSE: [&str; 2] = [
 /// what this refusal prints, and the test pinning the wording catches it.
 const VERSION_SKEW_REMEDY: &str = RECOVERY_VERBS[1];
 
+/// The imperative sentence pointing at [`VERSION_SKEW_REMEDY`], shared by
+/// The imperative naming the remedy, in the two shapes the formats need.
+///
+/// Deliberately two strings rather than one shared sentence. A `--format
+/// json` consumer gets a single-line message and needs the command inside
+/// it; the table form has layout, and printing the same sentence there
+/// would name the command twice -- once in prose and once on the indented
+/// line below it, which reads worse than the bare line it was meant to fix.
+///
+/// What must not drift is the COMMAND, and it cannot: both interpolate
+/// [`VERSION_SKEW_REMEDY`], itself read out of [`RECOVERY_VERBS`] rather
+/// than written twice. The framing around it differing per format is the
+/// point, not a leak.
+///
+/// The table label carries no blank line after it, unlike every other gap
+/// in this block. An operator hit this refusal in production and was not
+/// certain the trailing indented line was a command to run at all, so the
+/// label sits directly on top of it -- the association is the fix.
+fn version_skew_instruction(fmt: Format) -> String {
+    match fmt {
+        Format::Json => format!("Run `shep {VERSION_SKEW_REMEDY}`."),
+        Format::Table => format!("Run:\n  shep {VERSION_SKEW_REMEDY}"),
+    }
+}
+
 /// Refuses a shepherd whose crate version differs from this binary's.
 ///
 /// Any difference, not only a protocol difference. A protocol-only check
@@ -1712,10 +1737,8 @@ pub(crate) fn refuse_version_skew(
         // the layout below, and it still gets every fact in `error.message`.
         Format::Json => {
             let cause = VERSION_SKEW_CAUSE.join(" ");
-            streams.fail(
-                code,
-                &format!("{summary}. {cause} Run `shep {VERSION_SKEW_REMEDY}`."),
-            );
+            let instruction = version_skew_instruction(Format::Json);
+            streams.fail(code, &format!("{summary}. {cause} {instruction}"));
         }
         // Written straight to the stream rather than through
         // [`Streams::fail`], which routes into `output::emit_error` and so
@@ -1734,9 +1757,10 @@ pub(crate) fn refuse_version_skew(
             // multi-line layout, so it sanitises the interpolated value
             // itself. The fixed text around it is ours and needs nothing.
             let summary = crate::terminal_safe::sanitise(&summary).0;
+            let instruction = version_skew_instruction(Format::Table);
             let _ = writeln!(
                 streams.err,
-                "error[{}]: {summary}\n\n{cause}\n\n  shep {VERSION_SKEW_REMEDY}",
+                "error[{}]: {summary}\n\n{cause}\n\n{instruction}",
                 code.code_str()
             );
         }
@@ -2985,6 +3009,44 @@ mod tests {
             "{text}"
         );
         assert!(text.contains("shep daemon reload"), "{text}");
+    }
+
+    /// The table form used to print the remedy as a bare indented line with
+    /// no imperative anywhere near it, so an operator who hit this in
+    /// production was not certain the last line was a command to run. This
+    /// pins the sentence that now points at it, and that the sentence sits
+    /// on its own line ABOVE the copyable command rather than folded into
+    /// it -- the indentation is what makes the line copyable and stays
+    /// untouched.
+    #[tokio::test]
+    async fn the_table_form_names_the_remedy_as_an_instruction_not_only_a_line() {
+        let dir = tempfile::tempdir().unwrap();
+        let addr = shep_client::testing::control_address(dir.path());
+        let (client, _fake) = client_announcing(&addr, "0.1.8").await;
+
+        let mut out = Vec::new();
+        let mut err = Vec::new();
+        {
+            let mut streams = buffered_streams(&mut out, &mut err);
+            let _ = refuse_version_skew(&mut streams, &client, VersionGuard::Enforce);
+        }
+        let text = String::from_utf8(err).unwrap();
+
+        // The label sits DIRECTLY on the command, no blank line between:
+        // that adjacency is the whole fix, and a gap here is the shape an
+        // operator read as two unrelated things.
+        assert!(
+            text.contains("Run:\n  shep daemon reload"),
+            "the label must sit directly on the copyable line it points at: {text}"
+        );
+        // Named once, not twice. An earlier attempt printed the sentence
+        // "Run `shep daemon reload`." above the indented line, which reads
+        // worse than the bare line it was meant to fix.
+        assert_eq!(
+            text.matches("shep daemon reload").count(),
+            1,
+            "the remedy is named once, not restated in prose: {text}"
+        );
     }
 
     /// Task 6 / spec G4: `lib.rs`'s old blanket `Err(_) =>

--- a/crates/shep-cli/src/lookout/app.rs
+++ b/crates/shep-cli/src/lookout/app.rs
@@ -276,8 +276,14 @@ impl Row {
     /// [`super::view::detail`]), so they cannot drift on what a dog's
     /// STATUS cell says the way the table and the dashboard did before this
     /// existed.
+    ///
+    /// `pub(crate)` rather than `pub(super)`: `output::rows`' own test
+    /// module drives this method alongside `output::rows::reported` to pin
+    /// the agreement between the two copies (see
+    /// `the_flock_table_and_the_lookout_read_a_dogs_silence_the_same_way`),
+    /// and that test lives outside `lookout` entirely.
     #[must_use]
-    pub(super) fn reported(&self) -> Reported {
+    pub(crate) fn reported(&self) -> Reported {
         if self.info.dog.is_none() {
             return Reported::Live(self.info.status);
         }

--- a/crates/shep-cli/src/lookout/app.rs
+++ b/crates/shep-cli/src/lookout/app.rs
@@ -37,6 +37,7 @@ use shep_core::protocol::{
 use shep_core::status::ProcStatus;
 
 use super::theme::Palette;
+use crate::vocabulary::Reported;
 
 /// Whether this lookout may act on a sheep.
 ///
@@ -259,6 +260,29 @@ pub struct Row {
     /// When [`Self::info`] was received — the origin for this row's live
     /// uptime, so a value two seconds old is never rendered as current.
     pub anchor: Instant,
+}
+
+impl Row {
+    /// What this row's STATUS cell reports: [`Self::info`]'s lifecycle
+    /// status, or [`Reported::Silent`] for a dog whose process is up and
+    /// which has never handshook this shepherd.
+    ///
+    /// Mirrors `output::rows::reported` exactly, guard included: the `dog`
+    /// check is read here rather than left to [`Reported::of`] alone, so a
+    /// sheep -- which has no handshake and no version relationship with the
+    /// shepherd at all -- can never be painted silent by a future
+    /// daemon-side bug that leaves `handshook` set on a non-dog row. One
+    /// method for both panes that need it ([`super::view::flock`] and
+    /// [`super::view::detail`]), so they cannot drift on what a dog's
+    /// STATUS cell says the way the table and the dashboard did before this
+    /// existed.
+    #[must_use]
+    pub(super) fn reported(&self) -> Reported {
+        if self.info.dog.is_none() {
+            return Reported::Live(self.info.status);
+        }
+        Reported::of(self.info.status, self.info.handshook)
+    }
 }
 
 /// One app's rolled-up numbers, computed from its own instances.
@@ -1491,6 +1515,13 @@ impl App {
     /// agrees, else a count per state -- the same rule
     /// `output::rows::group_status` applies for `shep flock` (task 9), kept
     /// here so the two surfaces read a mixed group the same way.
+    ///
+    /// Reads `ProcStatus` directly, never [`Row::reported`]: `is_grouped`
+    /// requires every member's `instance` to be `Some`, and a dog is never
+    /// stocked to several instances, so no group this method can see has a
+    /// handshake to report. Same argument `output::rows::group_paint`
+    /// already makes for the table's own group row (task 5's own plan entry
+    /// spells this out rather than leaving it to be re-derived).
     #[must_use]
     pub fn group_status_text(&self, name: &str) -> String {
         let members = self.group_members(name);
@@ -1516,6 +1547,11 @@ impl App {
     /// [`view::detail`](super::view::detail)'s own status word key off,
     /// mirroring `output::rows::group_paint`'s "a mixed group's plain count
     /// text wears no colour" rule.
+    ///
+    /// `Option<ProcStatus>`, not `Option<Reported>`, for the same reason
+    /// [`Self::group_status_text`] reads `ProcStatus` directly above: a dog
+    /// is never stocked to several instances, so a group row has no
+    /// handshake to report and nothing here is ever silent.
     #[must_use]
     pub fn group_uniform_status(&self, name: &str) -> Option<ProcStatus> {
         let members = self.group_members(name);

--- a/crates/shep-cli/src/lookout/theme.rs
+++ b/crates/shep-cli/src/lookout/theme.rs
@@ -23,6 +23,8 @@ use std::ffi::OsStr;
 
 use shep_core::status::ProcStatus;
 
+use crate::vocabulary::Reported;
+
 /// The four semantic colours, resolved for one terminal.
 ///
 /// Constructed once at startup — by `super::mod`'s `lookout`, from
@@ -94,7 +96,9 @@ impl Palette {
         }
     }
 
-    /// The style for one sheep's STATUS cell.
+    /// The style for a group row's STATUS cell, where only a bare
+    /// `ProcStatus` is available -- see [`super::app::App::group_status_text`]'s
+    /// own doc for why a group row is never [`Reported::Silent`].
     ///
     /// `Errored` is the only status that gets `--bark`; `waiting-restart` is
     /// `--butter`, because it is a state to watch rather than damage that has
@@ -102,10 +106,23 @@ impl Palette {
     /// go and went is not a problem.
     #[must_use]
     pub fn status(self, status: ProcStatus) -> Style {
-        // The mapping lives in `crate::vocabulary`, so the CLI's table and
-        // this pane cannot drift. This method is now the ratatui BINDING of
-        // it, and nothing more.
-        Self::fg(match crate::vocabulary::role_of(status) {
+        self.role_style(crate::vocabulary::role_of(status))
+    }
+
+    /// The style for one row's STATUS cell, sheep or dog -- what
+    /// [`super::view::flock`] and [`super::view::detail`] use for every real
+    /// row, so a silent dog wears `--butter` there exactly as it does in
+    /// `shep flock`'s own table.
+    #[must_use]
+    pub fn reported(self, reported: Reported) -> Style {
+        self.role_style(reported.role())
+    }
+
+    /// The mapping lives in `crate::vocabulary`, so the CLI's table and this
+    /// pane cannot drift. This is the ratatui BINDING of it, and nothing
+    /// more.
+    fn role_style(self, role: crate::vocabulary::Role) -> Style {
+        Self::fg(match role {
             crate::vocabulary::Role::Meadow => self.meadow,
             crate::vocabulary::Role::Butter => self.butter,
             crate::vocabulary::Role::Bark => self.bark,

--- a/crates/shep-cli/src/lookout/view/detail.rs
+++ b/crates/shep-cli/src/lookout/view/detail.rs
@@ -71,6 +71,9 @@ fn group_lines(app: &App, name: &str, width: u16, palette: Palette) -> Vec<Line<
         totals.memory.map_or_else(|| "-".to_string(), human_bytes),
     );
     let used = head.chars().count() + status.chars().count();
+    // `palette.status`, not `palette.reported`: a selected group is always
+    // an app's own instances, never a dog -- see
+    // `App::group_uniform_status`'s own doc.
     let status_style = app
         .group_uniform_status(name)
         .map_or(Style::default(), |status| palette.status(status));
@@ -105,7 +108,10 @@ fn sheep_lines(app: &App, width: u16, palette: Palette) -> Vec<Line<'static>> {
     // Everything except the status word, which is the one coloured cell —
     // exactly the table's rule, for exactly the table's reason.
     let head = format!("sheep {}  {}   ", info.id, info.name);
-    let status = info.status.to_string();
+    // `Row::reported`, not `info.status.to_string()`: this pane must agree
+    // with the flock table's own STATUS cell for the same row, and a dog
+    // that has never handshook reads `silent` there.
+    let status = row.reported().word();
     let rest = format!(
         "   pid {}   restarts {}   uptime {}   cpu {}   mem {}   fold {}{}",
         info.pid
@@ -135,7 +141,7 @@ fn sheep_lines(app: &App, width: u16, palette: Palette) -> Vec<Line<'static>> {
     vec![
         Line::from(vec![
             Span::raw(head),
-            Span::styled(status, palette.status(info.status)),
+            Span::styled(status, palette.reported(row.reported())),
             Span::raw(fit(
                 &rest,
                 width.saturating_sub(u16::try_from(used).unwrap_or(width)),
@@ -449,5 +455,53 @@ mod tests {
             !rendered.contains("web-0-out.log"),
             "no arbitrarily-chosen instance's log path: {rendered:?}"
         );
+    }
+
+    /// fails if this pane and the flock table disagree about the same dog --
+    /// which is exactly what happened before this task: the table said
+    /// `silent` (task 4) and this pane still said `online`. Drives both
+    /// panes off the same [`App`] built from the same row, the way an
+    /// operator with both open sees them.
+    #[test]
+    fn a_silent_dogs_status_word_and_colour_agree_with_the_flock_pane() {
+        use shep_core::protocol::DogSource;
+        use shep_core::status::ProcStatus;
+
+        use super::super::flock::{columns_for, row_line};
+
+        let dog = ProcessInfo::builder(9, "log-rotate", ProcStatus::Online)
+            .pid(Some(4_242))
+            .dog(Some(DogSource::Adopted {
+                path: "/usr/local/bin/shep-log-rotate".to_string(),
+            }))
+            .handshook(Some(false))
+            .build();
+        let app = with_selection_and_palette(dog, coloured());
+        let palette = app.palette();
+
+        let detail_rendered = render_all(&detail_lines(&app, 200));
+        assert!(
+            detail_rendered.contains("silent"),
+            "detail pane must say silent: {detail_rendered:?}"
+        );
+        assert!(!detail_rendered.contains("online"), "{detail_rendered:?}");
+
+        let row = app.row(9).unwrap();
+        let flock_line = row_line(&app, row, columns_for(200), 200, false);
+        let flock_rendered: String = flock_line
+            .spans
+            .iter()
+            .map(|s| s.content.as_ref())
+            .collect();
+        assert!(flock_rendered.contains("silent"), "{flock_rendered:?}");
+
+        // Both panes colour the word `--butter`, the "gap the operator can
+        // close" role -- see `Reported::role`'s own doc for why not `--bark`.
+        let detail_colour = detail_lines(&app, 200)[0]
+            .spans
+            .iter()
+            .find(|span| span.content.as_ref() == "silent")
+            .map(|span| span.style.fg);
+        assert_eq!(detail_colour, Some(palette.attention().fg));
     }
 }

--- a/crates/shep-cli/src/lookout/view/flock.rs
+++ b/crates/shep-cli/src/lookout/view/flock.rs
@@ -121,7 +121,9 @@ impl Column {
         match self {
             Self::Id => 4,
             Self::Name => 0,
-            // 15: `waiting-restart`, the longest of the six statuses. A
+            // 15: `waiting-restart`, the longest word `Reported::word`
+            // returns. That vocabulary is the six lifecycle statuses plus
+            // `silent`, which is 6 columns and so does not move this. A
             // status is never truncated — it is the pane.
             Self::Status => 15,
             Self::Pid => 7,
@@ -1084,6 +1086,33 @@ mod tests {
         let line = row_line(&app, row, ALL, 200, false);
         let rendered: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
         assert!(rendered.contains("online"), "got {rendered:?}");
+        assert!(!rendered.contains("silent"), "got {rendered:?}");
+    }
+
+    /// fails if the `dog.is_none()` guard in `Row::reported` is ever
+    /// removed. The daemon never sends a sheep `handshook: Some(false)` --
+    /// a sheep has no handshake and no version relationship with the
+    /// shepherd at all, it is a supervised process, not a peer -- so this
+    /// is an input the guard exists for and no other test drives. Same
+    /// precedent as `output::rows`' own `a_sheep_never_reads_as_silent`.
+    #[test]
+    fn a_sheep_never_reads_as_silent() {
+        use shep_core::protocol::ProcessInfo;
+        use shep_core::status::ProcStatus;
+
+        let mut impossible = ProcessInfo::builder(1, "web", ProcStatus::Online)
+            .pid(Some(4_000))
+            .build();
+        impossible.handshook = Some(false);
+        let app = fixtures::app_with(vec![impossible], fixtures::plain());
+        let row = app.row(1).unwrap();
+
+        let line = row_line(&app, row, ALL, 200, false);
+        let rendered: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
+        assert!(
+            rendered.contains("online"),
+            "the sheep table has no dogs in it, and no silence rule either: {rendered:?}"
+        );
         assert!(!rendered.contains("silent"), "got {rendered:?}");
     }
 }

--- a/crates/shep-cli/src/lookout/view/flock.rs
+++ b/crates/shep-cli/src/lookout/view/flock.rs
@@ -412,6 +412,10 @@ fn group_line(app: &App, name: &str, columns: &[Column], width: u16) -> Line<'st
         };
         let text = fit(&group_cell(app, name, *column, &totals), cell_width);
         let style = if *column == Column::Status {
+            // `palette.status`, not `palette.reported`: a group row is
+            // always an app's own instances, never a dog, so it has nothing
+            // to be silent about -- see `App::group_uniform_status`'s own
+            // doc for the argument.
             app.group_uniform_status(name)
                 .map_or(Style::default(), |status| palette.status(status))
         } else {
@@ -484,7 +488,7 @@ pub fn row_line(
         };
         let text = fit(&cell(app, row, *column, grouped), cell_width);
         let style = if *column == Column::Status {
-            palette.status(row.info.status)
+            palette.reported(row.reported())
         } else {
             Style::default()
         };
@@ -515,7 +519,10 @@ fn cell(app: &App, row: &Row, column: Column, grouped: bool) -> String {
             .instance
             .map_or_else(String::new, |slot| format!(" \u{21b3} :{slot}")),
         Column::Name => info.name.clone(),
-        Column::Status => info.status.to_string(),
+        // `Row::reported`, not `info.status.to_string()`: a dog that has
+        // never handshook must not read `online` here any more than it does
+        // in `shep flock`'s own table -- see `Row::reported`'s own doc.
+        Column::Status => row.reported().word(),
         Column::Pid => info
             .pid
             .map_or_else(|| "-".to_string(), |pid| pid.to_string()),
@@ -1001,5 +1008,82 @@ mod tests {
         assert!(rendered.contains("solo"), "got {rendered:?}");
         assert!(rendered.contains("edge"), "got {rendered:?}");
         assert!(!rendered.contains('\u{21b3}'), "got {rendered:?}");
+    }
+
+    /// fails if a dog that has never handshook reads `online` in this pane
+    /// -- the same defect task 4 fixed in `shep flock`'s own table, this
+    /// time in the dashboard that never got routed through the fix. The
+    /// process IS alive, so nothing but `handshook` can catch this.
+    #[test]
+    fn a_silent_dog_reads_silent_not_online() {
+        use shep_core::protocol::{DogSource, ProcessInfo};
+        use shep_core::status::ProcStatus;
+
+        let dog = ProcessInfo::builder(9, "log-rotate", ProcStatus::Online)
+            .pid(Some(4_242))
+            .dog(Some(DogSource::Adopted {
+                path: "/usr/local/bin/shep-log-rotate".to_string(),
+            }))
+            .handshook(Some(false))
+            .build();
+        let app = fixtures::app_with(vec![dog], fixtures::plain());
+        let row = app.row(9).unwrap();
+
+        let line = row_line(&app, row, ALL, 200, false);
+        let rendered: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
+        assert!(
+            rendered.contains("silent"),
+            "expected silent, got {rendered:?}"
+        );
+        assert!(
+            !rendered.contains("online"),
+            "must not say online: {rendered:?}"
+        );
+    }
+
+    /// fails if this pane starts calling a dog silent once it has actually
+    /// handshook -- passing for the wrong reason is exactly what a test that
+    /// never drives the new lookup would do, so this is the guard on
+    /// [`a_silent_dog_reads_silent_not_online`] above.
+    #[test]
+    fn a_dog_that_has_handshook_still_reads_online() {
+        use shep_core::protocol::{DogSource, ProcessInfo};
+        use shep_core::status::ProcStatus;
+
+        let dog = ProcessInfo::builder(9, "log-rotate", ProcStatus::Online)
+            .pid(Some(4_242))
+            .dog(Some(DogSource::Adopted {
+                path: "/usr/local/bin/shep-log-rotate".to_string(),
+            }))
+            .handshook(Some(true))
+            .build();
+        let app = fixtures::app_with(vec![dog], fixtures::plain());
+        let row = app.row(9).unwrap();
+
+        let line = row_line(&app, row, ALL, 200, false);
+        let rendered: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
+        assert!(rendered.contains("online"), "got {rendered:?}");
+        assert!(!rendered.contains("silent"), "got {rendered:?}");
+    }
+
+    /// fails if a sheep -- which has no handshake at all, `handshook` is
+    /// always `None` -- ever gets caught by the same rule. A sheep's own
+    /// STATUS cell must render exactly as it did before this task.
+    #[test]
+    fn a_sheep_still_reads_online_and_has_no_handshake() {
+        use shep_core::protocol::ProcessInfo;
+        use shep_core::status::ProcStatus;
+
+        let sheep = ProcessInfo::builder(1, "web", ProcStatus::Online)
+            .pid(Some(4_000))
+            .build();
+        assert_eq!(sheep.handshook, None, "a sheep is never sent one");
+        let app = fixtures::app_with(vec![sheep], fixtures::plain());
+        let row = app.row(1).unwrap();
+
+        let line = row_line(&app, row, ALL, 200, false);
+        let rendered: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
+        assert!(rendered.contains("online"), "got {rendered:?}");
+        assert!(!rendered.contains("silent"), "got {rendered:?}");
     }
 }

--- a/crates/shep-cli/src/output/rows.rs
+++ b/crates/shep-cli/src/output/rows.rs
@@ -23,7 +23,7 @@ use shep_core::status::ProcStatus;
 
 use crate::dog_index::AvailableDog;
 use crate::style::Presentation;
-use crate::vocabulary::{self, Role};
+use crate::vocabulary::{Reported, Role};
 
 use super::Render;
 
@@ -179,7 +179,8 @@ impl Render for FlockRows {
         // together — a column here would wreck the table `flock` exists to
         // print. They ride the JSON so a programmatic consumer can find a
         // sheep's logs without re-deriving paths the daemon alone resolves.
-        "out_file", "err_file",
+        "out_file",
+        "err_file",
         // No SOURCE column, because every row this table renders is a
         // sheep — `dog` is always `null` here. A dog gets its own table
         // with its own SOURCE column; this field rides the JSON only so a
@@ -190,6 +191,11 @@ impl Render for FlockRows {
         // in a later task; this list just keeps the shape consistent with
         // every other verb answering `ProcessInfo`.
         "lambs",
+        // No column, and never a value either: a handshake is a fact about
+        // a DOG, and every row this table renders is a sheep. Rides the
+        // JSON only so a consumer that switches on `ProcessInfo` shape
+        // alone still sees it, exactly as `dog` above does.
+        "handshook",
         // No column: the table now groups an app's instances under one
         // header row (`rows_for`) and labels each slot rather than adding a
         // column for it, but JSON stays flat -- one object per process,
@@ -335,7 +341,10 @@ fn slot_row(p: &ProcessInfo) -> Vec<String> {
     vec![
         p.id.to_string(),
         slot,
-        p.status.to_string(),
+        // A slot row is one instance of a multi-instance app and so never a
+        // dog, but it goes through `Reported` anyway rather than restating
+        // that argument as a second spelling of the same cell.
+        reported(p).word(),
         p.pid.map_or_else(|| "-".to_string(), |pid| pid.to_string()),
         p.restarts.to_string(),
         exit_cell(p.pid, p.last_exit),
@@ -367,7 +376,9 @@ fn plain_row(p: &ProcessInfo, slotted: bool) -> Vec<String> {
     vec![
         p.id.to_string(),
         name,
-        p.status.to_string(),
+        // `Reported`, not `p.status`, so the plain path `bare` takes says
+        // exactly what the boxed path says -- see `process_info_paint`.
+        reported(p).word(),
         p.pid.map_or_else(|| "-".to_string(), |pid| pid.to_string()),
         p.restarts.to_string(),
         exit_cell(p.pid, p.last_exit),
@@ -379,6 +390,29 @@ fn plain_row(p: &ProcessInfo, slotted: bool) -> Vec<String> {
         p.fold.clone().unwrap_or_else(|| "-".to_string()),
         p.smit.clone().unwrap_or_else(|| "-".to_owned()),
     ]
+}
+
+/// What one row's STATUS column reports, from the two fields that decide
+/// it: the lifecycle status always, unless this row is a DOG whose process
+/// is up and which has never answered this shepherd.
+///
+/// The dog marker is read here rather than left to [`Reported::of`], and
+/// that is the guard rather than a formality. A sheep has no handshake and
+/// no version relationship with the shepherd at all -- it is a supervised
+/// process, not a peer -- so its `handshook` is always `None` and the rule
+/// would never fire for one anyway. Keying on `dog` as well makes that a
+/// property of this function instead of a promise about what the daemon
+/// sends, so a future field-filling bug on the daemon side cannot paint the
+/// whole flock silent.
+///
+/// One function for all four cells that need it -- `plain_row`, `slot_row`,
+/// `DogRows::rows` and `process_info_paint` -- so the boxed path and the
+/// plain path `bare` takes can never disagree about a word.
+fn reported(p: &ProcessInfo) -> Reported {
+    if p.dog.is_none() {
+        return Reported::Live(p.status);
+    }
+    Reported::of(p.status, p.handshook)
 }
 
 /// The group's status: the shared word when every instance agrees, else a
@@ -416,10 +450,13 @@ fn group_status(group: &[ProcessInfo]) -> String {
 fn group_paint(header: &str, group: &[ProcessInfo], totals: &GroupTotals) -> Paint {
     match header {
         "FOLD" => Paint::Role(Role::Ink3),
+        // No `Reported::of` here, deliberately: a group row is an app's
+        // instances rolled up, a dog is never stocked to several instances,
+        // and so no group this branch can see has a handshake to report.
         "STATUS" => {
             let first = group[0].status;
             if group.iter().all(|p| p.status == first) {
-                Paint::Status(first)
+                Paint::Status(Reported::Live(first))
             } else {
                 Paint::Default
             }
@@ -443,30 +480,36 @@ fn group_paint(header: &str, group: &[ProcessInfo], totals: &GroupTotals) -> Pai
 /// sheep is, and `vocabulary.rs` stays the single source for the faces and
 /// the status-to-role mapping rather than growing a second set for dogs.
 ///
+/// The cell is decided from a [`Reported`] rather than a bare `ProcStatus`,
+/// which is what lets one dog row say something the lifecycle state does
+/// not: see [`Reported::of`], and `reported` for the guard that keeps the
+/// rule off a sheep.
+///
 /// - `presentation.level.sheep()` decides whether a face appears at all
-///   ([`vocabulary::face`], always exactly 5 columns).
+///   ([`Reported::face`], always exactly 5 columns).
 /// - `status_word` decides whether the plain status word rides beside it --
 ///   `table_of` (`output/mod.rs`) is the only caller that ever passes
 ///   `false`, on a retry once a first pass already needed to drop a whole
 ///   column.
 /// - `presentation.colour` decides whether the whole cell (face, word, or
 ///   both) is wrapped in one [`crate::output::paint::style_for`] span, keyed
-///   off [`vocabulary::role_of`] -- one span rather than two separately
+///   off [`Reported::role`] -- one span rather than two separately
 ///   styled pieces, so there is exactly one ANSI boundary for
 ///   [`crate::output::width::visible_width`] to discount, never two to keep
 ///   straight.
-fn status_cell(status: ProcStatus, presentation: Presentation, status_word: bool) -> String {
+fn status_cell(reported: Reported, presentation: Presentation, status_word: bool) -> String {
+    let word = reported.word();
     let mut text = if presentation.level.sheep() {
-        let face = vocabulary::face(status);
+        let face = reported.face();
         if status_word {
-            format!("{face} {status}")
+            format!("{face} {word}")
         } else {
             face.to_string()
         }
     } else {
-        status.to_string()
+        word
     };
-    colour_cell(&mut text, vocabulary::role_of(status), presentation);
+    colour_cell(&mut text, reported.role(), presentation);
     text
 }
 
@@ -484,7 +527,13 @@ pub(super) enum Paint {
     /// Replace the cell with [`status_cell`]: the face, the word, and the
     /// role the status wears. The only variant that changes CONTENT rather
     /// than only colour, which is why STATUS cannot be expressed as a role.
-    Status(ProcStatus),
+    ///
+    /// A [`Reported`] rather than a bare [`ProcStatus`], so that the one
+    /// row a listing can report something other than its lifecycle state
+    /// for -- a dog that has never answered this shepherd -- travels the
+    /// same single path to the cell as every other status, instead of a
+    /// fourth variant that would be a second way to paint the same column.
+    Status(Reported),
 }
 
 /// Paints one table's cells, asking `paint_of` for each by COLUMN NAME.
@@ -525,7 +574,9 @@ where
     for (index, row) in rows.iter_mut().enumerate() {
         for (cell, header) in row.iter_mut().zip(headers) {
             match paint_of(header, cell, index) {
-                Paint::Status(status) => *cell = status_cell(status, presentation, status_word),
+                Paint::Status(reported) => {
+                    *cell = status_cell(reported, presentation, status_word);
+                }
                 Paint::Role(role) => colour_cell(cell, role, presentation),
                 Paint::Default => mute_a_dash(cell, presentation),
             }
@@ -552,7 +603,13 @@ fn process_info_paint(header: &str, p: &ProcessInfo) -> Paint {
         // reads, so they are muted for the same reason: an unchanging value
         // must not draw the eye away from one that moves.
         "ID" | "FOLD" => Paint::Role(Role::Ink3),
-        "STATUS" => Paint::Status(p.status),
+        // The one column that reads TWO fields off the row: `handshook`
+        // overrides `status` for a dog that has never answered this
+        // shepherd (see `Reported::of`). A sheep's `handshook` is always
+        // `None`, so the sheep table reaches the same arm and is untouched
+        // by it -- which is why this rule can live in the function both
+        // tables share rather than in the dogs table alone.
+        "STATUS" => Paint::Status(reported(p)),
         "RESTARTS" => Paint::Role(restarts_role(p.restarts)),
         "EXIT" => Paint::Role(exit_role(p.pid, p.last_exit)),
         "CPU" => Paint::Role(cpu_role(p.cpu_percent)),
@@ -628,7 +685,12 @@ fn dog_action_paint(header: &str, cell: &str) -> Paint {
             "-" => Paint::Default,
             _ => Paint::Role(Role::Butter),
         },
-        "STATUS" => status_named_by(cell).map_or(Paint::Default, Paint::Status),
+        // `Reported::Live`: these four rows carry a status as free text and
+        // no `handshook` field at all -- `adopt` and `enable` report what
+        // the shepherd did, before any dog has had a chance to answer.
+        "STATUS" => status_named_by(cell).map_or(Paint::Default, |status| {
+            Paint::Status(Reported::Live(status))
+        }),
         _ => Paint::Default,
     }
 }
@@ -966,7 +1028,10 @@ impl Render for DogRows {
                 vec![
                     p.id.to_string(),
                     p.name.clone(),
-                    p.status.to_string(),
+                    // The row this whole field exists for: a dog whose
+                    // process is up and which has never answered this
+                    // shepherd reads `silent`, not `online`.
+                    reported(p).word(),
                     p.pid.map_or_else(|| "-".to_string(), |pid| pid.to_string()),
                     p.restarts.to_string(),
                     exit_cell(p.pid, p.last_exit),
@@ -1031,7 +1096,8 @@ impl Render for DogRows {
         // Same reason `FlockRows` keeps them out of its own table: absolute
         // paths, often longer than every other column put together. They
         // ride the JSON so a programmatic consumer can still find them.
-        "out_file", "err_file",
+        "out_file",
+        "err_file",
         // Always `null` here: only `Describe` walks for lambs, and this
         // table renders `ListFlock`'s dog half. A dog is one process by
         // contract, so a lamb tree for one is not a rendering this table
@@ -1041,6 +1107,14 @@ impl Render for DogRows {
         // absent, like `fold` above, and in the JSON for the same
         // shape-consistency reason as the rest of this list.
         "smit",
+        // No column of its own, because it is not a column: it decides
+        // what the STATUS column says (`reported`), and a second column
+        // repeating that as `true`/`false` would say the same thing twice
+        // and be the less legible of the two. It rides the JSON because a
+        // consumer scripting against status needs the fact rather than the
+        // word -- `status` alone still reads `online` for a silent dog, and
+        // truthfully so.
+        "handshook",
         // Always `Some(0)` here: a dog is one process, never stocked to N
         // instances, so the slot the daemon reports is never meaningful.
         // Rides in the JSON only for the same shape-consistency reason as
@@ -1564,6 +1638,9 @@ impl Render for FlushedRows {
         // `null`. Stays in the JSON for the same shape-consistency reason
         // the rest of this list does.
         "dog",
+        // And `handshook` for the same reason `dog` is: a flush matches
+        // sheep, and a sheep has no handshake to report.
+        "handshook",
         // Always `null` here: only `Describe` walks for lambs, and `flush`
         // is not `Describe`. Same shape-consistency reason as the rest of
         // this list.
@@ -4986,5 +5063,192 @@ pub(crate) mod tests {
         // FOLD: chrome, always coloured, `-` here on both rows.
         assert!(rows[0][9].contains('\u{1b}'), "{:?}", rows[0][9]);
         assert!(rows[1][9].contains('\u{1b}'), "{:?}", rows[1][9]);
+    }
+
+    // --- A dog that has never answered the shepherd ----------------------
+    //
+    // `ProcessInfo::status` reports whether a PROCESS is alive. For a sheep
+    // that is the whole truth; for a dog it is not, and an operator read
+    // `(o.o) online`, restarts 0, for a dog whose own log was filling with
+    // protocol refusals. `handshook` is the fact that says otherwise, and
+    // these pin what the STATUS column does with it.
+
+    /// The `Presentation` for one style, at a width nothing drops at.
+    fn styled(level: crate::style::StyleLevel) -> Presentation {
+        Presentation::new(
+            level,
+            None,
+            Some(std::ffi::OsStr::new("xterm-256color")),
+            None,
+            200,
+        )
+    }
+
+    /// `sample_dog`, plus what this shepherd knows about its handshake.
+    fn dog_with_contact(handshook: Option<bool>) -> ProcessInfo {
+        let mut dog = sample_dog(ProcStatus::Online, Some(208_341));
+        dog.handshook = handshook;
+        dog
+    }
+
+    /// The cell under `header` in `T`'s only row.
+    fn cell_of<T: Render>(row: &[String], header: &str) -> String {
+        row[T::headers().iter().position(|h| *h == header).unwrap()].clone()
+    }
+
+    /// fails if a dog that has never handshaken reads as `online` — the
+    /// defect this field exists for. The process IS alive, so nothing in
+    /// `status` is wrong; what is wrong is answering the question an
+    /// operator is actually asking with the answer to a different one.
+    #[test]
+    fn a_dog_that_has_never_answered_the_shepherd_does_not_read_as_online() {
+        let rows = DogRows(vec![dog_with_contact(Some(false))]).rows();
+        assert_eq!(cell_of::<DogRows>(&rows[0], "STATUS"), "silent");
+    }
+
+    /// fails if the three styles disagree about a silent dog.
+    ///
+    /// `full` carries the face, and it must be a DIFFERENT face: a cell
+    /// reading `(o.o) silent` would keep the happy sheep that made the
+    /// original report look fine. `plain` is the word alone, coloured.
+    /// `bare` is machine-oriented and never reaches `rows_for` at all
+    /// (`StyleLevel::boxes` is false, so `table_of` takes `rows`'s plain
+    /// path), so its cell is the bare word with no escape in it.
+    #[test]
+    fn a_silent_dog_reads_the_same_in_all_three_styles() {
+        use crate::style::StyleLevel;
+        let dogs = DogRows(vec![dog_with_contact(Some(false))]);
+
+        let full = dogs.rows_for(styled(StyleLevel::Full), true);
+        assert_eq!(
+            cell_of::<DogRows>(&full[0], "STATUS"),
+            painted("(?_?) silent", Role::Butter)
+        );
+
+        let plain = dogs.rows_for(styled(StyleLevel::Plain), true);
+        assert_eq!(
+            cell_of::<DogRows>(&plain[0], "STATUS"),
+            painted("silent", Role::Butter)
+        );
+
+        let bare = dogs.rows();
+        let cell = cell_of::<DogRows>(&bare[0], "STATUS");
+        assert_eq!(cell, "silent");
+        assert!(!cell.contains('\u{1b}'), "bare carries no escape: {cell:?}");
+    }
+
+    /// fails if a dog that IS talking to this shepherd renders any
+    /// differently than it did before the field existed.
+    ///
+    /// The whole row is compared, not the STATUS cell alone: a guard keyed
+    /// on the wrong field could leave STATUS right and move something else.
+    #[test]
+    fn a_dog_that_has_answered_renders_exactly_as_before() {
+        use crate::style::StyleLevel;
+        let mut before = sample_dog(ProcStatus::Online, Some(208_341));
+        before.handshook = None;
+        let talking = dog_with_contact(Some(true));
+
+        assert_eq!(
+            DogRows(vec![talking.clone()]).rows(),
+            DogRows(vec![before.clone()]).rows()
+        );
+        assert_eq!(
+            DogRows(vec![talking]).rows_for(styled(StyleLevel::Full), true),
+            DogRows(vec![before]).rows_for(styled(StyleLevel::Full), true)
+        );
+    }
+
+    /// fails if a listing from a shepherd that predates the field renders
+    /// differently from one from a shepherd that has heard from the dog.
+    ///
+    /// `None` means "no handshake fact to report", never "this dog has
+    /// never handshaken" — the same skew rule every other optional field on
+    /// `ProcessInfo` follows. Getting this backwards would paint every dog
+    /// in an older shepherd's listing as broken.
+    #[test]
+    fn a_dog_from_a_shepherd_predating_the_field_reads_as_it_always_did() {
+        use crate::style::StyleLevel;
+        let rows = DogRows(vec![dog_with_contact(None)]).rows();
+        assert_eq!(cell_of::<DogRows>(&rows[0], "STATUS"), "online");
+
+        let full = DogRows(vec![dog_with_contact(None)]).rows_for(styled(StyleLevel::Full), true);
+        assert_eq!(
+            cell_of::<DogRows>(&full[0], "STATUS"),
+            painted("(o.o) online", Role::Meadow)
+        );
+    }
+
+    /// fails if the guard reaches a sheep.
+    ///
+    /// A sheep has no handshake and no version relationship with the
+    /// shepherd at all — it is a supervised process, not a peer — so its
+    /// `handshook` is always `None` and its row must be untouched. Driven
+    /// through a sheep carrying `Some(false)` as well, which the daemon
+    /// never sends, because "the field is always `None` for a sheep" is a
+    /// claim about the daemon and this is the renderer's own half of it.
+    #[test]
+    fn a_sheep_never_reads_as_silent() {
+        use crate::style::StyleLevel;
+        let sheep = sample_info(1, "web", 60_000);
+        assert_eq!(sheep.handshook, None, "the daemon sends nothing here");
+        let rows = FlockRows(vec![sheep.clone()]).rows();
+        assert_eq!(cell_of::<FlockRows>(&rows[0], "STATUS"), "online");
+
+        let mut impossible = sheep;
+        impossible.handshook = Some(false);
+        let full = FlockRows(vec![impossible]).rows_for(styled(StyleLevel::Full), true);
+        assert_eq!(
+            cell_of::<FlockRows>(&full[0], "STATUS"),
+            painted("(o.o) online", Role::Meadow),
+            "the sheep table has no dogs in it, and no silence rule either"
+        );
+    }
+
+    /// fails if only a lifecycle status a silence could not explain is
+    /// overridden.
+    ///
+    /// `online` is the one word that lies. `starting` already tells an
+    /// operator the relationship is not established yet, and a dog is
+    /// silent for a moment every single time it is spawned; `stopped` and
+    /// `errored` are honest about a process that is not there to answer.
+    /// Overriding any of those would report a fault where there is none.
+    #[test]
+    fn only_online_is_overridden_by_a_silence() {
+        for status in [
+            ProcStatus::Starting,
+            ProcStatus::Stopping,
+            ProcStatus::Stopped,
+            ProcStatus::Errored,
+            ProcStatus::WaitingRestart,
+        ] {
+            let mut dog = sample_dog(status, Some(208_341));
+            dog.handshook = Some(false);
+            let rows = DogRows(vec![dog]).rows();
+            assert_eq!(
+                cell_of::<DogRows>(&rows[0], "STATUS"),
+                status.to_string(),
+                "{status} says what it says without help"
+            );
+        }
+    }
+
+    /// fails if `--format json` cannot see what the table just said.
+    ///
+    /// The table's word is a rendering; a consumer scripting against status
+    /// needs the fact itself, and `status` alone still reads `online` for a
+    /// silent dog by design — it is a true statement about the process.
+    #[test]
+    fn the_json_form_carries_the_handshake_fact() {
+        let json = serde_json::to_value(DogRows(vec![
+            dog_with_contact(Some(false)),
+            dog_with_contact(Some(true)),
+            dog_with_contact(None),
+        ]))
+        .unwrap();
+        assert_eq!(json[0]["handshook"], serde_json::json!(false));
+        assert_eq!(json[0]["status"], "online");
+        assert_eq!(json[1]["handshook"], serde_json::json!(true));
+        assert_eq!(json[2]["handshook"], serde_json::Value::Null);
     }
 }

--- a/crates/shep-cli/src/output/rows.rs
+++ b/crates/shep-cli/src/output/rows.rs
@@ -5205,6 +5205,56 @@ pub(crate) mod tests {
         );
     }
 
+    /// fails if `Row::reported` (the lookout's own copy) and this module's
+    /// `reported` land on different words for the same `ProcessInfo`.
+    ///
+    /// The two are deliberately NOT shared code -- `Row::reported`'s own
+    /// doc says why, the same reason `the_flock_table_and_the_lookout_roll_a_group_up_the_same_way`
+    /// gives for `GroupTotals` -- so this decision table is the only thing
+    /// standing between them drifting apart one edit at a time. Every axis
+    /// that decides the answer is driven together: `dog` (`None` for a
+    /// sheep, `Some` for a dog), `handshook` (`None`/`Some(false)`/
+    /// `Some(true)`), and every `ProcStatus`, so a guard reachable through
+    /// only some of those combinations cannot slip past unnoticed.
+    #[test]
+    fn the_flock_table_and_the_lookout_read_a_dogs_silence_the_same_way() {
+        use crate::lookout::app::Row;
+
+        let statuses = [
+            ProcStatus::Starting,
+            ProcStatus::Online,
+            ProcStatus::Stopping,
+            ProcStatus::Stopped,
+            ProcStatus::Errored,
+            ProcStatus::WaitingRestart,
+        ];
+        let handshooks = [None, Some(false), Some(true)];
+        let dogs = [None, Some(DogSource::BuiltIn)];
+
+        for dog in &dogs {
+            for &handshook in &handshooks {
+                for &status in &statuses {
+                    let info = ProcessInfo::builder(9, "log-rotate", status)
+                        .dog(dog.clone())
+                        .handshook(handshook)
+                        .build();
+
+                    let table = reported(&info);
+                    let dashboard = Row {
+                        info: info.clone(),
+                        anchor: std::time::Instant::now(),
+                    }
+                    .reported();
+
+                    assert_eq!(
+                        table, dashboard,
+                        "dog={dog:?} handshook={handshook:?} status={status:?}"
+                    );
+                }
+            }
+        }
+    }
+
     /// fails if only a lifecycle status a silence could not explain is
     /// overridden.
     ///

--- a/crates/shep-cli/src/output/snapshots/shep__output__tests__the_json_envelope_shape_is_pinned.snap
+++ b/crates/shep-cli/src/output/snapshots/shep__output__tests__the_json_envelope_shape_is_pinned.snap
@@ -25,7 +25,8 @@ expression: out
         "signal": null
       },
       "smit": "▲ main@a1b2c3",
-      "instance": null
+      "instance": null,
+      "handshook": null
     },
     {
       "id": 2,
@@ -46,7 +47,8 @@ expression: out
         "signal": null
       },
       "smit": "▲ main@a1b2c3",
-      "instance": null
+      "instance": null,
+      "handshook": null
     },
     {
       "id": 3,
@@ -67,7 +69,8 @@ expression: out
         "signal": null
       },
       "smit": "▲ main@a1b2c3",
-      "instance": null
+      "instance": null,
+      "handshook": null
     }
   ]
 }

--- a/crates/shep-cli/src/vocabulary.rs
+++ b/crates/shep-cli/src/vocabulary.rs
@@ -70,6 +70,106 @@ pub(crate) const fn face(status: ProcStatus) -> &'static str {
     }
 }
 
+/// What a STATUS cell reports: the lifecycle status the shepherd holds, or
+/// the one fact that overrides it.
+///
+/// `ProcStatus` answers "is the process alive". For a sheep that is the
+/// whole of what STATUS means, and this type collapses to [`Self::Live`].
+/// For a dog it is not: a dog is a PEER as well as a process, and one that
+/// has never completed a handshake is not doing its job however alive it
+/// is. `shep flock` reported such a dog as `(o.o) online` with zero
+/// restarts while its own log filled with protocol refusals, which is the
+/// case [`Self::Silent`] exists to stop.
+///
+/// Deliberately not a seventh `ProcStatus` variant: `ProcStatus` is the wire
+/// contract for what the supervisor knows about a PROCESS, and silence is a
+/// fact about a CONNECTION that only a reader joining two fields can see.
+/// A variant would also be a protocol break, where
+/// [`ProcessInfo::handshook`](shep_core::protocol::ProcessInfo::handshook)
+/// is additive.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Reported {
+    /// What the shepherd's own lifecycle state says.
+    Live(ProcStatus),
+    /// A dog whose process is up and which has never answered this
+    /// shepherd.
+    Silent,
+}
+
+impl Reported {
+    /// What one row reports, from the two fields that decide it.
+    ///
+    /// # Why only `Online` is overridden
+    ///
+    /// `online` is the one word that lies here. Every other status is
+    /// already honest about a dog that is not answering: `starting` says
+    /// the relationship is not established yet — and a dog is silent for a
+    /// moment every single time it is spawned, so overriding that would
+    /// report a fault on every healthy start — while `stopped`, `errored`
+    /// and `waiting-restart` describe a process that is not there to
+    /// answer. Narrowing to `Online` is what keeps this a correction rather
+    /// than a second opinion.
+    ///
+    /// `handshook` is `None` for a sheep AND for a listing from a shepherd
+    /// that predates the field, and both must render exactly as they did
+    /// before it existed — see the field's own doc for why collapsing those
+    /// two costs nothing.
+    pub(crate) const fn of(status: ProcStatus, handshook: Option<bool>) -> Self {
+        match (status, handshook) {
+            (ProcStatus::Online, Some(false)) => Self::Silent,
+            _ => Self::Live(status),
+        }
+    }
+
+    /// The word this cell shows.
+    ///
+    /// A `String` because [`ProcStatus`]'s own spelling lives in its
+    /// `Display` impl, in shep-core, and restating those six words here to
+    /// hand back a `&'static str` would be a second source for the wire
+    /// contract's own vocabulary.
+    pub(crate) fn word(self) -> String {
+        match self {
+            Self::Live(status) => status.to_string(),
+            // One word, matching `dogs.rs`'s own `silent_dogs` /
+            // `DOG_SILENCE_BUDGET` / `record_silent_dog`: the shepherd
+            // already calls this population silent, and a surface that
+            // called it something else would make an operator reading a
+            // reload's report and a flock listing think they were two
+            // things.
+            Self::Silent => "silent".to_string(),
+        }
+    }
+
+    /// The sheep wearing it. Same five-column ASCII rule as [`face`].
+    pub(crate) const fn face(self) -> &'static str {
+        match self {
+            Self::Live(status) => face(status),
+            // Not a happy face, which is the whole point: a status that
+            // looks fine while being a problem is the defect being fixed,
+            // so `(o.o)` here would undo it. Not `(x.x)` either — that is
+            // `errored`, a process that failed, and this process has not.
+            // The dog is confused rather than dead, and it is exactly what
+            // the operator watching it was.
+            Self::Silent => "(?_?)",
+        }
+    }
+
+    /// The colour role it wears.
+    pub(crate) const fn role(self) -> Role {
+        match self {
+            Self::Live(status) => role_of(status),
+            // `Butter`, the "a gap the operator can close" tier
+            // `outcome_role` and `source_role` already use, and NOT
+            // `Bark`. Bark is reserved for a failure, and painting a
+            // running process the same red as a crashed one would send an
+            // operator looking for a crash that never happened. The gap
+            // here is real and closable — reinstall the dog and restart it
+            // — which is what Butter says everywhere else in this crate.
+            Self::Silent => Role::Butter,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -87,7 +187,7 @@ mod tests {
             ProcStatus::Stopped,
             ProcStatus::Errored,
         ] {
-            let face = face(status);
+            let face = Reported::Live(status).face();
             assert_eq!(
                 face.chars().count(),
                 5,
@@ -99,6 +199,55 @@ mod tests {
                  double-width, inconsistently so, and cannot take a colour"
             );
         }
+
+        // The sixth face, which no `ProcStatus` reaches: it is decided by
+        // `handshook` rather than by a lifecycle state, so the loop above
+        // cannot enumerate it and it would otherwise be the one face
+        // nothing measured.
+        let silent = Reported::Silent.face();
+        assert_eq!(silent.chars().count(), 5, "silent face {silent:?}");
+        assert!(silent.is_ascii(), "silent face {silent:?}");
+    }
+
+    /// fails if a silence stops overriding `online`, or starts overriding a
+    /// status that was already honest about it.
+    #[test]
+    fn a_silence_overrides_online_and_nothing_else() {
+        assert_eq!(
+            Reported::of(ProcStatus::Online, Some(false)),
+            Reported::Silent
+        );
+        for status in [
+            ProcStatus::Starting,
+            ProcStatus::Stopping,
+            ProcStatus::Stopped,
+            ProcStatus::Errored,
+            ProcStatus::WaitingRestart,
+        ] {
+            assert_eq!(Reported::of(status, Some(false)), Reported::Live(status));
+        }
+        // A dog that is talking, and a sheep or an older shepherd's row.
+        assert_eq!(
+            Reported::of(ProcStatus::Online, Some(true)),
+            Reported::Live(ProcStatus::Online)
+        );
+        assert_eq!(
+            Reported::of(ProcStatus::Online, None),
+            Reported::Live(ProcStatus::Online)
+        );
+    }
+
+    /// fails if `silent` stops being one word, or stops being the word the
+    /// shepherd's own `silent_dogs` population is named for.
+    #[test]
+    fn a_silent_row_says_silent_in_butter() {
+        assert_eq!(Reported::Silent.word(), "silent");
+        assert_eq!(Reported::Silent.role(), Role::Butter);
+        assert_eq!(
+            Reported::Live(ProcStatus::Online).word(),
+            ProcStatus::Online.to_string(),
+            "a live row still spells its status exactly as the wire does"
+        );
     }
 
     /// The mapping is the one `lookout` already shipped. Changing it here
@@ -126,6 +275,10 @@ mod tests {
             face(ProcStatus::WaitingRestart),
             face(ProcStatus::Stopped),
             face(ProcStatus::Errored),
+            // `Silent` is not a `ProcStatus` and so cannot be reached by the
+            // loop above, but it is a sixth face in the same column of the
+            // same table and has to be distinct from all five.
+            Reported::Silent.face(),
         ];
         // `dedup` is a `Vec` method, not a slice one -- it shrinks the
         // length, which a fixed-size array cannot do -- so the faces are

--- a/crates/shep-cli/src/whistle/facts.rs
+++ b/crates/shep-cli/src/whistle/facts.rs
@@ -93,6 +93,14 @@ pub struct SheepRow {
     /// Which instance slot of its app this sheep occupies, counting from 0;
     /// absent when the peer daemon predates the field.
     pub instance: Option<u32>,
+    /// Whether this DOG has completed a handshake with the shepherd;
+    /// absent for a sheep, which has none to complete.
+    ///
+    /// `false` is the one worth acting on: the dog's process is running and
+    /// the shepherd has never heard from it, so it is not doing its job
+    /// however healthy `status` looks. `status` still reads `online` there,
+    /// truthfully — it describes the process, not the relationship.
+    pub handshook: Option<bool>,
 }
 
 /// Where a dog came from. Mirrors `DogSource`'s tagged wire shape exactly.
@@ -158,6 +166,7 @@ impl From<&ProcessInfo> for SheepRow {
             last_exit: info.last_exit.as_ref().map(ExitInfoRow::from),
             smit: info.smit.clone(),
             instance: info.instance,
+            handshook: info.handshook,
         }
     }
 }

--- a/crates/shep-cli/tests/cli_e2e.rs
+++ b/crates/shep-cli/tests/cli_e2e.rs
@@ -7494,6 +7494,41 @@ fn poll_slot_lines(path: &Path, want: usize) -> Vec<(u32, u32)> {
     }
 }
 
+/// Polls `path` until the lines written after the first `before` of them
+/// satisfy `ready`, or the handover deadline passes.
+///
+/// A line COUNT is the wrong wait for a `merge_logs` app, and
+/// [`poll_slot_lines`] offers nothing else. Both instances write to one
+/// file, so "two more lines" is satisfied the moment EITHER of them writes
+/// twice. The sampled window can then legitimately hold no line from the
+/// instance being asked about, and the assertion blames the handover for a
+/// race in the test's own sampling. Measured on a loaded macOS runner: both
+/// fresh lines were slot 1, and slot 0 was reported as having written
+/// nothing after a reload it had in fact survived.
+///
+/// So the caller says what it is waiting FOR, rather than how many lines it
+/// expects to read before finding it. Waiting too long is harmless here and
+/// returning early is the whole defect, which is why the deadline is the
+/// only other way out.
+#[cfg(unix)]
+fn poll_fresh_lines(
+    path: &Path,
+    before: usize,
+    ready: impl Fn(&[(u32, u32)]) -> bool,
+) -> Vec<(u32, u32)> {
+    let start = Instant::now();
+    loop {
+        let lines = slot_lines(path);
+        if lines.len() > before && ready(&lines[before..]) {
+            return lines;
+        }
+        if start.elapsed() >= HANDOVER_DEADLINE {
+            return lines;
+        }
+        std::thread::sleep(FLOCK_POLL_INTERVAL);
+    }
+}
+
 /// A clustered app is carried, and every instance comes back in its own
 /// slot.
 ///
@@ -7614,14 +7649,25 @@ fn a_clustered_flock_keeps_every_pid_and_every_slot_across_a_daemon_reload() {
     // asked for its own file, and every line written into that file AFTER
     // the reload has to name that row's slot and that row's pid.
     for ((name, slot), (pid, out_file)) in &rows_after {
-        let want = counts_before[&(name.clone(), *slot)] + 2;
-        let lines = poll_slot_lines(out_file, want);
+        let before = counts_before[&(name.clone(), *slot)];
+        // What this row waits for depends on who else writes into the file.
+        // A split app's file holds nobody else, so two more lines in it are
+        // two more lines from this row. A merged app's file holds both
+        // instances, so the only wait that means "this row wrote again" is
+        // this row's own pid turning up.
+        let lines = if *name == "merged" {
+            poll_fresh_lines(out_file, before, |fresh| {
+                fresh.iter().any(|(_, line_pid)| line_pid == pid)
+            })
+        } else {
+            poll_fresh_lines(out_file, before, |fresh| fresh.len() >= 2)
+        };
+        let fresh = lines.get(before..).unwrap_or(&[]);
         assert!(
-            lines.len() >= want,
-            "{name}:{slot} stopped logging across the handover: {} lines, wanted {want}",
+            !fresh.is_empty(),
+            "{name}:{slot} stopped logging across the handover: {} lines, none of them new",
             lines.len()
         );
-        let fresh = &lines[counts_before[&(name.clone(), *slot)]..];
         if *name == "merged" {
             // One file for both slots, so the row's own lines are the ones
             // carrying its pid. Both instances have to be present, or a
@@ -7638,6 +7684,11 @@ fn a_clustered_flock_keeps_every_pid_and_every_slot_across_a_daemon_reload() {
                 );
             }
         } else {
+            assert!(
+                fresh.len() >= 2,
+                "{name}:{slot} stopped logging across the handover: {} fresh lines, wanted 2",
+                fresh.len()
+            );
             for (line_slot, line_pid) in fresh {
                 assert_eq!(
                     (*line_slot, *line_pid),

--- a/crates/shep-cli/tests/cli_e2e.rs
+++ b/crates/shep-cli/tests/cli_e2e.rs
@@ -7606,11 +7606,6 @@ fn a_clustered_flock_keeps_every_pid_and_every_slot_across_a_daemon_reload() {
             "{name}:{slot} must be logging before the reload"
         );
     }
-    let counts_before: HashMap<(String, u32), usize> = rows_before
-        .iter()
-        .map(|(key, (_, out_file))| (key.clone(), slot_lines(out_file).len()))
-        .collect();
-
     let reloaded = shep(dir.path())
         .arg("daemon")
         .arg("reload")
@@ -7644,6 +7639,18 @@ fn a_clustered_flock_keeps_every_pid_and_every_slot_across_a_daemon_reload() {
         rows_after, rows_before,
         "every instance keeps its pid and its own log file: {after}"
     );
+
+    // The mark is taken HERE, after the reload has returned, and not before
+    // it was issued. A pid is CARRIED across a handover -- that is the
+    // property this test exists to prove -- so a line written before the
+    // swap names the same pid as one written after it. A mark taken early
+    // therefore lets a pre-reload line satisfy "this instance wrote again",
+    // and the test passes while proving nothing about the successor. Every
+    // line past this point is unambiguously the new shepherd's.
+    let counts_before: HashMap<(String, u32), usize> = rows_after
+        .iter()
+        .map(|(key, (_, out_file))| (key.clone(), slot_lines(out_file).len()))
+        .collect();
 
     // The slot assertion, and the one a pid check cannot make. Each row is
     // asked for its own file, and every line written into that file AFTER

--- a/crates/shep-cli/tests/fixtures/describe.json
+++ b/crates/shep-cli/tests/fixtures/describe.json
@@ -23,7 +23,8 @@
       ],
       "last_exit": null,
       "smit": null,
-      "instance": 0
+      "instance": 0,
+      "handshook": null
     }
   ]
 }

--- a/crates/shep-cli/tests/fixtures/flock.json
+++ b/crates/shep-cli/tests/fixtures/flock.json
@@ -18,7 +18,8 @@
       "lambs": null,
       "last_exit": null,
       "smit": null,
-      "instance": 0
+      "instance": 0,
+      "handshook": null
     }
   ]
 }

--- a/crates/shep-cli/tests/fixtures/start.json
+++ b/crates/shep-cli/tests/fixtures/start.json
@@ -18,7 +18,8 @@
       "lambs": null,
       "last_exit": null,
       "smit": null,
-      "instance": 0
+      "instance": 0,
+      "handshook": null
     }
   ]
 }

--- a/crates/shep-core/src/protocol/events.rs
+++ b/crates/shep-core/src/protocol/events.rs
@@ -211,6 +211,7 @@ mod tests {
                     // the one field on this row a third party writes.
                     smit: Some("\u{25b2} main@a1b2c3".to_string()),
                     instance: None,
+                    handshook: None,
                 },
                 manually: false,
                 at_ms: 1_700_000_000_000,
@@ -360,6 +361,7 @@ mod tests {
                     last_exit: None,
                     smit: None,
                     instance: None,
+                    handshook: None,
                 },
                 manually: true,
                 at_ms: 0,

--- a/crates/shep-core/src/protocol/frame.rs
+++ b/crates/shep-core/src/protocol/frame.rs
@@ -67,6 +67,7 @@ mod tests {
                 last_exit: None,
                 smit: None,
                 instance: None,
+                handshook: None,
             },
             manually: false,
             at_ms: 1_700_000_000_000,

--- a/crates/shep-core/src/protocol/request.rs
+++ b/crates/shep-core/src/protocol/request.rs
@@ -1702,6 +1702,21 @@ mod tests {
             Some("\u{25b2} main@a1b2c3"),
             "an empty `smit` setter body is invisible to the comparison above"
         );
+
+        // `handshook` is the fourth field, on the same terms as the three
+        // above: `sample_info()`'s value is `None`, which is also the
+        // builder's default, so an EMPTY `handshook` setter body would pass
+        // the `assert_eq!` above. `sample_info()` still cannot be changed to
+        // a `Some(..)` — it feeds `reply_wire_snapshots` and
+        // `bus_event_wire_snapshots`, so altering it moves pinned bytes.
+        assert_eq!(
+            ProcessInfo::builder(1, "web", ProcStatus::Online)
+                .handshook(Some(false))
+                .build()
+                .handshook,
+            Some(false),
+            "an empty `handshook` setter body is invisible to the comparison above"
+        );
     }
 
     /// fails if `lambs` collapses to a bare `Vec`. The three states are the point:

--- a/crates/shep-core/src/protocol/request.rs
+++ b/crates/shep-core/src/protocol/request.rs
@@ -784,6 +784,32 @@ pub struct ProcessInfo {
     /// zero [`Self::dog`] warns against. A reader that finds `None` should
     /// render exactly what it rendered before this field existed.
     pub instance: Option<u32>,
+    /// Whether this dog has completed a handshake with the shepherd that is
+    /// reporting it, and not been refused since; `None` for a sheep.
+    ///
+    /// Read [`Self::dog`]'s own doc first — this field follows it rather
+    /// than [`Self::cpu_percent`], and for the same reason. `None` covers a
+    /// sheep and a peer daemon that predates the field, and collapsing the
+    /// two costs nothing: a sheep never handshakes with anything (it has no
+    /// connection to the shepherd at all, only a supervised process), so
+    /// "no handshake fact to report" is the true answer either way, and a
+    /// reader that finds `None` renders exactly what it rendered before
+    /// this field existed. Do not "fix" this into three cases.
+    ///
+    /// `Some(false)` is the one that matters and it is why this exists.
+    /// [`Self::status`] reports whether a PROCESS is alive, which for a
+    /// sheep is the whole truth and for a dog is not: a dog that cannot
+    /// talk to the shepherd is not doing its job, however alive it is. A
+    /// dog running on a protocol this shepherd refuses is exactly that, and
+    /// before this field a listing reported it `online` with zero restarts
+    /// while its own log filled with refusals.
+    ///
+    /// A fact and not a verdict, deliberately: this says whether the
+    /// handshake happened, never what a renderer should print about it. A
+    /// dog that has only just been spawned has not handshaken yet and is
+    /// perfectly healthy, so the decision about which lifecycle states that
+    /// silence is worth overriding belongs to the reader.
+    pub handshook: Option<bool>,
 }
 
 /// Orders one flock listing the way every operator-facing surface presents
@@ -855,6 +881,7 @@ impl ProcessInfo {
                 last_exit: None,
                 smit: None,
                 instance: None,
+                handshook: None,
             },
         }
     }
@@ -957,6 +984,13 @@ impl ProcessInfoBuilder {
     /// Sets the instance slot; `None` when the peer daemon predates the field.
     pub fn instance(mut self, instance: Option<u32>) -> Self {
         self.info.instance = instance;
+        self
+    }
+
+    /// Sets whether this dog has handshaken with the shepherd; `None` for a
+    /// sheep, which has no handshake to report.
+    pub fn handshook(mut self, handshook: Option<bool>) -> Self {
+        self.info.handshook = handshook;
         self
     }
 
@@ -1566,6 +1600,7 @@ mod tests {
             }),
             smit: None,
             instance: None,
+            handshook: None,
         }
     }
 
@@ -2462,6 +2497,23 @@ mod tests {
                     pending: vec!["bark".to_string()],
                 }),
             },
+            // `sample_info()` pins `handshook`'s absent shape (`None`, a
+            // sheep or an older peer); every row above reuses it, so
+            // without this row the shape that actually changes an
+            // operator's reading — a dog whose process is up and which has
+            // never answered this shepherd — is never on the wire at all.
+            Reply {
+                id: 31,
+                result: Ok(Response::Flock(vec![
+                    ProcessInfo::builder(10, "log-rotate", ProcStatus::Online)
+                        .pid(Some(208_341))
+                        .dog(Some(DogSource::Adopted {
+                            path: "/usr/local/bin/shep-log-rotate".to_string(),
+                        }))
+                        .handshook(Some(false))
+                        .build(),
+                ])),
+            },
         ];
         insta::assert_json_snapshot!("reply_wire_v2", replies);
     }
@@ -2475,6 +2527,27 @@ mod tests {
         let fixture = r#"{"id":1,"name":"web","status":"online","pid":42,"restarts":0,"uptime_ms":10,"fold":null,"out_file":null,"err_file":null,"cpu_percent":null,"memory_bytes":null,"dog":null,"lambs":null,"last_exit":null}"#;
         let info: ProcessInfo = serde_json::from_str(fixture).unwrap();
         assert_eq!(info.smit, None);
+    }
+
+    /// fails if `handshook` breaks an older peer, on the same terms as
+    /// `smit` and `instance` before it. A daemon that predates the field
+    /// sends no `handshook` key and still announces protocol 2, so this
+    /// decoding to `None` rather than erroring is what keeps
+    /// `PROTOCOL_VERSION` at 2: the evolution rule in this module's parent
+    /// says an additive optional field keeps the version, and a required
+    /// one would make a current client unable to list against that daemon
+    /// at all.
+    ///
+    /// The fixture is a DOG's row, deliberately — that is the one row where
+    /// the missing key changes what a renderer prints, and `None` there has
+    /// to keep meaning "render this exactly as it rendered before the field
+    /// existed" rather than "this dog has never handshaken".
+    #[test]
+    fn a_process_info_without_a_handshook_key_still_deserializes() {
+        let fixture = r#"{"id":1,"name":"metrics","status":"online","pid":42,"restarts":0,"uptime_ms":10,"fold":null,"out_file":null,"err_file":null,"cpu_percent":null,"memory_bytes":null,"dog":{"kind":"built_in"},"lambs":null,"last_exit":null,"smit":null,"instance":0}"#;
+        let info: ProcessInfo = serde_json::from_str(fixture).unwrap();
+        assert_eq!(info.handshook, None);
+        assert_eq!(info.dog, Some(DogSource::BuiltIn));
     }
 
     /// fails if the daemon accepts a smit it should refuse. [`Smit`] must

--- a/crates/shep-core/src/protocol/snapshots/shep_core__protocol__events__tests__bus_event_wire_v2.snap
+++ b/crates/shep-core/src/protocol/snapshots/shep_core__protocol__events__tests__bus_event_wire_v2.snap
@@ -26,7 +26,8 @@ expression: events
           "signal": null
         },
         "smit": "▲ main@a1b2c3",
-        "instance": null
+        "instance": null,
+        "handshook": null
       },
       "manually": false,
       "at_ms": 1700000000000
@@ -65,7 +66,8 @@ expression: events
         "lambs": null,
         "last_exit": null,
         "smit": null,
-        "instance": 2
+        "instance": 2,
+        "handshook": null
       },
       "manually": false,
       "at_ms": 1700000000000
@@ -94,7 +96,8 @@ expression: events
           "signal": null
         },
         "smit": null,
-        "instance": null
+        "instance": null,
+        "handshook": null
       },
       "manually": false,
       "at_ms": 1700000000000
@@ -123,7 +126,8 @@ expression: events
           "signal": null
         },
         "smit": null,
-        "instance": null
+        "instance": null,
+        "handshook": null
       },
       "manually": false,
       "at_ms": 1700000000000
@@ -152,7 +156,8 @@ expression: events
           "signal": null
         },
         "smit": null,
-        "instance": null
+        "instance": null,
+        "handshook": null
       },
       "manually": false,
       "at_ms": 1700000000000
@@ -181,7 +186,8 @@ expression: events
           "signal": null
         },
         "smit": null,
-        "instance": null
+        "instance": null,
+        "handshook": null
       },
       "manually": false,
       "at_ms": 1700000000000
@@ -210,7 +216,8 @@ expression: events
           "signal": null
         },
         "smit": null,
-        "instance": null
+        "instance": null,
+        "handshook": null
       },
       "manually": false,
       "at_ms": 1700000000000
@@ -239,7 +246,8 @@ expression: events
           "signal": null
         },
         "smit": null,
-        "instance": null
+        "instance": null,
+        "handshook": null
       },
       "manually": false,
       "at_ms": 1700000000000

--- a/crates/shep-core/src/protocol/snapshots/shep_core__protocol__request__tests__reply_wire_v2.snap
+++ b/crates/shep-core/src/protocol/snapshots/shep_core__protocol__request__tests__reply_wire_v2.snap
@@ -36,7 +36,8 @@ expression: replies
               "signal": null
             },
             "smit": null,
-            "instance": null
+            "instance": null,
+            "handshook": null
           }
         ]
       }
@@ -109,7 +110,8 @@ expression: replies
               "signal": null
             },
             "smit": null,
-            "instance": null
+            "instance": null,
+            "handshook": null
           }
         ]
       }
@@ -152,7 +154,8 @@ expression: replies
             "signal": null
           },
           "smit": null,
-          "instance": null
+          "instance": null,
+          "handshook": null
         }
       }
     }
@@ -314,7 +317,8 @@ expression: replies
               "signal": null
             },
             "smit": null,
-            "instance": null
+            "instance": null,
+            "handshook": null
           }
         ]
       }
@@ -383,7 +387,8 @@ expression: replies
             ],
             "last_exit": null,
             "smit": null,
-            "instance": null
+            "instance": null,
+            "handshook": null
           }
         ]
       }
@@ -414,7 +419,8 @@ expression: replies
               "signal": 15
             },
             "smit": null,
-            "instance": null
+            "instance": null,
+            "handshook": null
           }
         ]
       }
@@ -442,7 +448,8 @@ expression: replies
             "lambs": null,
             "last_exit": null,
             "smit": "▲ main@a1b2c3",
-            "instance": null
+            "instance": null,
+            "handshook": null
           }
         ]
       }
@@ -494,7 +501,8 @@ expression: replies
             "lambs": null,
             "last_exit": null,
             "smit": null,
-            "instance": 2
+            "instance": 2,
+            "handshook": null
           }
         ]
       }
@@ -535,6 +543,38 @@ expression: replies
             "bark"
           ]
         }
+      }
+    }
+  },
+  {
+    "id": 31,
+    "result": {
+      "Ok": {
+        "kind": "flock",
+        "data": [
+          {
+            "id": 10,
+            "name": "log-rotate",
+            "status": "online",
+            "pid": 208341,
+            "restarts": 0,
+            "uptime_ms": 0,
+            "fold": null,
+            "out_file": null,
+            "err_file": null,
+            "cpu_percent": null,
+            "memory_bytes": null,
+            "dog": {
+              "kind": "adopted",
+              "path": "/usr/local/bin/shep-log-rotate"
+            },
+            "lambs": null,
+            "last_exit": null,
+            "smit": null,
+            "instance": null,
+            "handshook": false
+          }
+        ]
       }
     }
   }

--- a/crates/shep-daemon/src/boot.rs
+++ b/crates/shep-daemon/src/boot.rs
@@ -1331,6 +1331,20 @@ pub async fn boot<R: ProcessRunner>(
     // carries on rather than propagating anything here.
     crate::dogs::spawn_enabled_dogs(&options.dogs, &paths, &supervisor).await;
 
+    // Built here rather than inside the `RpcContext` below because the watch
+    // on the next line shares it. Still empty, and still deliberately not
+    // carried across a handover: a successor has refused nobody yet, and a
+    // dog it can talk to is not stale by any definition it could apply.
+    let dog_refusals = crate::dogs::DogRefusals::new();
+    // Spawned at every boot, INCLUDING a successor's after an `execve` --
+    // that is why it is anchored here and not to a dog's own spawn (see
+    // `spawn_silent_dog_watch`'s doc). It restarts a dog that has been
+    // running without ever answering this shepherd, which costs a merely
+    // slow dog one restart it did not need; the tradeoff is argued at
+    // `record_silent_dog`.
+    let silent_dog_watch =
+        crate::dogs::spawn_silent_dog_watch(supervisor.clone(), dog_refusals.clone());
+
     let writer = spawn_snapshot_writer(
         paths.snapshot.clone(),
         supervisor.clone(),
@@ -1346,10 +1360,7 @@ pub async fn boot<R: ProcessRunner>(
         daemon_config: paths.daemon_config.clone(),
         paths: paths.clone(),
         daemon_version: env!("CARGO_PKG_VERSION").to_string(),
-        // Empty, and deliberately not carried across a handover: a
-        // successor has refused nobody yet, and a dog it can talk to is not
-        // stale by any definition it could apply.
-        dog_refusals: crate::dogs::DogRefusals::new(),
+        dog_refusals,
         pid,
         shutdown,
         stats,
@@ -1387,6 +1398,7 @@ pub async fn boot<R: ProcessRunner>(
         listener,
         writer,
         dog_watch,
+        silent_dog_watch,
         paths,
         socket,
         // Held from here into `RunningDaemon` — `watch::Sender::send` is a
@@ -1465,6 +1477,11 @@ pub struct RunningDaemon {
     // step 1 alongside `writer`: both are bus subscribers with no further
     // reason to run once serving ends.
     dog_watch: JoinHandle<()>,
+    // Parks on a timer rather than on the bus, and is stopped the same way
+    // and at the same moment: nothing may ask for a dog's restart once
+    // serving has ended. See `spawn_silent_dog_watch`'s own doc for why the
+    // task is anchored to boot at all.
+    silent_dog_watch: JoinHandle<()>,
     paths: ShepPaths,
     socket: PathBuf,
     // Held from `boot` onward, not created fresh in `run`: `watch::Sender::send`
@@ -1553,6 +1570,7 @@ impl RunningDaemon {
             listener,
             writer,
             dog_watch,
+            silent_dog_watch,
             paths,
             socket,
             shutdown_rx,
@@ -1579,11 +1597,14 @@ impl RunningDaemon {
             .serve(shutdown_rx)
             .await;
 
-        // 1. Stop the snapshot writer FIRST — see this fn's doc. The dog
-        //    watch stops alongside it: both are bus subscribers with
-        //    nothing left to watch for once serving ends.
+        // 1. Stop the snapshot writer FIRST — see this fn's doc. Both dog
+        //    watches stop alongside it: one is a bus subscriber with nothing
+        //    left to watch for once serving ends, and the other is a timer
+        //    that must not ask for a dog's restart while the flock is being
+        //    torn down.
         writer.stop().await;
         dog_watch.abort();
+        silent_dog_watch.abort();
 
         // 2. Write the final roll while every sheep is still online — UNLESS
         //    this boot asked for nothing to survive here at all

--- a/crates/shep-daemon/src/dogs.rs
+++ b/crates/shep-daemon/src/dogs.rs
@@ -33,6 +33,7 @@
 //! that exposure to a second surface.
 
 use core::fmt;
+use core::time::Duration;
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex, PoisonError};
@@ -40,9 +41,11 @@ use std::sync::{Arc, Mutex, PoisonError};
 use shep_core::barks::{self, Bark};
 use shep_core::config::{AppConfig, DaemonConfig, ResolvedApp, normalize};
 use shep_core::paths::ShepPaths;
-use shep_core::protocol::{BusEvent, DogSource, ProcessEventKind};
+use shep_core::protocol::{BusEvent, DogSource, ProcessEventKind, ProcessInfo};
 use shep_core::selector::ProcessSelector;
+use shep_core::status::ProcStatus;
 use tokio::sync::broadcast::{self, error::RecvError};
+use tokio::time::Instant;
 
 use crate::bus::SharedEvent;
 use crate::supervisor::SupervisorHandle;
@@ -535,6 +538,232 @@ async fn restart_refused_dog(supervisor: &SupervisorHandle, name: &str) {
     }
 }
 
+/// How long a registered, running dog may stay silent before this shepherd
+/// concludes it is never going to talk to it (IR-26).
+///
+/// A dog's handshake is one connect and one round trip on a local socket,
+/// measured in milliseconds, so this is not a tuned number — it is three
+/// orders of magnitude of slack. What it is actually sized against is the
+/// slowest LEGITIMATE silence: a dog carried across a handover has to notice
+/// its connection died and dial back, and a third-party dog is free to sleep
+/// a second or so before it does. Five seconds outlasts that and still fits
+/// inside the time an operator spends watching a reload.
+///
+/// **Deliberately not `shep daemon reload`'s own settle wait**, which is
+/// three seconds and lives in `shep-cli`. That budget answers how long a
+/// human's command should hold its output open before reporting; this one
+/// answers how long the shepherd should go on believing a silence. They
+/// happen to be the same order of magnitude today, and tying them together
+/// would make either one's tuning a silent change to the other's meaning.
+pub const DOG_SILENCE_BUDGET: Duration = Duration::from_secs(5);
+
+/// Gap between two of [`spawn_silent_dog_watch`]'s looks.
+///
+/// Finer than [`DOG_SILENCE_BUDGET`] so that a dog's restart is asked for
+/// near the moment its budget runs out rather than up to a whole budget
+/// after it. One look is one message to the supervisor actor and no syscall
+/// per dog, so the cost of looking often is nearly nothing.
+const DOG_SILENCE_POLL: Duration = Duration::from_secs(1);
+
+/// Every dog the supervisor is running that has never once handshaken with
+/// this daemon, sorted — the set that both [`spawn_silent_dog_watch`] and
+/// `rpc::dog_staleness` are built on.
+///
+/// The two callers read it for different purposes and must not disagree
+/// about the population: one REPORTS these dogs as unsettled and the other
+/// eventually gives up on them, and a dog that could be in one set but not
+/// the other would be reported forever or condemned unreported.
+///
+/// Only a dog with a PROCESS counts, and a stale one is already answered
+/// for — [`crate::rpc`]'s own doc has the long form of both exclusions.
+pub(crate) fn silent_dogs(infos: &[ProcessInfo], refusals: &DogRefusals) -> Vec<String> {
+    let stale = refusals.stale();
+    let mut names: Vec<String> = infos
+        .iter()
+        .filter(|info| {
+            info.dog.is_some()
+                && matches!(info.status, ProcStatus::Starting | ProcStatus::Online)
+                && !refusals.has_handshook(&info.name)
+                && !stale.contains(&info.name)
+        })
+        .map(|info| info.name.clone())
+        .collect();
+    names.sort();
+    names.dedup();
+    names
+}
+
+/// When each currently-silent dog was first SEEN silent.
+///
+/// The elapsed-time half of [`spawn_silent_dog_watch`], and the reason that
+/// watch is a task on a clock rather than a branch inside
+/// `rpc::dog_staleness`. Staleness is a query, and `shep daemon reload`
+/// polls it in a loop: a ladder driven from there would walk a merely slow
+/// dog from restart to stale in the time it takes to ask three times. A dog
+/// here is measured against how long it has been quiet and never against
+/// how often anybody looked.
+///
+/// `Debug` is derived and needs no redaction (IR-41), for the same reason
+/// [`DogRefusals`]'s is: the map holds dog names and instants, and a dog's
+/// name is a `[dog.<name>]` KEY rather than one of its values.
+#[derive(Debug, Default)]
+struct SilentDogs {
+    /// One instant per dog currently silent. A name absent from the map is a
+    /// dog that was talking, stopped, or deleted at the last look.
+    first_seen: BTreeMap<String, Instant>,
+}
+
+impl SilentDogs {
+    /// The dogs that have now been silent for a whole [`DOG_SILENCE_BUDGET`],
+    /// given the set observed silent at `now`.
+    ///
+    /// `now` is a parameter rather than read in here so that a test can move
+    /// the clock instead of waiting on one, and so that every dog in one look
+    /// is judged against the same instant.
+    fn due(&mut self, silent: &[String], now: Instant) -> Vec<String> {
+        // A dog that answered, stopped, or was deleted is not silent any
+        // more, and starts a fresh budget if it ever falls quiet again.
+        self.first_seen.retain(|name, _| silent.contains(name));
+        let mut due = Vec::new();
+        for name in silent {
+            let since = self.first_seen.entry(name.clone()).or_insert(now);
+            if now.saturating_duration_since(*since) >= DOG_SILENCE_BUDGET {
+                // Rearmed rather than forgotten: the next rung of the ladder
+                // costs another whole budget, so a dog whose restart was just
+                // asked for gets exactly the chance to speak that it had the
+                // first time.
+                *since = now;
+                due.push(name.clone());
+            }
+        }
+        due
+    }
+}
+
+/// One look: which of this daemon's dogs have now been quiet too long, and
+/// what each of them earned.
+///
+/// Returns what it acted on, which is what its tests assert against; the
+/// loop that calls it discards the answer.
+async fn check_silent_dogs(
+    supervisor: &SupervisorHandle,
+    refusals: &DogRefusals,
+    seen: &mut SilentDogs,
+    now: Instant,
+) -> Vec<(String, Refusal)> {
+    // A stopped engine has no dogs left to wait on. `seen` is left untouched
+    // rather than cleared: a look that could not see the flock has learned
+    // nothing about it, and must not hand every dog a fresh budget.
+    let Ok(infos) = supervisor.list_checked().await else {
+        return Vec::new();
+    };
+    let silent = silent_dogs(&infos, refusals);
+    let mut acted = Vec::new();
+    for name in seen.due(&silent, now) {
+        let verdict = record_silent_dog(&name, refusals, supervisor).await;
+        acted.push((name, verdict));
+    }
+    acted
+}
+
+/// Enters a dog that has gone quiet into G8's ladder — the same ladder a
+/// named refusal enters, reached by inference rather than by the dog saying
+/// who it is.
+///
+/// **Why the inference is needed at all.** `record_refused_dog` is keyed on
+/// `Hello::dog_name`, and that field was added in phase 3. A client speaking
+/// an OLDER protocol cannot send one, so the connection it refuses is
+/// anonymous and the ladder is never entered. G8's one restart therefore
+/// reached only dogs new enough to name themselves, which is the exact
+/// complement of the dogs that need it. The set difference this rides on
+/// needs no cooperation from the client — and no peer credentials, which
+/// would have meant `SO_PEERCRED` on unix against
+/// `GetNamedPipeClientProcessId` on Windows, re-forking a transport phase 15
+/// deliberately unified into `shep_core::transport`.
+///
+/// **The tradeoff, named where the decision is.** A dog that is merely SLOW
+/// to connect is restarted once, for nothing. That is bounded by the ladder
+/// it enters — one restart, then a report, then silence — and it is cheap
+/// for a process that is by definition not yet doing its job. It also heals
+/// itself: the moment such a dog does handshake, [`DogRefusals::handshook`]
+/// clears everything held against it, including a stale mark it should never
+/// have earned. Against that, the cost of NOT inferring was measured in
+/// production: a dog `online` with zero restarts and a refusal repeating in
+/// its own log without end.
+async fn record_silent_dog(
+    name: &str,
+    refusals: &DogRefusals,
+    supervisor: &SupervisorHandle,
+) -> Refusal {
+    let verdict = refusals.refused(name);
+    match verdict {
+        Refusal::Restart => {
+            tracing::warn!(
+                dog = %name,
+                silent_for_secs = DOG_SILENCE_BUDGET.as_secs(),
+                "a dog has been running without ever answering this shepherd; restarting it once from the binary on disk"
+            );
+            // Awaited rather than spawned, which is the one difference from
+            // `record_refused_dog`: that caller is a connection handler
+            // holding a socket, and this one is a background loop with
+            // nothing to delay. Awaiting it keeps the next look from running
+            // while a kill ladder is still in flight, so a dog is never
+            // judged mid-restart.
+            restart_refused_dog(supervisor, name).await;
+        }
+        Refusal::Stale => tracing::error!(
+            dog = %name,
+            "a dog restarted for never answering this shepherd has still not answered it: the binary on disk cannot talk to this shep either, so this dog is stale and will not be restarted again. Read its own log with `shep bleats`, then rebuild or reinstall it and restart it"
+        ),
+        // Unreachable through this path, because `silent_dogs` filters a
+        // stale dog out before it can be seen quiet again. Kept as a real
+        // arm anyway: it is the honest thing to do with a rung the ladder
+        // defines, and a future caller that stops filtering would otherwise
+        // find a `todo!` here.
+        Refusal::AlreadyStale => tracing::debug!(
+            dog = %name,
+            "a silent dog that was already reported stale"
+        ),
+    }
+    verdict
+}
+
+/// Watches for dogs that are running and have never once spoken to this
+/// shepherd, and enters each into G8's ladder after
+/// [`DOG_SILENCE_BUDGET`] of silence: restarted once from the binary on
+/// disk, then reported stale, then left alone.
+///
+/// **Anchored to the daemon's BOOT, and that is load-bearing.** A handover
+/// is an `execve`: same pid, same children, new image. Every task spawned
+/// before it belonged to the predecessor's runtime and simply stops existing
+/// at the exec, while the successor installs the state that task was meant
+/// to resolve. An earlier phase found and closed six instances of exactly
+/// that bug. `boot` runs again in the successor, so the successor spawns its
+/// own watch here — whereas a per-dog one-shot timer armed at spawn time
+/// would die at the exec, which is the precise moment a carried dog's
+/// silence matters most.
+///
+/// Its `JoinHandle` is held by the caller and aborted at teardown, for the
+/// same reason [`spawn_dog_watch`]'s is: the loop has no end of its own, and
+/// nothing may restart a dog while the daemon is shutting down.
+pub fn spawn_silent_dog_watch(
+    supervisor: SupervisorHandle,
+    refusals: DogRefusals,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        let mut ticks = tokio::time::interval(DOG_SILENCE_POLL);
+        // A look missed under load is not a look owed: the budget is measured
+        // off the clock and not off a tick count, so catching up would buy
+        // nothing and cost a burst of supervisor traffic.
+        ticks.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+        let mut seen = SilentDogs::default();
+        loop {
+            let now = ticks.tick().await;
+            check_silent_dogs(&supervisor, &refusals, &mut seen, now).await;
+        }
+    })
+}
+
 /// Watches the bus and records, locally, every enabled dog that exhausts
 /// its restart budget.
 ///
@@ -629,6 +858,7 @@ fn record_dog_errored(barks_path: &Path, name: &str, restarts: u32) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::fake::ProcScript;
     use crate::testing::test_paths;
     use shep_core::protocol::ProcessInfo;
     use shep_core::status::ProcStatus;
@@ -1006,6 +1236,203 @@ mod tests {
         assert!(
             !refusals.has_handshook("metrics"),
             "the handshake that earned the mark is the one that just died"
+        );
+    }
+
+    /// Registers one built-in dog on `ctx`'s supervisor, exactly as
+    /// `spawn_enabled_dogs` does at boot, and hands back the harness's own
+    /// refusal record.
+    async fn start_test_dog(ctx: &crate::rpc::RpcContext, name: &str) {
+        let spec = DogSpec {
+            name: name.to_string(),
+            source: DogSource::BuiltIn,
+        };
+        let app = dog_app(&spec, &ctx.paths).expect("the dog fixture must assemble");
+        ctx.supervisor
+            .start_dog(app, DogSource::BuiltIn)
+            .await
+            .expect("the dog fixture must start");
+    }
+
+    /// fails if a dog that never speaks to this shepherd is left alone.
+    ///
+    /// This is the production case, and the whole of why the inference
+    /// exists: a dog on an older protocol cannot send `Hello::dog_name`, so
+    /// the refusal it earns is anonymous and `record_refused_dog` never runs
+    /// for it. The ladder is the same one a named refusal walks -- one
+    /// restart from the binary on disk, then a report, then silence -- and
+    /// the assertion is that being unable to name itself does not exempt a
+    /// dog from it.
+    #[tokio::test(start_paused = true)]
+    async fn a_dog_that_never_answers_is_restarted_once_and_then_marked_stale() {
+        let h = crate::testing::harness(vec![
+            ProcScript::never_exits(),
+            ProcScript::never_exits(),
+            ProcScript::never_exits(),
+            ProcScript::never_exits(),
+        ]);
+        start_test_dog(&h.ctx, "metrics").await;
+        let refusals = &h.ctx.dog_refusals;
+        let mut seen = SilentDogs::default();
+        let t0 = Instant::now();
+
+        assert!(
+            check_silent_dogs(&h.ctx.supervisor, refusals, &mut seen, t0)
+                .await
+                .is_empty(),
+            "a dog seen quiet for the first time has not yet been quiet for any length of time"
+        );
+
+        assert_eq!(
+            check_silent_dogs(
+                &h.ctx.supervisor,
+                refusals,
+                &mut seen,
+                t0 + DOG_SILENCE_BUDGET
+            )
+            .await,
+            vec![("metrics".to_string(), Refusal::Restart)],
+            "a whole budget of silence buys the one restart from disk"
+        );
+        assert_eq!(refusals.restarting(), vec!["metrics".to_string()]);
+        assert!(
+            refusals.stale().is_empty(),
+            "one silence is a dog to restart, not a dog to give up on"
+        );
+
+        assert_eq!(
+            check_silent_dogs(
+                &h.ctx.supervisor,
+                refusals,
+                &mut seen,
+                t0 + 2 * DOG_SILENCE_BUDGET
+            )
+            .await,
+            vec![("metrics".to_string(), Refusal::Stale)],
+            "the restart ran and the dog still has not spoken: the binary on disk cannot talk to this shep either"
+        );
+        assert_eq!(refusals.stale(), vec!["metrics".to_string()]);
+
+        assert!(
+            check_silent_dogs(
+                &h.ctx.supervisor,
+                refusals,
+                &mut seen,
+                t0 + 3 * DOG_SILENCE_BUDGET
+            )
+            .await
+            .is_empty(),
+            "a dog already given up on is not laddered again, however long it stays quiet"
+        );
+    }
+
+    /// fails if a dog that answered is restarted anyway.
+    ///
+    /// The case that matters most, and the one that passes for the wrong
+    /// reason if the inference never fires at all -- so it is written
+    /// against a clock ten budgets past the point where a silent dog would
+    /// have been condemned twice over.
+    #[tokio::test(start_paused = true)]
+    async fn a_dog_that_answers_inside_the_budget_is_never_touched() {
+        let h = crate::testing::harness(vec![ProcScript::never_exits()]);
+        start_test_dog(&h.ctx, "metrics").await;
+        let refusals = &h.ctx.dog_refusals;
+        refusals.handshook("metrics");
+        let mut seen = SilentDogs::default();
+        let t0 = Instant::now();
+
+        for elapsed in [0, 1, 2, 10] {
+            assert!(
+                check_silent_dogs(
+                    &h.ctx.supervisor,
+                    refusals,
+                    &mut seen,
+                    t0 + elapsed * DOG_SILENCE_BUDGET
+                )
+                .await
+                .is_empty(),
+                "a dog this shepherd has heard from is not silent at any point on the clock"
+            );
+        }
+        assert!(refusals.restarting().is_empty());
+        assert!(refusals.stale().is_empty());
+    }
+
+    /// fails if a dog already reported stale is put back on the ladder.
+    ///
+    /// A stale dog goes on being quiet forever, so nothing about its silence
+    /// is news. Re-laddering it would spend a restart the record already
+    /// says was spent, and would write the same report once per budget for
+    /// as long as the daemon runs.
+    #[tokio::test(start_paused = true)]
+    async fn a_dog_already_stale_is_not_laddered_again() {
+        let h = crate::testing::harness(vec![ProcScript::never_exits()]);
+        start_test_dog(&h.ctx, "metrics").await;
+        let refusals = &h.ctx.dog_refusals;
+        refusals.refused("metrics");
+        refusals.refused("metrics");
+        assert_eq!(refusals.stale(), vec!["metrics".to_string()]);
+
+        let mut seen = SilentDogs::default();
+        let t0 = Instant::now();
+        for elapsed in [0, 1, 2, 5] {
+            assert!(
+                check_silent_dogs(
+                    &h.ctx.supervisor,
+                    refusals,
+                    &mut seen,
+                    t0 + elapsed * DOG_SILENCE_BUDGET
+                )
+                .await
+                .is_empty(),
+                "the ladder ends at stale; there is no rung after it to reach"
+            );
+        }
+    }
+
+    /// fails if the ladder is driven by how often somebody looks rather than
+    /// by how long a dog has been quiet.
+    ///
+    /// The regression test for the shape this fix deliberately avoids.
+    /// `Request::DogStaleness` derives the same set, and `shep daemon
+    /// reload` polls it every 50ms while it waits -- so a ladder driven from
+    /// there would restart a merely slow dog and report it stale inside a
+    /// second, before it had any chance to speak. Twenty looks inside one
+    /// budget must cost a dog nothing, and the twenty-first, one tick past
+    /// the budget, must cost it exactly one restart.
+    #[tokio::test(start_paused = true)]
+    async fn asking_repeatedly_does_not_advance_the_ladder() {
+        let h = crate::testing::harness(vec![ProcScript::never_exits(), ProcScript::never_exits()]);
+        start_test_dog(&h.ctx, "metrics").await;
+        let refusals = &h.ctx.dog_refusals;
+        let mut seen = SilentDogs::default();
+        let t0 = Instant::now();
+
+        for look in 0..20 {
+            assert!(
+                check_silent_dogs(
+                    &h.ctx.supervisor,
+                    refusals,
+                    &mut seen,
+                    t0 + (DOG_SILENCE_BUDGET / 20) * look
+                )
+                .await
+                .is_empty(),
+                "look {look} fell inside the budget and must not have moved the dog along"
+            );
+        }
+        assert!(refusals.restarting().is_empty());
+
+        assert_eq!(
+            check_silent_dogs(
+                &h.ctx.supervisor,
+                refusals,
+                &mut seen,
+                t0 + DOG_SILENCE_BUDGET
+            )
+            .await,
+            vec![("metrics".to_string(), Refusal::Restart)],
+            "the clock is what moves the dog along, and it has now moved"
         );
     }
 }

--- a/crates/shep-daemon/src/dogs.rs
+++ b/crates/shep-daemon/src/dogs.rs
@@ -1242,16 +1242,35 @@ mod tests {
     /// Registers one built-in dog on `ctx`'s supervisor, exactly as
     /// `spawn_enabled_dogs` does at boot, and hands back the harness's own
     /// refusal record.
+    /// How long [`start_test_dog`] waits on the supervisor before calling it
+    /// a hang rather than a slow start.
+    ///
+    /// Generous on purpose: this bounds a fixture, so it is a deadlock
+    /// guard and not a timing assertion. A value tight enough to measure
+    /// anything would be a test about how fast the supervisor accepts a
+    /// request, which is not what any caller here is asking.
+    const DOG_FIXTURE_START_BUDGET: Duration = Duration::from_secs(10);
+
     async fn start_test_dog(ctx: &crate::rpc::RpcContext, name: &str) {
         let spec = DogSpec {
             name: name.to_string(),
             source: DogSource::BuiltIn,
         };
         let app = dog_app(&spec, &ctx.paths).expect("the dog fixture must assemble");
-        ctx.supervisor
-            .start_dog(app, DogSource::BuiltIn)
-            .await
-            .expect("the dog fixture must start");
+        // Bounded, because the callers below run under a paused clock and
+        // this await is the one thing in them that is not already forced
+        // (IR-46). A supervisor that stopped consuming its request would
+        // otherwise hang the suite here, before any of the forcing
+        // machinery those tests set up has run. Under `start_paused` tokio
+        // auto-advances to the next deadline once every task is idle, so
+        // this timeout still fires rather than waiting on a wall clock.
+        tokio::time::timeout(
+            DOG_FIXTURE_START_BUDGET,
+            ctx.supervisor.start_dog(app, DogSource::BuiltIn),
+        )
+        .await
+        .expect("the dog fixture must start inside its budget")
+        .expect("the dog fixture must start");
     }
 
     /// fails if a dog that never speaks to this shepherd is left alone.

--- a/crates/shep-daemon/src/dogs.rs
+++ b/crates/shep-daemon/src/dogs.rs
@@ -1435,4 +1435,69 @@ mod tests {
             "the clock is what moves the dog along, and it has now moved"
         );
     }
+
+    /// fails if `spawn_silent_dog_watch`'s own loop stops calling
+    /// `check_silent_dogs` at all -- the gap none of the tests above can
+    /// see, since every one of them calls `check_silent_dogs` directly and
+    /// would keep passing even if the watcher's `ticks.tick().await` path
+    /// were deleted entirely.
+    ///
+    /// IR-46: paused virtual time, advanced past one whole
+    /// [`DOG_SILENCE_BUDGET`], is the forcing mechanism -- not a real sleep,
+    /// so this stays in the fast tier rather than `mod slow`. The loop of
+    /// `yield_now` calls below is what lets the watcher's own spawned task,
+    /// and the engine task it talks to over a channel, actually run:
+    /// `tokio::time::advance` wakes a sleeper whose deadline has elapsed,
+    /// it does not itself drive the scheduler through everything that
+    /// sleeper then does.
+    #[tokio::test(start_paused = true)]
+    async fn the_watcher_restarts_a_silent_dog_after_one_budget_of_paused_time() {
+        let h = crate::testing::harness(vec![ProcScript::never_exits(), ProcScript::never_exits()]);
+        start_test_dog(&h.ctx, "metrics").await;
+        let refusals = h.ctx.dog_refusals.clone();
+
+        let watch = spawn_silent_dog_watch(h.ctx.supervisor.clone(), refusals.clone());
+
+        // The watcher's own interval fires an immediate first tick, which
+        // records the dog as seen-silent-since-now the same way every
+        // direct-call test above seeds `seen`. That first tick has to
+        // actually run, against the PRE-advance clock, before time moves --
+        // otherwise the "first look" lands after the jump and the dog
+        // never accrues a whole budget of silence.
+        tokio::task::yield_now().await;
+
+        // `Interval::tick()` reports the DEADLINE it was scheduled for, not
+        // the clock's current instant -- so one large `advance` collapses
+        // every missed tick into a single wake whose reported time has only
+        // moved forward by one `DOG_SILENCE_POLL`, not by however far the
+        // clock actually jumped. Advancing one poll period at a time, and
+        // letting the watcher's own task run after each step, is what
+        // actually walks its reported `now` past a whole budget the way a
+        // real, un-paused clock would.
+        let ticks_in_a_budget = (DOG_SILENCE_BUDGET.as_nanos() / DOG_SILENCE_POLL.as_nanos())
+            .try_into()
+            .expect("a silence budget of a few seconds fits in a u32 tick count");
+        for _ in 0..ticks_in_a_budget {
+            tokio::time::advance(DOG_SILENCE_POLL).await;
+            tokio::task::yield_now().await;
+        }
+        for _ in 0..64 {
+            if !refusals.restarting().is_empty() {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+
+        assert_eq!(
+            refusals.restarting(),
+            vec!["metrics".to_string()],
+            "one budget of silence, driven through the watcher's own tick, must earn exactly one restart"
+        );
+        assert!(
+            refusals.stale().is_empty(),
+            "one silence is a dog to restart, not a dog to give up on"
+        );
+
+        watch.abort();
+    }
 }

--- a/crates/shep-daemon/src/rpc.rs
+++ b/crates/shep-daemon/src/rpc.rs
@@ -31,7 +31,6 @@ use shep_core::protocol::{
 };
 use shep_core::selector::ProcessSelector;
 use shep_core::signals::OperatorSignal;
-use shep_core::status::ProcStatus;
 
 use crate::bus::{Bus, TopicFilter};
 use crate::dogs::DogSpec;
@@ -586,22 +585,21 @@ async fn run(id: u64, conn: ConnId, request: Request, ctx: &RpcContext) -> Outco
 /// restart this daemon ASKED for is in `restarting` above whatever the
 /// supervisor's row says about it, and a carried dog that has not dialled
 /// back yet is `Online` — its process never died, only its socket did.
+///
+/// **A pure read, and it must stay one.** The set below is also what
+/// [`crate::dogs::spawn_silent_dog_watch`] eventually acts on, and it would
+/// be tempting to drive that ladder from here instead of from a clock. It
+/// would also be wrong: `shep daemon reload` POLLS this question every 50ms
+/// while it waits, so three asks would walk a merely slow dog from restart
+/// to stale inside a second. Giving up on a dog is a claim about elapsed
+/// time, never about how often somebody asked.
 async fn dog_staleness(ctx: &RpcContext) -> (Vec<String>, Vec<String>) {
     let stale = ctx.dog_refusals.stale();
     let mut pending = ctx.dog_refusals.restarting();
     // A stopped engine has no dogs left to wait on, so its rows are not
     // worth an error: the refusal record above is still the honest answer.
     if let Ok(infos) = ctx.supervisor.list_checked().await {
-        for info in infos {
-            let running = matches!(info.status, ProcStatus::Starting | ProcStatus::Online);
-            if info.dog.is_some()
-                && running
-                && !ctx.dog_refusals.has_handshook(&info.name)
-                && !stale.contains(&info.name)
-            {
-                pending.push(info.name);
-            }
-        }
+        pending.extend(crate::dogs::silent_dogs(&infos, &ctx.dog_refusals));
     }
     pending.sort();
     pending.dedup();

--- a/crates/shep-daemon/src/rpc.rs
+++ b/crates/shep-daemon/src/rpc.rs
@@ -228,9 +228,10 @@ async fn run(id: u64, conn: ConnId, request: Request, ctx: &RpcContext) -> Outco
         // [`with_live_stats`] for what that costs and why every lifecycle
         // verb below goes without.
         Request::ListFlock => match ctx.supervisor.list_checked().await {
-            Ok(infos) => reply(Ok(Response::Flock(
+            Ok(infos) => reply(Ok(Response::Flock(with_dog_contact(
+                &ctx.dog_refusals,
                 with_live_stats(&ctx.stats, infos).await,
-            ))),
+            )))),
             Err(err) => reply(Err(rpc_error(&err))),
         },
         // The other one. Sampled after the selector has narrowed the
@@ -259,7 +260,11 @@ async fn run(id: u64, conn: ConnId, request: Request, ctx: &RpcContext) -> Outco
                         reply(Err(not_found()))
                     } else {
                         let hits = with_live_stats(&ctx.stats, hits).await;
-                        reply(Ok(Response::Described(with_lambs(&ctx.stats, hits).await)))
+                        let hits = with_lambs(&ctx.stats, hits).await;
+                        reply(Ok(Response::Described(with_dog_contact(
+                            &ctx.dog_refusals,
+                            hits,
+                        ))))
                     }
                 }
             },
@@ -675,6 +680,39 @@ async fn with_live_stats(stats: &Arc<StatsState>, mut infos: Vec<ProcessInfo>) -
         if let Some(reading) = info.pid.and_then(|pid| sample.get(&pid)) {
             info.cpu_percent = reading.cpu_percent;
             info.memory_bytes = Some(reading.memory_bytes);
+        }
+    }
+    infos
+}
+
+/// Fills in each dog's handshake fact, which no sheep has and the supervisor
+/// does not hold.
+///
+/// The supervisor knows what a PROCESS is doing; whether a dog has ever
+/// spoken to this shepherd is connection state, and it lives in
+/// [`DogRefusals`](crate::dogs::DogRefusals) on the RPC context. So this is
+/// joined here for the same structural reason `with_live_stats` is, minus
+/// its cost: one map lookup per row under one lock, and no syscall at all.
+///
+/// **Applied to `ListFlock` and `Describe` and to nothing else**, which is
+/// the same pair `with_live_stats` covers and not a coincidence. Those are
+/// the two verbs an operator reads a listing FROM. Every other reply
+/// carrying a `ProcessInfo` is a lifecycle answer -- `start`, `restart`,
+/// `reload` -- and a dog has not had a chance to dial back by the time one
+/// of those returns, so reporting the silence there would say a dog was
+/// silent for having only just been asked to start.
+///
+/// A sheep is skipped rather than set to `Some(false)`: it has no handshake
+/// and no version relationship with this shepherd at all, so `None` is the
+/// honest answer and it is what keeps every sheep row rendering exactly as
+/// it did before this field existed.
+fn with_dog_contact(
+    refusals: &crate::dogs::DogRefusals,
+    mut infos: Vec<ProcessInfo>,
+) -> Vec<ProcessInfo> {
+    for info in &mut infos {
+        if info.dog.is_some() {
+            info.handshook = Some(refusals.has_handshook(&info.name));
         }
     }
     infos
@@ -2372,6 +2410,87 @@ mod tests {
         started.result.expect("the sheep must start");
 
         assert_eq!(staleness(&h.ctx).await, (Vec::new(), Vec::new()));
+    }
+
+    /// fails if a listing reports a dog as healthy that this shepherd has
+    /// never once heard from.
+    ///
+    /// The production defect this field exists for: `shep flock` printed
+    /// `(o.o) online`, restarts 0, for a dog whose own log was filling with
+    /// protocol refusals. `status` was not wrong — the process really was
+    /// up — but it is the answer to a question the operator was not asking.
+    /// Both halves are asserted, because reporting the silence and losing
+    /// the liveness would be the same defect pointed the other way.
+    #[tokio::test]
+    async fn a_listing_says_which_dogs_have_answered_this_shepherd() {
+        let h = harness(vec![ProcScript::never_exits(), ProcScript::never_exits()]);
+        start_dog(&h.ctx, "metrics").await;
+
+        let silent = list_flock(&h.ctx, 1).await;
+        let dog = silent
+            .iter()
+            .find(|info| info.name == "metrics")
+            .expect("the dog must be listed");
+        assert_eq!(dog.handshook, Some(false));
+        assert_eq!(
+            dog.status,
+            ProcStatus::Online,
+            "the process is up, and the listing still says so"
+        );
+
+        h.ctx.dog_refusals.handshook("metrics");
+        let talking = list_flock(&h.ctx, 2).await;
+        assert_eq!(
+            talking
+                .iter()
+                .find(|info| info.name == "metrics")
+                .expect("still listed")
+                .handshook,
+            Some(true)
+        );
+    }
+
+    /// fails if the join reaches a sheep.
+    ///
+    /// A sheep is an arbitrary executable and does not speak this protocol
+    /// at all (spec, part 4), so it has no handshake to report and `None`
+    /// is the only honest answer. `Some(false)` here would paint every
+    /// sheep in the flock as broken, which is a worse bug than the one this
+    /// field fixes.
+    #[tokio::test]
+    async fn a_sheep_carries_no_handshake_fact_at_all() {
+        let h = harness(vec![ProcScript::never_exits()]);
+        start_web(&h).await;
+
+        let infos = list_flock(&h.ctx, 1).await;
+        assert_eq!(infos[0].name, "web");
+        assert_eq!(infos[0].handshook, None);
+    }
+
+    /// fails if `describe` answers a different question from `flock` about
+    /// the same dog. It is the other verb an operator reads a listing from,
+    /// and the one `shep describe <dog>` reaches by name.
+    #[tokio::test]
+    async fn describe_carries_the_handshake_fact_too() {
+        let h = harness(vec![ProcScript::never_exits()]);
+        start_dog(&h.ctx, "metrics").await;
+
+        let described = reply_of(
+            dispatch(
+                envelope(
+                    1,
+                    Request::Describe {
+                        selector: SelectorSpec::Name("metrics".to_string()),
+                    },
+                ),
+                &h.ctx,
+            )
+            .await,
+        );
+        let Ok(Response::Described(rows)) = described.result else {
+            panic!("expected a describe listing");
+        };
+        assert_eq!(rows[0].handshook, Some(false));
     }
 
     /// fails if a registered dog that has never handshaken reads as an

--- a/docs/writing-plans/plans/2026-08-31-handover-phase3b.md
+++ b/docs/writing-plans/plans/2026-08-31-handover-phase3b.md
@@ -147,6 +147,61 @@ The rendering is the design work. A dog that has never handshook is not `online`
 - [ ] **Step 5: Drive it.** `shep flock` against a real skewed dog, in all three styles, and `--format json`.
 - [ ] **Step 6: `web/` and commit.** A STATUS value is documented surface.
 
+### Task 5: `shep lookout` stops disagreeing with `shep flock`
+
+**Files:** `crates/shep-cli/src/lookout/app.rs`, `crates/shep-cli/src/lookout/view/flock.rs`, `crates/shep-cli/src/lookout/view/detail.rs`, `crates/shep-cli/src/lookout/theme.rs`.
+
+Task 4 routed `shep flock` through `vocabulary::Reported`, so a dog that has
+never handshook prints `silent` there. It never touched the dashboard.
+`shep lookout`'s flock pane and detail pane still read `ProcessInfo::status`
+directly and still say `online`. That is worse than before task 4: an
+operator now has two shep surfaces open on the same dog, and they disagree.
+Nothing tells the operator which one to believe.
+
+`vocabulary.rs`'s own module doc already says the rule: a face or a status
+mapping decided anywhere but there is a review defect. Lookout deciding its
+own answer for the STATUS cell — which it does today, by reading
+`row.info.status` straight into `.to_string()` and into
+`Palette::status` — is exactly the defect the module doc warns about, just
+not caught at the time because task 4 had no reason to look past `output/`.
+
+`output::rows::reported` is the pattern to follow: it guards `Reported::of`
+behind `p.dog.is_none()` so a sheep, which has no handshake at all, can never
+be painted silent by a future daemon-side bug that leaves a field unset. Give
+`Row` in `lookout/app.rs` the same guarded lookup, and route both panes'
+STATUS cells through it and through `Reported`'s `word()`, `face()` is not
+used here — `theme.rs`'s own doc says lookout colours the word rather than
+growing a face — and `role()` via a new `Palette` method that takes a
+`Reported` instead of a bare `ProcStatus`.
+
+**The group/rollup row needs a decision, not a silent pass-through.**
+`output::rows::group_paint` already argued this for the table: a dog is
+never stocked to several instances, so no group row that function can see
+has a handshake to report, and it deliberately skips `Reported::of`.
+`lookout::app::App::is_grouped` has the identical shape (`instance.is_some()`
+on every member), so the identical argument applies — the group and detail
+rollups can keep reading `ProcStatus` unchanged. Write that argument down at
+each call site rather than leaving a reader to re-derive it, and confirm it
+with a test: a dog can never appear in a group row.
+
+- [ ] **Step 1: Write the failing tests.** A silent dog's row in the flock
+      pane reads `silent`, not `online`; a healthy dog is unchanged; a sheep
+      is unchanged; the detail pane's status word and colour agree with the
+      flock pane for the same dog.
+- [ ] **Step 2: Run them, watch them fail.**
+- [ ] **Step 3: Implement.**
+- [ ] **Step 4: Prove each non-vacuous**, the two unchanged cases most of
+      all — they pass for the wrong reason if the new lookup path is never
+      reached.
+- [ ] **Step 5: Drive it.** A real protocol-1 dog against a current
+      shepherd, `shep lookout` open beside `shep flock`, and confirm both say
+      the same word.
+- [ ] **Step 6: `web/` and commit.** Grep the docs site for a lookout STATUS
+      description before assuming nothing needs it. Regenerate the rendered
+      frames in `crates/shep-cli/src/lookout/snapshots/` and
+      `docs/lookout/frames.txt` if the STATUS cell's own rendering changed
+      for any fixture they cover, and read the diff line by line.
+
 ---
 
 ## Out of scope
@@ -167,7 +222,9 @@ Reproduce a protocol-1 dog with `cargo update -p shep-core --precise <old>`, nev
 
 ## Gate
 
-Per `CLAUDE.md`. One cargo shape per task: `-p shep` for tasks 1 and 3, `-p shep-daemon` for task 2, `--workspace` for task 4 since it crosses three crates.
+Per `CLAUDE.md`. One cargo shape per task: `-p shep` for tasks 1, 3 and 5,
+`-p shep-daemon` for task 2, `--workspace` for task 4 since it crosses three
+crates.
 
 Inner loop is `cargo test -p shep-daemon --lib --all-features -- --skip ::slow::`. Task 4's wire change wants the full workspace run before commit.
 

--- a/docs/writing-plans/plans/2026-08-31-handover-phase3b.md
+++ b/docs/writing-plans/plans/2026-08-31-handover-phase3b.md
@@ -58,9 +58,13 @@ Two claims were made against this incident and then measured false. Recorded so 
 
 Task 1 is unrelated to the other three and can ship alone.
 
-**Task 2 must precede task 3, and the reason is not obvious.** Today `log-rotate` lands in `pending`, so it reaches `unsettled_dog_report`. Once task 2 drives the ladder by inference, the same dog is restarted once, fails again, and is marked stale — so it reaches `stale_dog_report`, which already carries advice. Task 2 therefore *changes which sentence the motivating case hits*, and rewording `unsettled_dog_report` first would tune it for a population task 2 removes.
+**Task 2 must precede task 3.** The reason written here first was wrong, and task 2's drill measured it: this said the ladder would move the motivating case out of `unsettled_dog_report` and into `stale_dog_report`, which already carries advice. It does not. Task 2's `DOG_SILENCE_BUDGET` is 5s, so the first rung lands at +5s and the second at +10s, while the reload's own `DOG_SETTLE_WAIT` is 3s. At the moment the reload reports, neither rung has fired, and a live reload printed the unsettled sentence exactly as before.
 
-Two earlier phases in this series split tasks on a seam no drill could stand on. This is the same shape, caught before dispatch rather than after.
+Tuning cannot reconcile them either. Landing the second rung inside a 3s wait needs a sub-1.5s budget, which would restart a dog for being briefly slow.
+
+**So the dependency holds and the consequence inverts.** Task 3 must be written for a population that still contains the skewed dog at reload time — not for the transient remnant this plan originally predicted. What task 2 actually gives task 3 is the timing to be honest about: at reload time the shepherd does not yet know the verdict, but it does know a restart is coming and when. A report saying that is worth more than one saying nothing.
+
+Two earlier phases in this series split tasks on a seam no drill could stand on. This one had a sound seam and a wrong rationale, which a drill caught and reading never would have.
 
 ---
 

--- a/docs/writing-plans/plans/2026-08-31-handover-phase3b.md
+++ b/docs/writing-plans/plans/2026-08-31-handover-phase3b.md
@@ -1,0 +1,172 @@
+# Daemon handover, phase 3b: say what the shepherd already knows
+
+> **For agentic workers:** REQUIRED SUB-SKILL: use `superpowers:subagent-driven-development` to implement this task-by-task. Steps use `- [ ]` for tracking.
+
+**Goal:** Stop reporting a dog as healthy when the shepherd has never once heard from it.
+
+**Spec:** `docs/brainstorming/specs/2026-08-29-daemon-handover-design.md`, sections **G8**, **G12** and **G13**.
+
+**Base:** `origin/main` at v0.1.23.
+
+## Global constraints
+
+- MSRV 1.88, edition 2024.
+- `PROTOCOL_VERSION` is 2. Task 4 adds a field to `ProcessInfo`; follow the `dog: Option<DogSource>` precedent in the same struct, which is additive, absent-means-false, and moved neither constant.
+- `SCHEMA_VERSION` stays 1. Its rule is that only a rename, a removal or a retype moves it.
+- The CLI's package is named `shep`. `-p shep-cli` runs nothing and exits 0.
+- IR-11 (`# Errors`), IR-26 (named timing constants), IR-41 (deliberate `Debug`).
+
+---
+
+## Why this exists
+
+Found in production on 2026-08-31, not by a test. A shepherd upgraded to 0.1.23 while `log-rotate`, an adopted dog, still spoke protocol 1. The operator saw:
+
+- `shep daemon reload` — *"the `log-rotate` dog had not answered this shepherd after 3s, so this reload cannot say whether it came back"*, and no suggestion of what to do next
+- `shep flock` — `log-rotate`, `(o.o) online`, restarts 0, uptime 16s
+- `shep bleats log-rotate` — the same refusal repeating without end
+
+Three surfaces, and the only one telling the truth was the one nobody is directed to.
+
+**Every fact needed to say this correctly was already computed.** `dog_staleness` (`rpc.rs:589`) derives exactly the right set — a registered dog whose process is running and which has never handshook — and puts `log-rotate` in `pending`. The shepherd knew. Three call sites declined to say so.
+
+## The trace
+
+```
+dog connects           Hello { protocol: 1, dog_name: ABSENT }
+server.rs:475          protocol != PROTOCOL_VERSION, refuse
+server.rs:500          match &hello.dog_name -> None
+server.rs:520          debug!("refused a client on protocol skew")
+                       ...which the daemon's default `warn` level discards
+```
+
+`dog_name` was added to `Hello` in phase 3. A protocol-1 client predates it and cannot send one, so `record_refused_dog` never runs and the ladder in `DogRefusals::refused` is never entered.
+
+**G8's one-restart rule is keyed on a name, so it can only fire for dogs new enough to name themselves.** The dogs most likely to need it are the ones structurally unable to reach it. That is the defect, and everything else in this phase is a consequence of it.
+
+## What is NOT wrong
+
+Two claims were made against this incident and then measured false. Recorded so nobody re-derives them.
+
+**`cargo install` did not need `--force`.** Cargo skips only when the installed version equals the registry version; `log-rotate` went 0.1.2 to 0.1.3 and the install ran. The reinstall changed nothing because the *process* was never restarted — G10, a rename leaves the running inode mapped — and `shep restart log-rotate` was the missing step.
+
+**G9 is not falsified.** The spec already prescribes the whole fix at its line 504: *"`cargo install shep-log-rotate` then `shep restart log-rotate`. Verified."* The documentation was right. Nothing shep printed at any point said the second half.
+
+---
+
+## Order, and the dependency between tasks 2 and 3
+
+Task 1 is unrelated to the other three and can ship alone.
+
+**Task 2 must precede task 3, and the reason is not obvious.** Today `log-rotate` lands in `pending`, so it reaches `unsettled_dog_report`. Once task 2 drives the ladder by inference, the same dog is restarted once, fails again, and is marked stale — so it reaches `stale_dog_report`, which already carries advice. Task 2 therefore *changes which sentence the motivating case hits*, and rewording `unsettled_dog_report` first would tune it for a population task 2 removes.
+
+Two earlier phases in this series split tasks on a seam no drill could stand on. This is the same shape, caught before dispatch rather than after.
+
+---
+
+### Task 1: the table-form skew message says what to do
+
+**Files:** `crates/shep-cli/src/lib.rs`.
+
+The two output formats diverged on framing. JSON emits `... Run \`shep daemon reload\`.`; the table form emits the same remedy as a bare indented line with no imperative anywhere near it:
+
+```
+error[version-skew]: this shep is 0.1.23, the running shepherd is 0.1.22
+
+`cargo install shep` replaced the binary. It did not restart the
+shepherd, which is still running the old code.
+
+  shep daemon reload
+```
+
+An operator read that and was not certain the last line was a command to run. The indentation is deliberate and stays — the code comment at `lib.rs:1724` is explicit that the remedy "has to sit on a line of its own to be seen and copied". What is missing is the sentence pointing at it.
+
+`VERSION_SKEW_CAUSE`'s doc claims the two renderings "cannot drift into saying different things". The text did not drift; the framing around it did. Consider whether the fix belongs in a shared constant so that stays true.
+
+- [ ] **Step 1: Write the failing test.** The table form names the remedy as an instruction, not only as a line. Pin the exact string — an existing test at `lib.rs:2984` already pins this block's wording and moves with it.
+- [ ] **Step 2: Run it, watch it fail.**
+- [ ] **Step 3: Implement.**
+- [ ] **Step 4: Prove it non-vacuous.**
+- [ ] **Step 5: Drive it.** Force a real skew and read the output as an operator, not as a diff.
+- [ ] **Step 6: `web/` and commit.** Grep the prose pages for this block before assuming they are fine.
+
+### Task 2: G8's ladder reaches a dog that cannot name itself
+
+**Files:** `crates/shep-daemon/src/dogs.rs`, `crates/shep-daemon/src/rpc.rs`.
+
+`dog_staleness` already computes the set. Drive `DogRefusals::refused(name)` from it, so a registered dog that is running and has never handshook enters the same ladder a named refusal does: restarted once from disk, then marked stale, never spun.
+
+**Prefer this to peer credentials.** Attributing the refused connection by peer pid is more precise, but `SO_PEERCRED` has no named-pipe equivalent and Windows would need `GetNamedPipeClientProcessId`, forking a code path that phase 15 deliberately unified into `shep_core::transport`. The set difference needs no client cooperation and no platform arm.
+
+**Name the tradeoff at the call site.** A dog that is merely slow to connect gets restarted once. That is bounded by the existing ladder and cheap for a dog that is not yet doing anything, but it is a real behaviour change and a reader deserves to find the reasoning where the decision is.
+
+Decide what "has had long enough" means here and give it a named constant (IR-26). The reload path already waits a settle budget before reporting; whether this shares that budget or has its own is a design call, and the two answer different questions.
+
+- [ ] **Step 1: Write the failing tests.** A dog alive and never handshook is restarted once and then marked stale; one that handshakes inside the budget is untouched; a dog already stale is not re-laddered.
+- [ ] **Step 2: Run them, watch them fail.**
+- [ ] **Step 3: Implement.**
+- [ ] **Step 4: Prove each non-vacuous.** The untouched-healthy-dog case above all — it passes for the wrong reason if the inference never fires at all.
+- [ ] **Step 5: Drive it.** A real protocol-1 dog against a current shepherd, watching for exactly one restart and then silence.
+- [ ] **Step 6: Commit.** No operator-facing string changed yet; that is task 3.
+
+### Task 3: the unsettled report says what to check
+
+**Files:** `crates/shep-cli/src/commands/daemon.rs`.
+
+After task 2, `unsettled_dog_report` describes a smaller and genuinely transient population — dogs mid-restart inside the budget. Reword it for who actually lands there now.
+
+It still needs a call to action, because "cannot say whether it came back" leaves an operator with no next move, and the next move that worked in production was reading the dog's own log. `shep bleats <dog>` is where the answer was.
+
+Two sentences already exist in this file and `stale_dog_report` is the better model: it names a remedy. Match its register rather than inventing a third voice. Check whether it should also name the restart step, since the production incident turned on `cargo install` alone being insufficient and the spec's own fix is two commands.
+
+- [ ] **Step 1: Write the failing tests**, pinning both sentences exactly. The spec's verification list is explicit that "the exact strings" are the feature.
+- [ ] **Step 2: Run them, watch them fail.**
+- [ ] **Step 3: Implement.**
+- [ ] **Step 4: Prove each non-vacuous.**
+- [ ] **Step 5: Drive a real reload** with a skewed dog and read both sentences as an operator.
+- [ ] **Step 6: `web/` and commit.**
+
+### Task 4: `online` stops meaning "the process is alive"
+
+**Files:** `crates/shep-core/src/protocol/request.rs`, `crates/shep-daemon/src/rpc.rs`, `crates/shep-cli/src/output/`.
+
+`shep flock` showed `(o.o) online` for a dog that had never completed a handshake. The status column reports process liveness, which for a sheep is the whole truth and for a dog is not: a dog that cannot talk to the shepherd is not doing its job, however alive it is.
+
+`ProcessInfo` carries no handshake fact, so this is a wire change. Follow `dog: Option<DogSource>` in the same struct — additive, `Option`, absent means "this peer predates the field", neither version constant moves. Route it through `ProcessInfoBuilder` rather than adding a positional field.
+
+The rendering is the design work. A dog that has never handshook is not `online` and is not `errored` either; the process is fine and the relationship is not. Decide what the STATUS column says, whether the sheep face changes, and what `--format json` carries. Note that the dogs table has its own header set including `SOURCE`, so it can differ from the sheep table without disturbing it.
+
+- [ ] **Step 1: Write the failing tests.** A never-handshook dog does not render as `online`; a healthy dog is unchanged; the JSON form carries the fact; an absent field renders as it does today.
+- [ ] **Step 2: Run them, watch them fail.**
+- [ ] **Step 3: Implement.**
+- [ ] **Step 4: Prove each non-vacuous**, the unchanged-healthy-dog case included.
+- [ ] **Step 5: Drive it.** `shep flock` against a real skewed dog, in all three styles, and `--format json`.
+- [ ] **Step 6: `web/` and commit.** A STATUS value is documented surface.
+
+---
+
+## Out of scope
+
+**The `--version` contract and the disk check.** That is phase 4, which predicts staleness from the binary on disk. This phase reports what already happened, and the two are independent: prediction is worth nothing while the report says a dog is fine.
+
+**Bark's restart per reload.** Recorded in `deferred.md`, still needs a ruling on orphaned dogs.
+
+---
+
+## Verification
+
+Every phase of this work found its bugs by driving the real thing, and this one was found by an operator in production rather than by any of them. **A green suite is not evidence here.**
+
+Reproduce a protocol-1 dog with `cargo update -p shep-core --precise <old>`, never by pinning `shep-client` — the protocol lives in shep-core and the client's dependency on it floats within 0.1.x (G9).
+
+`$SHEP_HOME` stays under ~103 bytes or the control socket refuses the path.
+
+## Gate
+
+Per `CLAUDE.md`. One cargo shape per task: `-p shep` for tasks 1 and 3, `-p shep-daemon` for task 2, `--workspace` for task 4 since it crosses three crates.
+
+Inner loop is `cargo test -p shep-daemon --lib --all-features -- --skip ::slow::`. Task 4's wire change wants the full workspace run before commit.
+
+`web/` for tasks 1, 3 and 4: `cargo build --release`, `./web/scripts/generate-cli-reference.sh`, then `astro build` **and** `astro check`.
+
+CI's process-spawning tiers flake. A `slow`, `musl` or e2e failure is read against `main`'s own history before being treated as this branch's fault.

--- a/docs/writing-plans/plans/2026-08-31-handover-phase3b.md
+++ b/docs/writing-plans/plans/2026-08-31-handover-phase3b.md
@@ -117,7 +117,9 @@ Decide what "has had long enough" means here and give it a named constant (IR-26
 
 **Files:** `crates/shep-cli/src/commands/daemon.rs`.
 
-After task 2, `unsettled_dog_report` describes a smaller and genuinely transient population — dogs mid-restart inside the budget. Reword it for who actually lands there now.
+After task 2, `unsettled_dog_report` describes a UNION of two populations, and neither of them is what this plan first predicted. `dog_staleness` seeds `pending` from `DogRefusals::restarting()`, dogs whose restart the shepherd has already asked for, then adds every running dog that has not handshook and is not yet stale. So one entry may be mid-restart and the next may be merely silent inside the budget, and the skewed dog from the incident is still in there at reload time.
+
+That rules out any wording promising a restart is coming, since for half the population it has already been requested. State the rule instead of this dog's future: what the shepherd does with a dog that stays silent is true of every entry regardless of which half it is in.
 
 It still needs a call to action, because "cannot say whether it came back" leaves an operator with no next move, and the next move that worked in production was reading the dog's own log. `shep bleats <dog>` is where the answer was.
 

--- a/web/src/pages/docs/dogs.astro
+++ b/web/src/pages/docs/dogs.astro
@@ -105,6 +105,14 @@ $ shep disable metrics`}</CodeBlock>
       output</a>.
     </p>
     <p class="fine">
+      A dog whose <code>STATUS</code> reads <code>silent</code> is running
+      but has never spoken to the shepherd, usually because a
+      <code>cargo install</code> replaced its binary and the old process is
+      still up. <code>shep bleats &lt;dog&gt;</code> has the refusal;
+      <code>shep restart &lt;dog&gt;</code> is the fix. See <a
+      href="/docs/output#a-dog-that-never-answers">terminal output</a>.
+    </p>
+    <p class="fine">
       Running <code>enable</code> and <code>adopt</code> at once from a
       provisioning script is safe: each takes an exclusive lock on{" "}
       <code>shep.toml</code> for its whole read-edit-write, so the second

--- a/web/src/pages/docs/json-output.astro
+++ b/web/src/pages/docs/json-output.astro
@@ -54,7 +54,8 @@ import CodeBlock from "../../components/docs/CodeBlock.astro";
       "lambs": null,
       "last_exit": null,
       "smit": null,
-      "instance": 0
+      "instance": 0,
+      "handshook": null
     },
     {
       "id": 1,
@@ -72,7 +73,8 @@ import CodeBlock from "../../components/docs/CodeBlock.astro";
       "lambs": null,
       "last_exit": null,
       "smit": null,
-      "instance": 0
+      "instance": 0,
+      "handshook": null
     }
   ]
 }`}</CodeBlock>
@@ -152,6 +154,14 @@ import CodeBlock from "../../components/docs/CodeBlock.astro";
         a few hundred milliseconds old, most often. Table format prints the
         same case as <code>-</code>, for the same reason: a confident zero
         would be a claim shep can't back up.
+      </li>
+      <li>
+        <code>handshook</code> is about dogs and is <code>null</code> for
+        every sheep. <code>false</code> is the one to act on: the dog's
+        process is up and the shepherd has never heard from it, so it is
+        not doing its job. <code>status</code> still reads
+        <code>online</code> there, truthfully — it describes the process.
+        Table format shows this row as <code>silent</code>.
       </li>
       <li>
         <code>smit</code> is <code>null</code> until a dog attaches one over

--- a/web/src/pages/docs/output.astro
+++ b/web/src/pages/docs/output.astro
@@ -73,7 +73,12 @@ import CodeBlock from "../../components/docs/CodeBlock.astro";
       <div class="row"><span><code>(&gt;_&lt;)</code> flinching</span><span>waiting to restart</span></div>
       <div class="row"><span><code>(-.-)</code> asleep</span><span>stopping, stopped</span></div>
       <div class="row"><span><code>(x.x)</code> startled</span><span>errored</span></div>
+      <div class="row"><span><code>(?_?)</code> puzzled</span><span>silent, dogs only</span></div>
     </div>
+    <p class="fine">
+      <code>silent</code> is not a lifecycle status and no sheep ever wears
+      it. See <a href="#a-dog-that-never-answers">the dogs table</a>.
+    </p>
     <p class="fine">
       They are ASCII rather than emoji on purpose. An emoji is double-width,
       inconsistently so across terminals, and cannot take a foreground
@@ -173,6 +178,29 @@ Dogs
       <code>EXIT</code>. So the same dog reads the same way under
       <code>shep dogs</code>, under <code>shep flock</code>, and after
       <code>shep restart log-rotate</code>.
+    </p>
+
+    <h3 id="a-dog-that-never-answers">A dog that never answers reads <code>silent</code></h3>
+    <p>
+      A dog is a peer as well as a process. It dials back to the shepherd
+      and keeps a connection open, and one that never manages it is not
+      doing its job however alive it looks. So <code>online</code> becomes
+      <code>silent</code>, in amber, with a puzzled face instead of a
+      grazing one.
+    </p>
+    <p>
+      The usual cause is a version skew: <code>cargo install</code> replaced
+      the binary on disk and the process still running is the old one. Read
+      <code>shep bleats &lt;dog&gt;</code> for the refusal, then
+      <code>shep restart &lt;dog&gt;</code>.
+    </p>
+    <p class="fine">
+      Only <code>online</code> is replaced. <code>starting</code> already
+      says the connection is not up yet, and a dog is silent for a moment
+      every time it starts. <code>--format json</code> carries the fact as
+      <code>handshook</code>, beside a <code>status</code> that still reads
+      <code>online</code> — true of the process, which is what that field
+      has always described.
     </p>
 
     <h3 id="source-says-whose-code-is-running">SOURCE says whose code is running</h3>


### PR DESCRIPTION
Three surfaces reported a dog as healthy while it had never once completed a handshake with the shepherd. `shep flock` and `shep lookout` both printed `online`, and `shep daemon reload` said it could not tell whether the dog came back. Only the dog's own log knew, and nothing pointed an operator at it.

Found by running v0.1.23 against a real flock, not by any test. The suite was green throughout.

## What was actually broken

`Hello` gained `dog_name` in phase 3, so a client on an older protocol cannot send one. Those connections take the `None` arm in `server.rs`, log at `debug!` below the daemon's default level, and never reach `record_refused_dog`.

G8's one-restart ladder is keyed on that name. So it fires only for dogs new enough to name themselves, and the dogs most likely to need it cannot reach it at all. Restarts stay at 0 forever while the dog retries a handshake that can never succeed.

The shepherd was not missing the fact. `dog_staleness` already derived it: a registered dog, process running, never handshook. Three call sites declined to say so.

## The five pieces

- a silence budget in the daemon, so a dog that never speaks enters the same ladder a named refusal does. One restart from disk, then stale, never a spin
- `unsettled_dog_report` names what happens next and points at `shep bleats <dog>`, instead of ending at "cannot say whether it came back"
- `ProcessInfo` carries a handshake fact, and a dog that has never answered reads `silent` rather than `online`
- `shep lookout` reads the same word through the same seam, so the two renderers cannot disagree about one dog
- the table-form version-skew refusal labels its remedy, which previously sat as a bare indented line an operator was not sure they were meant to run

## Costs, both deliberate

A dog that is merely slow to connect gets restarted once. Bounded by the existing ladder and cheap for a process not yet doing anything, and the alternative is believing a silence indefinitely.

A silent dog is re-laddered once per daemon, so each reload buys it one more restart. That is `DogRefusals`' existing rule and it is the right one here: the disk binary may have been fixed since.

## Notes

The plan's original task ordering rationale was wrong and the drill caught it. It argued the ladder would move a skewed dog into the report that already carried advice. It does not: the ladder's rungs land at 5s and 10s while the reload waits 3s, so the dog is still unsettled when the reload speaks. Corrected in its own commit rather than edited away, because the claim reads plausibly and would otherwise be re-derived.

Neither `PROTOCOL_VERSION` nor `SCHEMA_VERSION` moves. The new field is an additive `Option`, which is the case both constants' own rules exempt, and it follows `dog: Option<DogSource>` in the same struct.

`shep restart <dog>` and the other lifecycle verbs still print `online`, argued at the call site: a dog has not had a chance to dial back by the time a restart returns.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a `silent` status for dogs that run without completing the shepherd handshake.
  - Added automatic monitoring, one-time restart, and stale reporting for silent dogs.
  - Added handshake details to JSON output while preserving compatibility with older responses.
  - Updated status colors, faces, and lookout views to identify silent dogs consistently.

- **Bug Fixes**
  - Improved version-mismatch recovery instructions and dog diagnostics.
  - Clarified stale and unsettled dog messages with actionable guidance.

- **Documentation**
  - Documented silent dog behavior, recovery commands, and JSON handshake fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->