### PR TITLE
chore: move to the shep-pm org

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,6 +1,6 @@
 name: pages
 # Builds `web/` and publishes it to GitHub Pages, served at
-# https://shep.turtlesocks.dev. The Pages source is set to "GitHub Actions"
+# https://shep-pm.com. The Pages source is set to "GitHub Actions"
 # in the repository settings, and the custom domain lives there too — with
 # an Actions-based deploy there is no `CNAME` file in the artifact.
 #

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -381,7 +381,7 @@ jobs:
           checksum=''
           for attempt in $(seq 1 10); do
             checksum="$(curl -fsSL \
-              -H 'User-Agent: shep-release-workflow (https://github.com/TurtIeSocks/shep)' \
+              -H 'User-Agent: shep-release-workflow (https://github.com/shep-pm/shep)' \
               "https://crates.io/api/v1/crates/shep/${version}" \
               | jq -r '.version.checksum // empty')" || checksum=''
             if [ -n "$checksum" ]; then break; fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 Clean-room Rust process manager (daemon + CLI + client lib), inspired by pm2's
 *feature list only*. License: MIT OR Apache-2.0. Sheep/sheepdog branding
-throughout. Published at `github.com/TurtIeSocks/shep`; the local checkout
+throughout. Published at `github.com/shep-pm/shep`; the local checkout
 directory is still named `pm2-rs`, which is expected and not a rename to make.
 
 ## ⚠️ Clean-room rule (non-negotiable)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ edition = "2024"
 # 1.88 forced by serde-saphyr (let-chains, stabilized 1.88) — a current dep,
 # not a future one. Also the floor for ratatui/sysinfo/rmcp in later phases.
 rust-version = "1.88"
-repository = "https://github.com/TurtIeSocks/shep"
+repository = "https://github.com/shep-pm/shep"
 # Clean-room implementation — pm2 is feature-list inspiration only (the maintainer, 2026-08-07).
 license = "MIT OR Apache-2.0"
 

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ Help             welcome init help completions style
 </details>
 
 Full documentation, including a generated reference for every flag of every
-verb, is at [shep.turtlesocks.dev](https://shep.turtlesocks.dev).
+verb, is at [shep-pm.com](https://shep-pm.com).
 
 ## Windows
 

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 [![Crates.io Version](https://img.shields.io/crates/v/shep.svg)](https://crates.io/crates/shep)
 [![docs.rs](https://img.shields.io/docsrs/shep)](https://docs.rs/shep)
-[![License](https://img.shields.io/crates/l/shep.svg)](https://github.com/TurtIeSocks/shep#license)
+[![License](https://img.shields.io/crates/l/shep.svg)](https://github.com/shep-pm/shep#license)
 [![MSRV](https://img.shields.io/crates/msrv/shep.svg)](https://crates.io/crates/shep)
-[![CI](https://github.com/TurtIeSocks/shep/actions/workflows/test.yml/badge.svg)](https://github.com/TurtIeSocks/shep/actions/workflows/test.yml)
+[![CI](https://github.com/shep-pm/shep/actions/workflows/test.yml/badge.svg)](https://github.com/shep-pm/shep/actions/workflows/test.yml)
 
 A process manager written in Rust. One binary runs a daemon called the
 shepherd, which keeps a flock of your long-running processes alive, restarts
@@ -216,7 +216,7 @@ than being narrowed the way `0700` narrows it on unix.
 ## Building
 
 ```bash
-git clone https://github.com/TurtIeSocks/shep
+git clone https://github.com/shep-pm/shep
 cd shep
 cargo build --release
 cargo test --workspace --all-features

--- a/README.md
+++ b/README.md
@@ -154,9 +154,9 @@ a config file has a diff and an mtime somebody can audit.
 
 A dog is a plugin process the shepherd supervises alongside your flock.
 
-- [shep-log-rotate](https://github.com/TurtIeSocks/shep-log-rotate) rotates
+- [shep-log-rotate](https://github.com/shep-pm/shep-log-rotate) rotates
   and compresses bleat logs.
-- [shep-deploy](https://github.com/TurtIeSocks/shep-deploy) redeploys a sheep
+- [shep-deploy](https://github.com/shep-pm/shep-deploy) redeploys a sheep
   when a watched git branch moves.
 
 `shep dogs` lists them, `shep adopt` takes one on.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -315,7 +315,7 @@ no long-term-support branch yet.
 ## Reporting a vulnerability
 
 Report security issues privately through
-[GitHub Security Advisories](https://github.com/TurtIeSocks/shep/security/advisories/new)
+[GitHub Security Advisories](https://github.com/shep-pm/shep/security/advisories/new)
 for this repository. Do not open a public issue for a suspected
 vulnerability.
 

--- a/crates/shep-cli-redirect/README.md
+++ b/crates/shep-cli-redirect/README.md
@@ -10,7 +10,7 @@ cargo install shep
 
 `shep`'s CLI binary was originally packaged under the name `shep-cli`. It was
 renamed to `shep` before the first publish (see
-[docs/releasing.md](https://github.com/TurtIeSocks/shep/blob/main/docs/releasing.md)
+[docs/releasing.md](https://github.com/shep-pm/shep/blob/main/docs/releasing.md)
 in the main repository) so the install command and the binary name match.
 
 Nothing was ever published under `shep-cli` — no version of it exists on

--- a/crates/shep-cli/CHANGELOG.md
+++ b/crates/shep-cli/CHANGELOG.md
@@ -33,7 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Carry stdin, the shepherd channel and clustered apps across a handover ([#77](https://github.com/TurtIeSocks/shep/pull/77))
+- Carry stdin, the shepherd channel and clustered apps across a handover ([#77](https://github.com/shep-pm/shep/pull/77))
 
 
 ## [0.1.19] - 2026-08-31

--- a/crates/shep-cli/Cargo.toml
+++ b/crates/shep-cli/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["command-line-utilities", "os", "development-tools"]
 # The docs site, not docs.rs: this crate ships a CLI, and its three [[bin]]
 # targets are what somebody installs. docs.rs would render the thin library
 # underneath them, which is not what a reader of this package came for.
-documentation = "https://shep.turtlesocks.dev"
+documentation = "https://shep-pm.com"
 
 [lib]
 name = "shep"

--- a/crates/shep-cli/README.md
+++ b/crates/shep-cli/README.md
@@ -1,6 +1,6 @@
 # shep
 
-The `shep` binary. [shep](https://github.com/TurtIeSocks/shep) is a process
+The `shep` binary. [shep](https://github.com/shep-pm/shep) is a process
 manager written in Rust: one binary runs a daemon called the shepherd, which
 keeps a flock of your long-running processes alive, captures what they print,
 and says plainly when something is wrong.

--- a/crates/shep-cli/src/dog_index.rs
+++ b/crates/shep-cli/src/dog_index.rs
@@ -86,7 +86,7 @@ use crate::terminal_safe::sanitise;
 /// this file verbatim, and `/dogs.json` is an exact file path that answers
 /// 200 rather than redirecting, which is what lets [`crate::fetch::get`]
 /// refuse redirects outright.
-pub const DEFAULT_INDEX_URL: &str = "https://shep.turtlesocks.dev/dogs.json";
+pub const DEFAULT_INDEX_URL: &str = "https://shep-pm.com/dogs.json";
 
 /// The environment variable that overrides [`DEFAULT_INDEX_URL`], for
 /// self-hosting an index and for pointing the integration tests at a local
@@ -605,7 +605,7 @@ mod tests {
     /// refuses now.
     fn wrap_index(entries: Vec<Value>) -> String {
         serde_json::json!({
-            "$schema": "https://shep.turtlesocks.dev/dogs.schema.json",
+            "$schema": "https://shep-pm.com/dogs.schema.json",
             "version": SUPPORTED_INDEX_VERSION,
             "dogs": entries,
         })
@@ -656,7 +656,7 @@ mod tests {
     /// absence is silent everywhere else, since a dog adopted under the
     /// wrong name loses its whole config section without saying so.
     const THREE_ENTRIES_MIDDLE_BROKEN: &[u8] = br#"{
-      "$schema": "https://shep.turtlesocks.dev/dogs.schema.json",
+      "$schema": "https://shep-pm.com/dogs.schema.json",
       "version": 1,
       "dogs": [
       {

--- a/crates/shep-cli/src/dog_index.rs
+++ b/crates/shep-cli/src/dog_index.rs
@@ -581,12 +581,12 @@ mod tests {
             "package": "shep-log-rotate",
             "adopt_as": "log-rotate",
             "description": "Rotates grown log files and asks the shepherd to reopen them.",
-            "repo": "https://github.com/TurtIeSocks/shep-log-rotate",
+            "repo": "https://github.com/shep-pm/shep-log-rotate",
             "license": "MIT OR Apache-2.0",
             "category": "logs",
             "source": {
                 "kind": "cargo-git",
-                "url": "https://github.com/TurtIeSocks/shep-log-rotate"
+                "url": "https://github.com/shep-pm/shep-log-rotate"
             }
         })
     }
@@ -664,10 +664,10 @@ mod tests {
         "package": "shep-log-rotate",
         "adopt_as": "log-rotate",
         "description": "Rotates grown log files.",
-        "repo": "https://github.com/TurtIeSocks/shep-log-rotate",
+        "repo": "https://github.com/shep-pm/shep-log-rotate",
         "license": "MIT OR Apache-2.0",
         "category": "logs",
-        "source": { "kind": "cargo-git", "url": "https://github.com/TurtIeSocks/shep-log-rotate" }
+        "source": { "kind": "cargo-git", "url": "https://github.com/shep-pm/shep-log-rotate" }
       },
       {
         "name": "Nameless",

--- a/crates/shep-cli/src/output/rows.rs
+++ b/crates/shep-cli/src/output/rows.rs
@@ -4142,11 +4142,11 @@ pub(crate) mod tests {
             adopt_as: "log-rotate".to_string(),
             description: "Rotates grown log files and asks the shepherd to reopen them."
                 .to_string(),
-            repo: "https://github.com/TurtIeSocks/shep-log-rotate".to_string(),
+            repo: "https://github.com/shep-pm/shep-log-rotate".to_string(),
             license: "MIT OR Apache-2.0".to_string(),
             category: "logs".to_string(),
             source: crate::dog_index::DogSourceKind::CargoGit {
-                url: "https://github.com/TurtIeSocks/shep-log-rotate".to_string(),
+                url: "https://github.com/shep-pm/shep-log-rotate".to_string(),
             },
         }
     }

--- a/crates/shep-cli/tests/cli_e2e.rs
+++ b/crates/shep-cli/tests/cli_e2e.rs
@@ -1515,7 +1515,7 @@ fn serve_dog_index(body: &str) -> String {
 /// on the accepted side of that line to test anything else.
 fn two_entry_index_json() -> String {
     serde_json::json!({
-        "$schema": "https://shep.turtlesocks.dev/dogs.schema.json",
+        "$schema": "https://shep-pm.com/dogs.schema.json",
         "version": 1,
         "dogs": [
             {

--- a/crates/shep-cli/tests/cli_e2e.rs
+++ b/crates/shep-cli/tests/cli_e2e.rs
@@ -1523,12 +1523,12 @@ fn two_entry_index_json() -> String {
                 "package": "shep-log-rotate",
                 "adopt_as": "log-rotate",
                 "description": "Rotates grown log files and asks the shepherd to reopen them.",
-                "repo": "https://github.com/TurtIeSocks/shep-log-rotate",
+                "repo": "https://github.com/shep-pm/shep-log-rotate",
                 "license": "MIT OR Apache-2.0",
                 "category": "logs",
                 "source": {
                     "kind": "cargo-git",
-                    "url": "https://github.com/TurtIeSocks/shep-log-rotate"
+                    "url": "https://github.com/shep-pm/shep-log-rotate"
                 }
             },
             {
@@ -5815,7 +5815,7 @@ fn available_dogs_detail_view_uses_adopt_as_never_name() {
         "detail header line: {stdout}"
     );
     assert!(
-        stdout.contains("$ cargo install --git https://github.com/TurtIeSocks/shep-log-rotate"),
+        stdout.contains("$ cargo install --git https://github.com/shep-pm/shep-log-rotate"),
         "install command: {stdout}"
     );
     assert!(

--- a/crates/shep-client/README.md
+++ b/crates/shep-client/README.md
@@ -1,6 +1,6 @@
 # shep-client
 
-The async client for [shep](https://github.com/TurtIeSocks/shep), a process
+The async client for [shep](https://github.com/shep-pm/shep), a process
 manager written in Rust. Use this crate to talk to a running shepherd from
 your own program instead of shelling out to the `shep` binary.
 

--- a/crates/shep-core/README.md
+++ b/crates/shep-core/README.md
@@ -1,6 +1,6 @@
 # shep-core
 
-The shared tier of [shep](https://github.com/TurtIeSocks/shep), a process
+The shared tier of [shep](https://github.com/shep-pm/shep), a process
 manager written in Rust. One binary runs a daemon called the shepherd, which
 keeps a flock of your long-running processes alive.
 

--- a/crates/shep-daemon/CHANGELOG.md
+++ b/crates/shep-daemon/CHANGELOG.md
@@ -47,7 +47,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Carry stdin, the shepherd channel and clustered apps across a handover ([#77](https://github.com/TurtIeSocks/shep/pull/77))
+- Carry stdin, the shepherd channel and clustered apps across a handover ([#77](https://github.com/shep-pm/shep/pull/77))
 
 
 ## [0.1.19] - 2026-08-31

--- a/crates/shep-daemon/README.md
+++ b/crates/shep-daemon/README.md
@@ -1,6 +1,6 @@
 # shep-daemon
 
-The supervision engine of [shep](https://github.com/TurtIeSocks/shep), a
+The supervision engine of [shep](https://github.com/shep-pm/shep), a
 process manager written in Rust. This crate is the shepherd: the part that
 spawns your processes, watches them, and restarts them when they die.
 

--- a/docs/brainstorming/specs/2026-08-20-community-dog-index-design.md
+++ b/docs/brainstorming/specs/2026-08-20-community-dog-index-design.md
@@ -67,10 +67,10 @@ consumes. This file has a second consumer that cannot import a `.ts` module.
   "package": "shep-log-rotate",
   "adopt_as": "log-rotate",
   "description": "Rotates grown log files and asks the shepherd to reopen them.",
-  "repo": "https://github.com/TurtIeSocks/shep-log-rotate",
+  "repo": "https://github.com/shep-pm/shep-log-rotate",
   "license": "MIT OR Apache-2.0",
   "category": "logs",
-  "source": { "kind": "cargo-git", "url": "https://github.com/TurtIeSocks/shep-log-rotate" }
+  "source": { "kind": "cargo-git", "url": "https://github.com/shep-pm/shep-log-rotate" }
 }
 ```
 

--- a/docs/brainstorming/specs/2026-08-21-dog-index-cli-design.md
+++ b/docs/brainstorming/specs/2026-08-21-dog-index-cli-design.md
@@ -84,7 +84,7 @@ that is not there. A wrong name is silent.
 
 ## 2. The fetch
 
-`GET https://shep.turtlesocks.dev/dogs.json`, hardcoded, overridable with
+`GET https://shep-pm.com/dogs.json`, hardcoded, overridable with
 `SHEP_DOG_INDEX` for testing and self-hosting. Without an override the
 integration tests cannot point at a local server, and an environment variable
 is trusted input by the project's own threat model.

--- a/docs/brainstorming/specs/2026-08-21-dog-index-cli-design.md
+++ b/docs/brainstorming/specs/2026-08-21-dog-index-cli-design.md
@@ -64,9 +64,9 @@ One match prints the whole entry, which is where `adopt_as` earns its place:
 ```
 Spot . shep-log-rotate . logs
 Rotates grown log files and asks the shepherd to reopen them.
-MIT OR Apache-2.0 . https://github.com/TurtIeSocks/shep-log-rotate
+MIT OR Apache-2.0 . https://github.com/shep-pm/shep-log-rotate
 
-  $ cargo install --git https://github.com/TurtIeSocks/shep-log-rotate
+  $ cargo install --git https://github.com/shep-pm/shep-log-rotate
   $ shep adopt log-rotate ~/.cargo/bin/shep-log-rotate
 ```
 

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -174,7 +174,7 @@ The "it is already on crates.io" objection does not apply. Homebrew's
 language-specific formulae policy excludes libraries, and welcomes
 command-line applications.
 
-So: `TurtIeSocks/homebrew-shep`, giving `brew install turtiesocks/shep/shep`,
+So: `shep-pm/homebrew-shep`, giving `brew install turtiesocks/shep/shep`,
 with `Formula/shep.rb`.
 
 The formula is written and lives at `packaging/homebrew/shep.rb`, which is

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -283,7 +283,7 @@ are up.
 
 ## `shep-log-rotate` publishes after this, not alongside it
 
-`github.com/TurtIeSocks/shep-log-rotate` is the first external dog and it
+`github.com/shep-pm/shep-log-rotate` is the first external dog and it
 depends on `shep-client`. Until `shep-client` is on the index, that crate
 cannot be published at all, so the order across the two repositories is:
 everything here first, then the dog.

--- a/docs/shep-design/README.md
+++ b/docs/shep-design/README.md
@@ -12,7 +12,7 @@ Three connected pages for **shep**, a process manager written in Rust (a pm2 rew
 
 The files in `design-files/` are **design references created in HTML** — prototypes showing intended look and behavior, not production code to copy directly. They are authored in a small in-house component format (`.dc.html`, driven by `support.js`), which exists only in the design tool. Do not try to port `support.js`, `<x-dc>`, `<sc-for>`, `<sc-if>` or `{{ }}` holes.
 
-**The task is to recreate these designs in the target codebase's existing environment**, using its established patterns and libraries. If no web environment exists yet, this is a static marketing site + docs — Astro or Next.js with plain CSS (or Tailwind, if preferred) is a good fit. The repo itself (`pm2-rs` / `github.com/TurtIeSocks/shep`) is a Rust workspace, so the site likely lives in its own directory or its own repo.
+**The task is to recreate these designs in the target codebase's existing environment**, using its established patterns and libraries. If no web environment exists yet, this is a static marketing site + docs — Astro or Next.js with plain CSS (or Tailwind, if preferred) is a good fit. The repo itself (`pm2-rs` / `github.com/shep-pm/shep`) is a Rust workspace, so the site likely lives in its own directory or its own repo.
 
 Read the files as: the template markup between `<x-dc>` and `</x-dc>` is the DOM; the `class Component` block at the bottom is the data and the event handlers. Anything referenced as `{{ name }}` in markup is defined by the `renderVals()` return at the bottom of the same file. `style-hover="…"` means a `:hover` rule with those declarations.
 
@@ -117,7 +117,7 @@ Google Fonts, one link:
 **Nav.** Sticky, `margin-bottom:-91px` so it overlaps the hero. Pill-shaped logo lockup (`paper-2`, 3px ink border, `4px 4px 0` shadow) + three pills: Lexicon (`paper-2`), Docs (`butter`), GitHub (ink fill, cream text, barn-colored shadow).
 
 **Scene copy** (verbatim):
-1. Eyebrow pill `pm2, rewritten in Rust`; h1 `shep keeps / your flock / alive.` in cream with `text-shadow:5px 5px 0 rgba(14,23,48,.45)`; paragraph in a fleece card; primary button `Get started →` (grass-deep) + a mono copy-to-clipboard button showing `$ git clone github.com/TurtIeSocks/shep` with a `copy`/`copied` label that reverts after 1800ms; a scroll hint pill `scroll — the sun comes up ↓`.
+1. Eyebrow pill `pm2, rewritten in Rust`; h1 `shep keeps / your flock / alive.` in cream with `text-shadow:5px 5px 0 rgba(14,23,48,.45)`; paragraph in a fleece card; primary button `Get started →` (grass-deep) + a mono copy-to-clipboard button showing `$ git clone github.com/shep-pm/shep` with a `copy`/`copied` label that reverts after 1800ms; a scroll hint pill `scroll — the sun comes up ↓`.
 2. `the flock, listed` — a terminal window (mac dots, `~/apps` title) showing `shep ls` output, then a note card about the CPU column printing `-` instead of `0.0%`.
 3. Fleece card, `rotate(-1.2deg)`, heading `A typo fails at load, not at 3am.` with a small TOML block.
 4. Barn-red card, `rotate(1deg)`, heading `Dogs work for the shepherd.` with a dark terminal block.
@@ -171,7 +171,7 @@ Do not add a second animal — one sheep and one dog is the whole cast. Never dr
 
 ## Interactions
 
-- **Copy button** (landing hero): writes `git clone https://github.com/TurtIeSocks/shep.git` to the clipboard, label flips `copy` → `copied`, reverts after 1800ms.
+- **Copy button** (landing hero): writes `git clone https://github.com/shep-pm/shep.git` to the clipboard, label flips `copy` → `copied`, reverts after 1800ms.
 - **Anchor nav:** `html { scroll-behavior: smooth }` on the landing page; `#pasture`, `#chalkboard`, `#scene-1` targets.
 - **Docs nav:** page state + scroll to top; `#terminology` deep link.
 - **Theme toggle:** docs and design language, `localStorage` key `shep-theme`.

--- a/docs/shep-design/design-files/Shep Docs.dc.html
+++ b/docs/shep-design/design-files/Shep Docs.dc.html
@@ -59,7 +59,7 @@
         <a href="Shep Landing v3 scene.dc.html" style="color:var(--ink-2);text-decoration:none;" style-hover="color:var(--bark);">Home</a>
         <a href="Shep Design Language.dc.html" style="color:var(--ink-2);text-decoration:none;" style-hover="color:var(--bark);">Design language</a>
         <button onClick="{{ toggleTheme }}" title="Toggle theme" style="font-family:'Space Mono',monospace;font-size:14px;background:var(--paper-2);color:var(--ink);border:2.5px solid var(--line);border-radius:999px;width:36px;height:36px;cursor:pointer;box-shadow:2px 2px 0 var(--shadow);" style-hover="transform:translate(1px,1px);box-shadow:1px 1px 0 var(--shadow);">{{ themeIcon }}</button>
-        <a href="https://github.com/TurtIeSocks/shep" style="font-family:'Bricolage Grotesque',sans-serif;font-weight:800;font-size:14.5px;background:var(--ink);color:var(--paper);border:2.5px solid var(--line);border-radius:11px;padding:10px 16px;text-decoration:none;box-shadow:3px 3px 0 var(--meadow);" style-hover="transform:translate(1px,1px);box-shadow:2px 2px 0 var(--meadow);color:var(--paper);">GitHub</a>
+        <a href="https://github.com/shep-pm/shep" style="font-family:'Bricolage Grotesque',sans-serif;font-weight:800;font-size:14.5px;background:var(--ink);color:var(--paper);border:2.5px solid var(--line);border-radius:11px;padding:10px 16px;text-decoration:none;box-shadow:3px 3px 0 var(--meadow);" style-hover="transform:translate(1px,1px);box-shadow:2px 2px 0 var(--meadow);color:var(--paper);">GitHub</a>
       </div>
     </div>
   </header>
@@ -98,7 +98,7 @@
 
           <h2 style="font-family:'Bricolage Grotesque',sans-serif;font-weight:800;font-size:29px;letter-spacing:-.03em;margin:0 0 8px;">1. Build it</h2>
           <p style="font-size:16.5px;line-height:1.65;color:var(--ink-2);margin:0 0 18px;">Rust 1.88 or newer, edition 2024.</p>
-          <div style="background:#0D1712;border:3px solid var(--line);border-radius:16px;padding:20px 22px;font-family:'Space Mono',monospace;font-size:13.5px;line-height:1.9;color:#E8E4D4;overflow-x:auto;white-space:pre;margin:0 0 12px;"><span style="color:#6FCB6B;">$</span> git clone https://github.com/TurtIeSocks/shep.git
+          <div style="background:#0D1712;border:3px solid var(--line);border-radius:16px;padding:20px 22px;font-family:'Space Mono',monospace;font-size:13.5px;line-height:1.9;color:#E8E4D4;overflow-x:auto;white-space:pre;margin:0 0 12px;"><span style="color:#6FCB6B;">$</span> git clone https://github.com/shep-pm/shep.git
 <span style="color:#6FCB6B;">$</span> cd shep
 <span style="color:#6FCB6B;">$</span> cargo build --release
 <span style="color:#6FCB6B;">$</span> ./target/release/shep --help</div>
@@ -227,7 +227,7 @@
             <div>
               <div style="font-family:'Bricolage Grotesque',sans-serif;font-weight:800;font-size:21px;margin-bottom:8px;">This page hasn't been written yet.</div>
               <p style="margin:0 0 16px;font-size:15px;line-height:1.6;color:var(--ink-2);">The material exists in the repo under <code style="font-family:'Space Mono',monospace;font-size:13.5px;background:var(--code-bg);border-radius:5px;padding:1px 6px;">{{ stubSource }}</code>. It gets a real page here before 1.0.</p>
-              <a href="https://github.com/TurtIeSocks/shep/tree/main/docs" style="font-family:'Bricolage Grotesque',sans-serif;font-weight:800;font-size:15px;background:var(--ink);color:var(--paper);border:3px solid var(--line);border-radius:12px;padding:12px 18px;text-decoration:none;display:inline-block;box-shadow:4px 4px 0 var(--meadow);" style-hover="transform:translate(2px,2px);box-shadow:2px 2px 0 var(--meadow);color:var(--paper);">Read it on GitHub →</a>
+              <a href="https://github.com/shep-pm/shep/tree/main/docs" style="font-family:'Bricolage Grotesque',sans-serif;font-weight:800;font-size:15px;background:var(--ink);color:var(--paper);border:3px solid var(--line);border-radius:12px;padding:12px 18px;text-decoration:none;display:inline-block;box-shadow:4px 4px 0 var(--meadow);" style-hover="transform:translate(2px,2px);box-shadow:2px 2px 0 var(--meadow);color:var(--paper);">Read it on GitHub →</a>
             </div>
           </div>
         </article>

--- a/docs/shep-design/design-files/Shep Landing v3 scene.dc.html
+++ b/docs/shep-design/design-files/Shep Landing v3 scene.dc.html
@@ -52,7 +52,7 @@
       <div style="display:flex;align-items:center;gap:10px;">
         <a href="#pasture" style="font-family:'Bricolage Grotesque',sans-serif;font-weight:800;font-size:15px;background:var(--paper-2);color:#17251C;border:3px solid var(--line);border-radius:999px;padding:11px 18px;text-decoration:none;box-shadow:4px 4px 0 var(--shadow);" style-hover="transform:translate(2px,2px);box-shadow:2px 2px 0 var(--shadow);color:#17251C;">Lexicon</a>
         <a href="Shep Docs.dc.html" style="font-family:'Bricolage Grotesque',sans-serif;font-weight:800;font-size:15px;background:var(--butter);color:#17251C;border:3px solid var(--line);border-radius:999px;padding:11px 18px;text-decoration:none;box-shadow:4px 4px 0 var(--shadow);" style-hover="transform:translate(2px,2px);box-shadow:2px 2px 0 var(--shadow);color:#17251C;">Docs</a>
-        <a href="https://github.com/TurtIeSocks/shep" style="font-family:'Bricolage Grotesque',sans-serif;font-weight:800;font-size:15px;background:#17251C;color:#FFFDF5;border:3px solid var(--line);border-radius:999px;padding:11px 18px;text-decoration:none;box-shadow:4px 4px 0 var(--barn);" style-hover="transform:translate(2px,2px);box-shadow:2px 2px 0 var(--barn);color:#FFFDF5;">GitHub</a>
+        <a href="https://github.com/shep-pm/shep" style="font-family:'Bricolage Grotesque',sans-serif;font-weight:800;font-size:15px;background:#17251C;color:#FFFDF5;border:3px solid var(--line);border-radius:999px;padding:11px 18px;text-decoration:none;box-shadow:4px 4px 0 var(--barn);" style-hover="transform:translate(2px,2px);box-shadow:2px 2px 0 var(--barn);color:#FFFDF5;">GitHub</a>
       </div>
     </div>
   </nav>
@@ -245,7 +245,7 @@
           <div style="display:flex;flex-wrap:wrap;gap:13px;align-items:center;">
             <a href="Shep Docs.dc.html" style="font-family:'Bricolage Grotesque',sans-serif;font-weight:800;font-size:17px;background:var(--grass-deep);color:#FFFDF5;border:3px solid var(--line);border-radius:16px;padding:15px 26px;text-decoration:none;box-shadow:6px 6px 0 var(--shadow);" style-hover="transform:translate(3px,3px);box-shadow:3px 3px 0 var(--shadow);color:#FFFDF5;">Get started →</a>
             <button onClick="{{ copyClone }}" style="font-family:'Space Mono',monospace;font-size:13.5px;background:var(--paper-2);color:#17251C;border:3px solid var(--line);border-radius:16px;padding:15px 19px;cursor:pointer;box-shadow:6px 6px 0 var(--shadow);display:inline-flex;align-items:center;gap:11px;white-space:nowrap;" style-hover="transform:translate(3px,3px);box-shadow:3px 3px 0 var(--shadow);">
-              <span style="color:var(--grass-deep);font-weight:700;">$</span> git clone github.com/TurtIeSocks/shep
+              <span style="color:var(--grass-deep);font-weight:700;">$</span> git clone github.com/shep-pm/shep
               <span style="font-family:'Space Grotesk',sans-serif;font-size:12px;font-weight:700;letter-spacing:.08em;text-transform:uppercase;color:var(--ink-3);border-left:2px solid var(--hair);padding-left:11px;">{{ copyLabel }}</span>
             </button>
           </div>
@@ -393,7 +393,7 @@
           <p style="margin:0;font-size:18px;line-height:1.5;color:#D6EADB;max-width:46ch;">Rust 1.88 or newer, edition 2024. 1030 tests, and every task ends with a mutation pass: break a line on purpose, confirm a test goes red, put it back.</p>
         </div>
         <div style="display:grid;gap:13px;">
-          <a href="https://github.com/TurtIeSocks/shep" style="font-family:'Bricolage Grotesque',sans-serif;font-weight:800;font-size:17px;background:var(--butter);color:#17251C;border:4px solid var(--line);border-radius:16px;padding:17px 30px;text-decoration:none;text-align:center;box-shadow:6px 6px 0 #17251C;white-space:nowrap;" style-hover="transform:translate(3px,3px);box-shadow:3px 3px 0 #17251C;color:#17251C;">Clone the repo</a>
+          <a href="https://github.com/shep-pm/shep" style="font-family:'Bricolage Grotesque',sans-serif;font-weight:800;font-size:17px;background:var(--butter);color:#17251C;border:4px solid var(--line);border-radius:16px;padding:17px 30px;text-decoration:none;text-align:center;box-shadow:6px 6px 0 #17251C;white-space:nowrap;" style-hover="transform:translate(3px,3px);box-shadow:3px 3px 0 #17251C;color:#17251C;">Clone the repo</a>
           <a href="Shep Docs.dc.html" style="font-family:'Bricolage Grotesque',sans-serif;font-weight:800;font-size:17px;background:#FFFDF5;color:#17251C;border:4px solid var(--line);border-radius:16px;padding:17px 30px;text-decoration:none;text-align:center;box-shadow:6px 6px 0 #17251C;white-space:nowrap;" style-hover="transform:translate(3px,3px);box-shadow:3px 3px 0 #17251C;color:#17251C;">Read the docs</a>
         </div>
       </div>
@@ -434,7 +434,7 @@ class Component extends DCLogic {
       showBarn: this.props.showBarn ?? true,
       copyLabel: this.state.copied ? "copied" : "copy",
       copyClone: () => {
-        navigator.clipboard?.writeText("git clone https://github.com/TurtIeSocks/shep.git");
+        navigator.clipboard?.writeText("git clone https://github.com/shep-pm/shep.git");
         this.setState({ copied: true });
         setTimeout(() => this.setState({ copied: false }), 1800);
       },

--- a/docs/specs/deferred-history.md
+++ b/docs/specs/deferred-history.md
@@ -1168,7 +1168,7 @@ whoever controls that repository to publish arbitrary content on shep's own
 domain, under shep's own styling, forever and unreviewed.
 
 **A disclaimer does not fix it, because the failure mode is trust, not
-confusion.** Nobody who lands on `shep.turtlesocks.dev/dogs/whatever` reads
+confusion.** Nobody who lands on `shep-pm.com/dogs/whatever` reads
 it as a stranger's unmoderated page; they read it as shep's docs, reviewed
 the way shep's docs are reviewed. That trust is the entire reason the feature
 would be worth building, and it is exactly what turns a compromised or

--- a/packaging/chocolatey/shep.nuspec
+++ b/packaging/chocolatey/shep.nuspec
@@ -10,11 +10,11 @@
     <authors>TurtIeSocks</authors>
     <owners>TurtIeSocks</owners>
     <projectUrl>https://shep.turtlesocks.dev</projectUrl>
-    <projectSourceUrl>https://github.com/TurtIeSocks/shep</projectSourceUrl>
-    <packageSourceUrl>https://github.com/TurtIeSocks/shep/tree/main/packaging/chocolatey</packageSourceUrl>
+    <projectSourceUrl>https://github.com/shep-pm/shep</projectSourceUrl>
+    <packageSourceUrl>https://github.com/shep-pm/shep/tree/main/packaging/chocolatey</packageSourceUrl>
     <docsUrl>https://shep.turtlesocks.dev/docs/getting-started</docsUrl>
-    <bugTrackerUrl>https://github.com/TurtIeSocks/shep/issues</bugTrackerUrl>
-    <licenseUrl>https://github.com/TurtIeSocks/shep#license</licenseUrl>
+    <bugTrackerUrl>https://github.com/shep-pm/shep/issues</bugTrackerUrl>
+    <licenseUrl>https://github.com/shep-pm/shep#license</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <!-- No iconUrl yet. It is a validator Guideline (CPMR0033) rather than a
          Requirement, so the package is approvable without one, and shep has
@@ -70,7 +70,7 @@ case, so they are installed without shims.
 `choco uninstall` refuses while a shepherd is still running, rather than
 stopping your processes on your behalf. Run `shep kill` first.
 ]]></description>
-    <releaseNotes>https://github.com/TurtIeSocks/shep/releases</releaseNotes>
+    <releaseNotes>https://github.com/shep-pm/shep/releases</releaseNotes>
   </metadata>
   <files>
     <file src="tools\**" target="tools" />

--- a/packaging/chocolatey/shep.nuspec
+++ b/packaging/chocolatey/shep.nuspec
@@ -9,10 +9,10 @@
     <version>0.0.0</version>
     <authors>TurtIeSocks</authors>
     <owners>TurtIeSocks</owners>
-    <projectUrl>https://shep.turtlesocks.dev</projectUrl>
+    <projectUrl>https://shep-pm.com</projectUrl>
     <projectSourceUrl>https://github.com/shep-pm/shep</projectSourceUrl>
     <packageSourceUrl>https://github.com/shep-pm/shep/tree/main/packaging/chocolatey</packageSourceUrl>
-    <docsUrl>https://shep.turtlesocks.dev/docs/getting-started</docsUrl>
+    <docsUrl>https://shep-pm.com/docs/getting-started</docsUrl>
     <bugTrackerUrl>https://github.com/shep-pm/shep/issues</bugTrackerUrl>
     <licenseUrl>https://github.com/shep-pm/shep#license</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>

--- a/packaging/chocolatey/tools/LICENSE.txt
+++ b/packaging/chocolatey/tools/LICENSE.txt
@@ -9,8 +9,8 @@ The binaries this package installs are built from the shep source tree by the
 project's own release workflow, and the archive they arrive in carries the
 full text of both licenses as LICENSE-APACHE and LICENSE-MIT.
 
-  https://github.com/TurtIeSocks/shep/blob/main/LICENSE-APACHE
-  https://github.com/TurtIeSocks/shep/blob/main/LICENSE-MIT
+  https://github.com/shep-pm/shep/blob/main/LICENSE-APACHE
+  https://github.com/shep-pm/shep/blob/main/LICENSE-MIT
 
 This package is maintained by the same person who maintains shep, so there is
 no separate redistribution permission to record here.

--- a/packaging/chocolatey/tools/VERIFICATION.txt
+++ b/packaging/chocolatey/tools/VERIFICATION.txt
@@ -7,7 +7,7 @@ This package downloads its binaries at install time rather than embedding
 them. They come from the shep project's own GitHub release, which is the
 official distribution point:
 
-  https://github.com/TurtIeSocks/shep/releases
+  https://github.com/shep-pm/shep/releases
 
 The archive is shep-x86_64-pc-windows-msvc.zip, and the SHA256 checked at
 install time is the one in chocolateyinstall.ps1. To verify it yourself,
@@ -23,7 +23,7 @@ The binaries are built from tagged source by
 .github/workflows/release-artifacts.yml, which also records Sigstore build
 provenance for each archive. That attestation can be checked with:
 
-  gh attestation verify shep-x86_64-pc-windows-msvc.zip --repo TurtIeSocks/shep
+  gh attestation verify shep-x86_64-pc-windows-msvc.zip --repo shep-pm/shep
 
-shep's source is at https://github.com/TurtIeSocks/shep and is licensed
+shep's source is at https://github.com/shep-pm/shep and is licensed
 MIT OR Apache-2.0. See LICENSE.txt beside this file.

--- a/packaging/chocolatey/tools/chocolateyinstall.ps1
+++ b/packaging/chocolatey/tools/chocolateyinstall.ps1
@@ -34,4 +34,4 @@ Install-ChocolateyZipPackage @packageArgs
 # entrypoint aliases with no desktop use case, and three shims on PATH for one
 # tool is noise.
 Write-Host "shep $version installed. Run 'shep welcome' for the tour."
-Write-Host "Boot-time supervision is not built on Windows: 'shep startup' refuses. See https://shep.turtlesocks.dev/docs/not-built"
+Write-Host "Boot-time supervision is not built on Windows: 'shep startup' refuses. See https://shep-pm.com/docs/not-built"

--- a/packaging/chocolatey/tools/chocolateyinstall.ps1
+++ b/packaging/chocolatey/tools/chocolateyinstall.ps1
@@ -16,7 +16,7 @@ if (-not [Environment]::Is64BitOperatingSystem) {
 # workflow replaces it and then fails the build if any sentinel survives.
 $checksum64 = '__CHECKSUM64__'
 
-$url64 = "https://github.com/TurtIeSocks/shep/releases/download/shep-v$version/shep-x86_64-pc-windows-msvc.zip"
+$url64 = "https://github.com/shep-pm/shep/releases/download/shep-v$version/shep-x86_64-pc-windows-msvc.zip"
 
 $packageArgs = @{
   packageName    = $packageName

--- a/packaging/homebrew/shep.rb
+++ b/packaging/homebrew/shep.rb
@@ -10,7 +10,7 @@
 # against a real release. docs/distribution.md records when to switch.
 class Shep < Formula
   desc "Process manager that keeps a flock of long-running processes alive"
-  homepage "https://shep.turtlesocks.dev"
+  homepage "https://shep-pm.com"
   # The crate tarball rather than a GitHub tag archive. Its sha256 is
   # published by the crates.io API as the version's `checksum`, so the bump
   # job reads the hash instead of downloading and computing one. GitHub

--- a/packaging/homebrew/shep.rb
+++ b/packaging/homebrew/shep.rb
@@ -1,4 +1,4 @@
-# The formula published to the tap at TurtIeSocks/homebrew-shep, where it
+# The formula published to the tap at shep-pm/homebrew-shep, where it
 # lives as Formula/shep.rb. This copy is the source of truth; the `homebrew`
 # job in .github/workflows/release-artifacts.yml rewrites the two version
 # lines and pushes the result to the tap on every release.

--- a/packaging/scoop/shep.json
+++ b/packaging/scoop/shep.json
@@ -24,7 +24,7 @@
     ],
     "version": "0.0.0",
     "description": "Process manager that keeps a flock of long-running processes alive, with logs, watch and cron restarts, and webhook alerts",
-    "homepage": "https://shep.turtlesocks.dev",
+    "homepage": "https://shep-pm.com",
     "license": "MIT|Apache-2.0",
     "architecture": {
         "64bit": {

--- a/packaging/scoop/shep.json
+++ b/packaging/scoop/shep.json
@@ -28,19 +28,19 @@
     "license": "MIT|Apache-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/TurtIeSocks/shep/releases/download/shep-v0.0.0/shep-x86_64-pc-windows-msvc.zip",
+            "url": "https://github.com/shep-pm/shep/releases/download/shep-v0.0.0/shep-x86_64-pc-windows-msvc.zip",
             "hash": "0000000000000000000000000000000000000000000000000000000000000000"
         }
     },
     "bin": "shep.exe",
     "checkver": {
-        "github": "https://github.com/TurtIeSocks/shep",
+        "github": "https://github.com/shep-pm/shep",
         "regex": "shep-v([\\d.]+)"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/TurtIeSocks/shep/releases/download/shep-v$version/shep-x86_64-pc-windows-msvc.zip"
+                "url": "https://github.com/shep-pm/shep/releases/download/shep-v$version/shep-x86_64-pc-windows-msvc.zip"
             }
         },
         "hash": {

--- a/web/README.md
+++ b/web/README.md
@@ -40,7 +40,7 @@ Node version is pinned in `.nvmrc` (`nvm use` picks it up automatically).
 
 ## Deploy
 
-**Target: GitHub Pages**, at `https://shep.turtlesocks.dev`. The Pages source
+**Target: GitHub Pages**, at `https://shep-pm.com`. The Pages source
 is set to **GitHub Actions** in the repository settings, and the custom domain
 is configured there too — so there is no `CNAME` file in `public/`, which is a
 branch-deploy mechanism and would only be dead weight here. If the domain ever

--- a/web/astro.config.mjs
+++ b/web/astro.config.mjs
@@ -8,5 +8,5 @@ export default defineConfig({
   // (`href="/docs/terminology"`), and at a domain root those resolve as
   // written. A GitHub Pages *project* URL would serve from `/shep/` instead
   // and 404 every one of them; the custom domain is what makes them correct.
-  site: 'https://shep.turtlesocks.dev',
+  site: 'https://shep-pm.com',
 });

--- a/web/public/CNAME
+++ b/web/public/CNAME
@@ -1,0 +1,1 @@
+shep-pm.com

--- a/web/public/dogs.json
+++ b/web/public/dogs.json
@@ -7,7 +7,7 @@
       "package": "shep-log-rotate",
       "adopt_as": "log-rotate",
       "description": "Rotates grown log files and asks the shepherd to reopen them.",
-      "repo": "https://github.com/TurtIeSocks/shep-log-rotate",
+      "repo": "https://github.com/shep-pm/shep-log-rotate",
       "license": "MIT OR Apache-2.0",
       "category": "logs",
       "source": {
@@ -19,7 +19,7 @@
       "package": "shep-deploy",
       "adopt_as": "deploy",
       "description": "Watches a git branch, builds a release in an isolated directory, swaps to it, and rolls back on its own if the new release does not come up.",
-      "repo": "https://github.com/TurtIeSocks/shep-deploy",
+      "repo": "https://github.com/shep-pm/shep-deploy",
       "license": "MIT OR Apache-2.0",
       "category": "deploy",
       "source": {

--- a/web/public/dogs.json
+++ b/web/public/dogs.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://shep.turtlesocks.dev/dogs.schema.json",
+  "$schema": "https://shep-pm.com/dogs.schema.json",
   "version": 1,
   "dogs": [
     {

--- a/web/src/components/docs/DocsHeader.astro
+++ b/web/src/components/docs/DocsHeader.astro
@@ -24,7 +24,7 @@ import DocsSearch from "./DocsSearch.astro";
       <DocsSearch />
       <ThemeToggle variant="icon" />
       <a
-        href="https://github.com/TurtIeSocks/shep"
+        href="https://github.com/shep-pm/shep"
         class="gh press"
         style="--shadow-offset:3px; --shadow-color:var(--meadow); --press-offset:1px;"
       >

--- a/web/src/components/docs/ReferencePills.astro
+++ b/web/src/components/docs/ReferencePills.astro
@@ -31,7 +31,7 @@ if (!item) {
   throw new Error(`ReferencePills: no docsNav item for slug "${slug}"`);
 }
 
-const REPO = "https://github.com/TurtIeSocks/shep";
+const REPO = "https://github.com/shep-pm/shep";
 const SPEC_FILE = "docs/specs/shep-v1.md";
 
 const sources = Array.isArray(item.source) ? item.source : [item.source];

--- a/web/src/components/landing/CtaFooter.astro
+++ b/web/src/components/landing/CtaFooter.astro
@@ -28,7 +28,7 @@
           </p>
         </div>
         <div class="buttons">
-          <a href="https://github.com/TurtIeSocks/shep" class="btn butter press" style="--shadow-offset:6px; --shadow-color:var(--ink); --press-offset:3px;">
+          <a href="https://github.com/shep-pm/shep" class="btn butter press" style="--shadow-offset:6px; --shadow-color:var(--ink); --press-offset:3px;">
             Clone the repo
           </a>
           <a href="/docs" class="btn cream press" style="--shadow-offset:6px; --shadow-color:var(--ink); --press-offset:3px;">

--- a/web/src/components/landing/Nav.astro
+++ b/web/src/components/landing/Nav.astro
@@ -18,7 +18,7 @@ import Sheep from "../marks/Sheep.astro";
       <a href="#pasture" class="pill press lexicon" style="--shadow-offset:4px;">Lexicon</a>
       <a href="/docs" class="pill press butter" style="--shadow-offset:4px;">Docs</a>
       <a
-        href="https://github.com/TurtIeSocks/shep"
+        href="https://github.com/shep-pm/shep"
         class="pill press ink"
         style="--shadow-offset:4px; --shadow-color:var(--barn);"
       >

--- a/web/src/pages/docs/getting-started.astro
+++ b/web/src/pages/docs/getting-started.astro
@@ -41,7 +41,7 @@ import CodeBlock from "../../components/docs/CodeBlock.astro";
     </div>
     <p>Prefer to build it yourself, or want to hack on it?</p>
     <div class="terminal">
-      <div><span class="prompt">$</span> git clone https://github.com/TurtIeSocks/shep.git</div>
+      <div><span class="prompt">$</span> git clone https://github.com/shep-pm/shep.git</div>
       <div><span class="prompt">$</span> cd shep</div>
       <div><span class="prompt">$</span> cargo build --release</div>
       <div><span class="prompt">$</span> ./target/release/shep --help</div>

--- a/web/src/pages/docs/whistle.astro
+++ b/web/src/pages/docs/whistle.astro
@@ -56,7 +56,7 @@ import { pillTargetsLive } from "../../data/docsNav";
       and <code>whistle/control.rs</code> build, not a second hand-typed
       copy beside them:{" "}
       {pillTargetsLive.github ? (
-        <a href="https://github.com/TurtIeSocks/shep/blob/main/docs/whistle/tools.md">
+        <a href="https://github.com/shep-pm/shep/blob/main/docs/whistle/tools.md">
           the full generated reference is on GitHub
         </a>
       ) : (


### PR DESCRIPTION
The repository and its siblings now live under the shep-pm organisation. This points everything that named the old location at the new one.

Three commits, split so each can be dropped on its own:

- `TurtIeSocks/shep` to `shep-pm/shep`, 26 files. The workspace manifest's `repository` field is the one that matters, since all five crates inherit it and it is baked immutably into whatever is on crates.io at publish time
- the siblings: `shep-log-rotate`, `shep-deploy`, and the `homebrew-shep` tap, which does not exist yet
- `shep.turtlesocks.dev` to `shep-pm.com`, plus a tracked CNAME

The CNAME is the part worth reading twice. The custom domain had only ever existed as a repository setting, which is invisible to review and not carried by a transfer. The first Pages deploy after the move would have served with no custom domain at all. A file in `web/public` lands at the site root through Astro's own static copy and survives.

Identity is deliberately left alone. `FUNDING.yml`, `LICENSE-MIT`'s copyright line, the `maintainer` field and chocolatey's authors and owners all still name the account. Those are attribution rather than location, and reassigning copyright is not a URL sweep.

One trap worth recording: `TurtIeSocks/shep` is a prefix of `TurtIeSocks/shep-log-rotate`, so a plain find and replace rewrites 20 links to other repositories while looking like it moved one. The first commit anchors against that, and the second names each sibling in full.

DNS for `shep-pm.com` already resolves to the Pages addresses, DNS only rather than proxied, so a certificate can be issued.

2222 tests, plus `astro build` and `astro check`.
