### PR TITLE
fix(pages): drop the inert CNAME file and record what actually moves a domain

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -4,6 +4,15 @@ name: pages
 # in the repository settings, and the custom domain lives there too — with
 # an Actions-based deploy there is no `CNAME` file in the artifact.
 #
+# A transfer to another owner CARRIES that setting verbatim, which is worse
+# than dropping it. Moving to the shep-pm org kept `shep.turtlesocks.dev`,
+# a domain whose DNS still aimed at the previous owner's Pages host, so the
+# site was unreachable while every setting looked populated and every
+# workflow ran green. Changing the owner means re-setting the domain by
+# hand, and a `CNAME` file committed under `web/public` does NOT do it: it
+# reaches `web/dist` exactly as you would expect and GitHub then ignores it,
+# which is a convincing way to believe the problem is solved.
+#
 # Unlike test.yml, this one runs on every push rather than by dispatch only.
 # test.yml is gated because one run is 19 jobs, five of them on the macOS
 # and Windows runners that bill at 10x and 2x on a private repo. This is a

--- a/web/public/CNAME
+++ b/web/public/CNAME
@@ -1,1 +1,0 @@
-shep-pm.com


### PR DESCRIPTION
The migration added `web/public/CNAME` on the reasoning that the custom domain would not survive a transfer and needed a tracked file to be durable. Both halves of that were wrong, and this workflow's own header already said the first half.

- with an Actions-based deploy there is no `CNAME` file in the artifact, so GitHub ignored it
- the transfer CARRIED the setting rather than dropping it, so the repo came up still claiming `shep.turtlesocks.dev`, a domain whose DNS aims at the previous owner's Pages host

The site was unreachable while the Pages settings looked populated, the deploy reported success, and every workflow was green. The fix was one API call setting the domain to `shep-pm.com`. That is already done and the site now serves on a Let's Encrypt certificate.

The file was not merely useless, it was convincing. Astro copied it to `web/dist` exactly as intended, so anything short of asking GitHub what domain it thought it was serving would have confirmed the wrong belief. Reading the cname back after the deploy is what caught it.

So the file goes, and the header records the real failure mode: a transfer keeps the domain, and a stale value is the thing to plan for.

Removing it changes nothing about what is served. GitHub was already ignoring it.
