### PR TITLE
feat(dogs): a dog says which protocol it speaks, and shep checks before it bites

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,8 +67,8 @@ both halves: `cargo test -p shep --lib --bins --all-features`. `--bins`
 alone now runs almost nothing, since every unit test in the crate lives in the
 library.
 
-`shep` has a `mod slow` of its own as of 2026-08-28, one test, in
-`commands/lifecycle.rs`. It needs a real node to start and exit inside a
+`shep` has a `mod slow` of its own as of 2026-08-28, seven tests as of
+2026-08-31, in `commands/lifecycle.rs`. It needs a real node to start and exit inside a
 budget, which is a claim about the machine's speed rather than about shep: at
 200ms it failed on four CI runners at once while passing every local run. Add
 `-- --skip ::slow::` to a shep-scoped run for the same reason the daemon one

--- a/crates/shep-cli/src/commands/dogs.rs
+++ b/crates/shep-cli/src/commands/dogs.rs
@@ -467,6 +467,10 @@ pub fn vet_binary(path: &Path, home: &Path, name: &str) -> Result<VettedBinary, 
 /// is running. The alternative considered and rejected was moving them all
 /// into `mod slow`, which would take roughly twenty tests out of the inner
 /// loop to fix a problem none of them are about.
+///
+/// # Errors
+/// The same [`AdoptRefusal`] set [`vet_binary`] raises, with the `--version`
+/// probe bounded by `budget` rather than by [`VERSION_BUDGET`].
 pub fn vet_binary_within(
     path: &Path,
     home: &Path,
@@ -642,6 +646,13 @@ fn ask_version(
     // place credentials live. Clearing and rebuilding models the run more
     // closely, not less. See `probe_env`.
     //
+    // The restart caller is the sharper case, and review is what made it
+    // visible. `vet_binary` WARNS about a group-writable binary and adopts
+    // it anyway, so a group member can replace an adopted dog. Every
+    // `shep restart <name>` after that runs their code, and a probe that
+    // ignores `--version` is a program of their choosing reading whatever
+    // the operator had exported.
+    //
     // An earlier revision of this comment said that filtered environment has
     // the dog's `[dog.<name>]` env merged over it, citing `AppConfig::env`'s
     // doc. That is true of a sheep and false of a dog: `dog_app` builds an
@@ -670,25 +681,8 @@ fn ask_version(
     // one could imitate shep's own output at the exact moment somebody is
     // deciding whether to trust it. The pipe is read by [`version_answer`]
     // and never rendered.
-    // `env_clear` and then an allowlist, NOT the operator's environment.
-    //
-    // An earlier revision inherited it, arguing that vetting has to model
-    // the run rather than an idealised one, and that clearing would refuse
-    // a binary needing `DYLD_LIBRARY_PATH` despite it working once adopted.
-    // The first half of that is right and the conclusion was backwards: the
-    // environment a dog actually runs with is the one the DAEMON builds,
-    // `assemble::base_env`, which is `PATH` plus a short allowlist. The
-    // operator's shell is a much richer thing, and it is the one place
-    // credentials live.
-    //
-    // That matters here more than at `adopt`, and review is what made it
-    // visible. `vet_binary` WARNS about a group-writable binary and adopts
-    // it anyway, so a group member can replace an adopted dog. Every
-    // `shep restart <name>` after that runs their code with whatever the
-    // operator had exported, and a probe that ignores `--version` is a
-    // program of their choosing reading it. Modelling the daemon's
-    // environment removes that and makes the vet a better model at the same
-    // time, which is why the original argument now points this way.
+    // `env_clear` and then the allowlist, never the operator's environment.
+    // Argued at the top of this function; `probe_env` builds the list.
     match Command::new(path)
         .arg(VERSION_FLAG)
         .env_clear()

--- a/crates/shep-cli/src/commands/dogs.rs
+++ b/crates/shep-cli/src/commands/dogs.rs
@@ -433,7 +433,46 @@ impl core::error::Error for AdoptRefusal {}
 /// [`AdoptRefusal::ProtocolMismatch`] when the candidate names a protocol
 /// this shep cannot speak. Nothing here is a shep fault, so none of these
 /// is an [`ExitCode::Internal`].
+/// Proves this kernel can exec `path`, and asks it what protocol it speaks.
+///
+/// The candidate is spawned twice over: once bare, to prove the exec works
+/// at all rather than discovering it at supervision time, and once with
+/// `--version` to read the contract in `docs/dogs.md`. A group-writable
+/// binary is reported rather than refused, since an operator naming a path
+/// has already made that call.
+///
+/// # Errors
+/// [`AdoptRefusal`] when the path does not resolve, is not a file this
+/// kernel will exec, or answers a protocol this shep cannot talk to. A
+/// candidate that does not answer `--version` is NOT an error: its protocol
+/// is recorded as unknown, which `docs/dogs.md` promises is never a refusal.
 pub fn vet_binary(path: &Path, home: &Path, name: &str) -> Result<VettedBinary, AdoptRefusal> {
+    vet_binary_within(path, home, name, VERSION_BUDGET)
+}
+
+/// [`vet_binary`], against a caller-chosen budget for the `--version` probe.
+///
+/// Production has exactly one budget and [`vet_binary`] passes it. This
+/// exists for tests, and for a specific failure rather than for symmetry:
+/// the probe spawns a real child and bounds the wait on a wall clock, so
+/// every test reaching it inherits that bound. Measured under a full
+/// workspace run, a `/bin/sh` candidate takes 180 to 300ms and over a
+/// second at high thread counts, against a [`VERSION_BUDGET`] of one. A
+/// test asking a question that has nothing to do with timing then fails
+/// because the machine was busy, which is a test reporting on the runner
+/// rather than on shep.
+///
+/// So a test that cares about the budget passes a small one and a test that
+/// does not passes a generous one, and neither is at the mercy of what else
+/// is running. The alternative considered and rejected was moving them all
+/// into `mod slow`, which would take roughly twenty tests out of the inner
+/// loop to fix a problem none of them are about.
+pub fn vet_binary_within(
+    path: &Path,
+    home: &Path,
+    name: &str,
+    budget: Duration,
+) -> Result<VettedBinary, AdoptRefusal> {
     let metadata = std::fs::metadata(path).map_err(|_| AdoptRefusal::Missing)?;
     if !metadata.is_file() {
         return Err(AdoptRefusal::NotAFile);
@@ -462,7 +501,7 @@ pub fn vet_binary(path: &Path, home: &Path, name: &str) -> Result<VettedBinary, 
         .map(|abs| shep_core::paths::strip_verbatim_prefix(&abs).into_owned())
         .map_err(|_| AdoptRefusal::Missing)?;
     let group_writable = writability(&canonical)?;
-    let answer = ask_version(&canonical, home, name)?;
+    let answer = ask_version(&canonical, home, name, budget)?;
     // Only a STATED protocol can refuse, and only this one thing can.
     // `answer.version` is deliberately not compared with anything: a
     // third-party dog's crate version has no relationship to shep's own --
@@ -505,9 +544,60 @@ pub fn vet_binary(path: &Path, home: &Path, name: &str) -> Result<VettedBinary, 
 /// # Errors
 /// [`AdoptRefusal::WillNotExec`], and only that: nothing here judges the
 /// answer it read, so [`AdoptRefusal::ProtocolMismatch`] stays
+/// The environment the probe runs a candidate with: what the daemon would
+/// give the dog, and nothing else.
+///
+/// Mirrors `shep_daemon::assemble::base_env` rather than importing it,
+/// because that function is private to a crate the CLI does not otherwise
+/// reach into for this. The lists are duplicated and that is a real cost:
+/// if the daemon's allowlist grows, this one has to follow, or a candidate
+/// is vetted under conditions its supervised run will not have.
+/// `a_probe_runs_with_the_daemons_environment_and_not_the_operators` is the
+/// test that fails when they disagree about the two variables that matter.
+fn probe_env() -> Vec<(String, String)> {
+    #[cfg(unix)]
+    const INHERITED: &[&str] = &["HOME", "USER", "LANG", "TZ"];
+    #[cfg(unix)]
+    const DEFAULT_PATH: &str = "/usr/local/bin:/usr/bin:/bin";
+    #[cfg(windows)]
+    const INHERITED: &[&str] = &[
+        "SystemRoot",
+        "SystemDrive",
+        "windir",
+        "TEMP",
+        "TMP",
+        "USERPROFILE",
+        "APPDATA",
+        "LOCALAPPDATA",
+        "COMSPEC",
+        "PATHEXT",
+        "NUMBER_OF_PROCESSORS",
+        "PROCESSOR_ARCHITECTURE",
+    ];
+    #[cfg(windows)]
+    const DEFAULT_PATH: &str = r"C:\Windows\system32;C:\Windows;C:\Windows\System32\Wbem";
+
+    let path = std::env::var("PATH")
+        .ok()
+        .filter(|p| !p.is_empty())
+        .unwrap_or_else(|| DEFAULT_PATH.to_string());
+    let mut env = vec![("PATH".to_string(), path)];
+    env.extend(
+        INHERITED
+            .iter()
+            .filter_map(|key| std::env::var(key).ok().map(|v| ((*key).to_string(), v))),
+    );
+    env
+}
+
 /// [`vet_binary`]'s to raise. A caller that only wants an answer treats the
 /// error as one more way of not getting one.
-fn ask_version(path: &Path, home: &Path, name: &str) -> Result<Option<DogVersion>, AdoptRefusal> {
+fn ask_version(
+    path: &Path,
+    home: &Path,
+    name: &str,
+    budget: Duration,
+) -> Result<Option<DogVersion>, AdoptRefusal> {
     // Spawned with ONE argument, `--version`, and torn down
     // unconditionally: `kill` is ignored (a process that already exited is
     // not a failure to vet), but `wait` always runs, on every path out of
@@ -537,14 +627,20 @@ fn ask_version(path: &Path, home: &Path, name: &str) -> Result<Option<DogVersion
     // to do would connect to the LIVE daemon and do it, during the command
     // whose entire purpose is deciding whether to trust the binary at all.
     //
-    // NOT `env_clear()`. A real
-    // adopted dog runs with a filtered environment the daemon builds
-    // (`assemble::base_env`: `PATH`, plus whichever of `HOME`/`USER`/`LANG`/
-    // `TZ` the daemon itself has), so clearing here would vet under stricter
-    // conditions than the dog will ever run under, and a binary needing
-    // `DYLD_LIBRARY_PATH` or its like would be refused despite working
-    // perfectly once adopted. Vetting has to model the real thing, not an
-    // idealised one.
+    // `env_clear()` and then the daemon's own allowlist, which is a
+    // REVERSAL of what this comment used to say and worth recording rather
+    // than quietly swapping. It argued that clearing would vet under
+    // stricter conditions than the dog ever runs under, so a binary needing
+    // `DYLD_LIBRARY_PATH` would be refused despite working once adopted,
+    // and that vetting has to model the real thing.
+    //
+    // The principle was right and the conclusion inverted. The real thing
+    // is not the operator's shell: an adopted dog runs with what the DAEMON
+    // builds (`assemble::base_env`: `PATH` plus a short allowlist), so
+    // inheriting the operator's environment vetted under LOOSER conditions
+    // than the dog will ever see, and handed a stranger's binary the one
+    // place credentials live. Clearing and rebuilding models the run more
+    // closely, not less. See `probe_env`.
     //
     // An earlier revision of this comment said that filtered environment has
     // the dog's `[dog.<name>]` env merged over it, citing `AppConfig::env`'s
@@ -574,8 +670,29 @@ fn ask_version(path: &Path, home: &Path, name: &str) -> Result<Option<DogVersion
     // one could imitate shep's own output at the exact moment somebody is
     // deciding whether to trust it. The pipe is read by [`version_answer`]
     // and never rendered.
+    // `env_clear` and then an allowlist, NOT the operator's environment.
+    //
+    // An earlier revision inherited it, arguing that vetting has to model
+    // the run rather than an idealised one, and that clearing would refuse
+    // a binary needing `DYLD_LIBRARY_PATH` despite it working once adopted.
+    // The first half of that is right and the conclusion was backwards: the
+    // environment a dog actually runs with is the one the DAEMON builds,
+    // `assemble::base_env`, which is `PATH` plus a short allowlist. The
+    // operator's shell is a much richer thing, and it is the one place
+    // credentials live.
+    //
+    // That matters here more than at `adopt`, and review is what made it
+    // visible. `vet_binary` WARNS about a group-writable binary and adopts
+    // it anyway, so a group member can replace an adopted dog. Every
+    // `shep restart <name>` after that runs their code with whatever the
+    // operator had exported, and a probe that ignores `--version` is a
+    // program of their choosing reading it. Modelling the daemon's
+    // environment removes that and makes the vet a better model at the same
+    // time, which is why the original argument now points this way.
     match Command::new(path)
         .arg(VERSION_FLAG)
+        .env_clear()
+        .envs(probe_env())
         .env("SHEP_HOME", home)
         .env("SHEP_DOG_NAME", name)
         .stdin(Stdio::null())
@@ -596,7 +713,7 @@ fn ask_version(path: &Path, home: &Path, name: &str) -> Result<Option<DogVersion
                 let _ = child.wait();
                 return Err(AdoptRefusal::WillNotExec { reason });
             }
-            let answer = version_answer(&mut child, reading);
+            let answer = version_answer(&mut child, reading, budget);
             let _ = child.kill();
             let _ = child.wait();
             Ok(answer)
@@ -653,7 +770,7 @@ const SHEP_PROTOCOL_KEY: &str = "shep-protocol";
 /// binary that hangs is killed at the budget and the restart proceeds
 /// unwarned, so the slowest thing a dog can do to `shep restart` is delay
 /// it, never block it.
-const VERSION_BUDGET: Duration = Duration::from_secs(1);
+pub(crate) const VERSION_BUDGET: Duration = Duration::from_secs(1);
 
 /// How often [`version_answer`] polls within [`VERSION_BUDGET`], following
 /// [`macos_deferred_exec_failure`]'s own polled-with-a-budget shape rather
@@ -666,6 +783,13 @@ const VERSION_POLL_INTERVAL: Duration = Duration::from_millis(2);
 /// The two fields answer different questions and only one of them can
 /// refuse an adopt: see [`AdoptRefusal::ProtocolMismatch`].
 #[derive(Debug, PartialEq, Eq)]
+/// What a dog answered `--version` with.
+///
+/// Two numbers rather than one, because they answer different questions:
+/// `protocol` decides whether the dog can handshake at all, and `version`
+/// only says which build it is. A dog may give the second and not the
+/// first, which is why `protocol` is optional and an absent one is unknown
+/// rather than incompatible.
 pub struct DogVersion {
     /// The last whitespace-separated field of line 1 -- the version. The
     /// name before it is ignored, so a crate whose name differs from the
@@ -743,18 +867,22 @@ fn read_in_background(mut stdout: std::process::ChildStdout) -> Receiver<String>
 /// failed are not an answer -- and believing them would let a candidate
 /// refuse its own adopt with a protocol number from a code path that did
 /// not work.
-fn version_answer(child: &mut Child, reading: Option<Receiver<String>>) -> Option<DogVersion> {
+fn version_answer(
+    child: &mut Child,
+    reading: Option<Receiver<String>>,
+    budget: Duration,
+) -> Option<DogVersion> {
     let reading = reading?;
     let started = Instant::now();
     loop {
         match child.try_wait() {
             Ok(Some(status)) if status.success() => break,
             Ok(Some(_)) | Err(_) => return None,
-            Ok(None) if started.elapsed() >= VERSION_BUDGET => return None,
+            Ok(None) if started.elapsed() >= budget => return None,
             Ok(None) => std::thread::sleep(VERSION_POLL_INTERVAL),
         }
     }
-    parse_version_answer(&reading.recv_timeout(VERSION_BUDGET).ok()?)
+    parse_version_answer(&reading.recv_timeout(budget).ok()?)
 }
 
 /// Who besides the owner can write `canonical` and the directory holding
@@ -997,10 +1125,21 @@ const DOG_BINARY_SKEW_NOTICE: &str = "dog_binary_skew";
 /// before it could look up a path, and a round trip is a lot to spend on
 /// the rarer way of typing the same thing. An operator who restarts a dog
 /// by id gets the restart and no warning.
+/// Takes the probe budget rather than reading [`VERSION_BUDGET`], for the
+/// same reason [`vet_binary_within`] exists. Both callers have a budget in
+/// hand, so there is no wrapper to add: `restart` passes the production
+/// one, and a test passes one that contention cannot exhaust.
+///
+/// A test here asks whether the warning fires, in what order, and what it
+/// says. At the production budget it was also asking how busy the machine
+/// was, because a probe that times out answers unknown, and unknown is
+/// deliberately silent, so the test failed reporting that no warning fired.
+/// True about the runner, empty about shep.
 pub fn warn_of_a_dog_a_restart_would_break(
     streams: &mut Streams<'_>,
     paths: &ShepPaths,
     selectors: &[SelectorSpec],
+    budget: Duration,
 ) {
     for selector in selectors {
         let SelectorSpec::Name(name) = selector else {
@@ -1039,7 +1178,7 @@ pub fn warn_of_a_dog_a_restart_would_break(
         // `online` for two days. It is a real cost though, so it is named
         // in `docs/dogs.md` where an operator can read it rather than only
         // here.
-        let Ok(Some(answer)) = ask_version(&binary, &paths.home, name) else {
+        let Ok(Some(answer)) = ask_version(&binary, &paths.home, name, budget) else {
             continue;
         };
         let Some(disk) = answer.protocol else {
@@ -1755,18 +1894,18 @@ mod tests {
     fn a_binary_shep_has_never_seen_is_vetted_before_anything_is_written() {
         let dir = tempfile::tempdir().unwrap();
         assert_eq!(
-            vet_binary(&dir.path().join("nope"), dir.path(), "probe"),
+            vet_binary_within(&dir.path().join("nope"), dir.path(), "probe", TEST_BUDGET),
             Err(AdoptRefusal::Missing)
         );
         assert_eq!(
-            vet_binary(dir.path(), dir.path(), "probe"),
+            vet_binary_within(dir.path(), dir.path(), "probe", TEST_BUDGET),
             Err(AdoptRefusal::NotAFile)
         );
 
         let plain = dir.path().join("plain");
         std::fs::write(&plain, "#!/bin/sh\nexit 0\n").unwrap();
         assert_eq!(
-            vet_binary(&plain, dir.path(), "probe"),
+            vet_binary_within(&plain, dir.path(), "probe", TEST_BUDGET),
             Err(AdoptRefusal::NotExecutable)
         );
 
@@ -1774,7 +1913,7 @@ mod tests {
         // mode bit, so a `vet_binary` that refused for some other reason
         // fails here rather than passing for the wrong one.
         chmod(&plain, 0o755);
-        let vetted = vet_binary(&plain, dir.path(), "probe").unwrap();
+        let vetted = vet_binary_within(&plain, dir.path(), "probe", TEST_BUDGET).unwrap();
         assert_eq!(vetted.path, plain.canonicalize().unwrap());
         assert!(
             vetted.group_writable.is_empty(),
@@ -1786,7 +1925,7 @@ mod tests {
         std::fs::write(&bogus, b"\x7fELF\x00\x00\x00 not really").unwrap();
         chmod(&bogus, 0o755);
         assert!(matches!(
-            vet_binary(&bogus, dir.path(), "probe"),
+            vet_binary_within(&bogus, dir.path(), "probe", TEST_BUDGET),
             Err(AdoptRefusal::WillNotExec { .. })
         ));
     }
@@ -1807,7 +1946,7 @@ mod tests {
         std::fs::write(&bin, "#!/bin/sh\nexit 0\n").unwrap();
         chmod(&bin, 0o757);
         assert_eq!(
-            vet_binary(&bin, dir.path(), "probe"),
+            vet_binary_within(&bin, dir.path(), "probe", TEST_BUDGET),
             Err(AdoptRefusal::WorldWritable {
                 path: bin.canonicalize().unwrap(),
             }),
@@ -1818,7 +1957,7 @@ mod tests {
         chmod(&bin, 0o755);
         chmod(dir.path(), 0o777);
         assert_eq!(
-            vet_binary(&bin, dir.path(), "probe"),
+            vet_binary_within(&bin, dir.path(), "probe", TEST_BUDGET),
             Err(AdoptRefusal::WorldWritable {
                 path: bin.canonicalize().unwrap().parent().unwrap().to_path_buf(),
             }),
@@ -1861,7 +2000,7 @@ mod tests {
         );
 
         assert_eq!(
-            vet_binary(&bin, dir.path(), "otel"),
+            vet_binary_within(&bin, dir.path(), "otel", TEST_BUDGET),
             Err(AdoptRefusal::ProtocolMismatch {
                 dog: stale,
                 shep: PROTOCOL_VERSION,
@@ -1909,7 +2048,7 @@ mod tests {
             &format!("echo 'shep-otel 9.9.9-rc1'\necho 'shep-protocol: {PROTOCOL_VERSION}'"),
         );
 
-        let vetted = vet_binary(&bin, dir.path(), "otel").unwrap();
+        let vetted = vet_binary_within(&bin, dir.path(), "otel", TEST_BUDGET).unwrap();
         assert_eq!(
             vetted.answer,
             Some(DogVersion {
@@ -1954,7 +2093,7 @@ mod tests {
         let paths = ShepPaths::resolve(&|_| None, dir.path());
         let bin = dog_script(dir.path(), "shep-otel", "exit 0");
 
-        let vetted = vet_binary(&bin, dir.path(), "otel").unwrap();
+        let vetted = vet_binary_within(&bin, dir.path(), "otel", TEST_BUDGET).unwrap();
         assert_eq!(vetted.answer, None, "silence is an unknown, not an answer");
 
         let mut out = Vec::new();
@@ -1985,7 +2124,7 @@ mod tests {
         let paths = ShepPaths::resolve(&|_| None, dir.path());
         let bin = dog_script(dir.path(), "shep-otel", "echo 'shep-otel 0.1.3'");
 
-        let vetted = vet_binary(&bin, dir.path(), "otel").unwrap();
+        let vetted = vet_binary_within(&bin, dir.path(), "otel", TEST_BUDGET).unwrap();
         assert_eq!(
             vetted.answer,
             Some(DogVersion {
@@ -2010,6 +2149,61 @@ mod tests {
         );
     }
 
+    /// A budget for tests that are not about the budget.
+    ///
+    /// The probe spawns a real child, so every test reaching `vet_binary`
+    /// inherits a wall-clock bound. At the production one second, a test
+    /// asking whether a version string parses fails when the machine is
+    /// busy, which is the runner reporting on itself. Thirty seconds is not
+    /// a claim that a probe should ever take that long; it is far enough
+    /// above any contention this suite produces that timing stops being a
+    /// variable in tests that never meant to measure it.
+    ///
+    /// `a_candidate_that_never_exits_does_not_hang_the_vet` deliberately
+    /// does NOT use this: it is the one test that is about the bound, so it
+    /// passes the real budget.
+    const TEST_BUDGET: Duration = Duration::from_secs(30);
+
+    /// fails if the probe hands a candidate the operator's environment.
+    ///
+    /// The candidate is somebody else's binary, and `vet_binary` warns
+    /// about a group-writable one rather than refusing it, so a group
+    /// member can replace an adopted dog and have their code run on the
+    /// next `shep restart <name>`. If the probe inherited the operator's
+    /// shell, that code would be reading whatever they had exported.
+    ///
+    /// `CARGO_PKG_NAME` is the sentinel because cargo sets it for this very
+    /// process and it is not on the daemon's allowlist, so no environment
+    /// has to be mutated to run this: a leak would show up as the child
+    /// seeing a variable this test never gave it.
+    #[cfg(unix)]
+    #[test]
+    fn a_probe_runs_with_the_daemons_environment_and_not_the_operators() {
+        assert!(
+            std::env::var("CARGO_PKG_NAME").is_ok(),
+            "the sentinel has to be in this process for its absence downstream to mean anything"
+        );
+        let dir = tempfile::tempdir().unwrap();
+        // The sentinel has to be the LAST field of line 1, because that is
+        // the only part `parse_version_answer` keeps. An earlier version of
+        // this test put it first and asserted on `version`, so the string it
+        // checked could never have contained the sentinel: it passed with
+        // `env_clear` removed, which is the definition of proving nothing.
+        let bin = dog_script(
+            dir.path(),
+            "shep-otel",
+            "echo \"shep-otel ${CARGO_PKG_NAME:-clean}\"",
+        );
+
+        let vetted = vet_binary_within(&bin, dir.path(), "otel", TEST_BUDGET).unwrap();
+        let version = vetted.answer.expect("the candidate answered").version;
+
+        assert_eq!(
+            version, "clean",
+            "the operator's environment reached a candidate: it saw CARGO_PKG_NAME"
+        );
+    }
+
     /// fails if a candidate that never exits hangs `adopt`. The vet spawns
     /// somebody else's binary and cannot assume it is well behaved, and a
     /// hung `adopt` is worse than an unknown protocol: the operator has no
@@ -2025,7 +2219,8 @@ mod tests {
         let bin = dog_script(dir.path(), "shep-otel", "sleep 30");
 
         let started = std::time::Instant::now();
-        let vetted = vet_binary(&bin, dir.path(), "otel").unwrap();
+        // The real budget, not `TEST_BUDGET`: this test IS the bound.
+        let vetted = vet_binary_within(&bin, dir.path(), "otel", VERSION_BUDGET).unwrap();
         let elapsed = started.elapsed();
 
         assert_eq!(
@@ -2061,7 +2256,7 @@ mod tests {
             &format!("echo 'shep-otel 0.1.3'\necho 'shep-protocol: {stale}'\nexit 3"),
         );
 
-        let vetted = vet_binary(&bin, dir.path(), "otel").unwrap();
+        let vetted = vet_binary_within(&bin, dir.path(), "otel", TEST_BUDGET).unwrap();
         assert_eq!(vetted.answer, None);
     }
 
@@ -2078,7 +2273,7 @@ mod tests {
             "echo 'error: unrecognized option --version'",
         );
 
-        let vetted = vet_binary(&bin, dir.path(), "otel").unwrap();
+        let vetted = vet_binary_within(&bin, dir.path(), "otel", TEST_BUDGET).unwrap();
         assert_eq!(
             vetted.answer,
             Some(DogVersion {
@@ -2137,7 +2332,7 @@ mod tests {
         chmod(&bin, 0o775);
         chmod(&deploy, 0o775);
 
-        let vetted = vet_binary(&bin, dir.path(), "otel").unwrap();
+        let vetted = vet_binary_within(&bin, dir.path(), "otel", TEST_BUDGET).unwrap();
         assert_eq!(
             vetted.group_writable,
             vec![bin.canonicalize().unwrap(), deploy.canonicalize().unwrap()],

--- a/crates/shep-cli/src/commands/dogs.rs
+++ b/crates/shep-cli/src/commands/dogs.rs
@@ -33,9 +33,11 @@
 
 use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
-use std::process::{Command, Stdio};
+use std::process::{Child, Command, Stdio};
+use std::sync::mpsc::Receiver;
+use std::time::{Duration, Instant};
 
-use shep_client::{Client, ConnectError};
+use shep_client::{Client, ConnectError, PROTOCOL_VERSION};
 use shep_core::barks;
 use shep_core::paths::ShepPaths;
 use shep_core::protocol::{DogSource, Request, Response};
@@ -345,6 +347,20 @@ pub enum AdoptRefusal {
         /// What `exec` reported.
         reason: String,
     },
+    /// It answered `--version` (see [`DogVersion`]) with a `shep-protocol`
+    /// this shep does not speak. The two cannot handshake, so adopting it
+    /// would register a dog that connects to nothing — G11's
+    /// online-and-idle entry, refused here instead of discovered days
+    /// later.
+    ///
+    /// Only a stated protocol reaches this. A dog that names none is
+    /// [`DogVersion::protocol`]'s `None` and is adopted.
+    ProtocolMismatch {
+        /// What the candidate said it speaks.
+        dog: u32,
+        /// [`PROTOCOL_VERSION`], what this shep speaks.
+        shep: u32,
+    },
 }
 
 impl std::fmt::Display for AdoptRefusal {
@@ -362,6 +378,12 @@ impl std::fmt::Display for AdoptRefusal {
             Self::WillNotExec { reason } => {
                 write!(f, "this kernel refused to run that file: {reason}")
             }
+            Self::ProtocolMismatch { dog, shep } => write!(
+                f,
+                "this dog was built for shep protocol {dog}, and this shep speaks {shep}; \
+                 reinstall the dog without --locked so it builds against the current \
+                 shep-core, or run a shep that speaks {dog}"
+            ),
         }
     }
 }
@@ -385,14 +407,21 @@ impl core::error::Error for AdoptRefusal {}
 /// binary, and a binary any user can rewrite is not one to run in order to
 /// find out whether it runs. The fifth,
 /// [`AdoptRefusal::WillNotExec`], is answered by actually trying it —
-/// spawned with the same (empty) argument list the daemon uses for an
-/// adopted dog (`shep-daemon/src/dogs.rs`'s `dog_app`), and killed once it
-/// is confirmed either to have run or to be still running. The question is
-/// whether this kernel can exec this file, and the only authority on that
-/// is this kernel; reading a header instead would mean writing a second,
-/// partial loader that disagrees with the real one — on a fat Mach-O, on a
-/// shebang naming an absent interpreter, on a binary needing a missing
-/// dynamic library.
+/// spawned, and killed once it is confirmed either to have run or to be
+/// still running. The question is whether this kernel can exec this file,
+/// and the only authority on that is this kernel; reading a header instead
+/// would mean writing a second, partial loader that disagrees with the real
+/// one — on a fat Mach-O, on a shebang naming an absent interpreter, on a
+/// binary needing a missing dynamic library.
+///
+/// The sixth, [`AdoptRefusal::ProtocolMismatch`], rides on that same
+/// process: it is spawned with [`VERSION_FLAG`], so the run that proves the
+/// kernel can exec the file is the same run that answers what protocol it
+/// speaks. A dog that answers a protocol this shep does not speak is
+/// refused here rather than adopted into an entry that connects to nothing.
+/// A dog that answers nothing is adopted with [`VettedBinary::answer`]
+/// `None`: answering is optional and stays optional, so every dog written
+/// before the contract existed is still adoptable.
 ///
 /// `home` and `name` are the ones this invocation resolved, not the ambient
 /// ones — the probe is handed exactly the environment the adopted dog will
@@ -400,8 +429,10 @@ impl core::error::Error for AdoptRefusal {}
 /// under the section key `adopt` is about to record.
 ///
 /// # Errors
-/// The refusal, which the caller renders. Nothing here is a shep fault, so
-/// none of these is an [`ExitCode::Internal`].
+/// The refusal, which the caller renders — including
+/// [`AdoptRefusal::ProtocolMismatch`] when the candidate names a protocol
+/// this shep cannot speak. Nothing here is a shep fault, so none of these
+/// is an [`ExitCode::Internal`].
 pub fn vet_binary(path: &Path, home: &Path, name: &str) -> Result<VettedBinary, AdoptRefusal> {
     let metadata = std::fs::metadata(path).map_err(|_| AdoptRefusal::Missing)?;
     if !metadata.is_file() {
@@ -431,11 +462,26 @@ pub fn vet_binary(path: &Path, home: &Path, name: &str) -> Result<VettedBinary, 
         .map(|abs| shep_core::paths::strip_verbatim_prefix(&abs).into_owned())
         .map_err(|_| AdoptRefusal::Missing)?;
     let group_writable = writability(&canonical)?;
-    // Spawned with no arguments — an adopted dog is run exactly this way
-    // (`dog_app`'s own doc) — and torn down unconditionally: `kill` is
-    // ignored (a process that already exited is not a failure to vet), but
-    // `wait` always runs, on every path out of this match, so no zombie
-    // survives a refusal or a success.
+    // Spawned with ONE argument, `--version`, and torn down
+    // unconditionally: `kill` is ignored (a process that already exited is
+    // not a failure to vet), but `wait` always runs, on every path out of
+    // this match, so no zombie survives a refusal or a success.
+    //
+    // That argument is the one place shep invents an argv for an adopted
+    // dog, and `dog_app`'s own doc argues the other way for the SUPERVISED
+    // run: "an argv shep invented for it is one more thing it has to agree
+    // with before it can start", so a dog is run with none. Both are
+    // right, because they are different runs. A supervised dog must work
+    // for a stranger who never read this repo, so shep asks it for nothing.
+    // This process is a throwaway that exists only to be observed and
+    // killed, so the cost of a candidate disagreeing about `--version` is
+    // an unknown protocol -- and `docs/dogs.md` promises that an unknown
+    // protocol is never a refusal. The vet asks; the supervisor does not.
+    //
+    // A candidate is somebody else's binary and is not assumed to be well
+    // behaved about any of it: [`version_answer`] bounds the wait, so a
+    // candidate that never exits costs [`VERSION_BUDGET`] rather than
+    // hanging the `adopt` that is trying to vet it.
     //
     // `SHEP_HOME` is set to the home this invocation actually resolved, not
     // inherited: an inherited `SHEP_HOME` is usually unset, so the
@@ -476,15 +522,18 @@ pub fn vet_binary(path: &Path, home: &Path, name: &str) -> Result<VettedBinary, 
     // killed on sight (immediately, on every kernel but macOS), so anything
     // it writes to prove what it received is a race with its own teardown.
     //
-    // Stdio goes to null. A candidate that writes on its way up would
+    // Stdin and stderr go to null, and stdout to a pipe shep reads rather
+    // than to the terminal. A candidate that writes on its way up would
     // otherwise scribble over the operator's terminal mid-vet, and a hostile
     // one could imitate shep's own output at the exact moment somebody is
-    // deciding whether to trust it.
+    // deciding whether to trust it. The pipe is read by [`version_answer`]
+    // and never rendered.
     match Command::new(&canonical)
+        .arg(VERSION_FLAG)
         .env("SHEP_HOME", home)
         .env("SHEP_DOG_NAME", name)
         .stdin(Stdio::null())
-        .stdout(Stdio::null())
+        .stdout(Stdio::piped())
         .stderr(Stdio::null())
         .spawn()
     {
@@ -492,15 +541,39 @@ pub fn vet_binary(path: &Path, home: &Path, name: &str) -> Result<VettedBinary, 
             reason: err.to_string(),
         }),
         Ok(mut child) => {
+            // Started before the exec probe below and before any wait: a
+            // candidate that writes more than a pipe buffer holds would
+            // otherwise block on its own `write` forever, and be
+            // indistinguishable from one that simply never exits.
+            let reading = child.stdout.take().map(read_in_background);
             if let Some(reason) = macos_deferred_exec_failure(&mut child) {
                 let _ = child.wait();
                 return Err(AdoptRefusal::WillNotExec { reason });
             }
+            let answer = version_answer(&mut child, reading);
             let _ = child.kill();
             let _ = child.wait();
+            // Only a STATED protocol can refuse, and only this one thing
+            // can. `answer.version` is deliberately not compared with
+            // anything: a third-party dog's crate version has no
+            // relationship to shep's own -- `shep-log-rotate` 0.1.3 against
+            // shep 0.1.24 is the ordinary case, not a skew -- so comparing
+            // them would refuse, or warn about, every dog that exists.
+            // `docs/dogs.md`'s table is what this implements: the protocol
+            // decides whether the dog can connect at all and is hard, the
+            // version says which build it is and is reported.
+            if let Some(dog) = answer.as_ref().and_then(|answer| answer.protocol)
+                && dog != PROTOCOL_VERSION
+            {
+                return Err(AdoptRefusal::ProtocolMismatch {
+                    dog,
+                    shep: PROTOCOL_VERSION,
+                });
+            }
             Ok(VettedBinary {
                 path: canonical,
                 group_writable,
+                answer,
             })
         }
     }
@@ -517,6 +590,128 @@ pub struct VettedBinary {
     /// directory, both, or (the ordinary case) neither. `adopt` reports one
     /// notice per entry; nothing here is a refusal.
     pub group_writable: Vec<PathBuf>,
+    /// What it answered when asked for its version, and `None` when it
+    /// answered nothing shep could read -- silence, a failed run, or output
+    /// with no first line. `adopt` reports it and does not record it; see
+    /// [`DogVersion`].
+    pub answer: Option<DogVersion>,
+}
+
+/// The flag [`vet_binary`] asks a candidate with, and the one
+/// `docs/dogs.md` publishes as the contract.
+const VERSION_FLAG: &str = "--version";
+
+/// The one key [`parse_version_answer`] reads. Every other `shep-` key is
+/// reserved for a number this shep has not heard of, and is ignored rather
+/// than refused, so a dog written against a later contract stays adoptable
+/// by this one.
+const SHEP_PROTOCOL_KEY: &str = "shep-protocol";
+
+/// How long [`version_answer`] gives a candidate to answer, and separately
+/// how long it then waits for that answer to reach the reader thread.
+///
+/// One second, against the milliseconds a `println!` and an exit take. The
+/// generosity is for a cold, dynamically linked binary on a loaded machine,
+/// and the ceiling is what an operator will sit through: `adopt` is
+/// interactive and runs once. Both ways of being wrong are survivable and
+/// they are not symmetric -- too short records an unknown protocol for a
+/// slow dog, which costs the gate and not the adopt, while too long stalls
+/// every adopt of the dogs that exist today, none of which answer at all.
+const VERSION_BUDGET: Duration = Duration::from_secs(1);
+
+/// How often [`version_answer`] polls within [`VERSION_BUDGET`], following
+/// [`macos_deferred_exec_failure`]'s own polled-with-a-budget shape rather
+/// than inventing a second one.
+const VERSION_POLL_INTERVAL: Duration = Duration::from_millis(2);
+
+/// What a candidate answered to `--version`, parsed by
+/// [`parse_version_answer`] from the format `docs/dogs.md` publishes.
+///
+/// The two fields answer different questions and only one of them can
+/// refuse an adopt: see [`AdoptRefusal::ProtocolMismatch`].
+#[derive(Debug, PartialEq, Eq)]
+pub struct DogVersion {
+    /// The last whitespace-separated field of line 1 -- the version. The
+    /// name before it is ignored, so a crate whose name differs from the
+    /// dog's registered name answers correctly without knowing it.
+    pub version: String,
+    /// The `shep-protocol` line's value, and `None` when the answer carried
+    /// no such line or carried one that is not a decimal number. Answering
+    /// is optional, so `None` is an unknown protocol rather than a fault.
+    pub protocol: Option<u32>,
+}
+
+/// Parses the format `docs/dogs.md` publishes: `<name> <version>` on line
+/// 1, then `<key>: <value>` lines.
+///
+/// `None` when there is no line 1 to read a version from. Everything past
+/// that is tolerated rather than refused -- unknown keys, blank lines, key
+/// order, and a `shep-protocol` that is not a number -- because a shep that
+/// refuses a dog over the shape of text the dog never promised to print is
+/// refusing on its own guess. The strictness is all in the other direction:
+/// only an exact [`SHEP_PROTOCOL_KEY`] carrying a decimal is believed, and
+/// only a believed protocol can refuse.
+fn parse_version_answer(text: &str) -> Option<DogVersion> {
+    let mut lines = text.lines();
+    let version = lines.next()?.split_whitespace().next_back()?.to_string();
+    let mut protocol = None;
+    for line in lines {
+        if let Some((key, value)) = line.split_once(':')
+            && key.trim() == SHEP_PROTOCOL_KEY
+        {
+            protocol = value.trim().parse().ok();
+        }
+    }
+    Some(DogVersion { version, protocol })
+}
+
+/// Drains `stdout` to end on a thread, handing the text back through the
+/// returned channel.
+///
+/// A thread rather than a read on this one, because every read here has to
+/// be bounded and none of them can be. Reading before the candidate exits
+/// blocks until it writes; reading after it exits blocks for as long as
+/// anything the candidate spawned still holds the inherited pipe open,
+/// which a candidate shep is vetting precisely because it does not trust it
+/// could do forever. On the timeout path the thread is left to end on its
+/// own when the pipe closes: it holds nothing but a `String` and a sender,
+/// and `adopt` is a one-shot command.
+fn read_in_background(mut stdout: std::process::ChildStdout) -> Receiver<String> {
+    let (tx, rx) = std::sync::mpsc::channel();
+    std::thread::spawn(move || {
+        use std::io::Read as _;
+        let mut text = String::new();
+        // A candidate answering in bytes that are not UTF-8 is answering
+        // nothing shep can read, which is the same unknown as silence.
+        let _ = stdout.read_to_string(&mut text);
+        let _ = tx.send(text);
+    });
+    rx
+}
+
+/// Waits, bounded by [`VERSION_BUDGET`], for `child` to answer.
+///
+/// `None` -- an unknown protocol, never a refusal -- for every way of not
+/// answering: no pipe to read, a run that did not exit inside the budget, a
+/// run that exited non-zero, or output with no line 1.
+///
+/// The non-zero exit is not a technicality. `docs/dogs.md` says a dog
+/// answers on stdout AND exits 0, so lines printed by a run that then
+/// failed are not an answer -- and believing them would let a candidate
+/// refuse its own adopt with a protocol number from a code path that did
+/// not work.
+fn version_answer(child: &mut Child, reading: Option<Receiver<String>>) -> Option<DogVersion> {
+    let reading = reading?;
+    let started = Instant::now();
+    loop {
+        match child.try_wait() {
+            Ok(Some(status)) if status.success() => break,
+            Ok(Some(_)) | Err(_) => return None,
+            Ok(None) if started.elapsed() >= VERSION_BUDGET => return None,
+            Ok(None) => std::thread::sleep(VERSION_POLL_INTERVAL),
+        }
+    }
+    parse_version_answer(&reading.recv_timeout(VERSION_BUDGET).ok()?)
 }
 
 /// Who besides the owner can write `canonical` and the directory holding
@@ -680,6 +875,38 @@ fn warn_group_writable(streams: &mut Streams<'_>, path: &Path) {
     streams.aside(GROUP_WRITABLE_NOTICE, &message);
 }
 
+/// [`emit_notice`] code for the version report -- caller-defined, like
+/// [`GROUP_WRITABLE_NOTICE`], and like it not a failure: `adopt` succeeded.
+const DOG_VERSION_NOTICE: &str = "dog_version";
+
+/// Tells the operator what the candidate answered.
+///
+/// Only the version is reported, never compared -- see [`vet_binary`] for
+/// why comparing a third-party dog's crate version with shep's own would
+/// report every dog that exists. The protocol is not reported when it
+/// matches, because by then it has already decided the only thing it can
+/// decide; it is reported when it is missing, because that is the operator's
+/// one chance to hear that this dog's compatibility is unknown and will be
+/// found out at a handshake instead.
+///
+/// A dog that answered nothing at all gets no notice. Every dog that
+/// existed when this contract was written is in that group, and a line on
+/// stderr for each of them would be noise about the ordinary case.
+fn report_dog_version(streams: &mut Streams<'_>, name: &str, answer: &DogVersion) {
+    let message = match answer.protocol {
+        Some(protocol) => format!(
+            "{name} reports version {}, shep protocol {protocol}",
+            answer.version
+        ),
+        None => format!(
+            "{name} reports version {} and names no shep protocol, so whether it can \
+             speak to this shep is unknown until it connects",
+            answer.version
+        ),
+    };
+    streams.aside(DOG_VERSION_NOTICE, &message);
+}
+
 /// `shep adopt <path> [--name <name>]`: vets a binary shep has never seen,
 /// records it, and starts it if a shepherd is running.
 ///
@@ -718,6 +945,9 @@ pub async fn adopt(streams: &mut Streams<'_>, paths: &ShepPaths, args: &AdoptArg
     let path = vetted.path;
     for writable in &vetted.group_writable {
         warn_group_writable(streams, writable);
+    }
+    if let Some(answer) = &vetted.answer {
+        report_dog_version(streams, &name, answer);
     }
     if let Err(err) = ShepToml::edit(&paths.daemon_config, |cfg| {
         cfg.adopt_dog(&name, &path);
@@ -1444,6 +1674,299 @@ mod tests {
         );
         // Restored so the tempdir cleans up from a known state.
         chmod(dir.path(), 0o700);
+    }
+
+    /// Writes an executable `/bin/sh` script at `dir/name` whose body is
+    /// `body`, for the `--version` cases below: a dog's answer is text on
+    /// stdout and an exit status, and a shell script is the shortest thing
+    /// that can produce any pair of those on demand.
+    fn dog_script(dir: &Path, name: &str, body: &str) -> PathBuf {
+        let path = dir.join(name);
+        std::fs::write(&path, format!("#!/bin/sh\n{body}\n")).unwrap();
+        chmod(&path, 0o755);
+        path
+    }
+
+    /// fails if a dog built against a protocol this shep cannot speak is
+    /// adopted anyway — G11's whole point: it would become an
+    /// online-and-idle entry whose failure surfaces days later, at a
+    /// handshake nobody is watching.
+    ///
+    /// Pins both numbers and both fixes in the message, per the spec's
+    /// "a message naming the fix is the feature".
+    ///
+    /// Mutation check: dropping the `protocol != PROTOCOL_VERSION` guard
+    /// reddens this — the vet returns `Ok` and the adopt succeeds.
+    #[tokio::test]
+    async fn a_dog_that_speaks_another_protocol_is_refused_at_adopt() {
+        let dir = tempfile::tempdir().unwrap();
+        let paths = ShepPaths::resolve(&|_| None, dir.path());
+        let stale = PROTOCOL_VERSION + 1;
+        let bin = dog_script(
+            dir.path(),
+            "shep-otel",
+            &format!("echo 'shep-otel 0.1.3'\necho 'shep-protocol: {stale}'"),
+        );
+
+        assert_eq!(
+            vet_binary(&bin, dir.path(), "otel"),
+            Err(AdoptRefusal::ProtocolMismatch {
+                dog: stale,
+                shep: PROTOCOL_VERSION,
+            })
+        );
+
+        let mut out = Vec::new();
+        let mut err = Vec::new();
+        let args = AdoptArgs {
+            name: Some("otel".to_string()),
+            path: bin,
+        };
+        let code = adopt(&mut streams(&mut out, &mut err), &paths, &args).await;
+
+        assert_eq!(code, ExitCode::InvalidConfig);
+        let text = String::from_utf8(err).unwrap();
+        assert!(
+            text.contains(&stale.to_string()) && text.contains(&PROTOCOL_VERSION.to_string()),
+            "the refusal names both numbers: {text}"
+        );
+        assert!(
+            text.contains("--locked") && text.contains("run a shep that speaks"),
+            "the refusal names both fixes, and picks neither: {text}"
+        );
+        assert!(
+            !paths.daemon_config.exists(),
+            "a refused adopt must not write shep.toml"
+        );
+    }
+
+    /// fails if a version difference is treated as a protocol difference.
+    /// The two numbers answer different questions (`docs/dogs.md`): a
+    /// third-party dog's crate version has no relationship to shep's own,
+    /// so it is reported and never compared, while the protocol is the
+    /// only one that can refuse.
+    ///
+    /// Mutation check: refusing on anything but the protocol reddens this.
+    #[tokio::test]
+    async fn a_dog_whose_version_is_nothing_like_sheps_is_still_adopted() {
+        let dir = tempfile::tempdir().unwrap();
+        let paths = ShepPaths::resolve(&|_| None, dir.path());
+        let bin = dog_script(
+            dir.path(),
+            "shep-otel",
+            &format!("echo 'shep-otel 9.9.9-rc1'\necho 'shep-protocol: {PROTOCOL_VERSION}'"),
+        );
+
+        let vetted = vet_binary(&bin, dir.path(), "otel").unwrap();
+        assert_eq!(
+            vetted.answer,
+            Some(DogVersion {
+                version: "9.9.9-rc1".to_string(),
+                protocol: Some(PROTOCOL_VERSION),
+            })
+        );
+
+        let mut out = Vec::new();
+        let mut err = Vec::new();
+        let args = AdoptArgs {
+            name: Some("otel".to_string()),
+            path: bin,
+        };
+        let code = adopt(&mut streams(&mut out, &mut err), &paths, &args).await;
+
+        assert_eq!(
+            code,
+            ExitCode::Success,
+            "a version difference is not a refusal"
+        );
+        let text = String::from_utf8(err).unwrap();
+        assert!(
+            text.contains("9.9.9-rc1"),
+            "the version it answered is reported: {text}"
+        );
+    }
+
+    /// fails if a dog that says nothing at all is refused. Every dog that
+    /// exists predates this contract, including both published ones, so
+    /// refusing silence would break the entire population —
+    /// `docs/dogs.md` promises in published prose that it never happens.
+    /// The protocol is unknown and prediction degrades to G8's
+    /// post-connection detection for that dog alone.
+    ///
+    /// Mutation check: making the parser answer `Some(PROTOCOL_VERSION)`
+    /// for empty output reddens the `answer` assertion here rather than
+    /// leaving it passing for the wrong reason.
+    #[tokio::test]
+    async fn a_dog_that_does_not_answer_is_adopted_with_an_unknown_protocol() {
+        let dir = tempfile::tempdir().unwrap();
+        let paths = ShepPaths::resolve(&|_| None, dir.path());
+        let bin = dog_script(dir.path(), "shep-otel", "exit 0");
+
+        let vetted = vet_binary(&bin, dir.path(), "otel").unwrap();
+        assert_eq!(vetted.answer, None, "silence is an unknown, not an answer");
+
+        let mut out = Vec::new();
+        let mut err = Vec::new();
+        let args = AdoptArgs {
+            name: Some("otel".to_string()),
+            path: bin,
+        };
+        let code = adopt(&mut streams(&mut out, &mut err), &paths, &args).await;
+
+        assert_eq!(
+            code,
+            ExitCode::Success,
+            "a dog predating the contract is adoptable"
+        );
+        let cfg = std::fs::read_to_string(&paths.daemon_config).unwrap();
+        assert!(cfg.contains("otel"), "and it is recorded: {cfg}");
+    }
+
+    /// fails if the version line alone is treated as a protocol claim. A
+    /// clap-built dog prints `<name> <version>` for free without ever
+    /// having heard of `shep-protocol`, so this is the commonest partial
+    /// answer there is, and it is an unknown protocol rather than a
+    /// mismatched one.
+    #[tokio::test]
+    async fn a_dog_that_names_no_protocol_is_adopted_with_the_version_it_gave() {
+        let dir = tempfile::tempdir().unwrap();
+        let paths = ShepPaths::resolve(&|_| None, dir.path());
+        let bin = dog_script(dir.path(), "shep-otel", "echo 'shep-otel 0.1.3'");
+
+        let vetted = vet_binary(&bin, dir.path(), "otel").unwrap();
+        assert_eq!(
+            vetted.answer,
+            Some(DogVersion {
+                version: "0.1.3".to_string(),
+                protocol: None,
+            })
+        );
+
+        let mut out = Vec::new();
+        let mut err = Vec::new();
+        let args = AdoptArgs {
+            name: Some("otel".to_string()),
+            path: bin,
+        };
+        let code = adopt(&mut streams(&mut out, &mut err), &paths, &args).await;
+
+        assert_eq!(code, ExitCode::Success);
+        let text = String::from_utf8(err).unwrap();
+        assert!(
+            text.contains("0.1.3") && text.contains("unknown"),
+            "the operator hears the version and that the protocol is unknown: {text}"
+        );
+    }
+
+    /// fails if a candidate that never exits hangs `adopt`. The vet spawns
+    /// somebody else's binary and cannot assume it is well behaved, and a
+    /// hung `adopt` is worse than an unknown protocol: the operator has no
+    /// output, no refusal, and nothing to interrupt but the command.
+    ///
+    /// Mutation check: replacing the bounded wait with a blocking
+    /// `child.wait()` hangs this test rather than reddening it, which is
+    /// the point — the assertion on elapsed time is what turns that into a
+    /// failure a CI run can report.
+    #[test]
+    fn a_candidate_that_never_exits_does_not_hang_the_vet() {
+        let dir = tempfile::tempdir().unwrap();
+        let bin = dog_script(dir.path(), "shep-otel", "sleep 30");
+
+        let started = std::time::Instant::now();
+        let vetted = vet_binary(&bin, dir.path(), "otel").unwrap();
+        let elapsed = started.elapsed();
+
+        assert_eq!(
+            vetted.answer, None,
+            "a candidate that never answered is unknown"
+        );
+        // Absolute rather than a multiple of `VERSION_BUDGET`: the bound
+        // has to stay wrong when the budget is what got mutated away. Ten
+        // seconds against a one-second budget and a candidate that sleeps
+        // thirty -- wide enough for a loaded CI runner, narrow enough that
+        // waiting on the candidate reddens this rather than passing slowly.
+        assert!(
+            elapsed < Duration::from_secs(10),
+            "the vet is bounded by its own budget, not by the candidate: {elapsed:?}"
+        );
+    }
+
+    /// fails if an answer from a candidate that exited non-zero is
+    /// believed. `docs/dogs.md` says a dog answers on stdout **and exits
+    /// 0**; a non-zero exit means the run that printed those lines failed,
+    /// so what it printed is not an answer — least of all one that can
+    /// refuse an adopt.
+    ///
+    /// Mutation check: dropping the `status.success()` test reddens this —
+    /// the mismatched protocol on stdout becomes a refusal.
+    #[test]
+    fn an_answer_from_a_failed_run_is_not_an_answer() {
+        let dir = tempfile::tempdir().unwrap();
+        let stale = PROTOCOL_VERSION + 1;
+        let bin = dog_script(
+            dir.path(),
+            "shep-otel",
+            &format!("echo 'shep-otel 0.1.3'\necho 'shep-protocol: {stale}'\nexit 3"),
+        );
+
+        let vetted = vet_binary(&bin, dir.path(), "otel").unwrap();
+        assert_eq!(vetted.answer, None);
+    }
+
+    /// fails if unparseable output is a refusal. A binary that answers
+    /// `--version` with a usage message, a banner, or bytes is answering
+    /// nothing shep asked for, and shep has no standing to refuse a dog
+    /// over the shape of text it never promised to print.
+    #[test]
+    fn output_that_answers_nothing_shep_asked_is_not_a_refusal() {
+        let dir = tempfile::tempdir().unwrap();
+        let bin = dog_script(
+            dir.path(),
+            "shep-otel",
+            "echo 'error: unrecognized option --version'",
+        );
+
+        let vetted = vet_binary(&bin, dir.path(), "otel").unwrap();
+        assert_eq!(
+            vetted.answer,
+            Some(DogVersion {
+                version: "--version".to_string(),
+                protocol: None,
+            }),
+            "the last field of line 1 is taken as the version, whatever it is"
+        );
+    }
+
+    /// fails if the parser stops tolerating what `docs/dogs.md` says it
+    /// tolerates: a name on line 1 that is ignored, blank lines, key order,
+    /// unknown keys, and above all a reserved `shep-` key that does not
+    /// exist yet. That last one is the compatibility promise the published
+    /// contract makes on behalf of a parser nobody has written — a third
+    /// number gets its own line later, and a shep that predates it must
+    /// ignore the line rather than refuse the dog.
+    #[test]
+    fn a_future_shep_key_is_ignored_rather_than_breaking_the_parser() {
+        let answer = parse_version_answer(
+            "some-other-crate-name 0.4.0\n\nshep-channel: 7\nother: whatever\n\
+             shep-protocol: 2\nshep-lambs: 9\n",
+        );
+        assert_eq!(
+            answer,
+            Some(DogVersion {
+                version: "0.4.0".to_string(),
+                protocol: Some(2),
+            })
+        );
+
+        assert_eq!(parse_version_answer(""), None, "no output is no answer");
+        assert_eq!(
+            parse_version_answer("shep-otel 0.1.3\nshep-protocol: two\n"),
+            Some(DogVersion {
+                version: "0.1.3".to_string(),
+                protocol: None,
+            }),
+            "a protocol that is not a decimal is unknown, not a refusal"
+        );
     }
 
     /// fails if a group-writable deployment directory is refused rather

--- a/crates/shep-cli/src/commands/dogs.rs
+++ b/crates/shep-cli/src/commands/dogs.rs
@@ -40,7 +40,7 @@ use std::time::{Duration, Instant};
 use shep_client::{Client, ConnectError, PROTOCOL_VERSION};
 use shep_core::barks;
 use shep_core::paths::ShepPaths;
-use shep_core::protocol::{DogSource, Request, Response};
+use shep_core::protocol::{DogSource, Request, Response, SelectorSpec};
 
 use crate::cli::{AdoptArgs, BarksArgs};
 use crate::commands::shep_toml::{ShepToml, ShepTomlError};
@@ -462,6 +462,52 @@ pub fn vet_binary(path: &Path, home: &Path, name: &str) -> Result<VettedBinary, 
         .map(|abs| shep_core::paths::strip_verbatim_prefix(&abs).into_owned())
         .map_err(|_| AdoptRefusal::Missing)?;
     let group_writable = writability(&canonical)?;
+    let answer = ask_version(&canonical, home, name)?;
+    // Only a STATED protocol can refuse, and only this one thing can.
+    // `answer.version` is deliberately not compared with anything: a
+    // third-party dog's crate version has no relationship to shep's own --
+    // `shep-log-rotate` 0.1.3 against shep 0.1.24 is the ordinary case, not
+    // a skew -- so comparing them would refuse, or warn about, every dog
+    // that exists. `docs/dogs.md`'s table is what this implements: the
+    // protocol decides whether the dog can connect at all and is hard, the
+    // version says which build it is and is reported.
+    if let Some(dog) = answer.as_ref().and_then(|answer| answer.protocol)
+        && dog != PROTOCOL_VERSION
+    {
+        return Err(AdoptRefusal::ProtocolMismatch {
+            dog,
+            shep: PROTOCOL_VERSION,
+        });
+    }
+    Ok(VettedBinary {
+        path: canonical,
+        group_writable,
+        answer,
+    })
+}
+
+/// Runs `path` with [`VERSION_FLAG`] and reads what it answers, within
+/// [`VERSION_BUDGET`].
+///
+/// `Ok(None)` is an UNKNOWN protocol and is never a fault: silence, output
+/// shep cannot read, a run that failed, and a run still going when the
+/// budget ran out all arrive here the same way. Answering is optional and stays
+/// optional, so every dog written before the contract existed reads as
+/// unknown rather than as broken.
+///
+/// Two callers ask the same binary the same question for different reasons.
+/// [`vet_binary`] asks a candidate nobody has adopted yet;
+/// [`warn_of_a_dog_a_restart_would_break`] asks a dog that has been adopted
+/// for months, because the answer lives in the binary and the binary
+/// changes on disk with nothing watching (G12 row 5). Neither writes the
+/// answer down.
+///
+/// # Errors
+/// [`AdoptRefusal::WillNotExec`], and only that: nothing here judges the
+/// answer it read, so [`AdoptRefusal::ProtocolMismatch`] stays
+/// [`vet_binary`]'s to raise. A caller that only wants an answer treats the
+/// error as one more way of not getting one.
+fn ask_version(path: &Path, home: &Path, name: &str) -> Result<Option<DogVersion>, AdoptRefusal> {
     // Spawned with ONE argument, `--version`, and torn down
     // unconditionally: `kill` is ignored (a process that already exited is
     // not a failure to vet), but `wait` always runs, on every path out of
@@ -479,9 +525,9 @@ pub fn vet_binary(path: &Path, home: &Path, name: &str) -> Result<VettedBinary, 
     // protocol is never a refusal. The vet asks; the supervisor does not.
     //
     // A candidate is somebody else's binary and is not assumed to be well
-    // behaved about any of it: [`version_answer`] bounds the wait, so a
-    // candidate that never exits costs [`VERSION_BUDGET`] rather than
-    // hanging the `adopt` that is trying to vet it.
+    // behaved about any of it: [`version_answer`] bounds the wait by
+    // `budget`, so one that never exits costs that and is then killed,
+    // rather than hanging the command that asked.
     //
     // `SHEP_HOME` is set to the home this invocation actually resolved, not
     // inherited: an inherited `SHEP_HOME` is usually unset, so the
@@ -528,7 +574,7 @@ pub fn vet_binary(path: &Path, home: &Path, name: &str) -> Result<VettedBinary, 
     // one could imitate shep's own output at the exact moment somebody is
     // deciding whether to trust it. The pipe is read by [`version_answer`]
     // and never rendered.
-    match Command::new(&canonical)
+    match Command::new(path)
         .arg(VERSION_FLAG)
         .env("SHEP_HOME", home)
         .env("SHEP_DOG_NAME", name)
@@ -553,28 +599,7 @@ pub fn vet_binary(path: &Path, home: &Path, name: &str) -> Result<VettedBinary, 
             let answer = version_answer(&mut child, reading);
             let _ = child.kill();
             let _ = child.wait();
-            // Only a STATED protocol can refuse, and only this one thing
-            // can. `answer.version` is deliberately not compared with
-            // anything: a third-party dog's crate version has no
-            // relationship to shep's own -- `shep-log-rotate` 0.1.3 against
-            // shep 0.1.24 is the ordinary case, not a skew -- so comparing
-            // them would refuse, or warn about, every dog that exists.
-            // `docs/dogs.md`'s table is what this implements: the protocol
-            // decides whether the dog can connect at all and is hard, the
-            // version says which build it is and is reported.
-            if let Some(dog) = answer.as_ref().and_then(|answer| answer.protocol)
-                && dog != PROTOCOL_VERSION
-            {
-                return Err(AdoptRefusal::ProtocolMismatch {
-                    dog,
-                    shep: PROTOCOL_VERSION,
-                });
-            }
-            Ok(VettedBinary {
-                path: canonical,
-                group_writable,
-                answer,
-            })
+            Ok(answer)
         }
     }
 }
@@ -607,8 +632,8 @@ const VERSION_FLAG: &str = "--version";
 /// by this one.
 const SHEP_PROTOCOL_KEY: &str = "shep-protocol";
 
-/// How long [`version_answer`] gives a candidate to answer, and separately
-/// how long it then waits for that answer to reach the reader thread.
+/// How long [`ask_version`] gives a binary to answer, and separately how
+/// long it then waits for that answer to reach the reader thread.
 ///
 /// One second, against the milliseconds a `println!` and an exit take. The
 /// generosity is for a cold, dynamically linked binary on a loaded machine,
@@ -617,6 +642,17 @@ const SHEP_PROTOCOL_KEY: &str = "shep-protocol";
 /// they are not symmetric -- too short records an unknown protocol for a
 /// slow dog, which costs the gate and not the adopt, while too long stalls
 /// every adopt of the dogs that exist today, none of which answer at all.
+///
+/// `restart` asks with the same number rather than a tighter one of its
+/// own, and the tighter one was tried first: a 250ms budget lost the answer
+/// outright on a loaded machine, where a probe measured 180-300ms against
+/// single-digit milliseconds idle. A budget that drops the warning whenever
+/// the box is busy is worse than one that occasionally costs a second,
+/// because a busy box is where an operator restarts things. The cost is
+/// bounded and it is paid only by a restart that NAMED an adopted dog: a
+/// binary that hangs is killed at the budget and the restart proceeds
+/// unwarned, so the slowest thing a dog can do to `shep restart` is delay
+/// it, never block it.
 const VERSION_BUDGET: Duration = Duration::from_secs(1);
 
 /// How often [`version_answer`] polls within [`VERSION_BUDGET`], following
@@ -690,6 +726,13 @@ fn read_in_background(mut stdout: std::process::ChildStdout) -> Receiver<String>
 }
 
 /// Waits, bounded by [`VERSION_BUDGET`], for `child` to answer.
+///
+/// Twice that is the worst case rather than once, because the wait for the
+/// exit and the wait for the text the reader thread collected are bounded
+/// separately. Only a child that has ALREADY exited successfully reaches
+/// the second one, so its text is written and its own end of the pipe is
+/// closed; that bound is there for a grandchild still holding the inherited
+/// pipe open, not for anything the dog itself is doing.
 ///
 /// `None` -- an unknown protocol, never a refusal -- for every way of not
 /// answering: no pipe to read, a run that did not exit inside the budget, a
@@ -905,6 +948,93 @@ fn report_dog_version(streams: &mut Streams<'_>, name: &str, answer: &DogVersion
         ),
     };
     streams.aside(DOG_VERSION_NOTICE, &message);
+}
+
+/// [`emit_notice`](crate::output::emit_notice) code for the warning
+/// `restart` prints before it restarts a dog whose binary on disk cannot
+/// speak to this shepherd -- caller-defined, like the two above, and like
+/// them not a failure: the restart still happens.
+const DOG_BINARY_SKEW_NOTICE: &str = "dog_binary_skew";
+
+/// Warns, before `restart` sends anything, about a dog whose binary ON DISK
+/// speaks a protocol this shepherd does not -- G12's row 5.
+///
+/// Row 5 is the one state in that matrix where nothing is wrong yet. The
+/// running dog is connected and working, the binary it would come back from
+/// is not, and the two only meet at the next restart, which may be days
+/// away and for an unrelated reason. This is the moment that restart
+/// happens, so this is where the operator can still be told.
+///
+/// **A warning, never a refusal.** They asked for the restart, the binary on
+/// disk may be exactly what they just installed, and refusing an explicit
+/// command on a prediction is a worse failure than letting them watch it
+/// happen with the warning in hand. G12 row 5's fix names two ways out and
+/// picks neither, so the message does the same.
+///
+/// **Silence is the answer for everything else.** A dog that does not answer
+/// [`VERSION_FLAG`] is unknown, not stale -- that is the state `adopt`
+/// records under G11's "recorded as unknown", and this is its reader. Every
+/// dog that existed when the contract was written is in that group, so a
+/// warning there would be a line on stderr for the ordinary case, which is
+/// how an operator learns to skip the one that matters.
+///
+/// # A built-in dog cannot reach this, by construction
+///
+/// The only way in is a path out of `[daemon] adopted_dogs`. A built-in dog
+/// has no entry there ([`dog_source`]), and could not use one: the shepherd
+/// runs `metrics` and `bark` as `<its own binary> dog <name>`, so a built-in
+/// dog's binary on disk IS the shepherd's, and there is no second thing to
+/// drift. There is no branch here skipping them, and none to forget to
+/// write.
+///
+/// # Why only a `Name` selector
+///
+/// The daemon includes a dog only for a selector that NAMED it
+/// (`ProcessSelector::is_exact`), so `restart all` and a `/regex/` sweep
+/// pass every dog by and there is nothing for this to warn about. That
+/// leaves `Id`, which is exact and could name a dog: it is not probed,
+/// because the CLI would have to ask the daemon what that id is called
+/// before it could look up a path, and a round trip is a lot to spend on
+/// the rarer way of typing the same thing. An operator who restarts a dog
+/// by id gets the restart and no warning.
+pub fn warn_of_a_dog_a_restart_would_break(
+    streams: &mut Streams<'_>,
+    paths: &ShepPaths,
+    selectors: &[SelectorSpec],
+) {
+    for selector in selectors {
+        let SelectorSpec::Name(name) = selector else {
+            continue;
+        };
+        // The one way in, and the reason a built-in dog is not a case here:
+        // this answers `None` for every name `[daemon] adopted_dogs` has
+        // never heard of, which is every built-in dog and every sheep.
+        let Ok(Some(binary)) = ShepToml::adopted_dog_path_readonly(&paths.daemon_config, name)
+        else {
+            continue;
+        };
+        // Asked, never remembered. A protocol recorded at adopt time would
+        // be a copy of a number that changes on disk with nothing watching,
+        // and row 5 IS the binary changing after the adopt -- so the stored
+        // copy would be wrong at precisely the moment it was needed.
+        let Ok(Some(answer)) = ask_version(&binary, &paths.home, name) else {
+            continue;
+        };
+        let Some(disk) = answer.protocol else {
+            continue;
+        };
+        if disk == PROTOCOL_VERSION {
+            continue;
+        }
+        let message = format!(
+            "`{name}`'s binary at {} was built for shep protocol {disk}, and this shep \
+             speaks {PROTOCOL_VERSION}; restarting it brings it back on that binary, \
+             unable to connect. Run a shep that speaks {disk}, or reinstall the dog \
+             against protocol {PROTOCOL_VERSION}, and restart it again",
+            binary.display()
+        );
+        streams.aside(DOG_BINARY_SKEW_NOTICE, &message);
+    }
 }
 
 /// `shep adopt <path> [--name <name>]`: vets a binary shep has never seen,

--- a/crates/shep-cli/src/commands/dogs.rs
+++ b/crates/shep-cli/src/commands/dogs.rs
@@ -1017,6 +1017,28 @@ pub fn warn_of_a_dog_a_restart_would_break(
         // be a copy of a number that changes on disk with nothing watching,
         // and row 5 IS the binary changing after the adopt -- so the stored
         // copy would be wrong at precisely the moment it was needed.
+        //
+        // Reusing `ask_version` here costs something `adopt` does not pay,
+        // and the trade is different enough to argue separately rather than
+        // inherit. That function's own comment is explicit that a candidate
+        // ignoring `--version` runs its ordinary job instead, with
+        // `SHEP_HOME` pointing at the live daemon. For `adopt` that is a
+        // one-off against a binary nobody trusts yet. Here the dog is
+        // already adopted and already running, the probe repeats on every
+        // named restart, and the population that ignores `--version` is
+        // every dog written before this contract existed, which today is
+        // all of them. So `shep restart log-rotate` can rotate once before
+        // the restart, and a bark dog can open a second subscription, both
+        // for up to `VERSION_BUDGET`.
+        //
+        // Accepted rather than overlooked, on three grounds. The command
+        // is about to restart that dog anyway, so the dog runs either way
+        // and the question is only whether it briefly overlaps itself. The
+        // window is bounded and the process is killed. And the alternative
+        // is not asking, which is the state that let a stale dog sit
+        // `online` for two days. It is a real cost though, so it is named
+        // in `docs/dogs.md` where an operator can read it rather than only
+        // here.
         let Ok(Some(answer)) = ask_version(&binary, &paths.home, name) else {
             continue;
         };

--- a/crates/shep-cli/src/commands/dogs.rs
+++ b/crates/shep-cli/src/commands/dogs.rs
@@ -471,6 +471,23 @@ pub fn vet_binary(path: &Path, home: &Path, name: &str) -> Result<VettedBinary, 
 /// # Errors
 /// The same [`AdoptRefusal`] set [`vet_binary`] raises, with the `--version`
 /// probe bounded by `budget` rather than by [`VERSION_BUDGET`].
+///
+/// # What `budget` actually bounds
+///
+/// One wait, not the call. [`version_answer`] bounds two things separately
+/// and gives each the full `budget`: the wait for the child to exit, and
+/// the wait for its output to arrive. So the call is bounded by roughly
+/// twice `budget`, plus up to 50ms on macOS for
+/// `macos_deferred_exec_failure`'s own poll.
+///
+/// Deliberate, and the alternative is worse. One absolute deadline shared
+/// between the two waits reads tidier and would make this doc a single
+/// number, but it means a child that exits at 0.9 of the budget leaves 0.1
+/// for its output to be read. A probe that runs out answers unknown, and
+/// unknown is deliberately silent, so tightening this would make shep go
+/// quiet about exactly the dogs it is meant to notice. The two waits bound
+/// different failures, a child that will not exit and a pipe a grandchild
+/// is holding, and neither should be able to consume the other's room.
 pub fn vet_binary_within(
     path: &Path,
     home: &Path,

--- a/crates/shep-cli/src/commands/lifecycle.rs
+++ b/crates/shep-cli/src/commands/lifecycle.rs
@@ -15,12 +15,14 @@ use std::time::Duration;
 
 use shep_client::{Client, START_DEADLINE};
 use shep_core::config::{AppConfig, FlockFormat, Flockfile, FlockfileError};
+use shep_core::paths::ShepPaths;
 use shep_core::protocol::{ProcessInfo, Request, Response, SelectorSpec};
 use shep_core::selector::ProcessSelector;
 
 use crate::cli::Format;
 use crate::cli::{SelectorArgs, StartArgs, StockArgs};
 use crate::commands::bounded::{Bounded, run_bounded};
+use crate::commands::dogs;
 use crate::commands::selector::parse_selector;
 use crate::exit::ExitCode;
 use crate::output::{DeletedIds, FlockRows, Render, Streams, emit, emit_flock, write_outcome};
@@ -1450,11 +1452,25 @@ pub async fn stop(client: &Client, streams: &mut Streams<'_>, args: &SelectorArg
 }
 
 /// Restarts the sheep matching `args.selector`.
-pub async fn restart(client: &Client, streams: &mut Streams<'_>, args: &SelectorArgs) -> ExitCode {
+///
+/// `paths` is here for one thing: a restart that names a dog is warned about
+/// BEFORE the request goes out, when the operator can still act on it. See
+/// [`dogs::warn_of_a_dog_a_restart_would_break`] for what it warns about and
+/// why nothing is refused.
+pub async fn restart(
+    client: &Client,
+    streams: &mut Streams<'_>,
+    paths: &ShepPaths,
+    args: &SelectorArgs,
+) -> ExitCode {
     let selectors = match parse_selectors(streams, &args.selectors) {
         Ok(selectors) => selectors,
         Err(code) => return code,
     };
+    // Before `request_each`, deliberately, and this is the whole ordering
+    // the spec asks for: a warning that arrives after the restart is a
+    // description of a state the operator is already in.
+    dogs::warn_of_a_dog_a_restart_would_break(streams, paths, &selectors);
     let (procs, failure) = request_each(
         client,
         streams,
@@ -1623,7 +1639,9 @@ mod tests {
     use super::*;
     use crate::cli::Format;
     use shep_client::DEFAULT_DEADLINE;
-    use shep_client::testing::{fake_client_capturing_envelopes, fake_client_replying_err};
+    use shep_client::testing::{
+        fake_client_answering, fake_client_capturing_envelopes, fake_client_replying_err,
+    };
     use shep_core::protocol::RpcErrorCode;
 
     /// Bare `shep start` with a Flockfile discovered by the caller must
@@ -2905,6 +2923,9 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = shep_client::testing::control_address(dir.path());
         let (client, mut envelopes) = fake_client_capturing_envelopes(&path).await;
+        // No `shep.toml` in this tempdir, so `restart`'s dog check finds
+        // nothing adopted and spawns nothing -- this test is about the wire.
+        let paths = ShepPaths::resolve(&|_| None, dir.path());
 
         #[derive(Clone, Copy, Debug)]
         enum Verb {
@@ -2941,7 +2962,7 @@ mod tests {
                 };
                 let _ = match verb {
                     Verb::Stop => stop(&client, &mut streams, &args).await,
-                    Verb::Restart => restart(&client, &mut streams, &args).await,
+                    Verb::Restart => restart(&client, &mut streams, &paths, &args).await,
                     Verb::Reload => reload(&client, &mut streams, &args).await,
                     Verb::Delete => delete(&client, &mut streams, &args).await,
                 };
@@ -2961,6 +2982,29 @@ mod tests {
                 );
             }
         }
+    }
+
+    /// Everything G12 row 5 needs to exist: a `$SHEP_HOME`, a dog binary
+    /// answering `--version` with `protocol`, and a `shep.toml` that has
+    /// adopted it under `name`.
+    ///
+    /// Written through `ShepToml::adopt_dog`, the same writer `shep adopt`
+    /// uses, so a test dog is recorded exactly the way a real one is rather
+    /// than by a hand-built table that could drift from it.
+    fn adopted_dog(dir: &Path, name: &str, answer: &str) -> ShepPaths {
+        let paths = ShepPaths::resolve(&|_| None, dir);
+        let binary = dir.join(format!("shep-{name}"));
+        std::fs::write(&binary, format!("#!/bin/sh\n{answer}\n")).unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt as _;
+            std::fs::set_permissions(&binary, std::fs::Permissions::from_mode(0o755)).unwrap();
+        }
+        crate::commands::shep_toml::ShepToml::edit(&paths.daemon_config, |cfg| {
+            cfg.adopt_dog(name, &binary);
+        })
+        .unwrap();
+        paths
     }
 
     /// `"/[/"` is one of the only three inputs the selector grammar rejects.
@@ -3357,7 +3401,19 @@ mod tests {
 
     /// Wall-clock tests, skipped by every CI job but the serial `slow` one.
     ///
-    /// The case below needs a real node to START AND EXIT inside the budget,
+    /// Two kinds live here now. The `restart` cases below ask a dog's binary
+    /// on disk what protocol it speaks, which means a real fork, exec and
+    /// exit inside `commands::dogs`'s one-second budget; a probe that runs
+    /// out of budget answers "unknown", and unknown is deliberately silent,
+    /// so contention turns those tests' subject into thin air rather than
+    /// into a failure with a cause in it. Measured 2026-08-31 on this
+    /// machine: a `/bin/sh` probe takes single-digit milliseconds idle,
+    /// 180-300ms alongside the ordinary suite, and over a second at
+    /// `--test-threads=64`. The product behaviour under that load is right
+    /// -- a busy machine loses the warning and still performs the restart --
+    /// but a test cannot assert it.
+    ///
+    /// The node case needs a real node to START AND EXIT inside the budget,
     /// which is a claim about how fast the machine is rather than about shep.
     /// At 200ms it failed on four CI runners at once (arm, macos, musl and
     /// the coverage job) while passing every local run: node took longer than
@@ -3370,6 +3426,317 @@ mod tests {
     /// See `HELD_PIPE_BUDGET` below for both ends of the number.
     mod slow {
         use super::*;
+
+        /// A shepherd that restarts whatever it is asked to and lists an empty
+        /// flock afterwards -- enough for `restart` to run to the end and print
+        /// its receipt, so a test asserting that stderr is EMPTY is asserting
+        /// about the dog check and not about a reply the CLI could not read.
+        fn answering_a_restart(request: &Request) -> Response {
+            match request {
+                Request::Restart { .. } => Response::Restarted(Vec::new()),
+                _ => Response::Flock(Vec::new()),
+            }
+        }
+
+        /// The answer a dog gives when its binary was built against a protocol
+        /// this shep does not speak -- G12 row 5's binary on disk.
+        fn stale_answer() -> String {
+            format!(
+                "echo 'shep-log-rotate 0.1.3'\necho 'shep-protocol: {}'",
+                shep_client::PROTOCOL_VERSION + 1
+            )
+        }
+
+        /// fails if the warning about a dog whose disk binary cannot talk to
+        /// this shepherd arrives after the restart that acts on it. The whole
+        /// point of row 5 is that the operator can still do something at this
+        /// moment and cannot afterwards, so a warning printed after the request
+        /// is a description of a state they are already in.
+        ///
+        /// The ordering is read off stderr rather than off a clock. The
+        /// shepherd here refuses the restart, so its refusal lands on the same
+        /// stream as the warning, and the two offsets say which ran first --
+        /// the same path-shaped signal `dogs.rs`'s
+        /// `a_name_collision_is_refused_before_vet_binary_ever_runs` uses, for
+        /// the same reason: there is no timing here to race.
+        ///
+        /// Mutation check: moving the `warn_of_a_dog_a_restart_would_break`
+        /// call below `request_each` reddens this on the offsets, with both
+        /// messages still present.
+        #[tokio::test]
+        async fn a_dog_whose_disk_binary_cannot_connect_is_warned_about_before_the_restart() {
+            let dir = tempfile::tempdir().unwrap();
+            let paths = adopted_dog(dir.path(), "log-rotate", &stale_answer());
+            let sock = shep_client::testing::control_address(dir.path());
+            let (client, _daemon) =
+                fake_client_replying_err(&sock, RpcErrorCode::NotFound, "no such sheep").await;
+
+            let mut out = Vec::new();
+            let mut err = Vec::new();
+            {
+                let mut streams = Streams {
+                    out: &mut out,
+                    err: &mut err,
+                    style: crate::style::Presentation::BARE,
+                    fmt: Format::Table,
+                };
+                let args = SelectorArgs {
+                    selectors: vec!["log-rotate".into()],
+                };
+                let _ = restart(&client, &mut streams, &paths, &args).await;
+            }
+
+            let text = String::from_utf8(err).unwrap();
+            let warning = text
+                .find("dog_binary_skew")
+                .unwrap_or_else(|| panic!("the restart must warn first: {text}"));
+            let refusal = text
+                .find("no such sheep")
+                .unwrap_or_else(|| panic!("the restart must still be attempted: {text}"));
+            assert!(
+                warning < refusal,
+                "the warning must reach the operator before the restart does: {text}"
+            );
+        }
+
+        /// fails if the warning does not carry both numbers and both ways out
+        /// of row 5. G12 gives that row two fixes and picks neither -- the
+        /// operator knows which of the two they meant -- so the message names
+        /// both and tells them what the restart just did.
+        ///
+        /// Mutation check: dropping either clause from the message reddens
+        /// this.
+        #[tokio::test]
+        async fn the_restart_warning_names_both_numbers_and_both_ways_out() {
+            let dir = tempfile::tempdir().unwrap();
+            let paths = adopted_dog(dir.path(), "log-rotate", &stale_answer());
+            let sock = shep_client::testing::control_address(dir.path());
+            let (client, _envelopes) = fake_client_answering(&sock, answering_a_restart).await;
+
+            let mut out = Vec::new();
+            let mut err = Vec::new();
+            {
+                let mut streams = Streams {
+                    out: &mut out,
+                    err: &mut err,
+                    style: crate::style::Presentation::BARE,
+                    fmt: Format::Table,
+                };
+                let args = SelectorArgs {
+                    selectors: vec!["log-rotate".into()],
+                };
+                let _ = restart(&client, &mut streams, &paths, &args).await;
+            }
+
+            let text = String::from_utf8(err).unwrap();
+            let disk = (shep_client::PROTOCOL_VERSION + 1).to_string();
+            let shep = shep_client::PROTOCOL_VERSION.to_string();
+            assert!(
+                text.contains(&disk) && text.contains(&shep),
+                "the warning names both numbers: {text}"
+            );
+            assert!(
+                text.contains("Run a shep that speaks") && text.contains("reinstall the dog"),
+                "the warning names both ways out, and picks neither: {text}"
+            );
+            assert!(
+                text.contains("log-rotate"),
+                "the warning names the dog it is about: {text}"
+            );
+        }
+
+        /// fails if an ordinary restart of a healthy dog says anything at all.
+        /// This is the case every restart of every working flock is in, so a
+        /// line here is a line an operator learns to skip, and the one warning
+        /// that matters goes with it.
+        ///
+        /// Mutation check: warning on any answer rather than on a protocol this
+        /// shep does not speak reddens this.
+        #[tokio::test]
+        async fn a_dog_whose_disk_binary_is_current_restarts_in_silence() {
+            let dir = tempfile::tempdir().unwrap();
+            let answer = format!(
+                "echo 'shep-log-rotate 0.1.3'\necho 'shep-protocol: {}'",
+                shep_client::PROTOCOL_VERSION
+            );
+            let paths = adopted_dog(dir.path(), "log-rotate", &answer);
+            let sock = shep_client::testing::control_address(dir.path());
+            let (client, mut envelopes) = fake_client_answering(&sock, answering_a_restart).await;
+
+            let mut out = Vec::new();
+            let mut err = Vec::new();
+            {
+                let mut streams = Streams {
+                    out: &mut out,
+                    err: &mut err,
+                    style: crate::style::Presentation::BARE,
+                    fmt: Format::Table,
+                };
+                let args = SelectorArgs {
+                    selectors: vec!["log-rotate".into()],
+                };
+                let _ = restart(&client, &mut streams, &paths, &args).await;
+            }
+
+            assert_eq!(
+                String::from_utf8(err).unwrap(),
+                "",
+                "a healthy dog restarts with nothing said about it"
+            );
+            assert_eq!(
+                envelopes.recv().await.unwrap().body,
+                Request::Restart {
+                    selector: SelectorSpec::Name("log-rotate".into()),
+                },
+                "and it is still restarted"
+            );
+        }
+
+        /// fails if a dog that answers nothing is warned about. Every dog that
+        /// existed when the `--version` contract was written is in this state,
+        /// and `docs/dogs.md` promises that not answering is never held against
+        /// one. Unknown is not stale: it is the state `adopt` records, and the
+        /// silence here is what reads it.
+        ///
+        /// Mutation check: treating an unreadable answer as a mismatch -- for
+        /// instance warning whenever the disk protocol is not exactly
+        /// `PROTOCOL_VERSION`, `None` included -- reddens this.
+        #[tokio::test]
+        async fn a_dog_that_answers_nothing_restarts_in_silence() {
+            let dir = tempfile::tempdir().unwrap();
+            let paths = adopted_dog(
+                dir.path(),
+                "log-rotate",
+                "echo 'shep-log-rotate does not understand --version' >&2\nexit 2",
+            );
+            let sock = shep_client::testing::control_address(dir.path());
+            let (client, mut envelopes) = fake_client_answering(&sock, answering_a_restart).await;
+
+            let mut out = Vec::new();
+            let mut err = Vec::new();
+            {
+                let mut streams = Streams {
+                    out: &mut out,
+                    err: &mut err,
+                    style: crate::style::Presentation::BARE,
+                    fmt: Format::Table,
+                };
+                let args = SelectorArgs {
+                    selectors: vec!["log-rotate".into()],
+                };
+                let _ = restart(&client, &mut streams, &paths, &args).await;
+            }
+
+            assert_eq!(
+                String::from_utf8(err).unwrap(),
+                "",
+                "a dog that does not answer is not a dog that is stale"
+            );
+            assert_eq!(
+                envelopes.recv().await.unwrap().body,
+                Request::Restart {
+                    selector: SelectorSpec::Name("log-rotate".into()),
+                },
+                "and it is still restarted"
+            );
+        }
+
+        /// fails if a dog that answers a version but names no protocol is
+        /// warned about. It is the second shape of unknown, and it reaches a
+        /// different line from the dog that answers nothing at all: there IS an
+        /// answer here, it just does not say. `docs/dogs.md` puts both in the
+        /// same place -- "its protocol is simply unknown" -- and a shep that
+        /// guessed a number for the missing line would be warning on its own
+        /// guess.
+        ///
+        /// Mutation check: reading a missing protocol as some sentinel number
+        /// (`answer.protocol.unwrap_or(0)`) reddens this, and leaves the dog
+        /// that answers nothing at all green -- that one never gets this far.
+        #[tokio::test]
+        async fn a_dog_that_names_no_protocol_restarts_in_silence() {
+            let dir = tempfile::tempdir().unwrap();
+            let paths = adopted_dog(dir.path(), "log-rotate", "echo 'shep-log-rotate 0.1.3'");
+            let sock = shep_client::testing::control_address(dir.path());
+            let (client, mut envelopes) = fake_client_answering(&sock, answering_a_restart).await;
+
+            let mut out = Vec::new();
+            let mut err = Vec::new();
+            {
+                let mut streams = Streams {
+                    out: &mut out,
+                    err: &mut err,
+                    style: crate::style::Presentation::BARE,
+                    fmt: Format::Table,
+                };
+                let args = SelectorArgs {
+                    selectors: vec!["log-rotate".into()],
+                };
+                let _ = restart(&client, &mut streams, &paths, &args).await;
+            }
+
+            assert_eq!(
+                String::from_utf8(err).unwrap(),
+                "",
+                "an unstated protocol is unknown, and unknown is not stale"
+            );
+            assert_eq!(
+                envelopes.recv().await.unwrap().body,
+                Request::Restart {
+                    selector: SelectorSpec::Name("log-rotate".into()),
+                },
+                "and it is still restarted"
+            );
+        }
+
+        /// fails if a built-in dog is probed. It cannot be stale on disk: the
+        /// shepherd runs `metrics` and `bark` as `<its own binary> dog <name>`,
+        /// so a built-in dog's binary IS the shepherd's and there is no second
+        /// thing to drift. The config here has a stale adopted dog in it as
+        /// well, so the silence is about this name rather than about an empty
+        /// `adopted_dogs`.
+        ///
+        /// Mutation check: making the lookup fall back to any adopted path when
+        /// the name is not in `adopted_dogs` reddens this, and leaves every
+        /// other test in this group green.
+        #[tokio::test]
+        async fn a_built_in_dog_is_never_asked_what_its_binary_speaks() {
+            let dir = tempfile::tempdir().unwrap();
+            let paths = adopted_dog(dir.path(), "log-rotate", &stale_answer());
+            crate::commands::shep_toml::ShepToml::edit(&paths.daemon_config, |cfg| {
+                cfg.enable_dog("metrics");
+            })
+            .unwrap();
+            let sock = shep_client::testing::control_address(dir.path());
+            let (client, mut envelopes) = fake_client_answering(&sock, answering_a_restart).await;
+
+            let mut out = Vec::new();
+            let mut err = Vec::new();
+            {
+                let mut streams = Streams {
+                    out: &mut out,
+                    err: &mut err,
+                    style: crate::style::Presentation::BARE,
+                    fmt: Format::Table,
+                };
+                let args = SelectorArgs {
+                    selectors: vec!["metrics".into()],
+                };
+                let _ = restart(&client, &mut streams, &paths, &args).await;
+            }
+
+            assert_eq!(
+                String::from_utf8(err).unwrap(),
+                "",
+                "a built-in dog has no binary of its own to be stale"
+            );
+            assert_eq!(
+                envelopes.recv().await.unwrap().body,
+                Request::Restart {
+                    selector: SelectorSpec::Name("metrics".into()),
+                },
+                "and it is still restarted"
+            );
+        }
 
         /// fails if a module that leaves a process on node's stdout is
         /// reported as a module shep killed. node itself exits here:

--- a/crates/shep-cli/src/commands/lifecycle.rs
+++ b/crates/shep-cli/src/commands/lifecycle.rs
@@ -3584,7 +3584,11 @@ mod tests {
                 "a healthy dog restarts with nothing said about it"
             );
             assert_eq!(
-                envelopes.recv().await.unwrap().body,
+                tokio::time::timeout(Duration::from_secs(5), envelopes.recv())
+                    .await
+                    .expect("restart must reach the wire; it hung instead of sending a request")
+                    .unwrap()
+                    .body,
                 Request::Restart {
                     selector: SelectorSpec::Name("log-rotate".into()),
                 },
@@ -3633,7 +3637,11 @@ mod tests {
                 "a dog that does not answer is not a dog that is stale"
             );
             assert_eq!(
-                envelopes.recv().await.unwrap().body,
+                tokio::time::timeout(Duration::from_secs(5), envelopes.recv())
+                    .await
+                    .expect("restart must reach the wire; it hung instead of sending a request")
+                    .unwrap()
+                    .body,
                 Request::Restart {
                     selector: SelectorSpec::Name("log-rotate".into()),
                 },
@@ -3680,7 +3688,11 @@ mod tests {
                 "an unstated protocol is unknown, and unknown is not stale"
             );
             assert_eq!(
-                envelopes.recv().await.unwrap().body,
+                tokio::time::timeout(Duration::from_secs(5), envelopes.recv())
+                    .await
+                    .expect("restart must reach the wire; it hung instead of sending a request")
+                    .unwrap()
+                    .body,
                 Request::Restart {
                     selector: SelectorSpec::Name("log-rotate".into()),
                 },
@@ -3730,7 +3742,11 @@ mod tests {
                 "a built-in dog has no binary of its own to be stale"
             );
             assert_eq!(
-                envelopes.recv().await.unwrap().body,
+                tokio::time::timeout(Duration::from_secs(5), envelopes.recv())
+                    .await
+                    .expect("restart must reach the wire; it hung instead of sending a request")
+                    .unwrap()
+                    .body,
                 Request::Restart {
                     selector: SelectorSpec::Name("metrics".into()),
                 },

--- a/crates/shep-cli/src/commands/lifecycle.rs
+++ b/crates/shep-cli/src/commands/lifecycle.rs
@@ -1463,6 +1463,25 @@ pub async fn restart(
     paths: &ShepPaths,
     args: &SelectorArgs,
 ) -> ExitCode {
+    restart_within(client, streams, paths, args, dogs::VERSION_BUDGET).await
+}
+
+/// [`restart`], against a caller-chosen budget for the dog probe below.
+///
+/// Exists for the same reason `dogs::vet_binary_within` does. A test here
+/// asks whether the warning fires, in what order, and what it says. None of
+/// those are questions about how long a probe may take, but at the
+/// production budget they all became one: a busy machine makes the probe
+/// time out, a timed-out probe answers unknown, and unknown is deliberately
+/// silent, so the test fails saying no warning fired. That is a true
+/// statement about the runner and an empty one about shep.
+pub async fn restart_within(
+    client: &Client,
+    streams: &mut Streams<'_>,
+    paths: &ShepPaths,
+    args: &SelectorArgs,
+    probe: Duration,
+) -> ExitCode {
     let selectors = match parse_selectors(streams, &args.selectors) {
         Ok(selectors) => selectors,
         Err(code) => return code,
@@ -1470,7 +1489,7 @@ pub async fn restart(
     // Before `request_each`, deliberately, and this is the whole ordering
     // the spec asks for: a warning that arrives after the restart is a
     // description of a state the operator is already in.
-    dogs::warn_of_a_dog_a_restart_would_break(streams, paths, &selectors);
+    dogs::warn_of_a_dog_a_restart_would_break(streams, paths, &selectors, probe);
     let (procs, failure) = request_each(
         client,
         streams,
@@ -3425,12 +3444,24 @@ mod tests {
     /// spends every run is the price of a red board that means something.
     /// See `HELD_PIPE_BUDGET` below for both ends of the number.
     mod slow {
+        /// A probe budget no contention can exhaust.
+        ///
+        /// These tests ask whether the warning fires, in what order, and
+        /// what it says. At the production budget they were also asking how
+        /// busy the machine was, because a probe that times out answers
+        /// unknown and unknown is silent by design, so a loaded runner made
+        /// them fail reporting no warning. Thirty seconds is not a claim
+        /// about how long a probe should take; it is far enough above this
+        /// suite's contention that timing stops being one of the variables.
+        const PROBE_BUDGET: Duration = Duration::from_secs(30);
+
         use super::*;
 
         /// A shepherd that restarts whatever it is asked to and lists an empty
         /// flock afterwards -- enough for `restart` to run to the end and print
         /// its receipt, so a test asserting that stderr is EMPTY is asserting
         /// about the dog check and not about a reply the CLI could not read.
+        #[cfg(unix)]
         fn answering_a_restart(request: &Request) -> Response {
             match request {
                 Request::Restart { .. } => Response::Restarted(Vec::new()),
@@ -3440,6 +3471,7 @@ mod tests {
 
         /// The answer a dog gives when its binary was built against a protocol
         /// this shep does not speak -- G12 row 5's binary on disk.
+        #[cfg(unix)]
         fn stale_answer() -> String {
             format!(
                 "echo 'shep-log-rotate 0.1.3'\necho 'shep-protocol: {}'",
@@ -3463,6 +3495,21 @@ mod tests {
         /// Mutation check: moving the `warn_of_a_dog_a_restart_would_break`
         /// call below `request_each` reddens this on the offsets, with both
         /// messages still present.
+        // Unix only, and not because the behaviour is. The warning path is
+        // platform-neutral: it reads a config, spawns a probe, compares two
+        // numbers. The FIXTURE is not. `adopted_dog` writes a `#!/bin/sh`
+        // script, which Windows cannot execute, so the probe fails there and
+        // answers unknown.
+        //
+        // That is worse than a failure for three of these. A probe that
+        // answers unknown is deliberately silent, so the three
+        // `restarts_in_silence` tests PASSED on Windows by way of the
+        // fixture never running, which is the definition of a vacuous test.
+        // Only the two that require a warning failed and made the problem
+        // visible. Gating all of them says what is true: this fixture is a
+        // shell script, so these tests are about unix until somebody writes
+        // a portable fake dog.
+        #[cfg(unix)]
         #[tokio::test]
         async fn a_dog_whose_disk_binary_cannot_connect_is_warned_about_before_the_restart() {
             let dir = tempfile::tempdir().unwrap();
@@ -3483,7 +3530,7 @@ mod tests {
                 let args = SelectorArgs {
                     selectors: vec!["log-rotate".into()],
                 };
-                let _ = restart(&client, &mut streams, &paths, &args).await;
+                let _ = restart_within(&client, &mut streams, &paths, &args, PROBE_BUDGET).await;
             }
 
             let text = String::from_utf8(err).unwrap();
@@ -3506,6 +3553,7 @@ mod tests {
         ///
         /// Mutation check: dropping either clause from the message reddens
         /// this.
+        #[cfg(unix)]
         #[tokio::test]
         async fn the_restart_warning_names_both_numbers_and_both_ways_out() {
             let dir = tempfile::tempdir().unwrap();
@@ -3525,7 +3573,7 @@ mod tests {
                 let args = SelectorArgs {
                     selectors: vec!["log-rotate".into()],
                 };
-                let _ = restart(&client, &mut streams, &paths, &args).await;
+                let _ = restart_within(&client, &mut streams, &paths, &args, PROBE_BUDGET).await;
             }
 
             let text = String::from_utf8(err).unwrap();
@@ -3552,6 +3600,7 @@ mod tests {
         ///
         /// Mutation check: warning on any answer rather than on a protocol this
         /// shep does not speak reddens this.
+        #[cfg(unix)]
         #[tokio::test]
         async fn a_dog_whose_disk_binary_is_current_restarts_in_silence() {
             let dir = tempfile::tempdir().unwrap();
@@ -3575,7 +3624,7 @@ mod tests {
                 let args = SelectorArgs {
                     selectors: vec!["log-rotate".into()],
                 };
-                let _ = restart(&client, &mut streams, &paths, &args).await;
+                let _ = restart_within(&client, &mut streams, &paths, &args, PROBE_BUDGET).await;
             }
 
             assert_eq!(
@@ -3605,6 +3654,7 @@ mod tests {
         /// Mutation check: treating an unreadable answer as a mismatch -- for
         /// instance warning whenever the disk protocol is not exactly
         /// `PROTOCOL_VERSION`, `None` included -- reddens this.
+        #[cfg(unix)]
         #[tokio::test]
         async fn a_dog_that_answers_nothing_restarts_in_silence() {
             let dir = tempfile::tempdir().unwrap();
@@ -3628,7 +3678,7 @@ mod tests {
                 let args = SelectorArgs {
                     selectors: vec!["log-rotate".into()],
                 };
-                let _ = restart(&client, &mut streams, &paths, &args).await;
+                let _ = restart_within(&client, &mut streams, &paths, &args, PROBE_BUDGET).await;
             }
 
             assert_eq!(
@@ -3660,6 +3710,7 @@ mod tests {
         /// Mutation check: reading a missing protocol as some sentinel number
         /// (`answer.protocol.unwrap_or(0)`) reddens this, and leaves the dog
         /// that answers nothing at all green -- that one never gets this far.
+        #[cfg(unix)]
         #[tokio::test]
         async fn a_dog_that_names_no_protocol_restarts_in_silence() {
             let dir = tempfile::tempdir().unwrap();
@@ -3679,7 +3730,7 @@ mod tests {
                 let args = SelectorArgs {
                     selectors: vec!["log-rotate".into()],
                 };
-                let _ = restart(&client, &mut streams, &paths, &args).await;
+                let _ = restart_within(&client, &mut streams, &paths, &args, PROBE_BUDGET).await;
             }
 
             assert_eq!(
@@ -3710,6 +3761,7 @@ mod tests {
         /// Mutation check: making the lookup fall back to any adopted path when
         /// the name is not in `adopted_dogs` reddens this, and leaves every
         /// other test in this group green.
+        #[cfg(unix)]
         #[tokio::test]
         async fn a_built_in_dog_is_never_asked_what_its_binary_speaks() {
             let dir = tempfile::tempdir().unwrap();
@@ -3733,7 +3785,7 @@ mod tests {
                 let args = SelectorArgs {
                     selectors: vec!["metrics".into()],
                 };
-                let _ = restart(&client, &mut streams, &paths, &args).await;
+                let _ = restart_within(&client, &mut streams, &paths, &args, PROBE_BUDGET).await;
             }
 
             assert_eq!(

--- a/crates/shep-cli/src/lib.rs
+++ b/crates/shep-cli/src/lib.rs
@@ -1271,7 +1271,7 @@ async fn run(cli: Cli, style: style::Presentation) -> ExitCode {
             }
         }
         Commands::Restart(ref args) => match connect_client(&mut streams, &paths, guard).await {
-            Ok(client) => lifecycle::restart(&client, &mut streams, args).await,
+            Ok(client) => lifecycle::restart(&client, &mut streams, &paths, args).await,
             Err(code) => code,
         },
         Commands::Reload(ref args) => match connect_client(&mut streams, &paths, guard).await {

--- a/crates/shep-client/src/lib.rs
+++ b/crates/shep-client/src/lib.rs
@@ -81,6 +81,22 @@ pub mod testing;
 
 pub use shep_core;
 
+/// The wire protocol this client speaks, re-exported from
+/// [`shep_core::protocol::PROTOCOL_VERSION`].
+///
+/// Here because `docs/dogs.md` asks every dog to print it, and the path
+/// through the crate re-export above reads as though a dog is reaching
+/// somewhere it should not: `shep_client::shep_core::protocol::PROTOCOL_VERSION`
+/// is four segments of plumbing for a number that is part of the dog
+/// contract. A dog depends on this crate and on nothing else, so the number
+/// it has to publish should be reachable from this crate's own root.
+///
+/// It is a re-export rather than a copy for the reason the protocol has bitten
+/// twice already: the value lives in shep-core, this crate's dependency on it
+/// floats within 0.1.x, and a second definition here could disagree with the
+/// one the handshake actually compares.
+pub use shep_core::protocol::PROTOCOL_VERSION;
+
 #[cfg(test)]
 mod tests {
     /// Not an assertion about behaviour — a line of output where a wrong

--- a/crates/shep-daemon/src/dogs.rs
+++ b/crates/shep-daemon/src/dogs.rs
@@ -129,10 +129,10 @@ impl core::error::Error for DogError {
 /// The program a built-in dog is spawned as: this binary's own resolved
 /// path.
 ///
-/// # Why [`crate::handover::exec_target`] and not `std::env::current_exe()`
+/// # Why `handover::exec_target` and not `std::env::current_exe()`, on unix
 ///
 /// This used to call `current_exe` directly, and on Linux that is wrong for
-/// exactly the reason [`crate::handover::exec_target`]'s own doc gives for
+/// exactly the reason `handover::exec_target`'s own doc gives for
 /// a handover: `current_exe` reads `/proc/self/exe`, a symlink to the
 /// *inode* this process was executed from. A package manager replaces the
 /// shepherd's binary by renaming a new file over it, which leaves the old
@@ -162,8 +162,29 @@ impl core::error::Error for DogError {
 /// version-skew question for the `--version` contract this phase's later
 /// tasks add, not a spawn failure — this function's only job is to never
 /// hand a dog a path that cannot be exec'd at all.
+///
+/// # Windows resolves it the plain way, and that is not a shortcut
+///
+/// `handover` is `#[cfg(unix)]` because `execve` and raw descriptor numbers
+/// have no Windows equivalent, so `exec_target` is not reachable there and
+/// this module does not compile for a Windows target if it asks for one.
+/// The guard would also have nothing to catch. `" (deleted)"` is what Linux
+/// puts in `/proc/self/exe` for an unlinked inode, and the rename that
+/// creates one cannot happen on Windows in the first place: the filesystem
+/// refuses to replace a running executable, which is why upgrading shep
+/// there means stopping it. So Windows keeps `current_exe`, which answers
+/// the same question correctly on a platform where the failure mode does
+/// not exist.
+#[cfg(unix)]
 fn builtin_program() -> Result<PathBuf, DogError> {
     crate::handover::exec_target().map_err(DogError::NoBinary)
+}
+
+/// The program a built-in dog is spawned as, on a platform with no
+/// handover. See the unix version above for why the two differ.
+#[cfg(windows)]
+fn builtin_program() -> Result<PathBuf, DogError> {
+    std::env::current_exe().map_err(DogError::NoBinary)
 }
 
 /// The app config the daemon spawns `spec` from.
@@ -924,6 +945,12 @@ mod tests {
     /// — and pins what a dog's own error reads once that refusal reaches
     /// `DogError`, since a message naming the fix is the feature this
     /// phase asks for.
+    ///
+    /// Unix only, because the guard it pins is: `handover` is `#[cfg(unix)]`,
+    /// and the `" (deleted)"` string it refuses is Linux's answer for an
+    /// unlinked `/proc/self/exe`. Windows resolves a built-in dog's program
+    /// with `current_exe` and has no such state to refuse.
+    #[cfg(unix)]
     #[test]
     fn a_deleted_inode_answer_from_current_exe_never_becomes_a_dogs_script() {
         let refusal = crate::handover::resolve_target(

--- a/crates/shep-daemon/src/dogs.rs
+++ b/crates/shep-daemon/src/dogs.rs
@@ -83,8 +83,13 @@ pub struct DogSpec {
 #[non_exhaustive]
 #[derive(Debug)]
 pub enum DogError {
-    /// [`std::env::current_exe`] failed, so a built-in dog has no program to
-    /// run
+    /// A built-in dog has no program it can be spawned with. Two different
+    /// causes wrap the same [`std::io::Error`]: [`std::env::current_exe`]
+    /// itself failing, or — the more common case, and Linux-only — this
+    /// crate's own handover-target resolution refusing every candidate it
+    /// found, which includes a `current_exe` answer naming a deleted inode
+    /// after this binary was replaced on disk (`dog_app`'s doc has the
+    /// full argument).
     NoBinary(std::io::Error),
     /// The dog's binary comes from a source this build cannot spawn
     /// (carries the source as `Debug` renders it). [`DogSource`] is
@@ -102,7 +107,7 @@ pub enum DogError {
 impl fmt::Display for DogError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::NoBinary(err) => write!(f, "this binary's own path is unreadable: {err}"),
+            Self::NoBinary(err) => write!(f, "this binary's own path is unresolvable: {err}"),
             Self::UnsupportedSource(source) => {
                 write!(f, "no way to spawn a dog from source {source}")
             }
@@ -119,6 +124,46 @@ impl core::error::Error for DogError {
             Self::UnsupportedSource(_) | Self::Config(_) => None,
         }
     }
+}
+
+/// The program a built-in dog is spawned as: this binary's own resolved
+/// path.
+///
+/// # Why [`crate::handover::exec_target`] and not `std::env::current_exe()`
+///
+/// This used to call `current_exe` directly, and on Linux that is wrong for
+/// exactly the reason [`crate::handover::exec_target`]'s own doc gives for
+/// a handover: `current_exe` reads `/proc/self/exe`, a symlink to the
+/// *inode* this process was executed from. A package manager replaces the
+/// shepherd's binary by renaming a new file over it, which leaves the old
+/// inode unlinked and still open, so `current_exe` comes back
+/// `"<path> (deleted)"`. No handover has to be in flight for that to bite —
+/// a built-in dog crashing, autorestarting, or `shep restart metrics` after
+/// such a rename hit it on the very next respawn, and the string cannot be
+/// exec'd.
+///
+/// `exec_target`'s own doc frames its candidate order — the recorded
+/// launch path preferred over `current_exe` — as chosen for an exec that
+/// must reach the binary an operator just installed. A dog respawn does
+/// not share that requirement in the same words; it only needs a file it
+/// can exec, not specifically the newest one. The order still serves it
+/// here, for a narrower reason: after a rename, the recorded launch path
+/// is exactly the candidate that still resolves to a file, while
+/// `current_exe` is the one that comes back `" (deleted)"`. Reusing
+/// `exec_target` also keeps one place in this crate that decides "which
+/// file holds my own binary" instead of two, and the one already there
+/// validates every candidate before handing it to a spawn rather than
+/// trusting either blindly.
+///
+/// One consequence is worth stating rather than discovering later: if the
+/// shepherd's own binary has been replaced on disk but the running process
+/// has not yet reloaded or handed over, a dog respawned this way can run
+/// NEWER code than the shepherd currently has loaded in memory. That is a
+/// version-skew question for the `--version` contract this phase's later
+/// tasks add, not a spawn failure — this function's only job is to never
+/// hand a dog a path that cannot be exec'd at all.
+fn builtin_program() -> Result<PathBuf, DogError> {
+    crate::handover::exec_target().map_err(DogError::NoBinary)
 }
 
 /// The app config the daemon spawns `spec` from.
@@ -139,18 +184,18 @@ impl core::error::Error for DogError {
 /// is supervised exactly as a sheep is.
 ///
 /// # Errors
-/// - [`DogError::NoBinary`] — [`std::env::current_exe`] failed, so a
-///   built-in dog has no program to run.
+/// - [`DogError::NoBinary`] — a built-in dog has no program to run, either
+///   because [`std::env::current_exe`] itself failed or because the
+///   `builtin_program` helper above refused every candidate it found (see
+///   its doc for why that includes a Linux `current_exe` answer naming a
+///   deleted inode).
 /// - [`DogError::UnsupportedSource`] — the source is a kind this build does
 ///   not know how to spawn.
 /// - [`DogError::Config`] — the assembled config failed `normalize`.
 pub fn dog_app(spec: &DogSpec, paths: &ShepPaths) -> Result<ResolvedApp, DogError> {
     let (script, args) = match &spec.source {
         DogSource::BuiltIn => (
-            std::env::current_exe()
-                .map_err(DogError::NoBinary)?
-                .display()
-                .to_string(),
+            builtin_program()?.display().to_string(),
             vec!["dog".to_string(), spec.name.clone()],
         ),
         // No arguments: an adopted dog is a binary somebody else wrote, and
@@ -862,6 +907,37 @@ mod tests {
     use crate::testing::test_paths;
     use shep_core::protocol::ProcessInfo;
     use shep_core::status::ProcStatus;
+
+    /// fails if a `current_exe` answer carrying Linux's `" (deleted)"`
+    /// suffix ever becomes a built-in dog's script. Before this fix
+    /// `dog_app` called `std::env::current_exe()` unguarded and used
+    /// whatever it returned as the script directly; on Linux, a package
+    /// manager renaming a new file over the running shepherd's inode makes
+    /// that string literal, and exec'ing it fails.
+    ///
+    /// `current_exe` cannot be made to return that string on this platform
+    /// (or on any platform, safely), so this exercises the exact function
+    /// `builtin_program` now delegates to —
+    /// `crate::handover::resolve_target`, proven to refuse a deleted-inode
+    /// candidate by
+    /// `handover::tests::resolve_target_refuses_a_synthetic_deleted_inode_candidate`
+    /// — and pins what a dog's own error reads once that refusal reaches
+    /// `DogError`, since a message naming the fix is the feature this
+    /// phase asks for.
+    #[test]
+    fn a_deleted_inode_answer_from_current_exe_never_becomes_a_dogs_script() {
+        let refusal = crate::handover::resolve_target(
+            [None, Some(PathBuf::from("/opt/shep/shep (deleted)"))],
+            None,
+        )
+        .unwrap_err();
+        let err = DogError::NoBinary(refusal);
+        assert_eq!(
+            err.to_string(),
+            "this binary's own path is unresolvable: no binary to exec: \
+             /opt/shep/shep (deleted) (names a deleted inode, not a file)"
+        );
+    }
 
     /// fails if a `[dog.<name>]` value is folded into the child's
     /// environment. That is the design's whole reason for putting config on

--- a/crates/shep-daemon/src/handover/mod.rs
+++ b/crates/shep-daemon/src/handover/mod.rs
@@ -1188,9 +1188,37 @@ pub fn record_launch_path() {
 pub fn exec_target() -> io::Result<PathBuf> {
     let recorded = LAUNCH_PATH.get().cloned().flatten();
     let current = std::env::current_exe();
+    resolve_target(
+        [recorded, current.as_deref().ok().map(Path::to_path_buf)],
+        current.as_ref().err(),
+    )
+}
 
+/// The validated-candidate loop [`exec_target`] runs, pulled out so a test
+/// can hand it a synthetic `" (deleted)"` path directly rather than needing
+/// a real Linux inode-unlink to produce one — `current_exe` cannot be made
+/// to return that string on any other platform, or by any safe means at
+/// all.
+///
+/// `pub(crate)` rather than private: [`crate::dogs::dog_app`] resolves a
+/// built-in dog's own program through [`exec_target`] for the same reason a
+/// handover does (see that module's `builtin_program` for the argument),
+/// and its tests use this seam the same way `exec_target`'s own tests do.
+///
+/// Returns the first candidate in `candidates` that [`check_target`]
+/// accepts, in order; a `None` entry is skipped (the "nothing recorded
+/// yet" case). `current_exe_error` is folded into the diagnostic only —
+/// a `current_exe()` failure is not itself a path to validate.
+///
+/// # Errors
+/// [`io::ErrorKind::NotFound`] if every candidate is `None` or refused.
+/// The message names each candidate tried and what was wrong with it.
+pub(crate) fn resolve_target(
+    candidates: [Option<PathBuf>; 2],
+    current_exe_error: Option<&io::Error>,
+) -> io::Result<PathBuf> {
     let mut refusals = Vec::new();
-    for candidate in [recorded, current.as_deref().ok().map(Path::to_path_buf)] {
+    for candidate in candidates {
         let Some(candidate) = candidate else { continue };
         match check_target(&candidate) {
             Ok(()) => return Ok(candidate),
@@ -1198,7 +1226,7 @@ pub fn exec_target() -> io::Result<PathBuf> {
         }
     }
 
-    if let Err(e) = &current {
+    if let Some(e) = current_exe_error {
         refusals.push(format!("this process's own image ({e})"));
     }
     if refusals.is_empty() {
@@ -1206,7 +1234,7 @@ pub fn exec_target() -> io::Result<PathBuf> {
     }
     Err(io::Error::new(
         io::ErrorKind::NotFound,
-        format!("no binary to hand over to: {}", refusals.join("; ")),
+        format!("no binary to exec: {}", refusals.join("; ")),
     ))
 }
 
@@ -2511,6 +2539,21 @@ mod tests {
             !p.to_string_lossy().contains("(deleted)"),
             "exec target resolved to a deleted inode: {}",
             p.display()
+        );
+    }
+
+    #[test]
+    fn resolve_target_refuses_a_synthetic_deleted_inode_candidate() {
+        // The seam `dogs::builtin_program` depends on through
+        // `exec_target`. `current_exe` cannot be made to return a
+        // `" (deleted)"` string on this platform, so this hands
+        // `resolve_target` one directly — proving the refusal without
+        // needing a real Linux inode-unlink to produce the string.
+        let deleted = PathBuf::from("/opt/shep/shep (deleted)");
+        let err = resolve_target([None, Some(deleted)], None).unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "no binary to exec: /opt/shep/shep (deleted) (names a deleted inode, not a file)"
         );
     }
 

--- a/docs/brainstorming/specs/2026-08-29-daemon-handover-design.md
+++ b/docs/brainstorming/specs/2026-08-29-daemon-handover-design.md
@@ -576,13 +576,35 @@ Forcing protocol 1 needed `cargo update -p shep-core --precise 0.1.14`.
 Two consequences, in opposite directions:
 
 - Good: a plain `cargo install <dog>` genuinely does fix the protocol,
-  because shep-core resolves forward on every rebuild.
+  because shep-core resolves forward on every rebuild. Measured 2026-08-31:
+  it also ignores the packaged lockfile, so this holds even for a crate
+  that published one pinning an old shep-core. `cargo install --locked`,
+  and most CI, honour that lockfile and produce whatever protocol was
+  pinned on publish day.
 - Bad: nothing an operator can read tells them which protocol an installed
-  dog speaks. Its manifest does not say, its lockfile is not shipped, and
-  the answer depends on the day it was last compiled.
+  dog speaks. Its manifest does not say, the shipped lockfile may or may
+  not have applied, and the answer depends on the day it was last compiled.
 
-So `Hello.client_version`, which the daemon already receives and discards,
-is not a convenience. It is the only thing that knows.
+**Corrected 2026-08-31: this named the wrong field.** It closed with "So
+`Hello.client_version`, which the daemon already receives and discards, is
+not a convenience. It is the only thing that knows." Wrong twice. `Hello`
+carries `client_version: String` and `protocol: u32` as separate fields,
+and `server.rs` refuses on `hello.protocol`, never on the version. So the
+crate version is not what decides compatibility, and it is not the only
+thing that knows: the field that knows sits beside it.
+
+The finding survives the correction and gets sharper for it. Both fields
+reach the daemon only AFTER the dog connects, so neither helps an operator
+holding a binary that has not started yet. That is the gap, and G11 is what
+closes it: the binary is the only thing that can be asked before it runs.
+
+Both numbers matter, for different questions, which is why `Hello` has
+carried both since before any of this:
+
+| number | answers | on a mismatch |
+|---|---|---|
+| protocol | can this dog connect at all | hard: refuse |
+| crate version | is this dog the same build as everything else | soft: report |
 
 ### G10. Why `cargo install` can replace a running dog at all
 

--- a/docs/brainstorming/specs/2026-08-29-daemon-handover-design.md
+++ b/docs/brainstorming/specs/2026-08-29-daemon-handover-design.md
@@ -633,6 +633,16 @@ That is a gap in the dog contract rather than a bug in one dog. So it
 becomes part of what a dog is: **a dog answers `--version` on stdout and
 exits 0.**
 
+**The format lives in `docs/dogs.md`'s "Answering `--version`" section,
+which is the contract third parties implement and shep parses.** That
+sentence above says less than the format needs, and the two would drift if
+this document tried to carry it too. The short of it: a version on line 1,
+`<key>: <value>` lines after it, `shep-protocol` carrying
+`PROTOCOL_VERSION` in decimal, `shep-` reserved so a third number gets its
+own line later, and everything else ignored. The section also records why
+the built-in dogs are outside the contract, and what a `--version` answer
+cannot catch.
+
 `shep adopt` vets it. Adopt already spawns the candidate to prove the
 kernel can exec it, so asking its version costs one more argument on a
 process it was already going to start. A dog that cannot satisfy the

--- a/docs/dogs.md
+++ b/docs/dogs.md
@@ -409,6 +409,51 @@ has never seen gets two `printf` calls right on the first try. Hand
 written JSON is where the quoting and the trailing comma go wrong, and
 nothing here nests.
 
+### What `shep restart <dog>` does with the answer
+
+`cargo install` replaces a file and never touches a process, so a dog
+upgraded on disk leaves a working system: the dog running now is the old
+binary, still connected, still doing its job. The two only meet at the next
+restart, which may be days away and for a reason that has nothing to do with
+the upgrade.
+
+`shep restart <name>` is that restart, so it asks the same question first:
+
+```
+notice[dog_binary_skew]: `log-rotate`'s binary at /usr/local/bin/shep-log-rotate
+was built for shep protocol 3, and this shep speaks 2; restarting it brings it
+back on that binary, unable to connect. Run a shep that speaks 3, or reinstall
+the dog against protocol 2, and restart it again
+```
+
+Then it restarts the dog. This is a warning and never a refusal: the
+operator asked for the restart, the binary on disk may be exactly what they
+just installed, and there are two ways out of the state rather than one, so
+the message names both and picks neither.
+
+| what the binary answers | what `restart` does |
+|---|---|
+| a `shep-protocol` this shep does not speak | warns, then restarts |
+| a protocol this shep speaks | restarts, silently |
+| a version and no protocol line | restarts, silently |
+| nothing, or a run that exits non-zero | restarts, silently |
+
+**Unknown is not stale.** Every dog written before this contract is in the
+last two rows, and a line on stderr for each of them is how an operator
+learns to skip the one that matters.
+
+Three things are never asked at all. A built-in dog has no binary of its
+own, so there is nothing to be stale. A selector that sweeps rather than
+names, `all` or a `/regex/`, does not reach a dog in the first place. And a
+dog named by id rather than by name is restarted without a check, because
+looking up its name would cost a round trip before the restart the operator
+asked for.
+
+The cost is the same second `adopt` spends, and it is paid only by a restart
+that named an adopted dog. A binary that hangs is killed when the second is
+up and the restart goes ahead unwarned, so the slowest a dog can make
+`shep restart` is one second, never indefinitely.
+
 ### Why the binary is the only thing that can answer
 
 A dog's crate version does not imply its protocol, and neither does

--- a/docs/dogs.md
+++ b/docs/dogs.md
@@ -459,14 +459,16 @@ because the wait for the process to exit and the wait for its text are
 bounded separately: a grandchild holding the pipe open can cost the second
 budget after a clean exit.
 
-A named restart briefly runs your dog twice. To read the binary on disk,
-shep runs it with `--version`, and a dog that does not recognise that flag
+A named restart can briefly run your dog twice. To read the binary on disk,
+shep runs it with `--version`, and a dog that does not RECOGNISE that flag
 ignores it and starts doing its ordinary job instead, with `SHEP_HOME`
 pointing at the live shepherd. So a rotator can rotate once and a bark dog
 can open a second subscription, for up to the budget above, before the
 process is killed.
 
-Every dog written before this contract is in that group. The trade is
+Only dogs that ignore the flag are affected. A dog that recognises
+`--version` and exits, even without naming a protocol, does no work: its
+protocol is unknown and nothing overlaps. The trade is
 deliberate: the command is about to restart that dog anyway, so the only
 question is whether it briefly overlaps itself, and the alternative is not
 asking at all, which is what let a stale dog sit `online` unnoticed. Adding

--- a/docs/dogs.md
+++ b/docs/dogs.md
@@ -361,7 +361,7 @@ have:
 ```rust
 if std::env::args().nth(1).as_deref() == Some("--version") {
     println!("{} {}", env!("CARGO_PKG_NAME"), env!("CARGO_PKG_VERSION"));
-    println!("shep-protocol: {}", shep_client::shep_core::protocol::PROTOCOL_VERSION);
+    println!("shep-protocol: {}", shep_client::PROTOCOL_VERSION);
     return;
 }
 ```

--- a/docs/dogs.md
+++ b/docs/dogs.md
@@ -355,6 +355,43 @@ Answering is optional and stays optional. Dogs predating the convention
 are still adoptable, and a dog that does not answer is never refused for
 it: its protocol is simply unknown.
 
+### What `shep adopt` does with the answer
+
+`shep adopt` asks the candidate before it records anything. The vet was
+already spawning the binary to prove this kernel can exec it, so the
+question costs one argument on a process that was going to start anyway.
+
+| what the candidate answers | what `adopt` does |
+|---|---|
+| a `shep-protocol` this shep does not speak | refuses, before `shep.toml` is touched |
+| a protocol this shep speaks | adopts, and reports the version it gave |
+| a version and no protocol line | adopts, and says the protocol is unknown |
+| nothing, or a run that exits non-zero | adopts, protocol unknown, no notice |
+
+The refusal names both numbers and both ways out:
+
+```
+/usr/local/bin/shep-otel: this dog was built for shep protocol 1, and this
+shep speaks 2; reinstall the dog without --locked so it builds against the
+current shep-core, or run a shep that speaks 1
+```
+
+Only a stated protocol can refuse an adopt. The version is never compared
+with anything, because a third-party dog's crate version has no
+relationship to shep's own: `shep-log-rotate` 0.1.3 against shep 0.1.24 is
+the ordinary case, not a skew, and comparing the two would report every
+dog that exists.
+
+A candidate gets one second to answer and is killed either way, so a dog
+that ignores `--version` and runs costs that second and is adopted with an
+unknown protocol. It cannot hang the `adopt` that is vetting it.
+
+None of the answer is written down. `[daemon] adopted_dogs` records the
+path and nothing else, and a protocol stored at adopt time would be a copy
+of a number that can change on disk with nothing watching. That is G12's
+row 5, the one case where the stored copy would be wrong exactly when it
+mattered, so the binary is asked again rather than remembered.
+
 Emitting it needs four lines and no dependency a dog does not already
 have:
 

--- a/docs/dogs.md
+++ b/docs/dogs.md
@@ -322,6 +322,109 @@ comparison, not a hand-wave: you were already trusting whatever you point
 a Flockfile's `script` at, and a third-party dog is held to no higher bar
 than that.
 
+## Answering `--version`
+
+A dog answers `--version` on stdout and exits 0. Two numbers come back,
+and they answer different questions:
+
+| what | answers | on a mismatch |
+|---|---|---|
+| the version on line 1 | which build of the dog this is | reported |
+| `shep-protocol` | whether this dog can handshake with this shepherd at all | it cannot connect until one side moves |
+
+The format is line-oriented text:
+
+```
+shep-log-rotate 0.1.3
+shep-protocol: 2
+```
+
+- Line 1 is `<name> <version>`. Shep takes the last whitespace-separated
+  field as the version and ignores the name, so a crate whose name differs
+  from the dog's registered name is fine. This is the line clap already
+  prints for free.
+- Every later line is `<key>: <value>`, one pair to a line.
+  `shep-protocol` carries, in decimal, the `PROTOCOL_VERSION` the binary
+  was compiled against.
+- Unknown keys, blank lines, and the order of the key lines are all
+  ignored. Keys beginning `shep-` are reserved, so a third number can get
+  its own line later without breaking a parser that predates it. Put keys
+  of your own under a prefix of your own.
+
+Answering is optional and stays optional. Dogs predating the convention
+are still adoptable, and a dog that does not answer is never refused for
+it: its protocol is simply unknown.
+
+Emitting it needs four lines and no dependency a dog does not already
+have:
+
+```rust
+if std::env::args().nth(1).as_deref() == Some("--version") {
+    println!("{} {}", env!("CARGO_PKG_NAME"), env!("CARGO_PKG_VERSION"));
+    println!("shep-protocol: {}", shep_client::shep_core::protocol::PROTOCOL_VERSION);
+    return;
+}
+```
+
+Lines rather than JSON, because a human runs `--version` far more often
+than shep does, and because a stranger writing a dog in a language shep
+has never seen gets two `printf` calls right on the first try. Hand
+written JSON is where the quoting and the trailing comma go wrong, and
+nothing here nests.
+
+### Why the binary is the only thing that can answer
+
+A dog's crate version does not imply its protocol, and neither does
+knowing that somebody installed it:
+
+| how the dog was built | which `shep-core` | so which protocol |
+|---|---|---|
+| `cargo install <dog>` | re-resolved, newest compatible | current |
+| `cargo install --locked`, and most CI | whatever the shipped lockfile pins | whatever was pinned on publish day |
+
+Measured 2026-08-31: `shep-log-rotate` 0.1.3 installed plain compiled
+`shep-core` 0.1.24, so the packaged lockfile was ignored, while the same
+crate built `--locked` produced a protocol 1 dog. Both published dogs
+were shipping a lockfile pinning a protocol 1 `shep-core` that day, and
+both repositories' CI had been red on it for two days. The crate version
+was identical either way. That is the whole argument for asking the
+binary: nothing outside it knows.
+
+### The built-in dogs are outside this
+
+`metrics` and `bark` are not separate binaries. The shepherd starts them
+as `<its own binary> dog <name>`, so a built-in dog **is** the shep
+binary that spawned it and cannot skew from it on disk. There is no
+question here for a contract to answer:
+
+```
+$ shep --version
+shep 0.1.24
+$ shep dog metrics --version
+shep-dog 0.1.24
+```
+
+Neither prints a `shep-protocol` line, and that is not a gap to close.
+The protocol a built-in dog speaks is the shepherd's own, because it is
+the shepherd's binary.
+
+### What this does not catch
+
+Two dogs can agree on the protocol and still be different code.
+`RpcError` gained a public `daemon_version` field inside the 0.1.x range;
+its fields are public and it has no constructor, so every literal built
+outside `shep-client` stopped compiling while `PROTOCOL_VERSION` stood
+still. Protocol equality is necessary and not sufficient.
+
+Closing that is deferred, and the reason is that `--version` cannot close
+it. A break of that kind is source level: it lands when the dog is
+compiled, in the dog's own repository, and a dog nobody rebuilt keeps
+running. Shep has no table of which `shep-client` versions build against
+which daemon, and a version comparison standing in for one would report
+dogs that are fine. What catches it is the dog's own CI building against
+a current `shep-core`, which is where both published dogs' breakage was
+already visible and unread.
+
 ## When a dog dies
 
 If an enabled dog exhausts its own restart budget and lands on `Errored`,

--- a/docs/dogs.md
+++ b/docs/dogs.md
@@ -382,7 +382,9 @@ relationship to shep's own: `shep-log-rotate` 0.1.3 against shep 0.1.24 is
 the ordinary case, not a skew, and comparing the two would report every
 dog that exists.
 
-A candidate gets one second to answer and is killed either way, so a dog
+A candidate gets one second to exit and another to have its output read,
+so two seconds is the worst case rather than one. It is killed either way,
+so a dog
 that ignores `--version` and runs costs that second and is adopted with an
 unknown protocol. It cannot hang the `adopt` that is vetting it.
 
@@ -452,7 +454,25 @@ asked for.
 The cost is the same second `adopt` spends, and it is paid only by a restart
 that named an adopted dog. A binary that hangs is killed when the second is
 up and the restart goes ahead unwarned, so the slowest a dog can make
-`shep restart` is one second, never indefinitely.
+`shep restart` is two seconds, never indefinitely. Two rather than one
+because the wait for the process to exit and the wait for its text are
+bounded separately: a grandchild holding the pipe open can cost the second
+budget after a clean exit.
+
+A named restart briefly runs your dog twice. To read the binary on disk,
+shep runs it with `--version`, and a dog that does not recognise that flag
+ignores it and starts doing its ordinary job instead, with `SHEP_HOME`
+pointing at the live shepherd. So a rotator can rotate once and a bark dog
+can open a second subscription, for up to the budget above, before the
+process is killed.
+
+Every dog written before this contract is in that group. The trade is
+deliberate: the command is about to restart that dog anyway, so the only
+question is whether it briefly overlaps itself, and the alternative is not
+asking at all, which is what let a stale dog sit `online` unnoticed. Adding
+`--version` to your dog removes the overlap, since a dog that answers exits
+immediately.
+
 
 ### Why the binary is the only thing that can answer
 

--- a/docs/writing-plans/plans/2026-08-31-handover-phase4.md
+++ b/docs/writing-plans/plans/2026-08-31-handover-phase4.md
@@ -41,11 +41,11 @@ Phase 3's task 2 measured the first half directly: two builds differing only in 
 
 **A `--version` answer carries both.** Neither is sufficient, which is precisely why `Hello` has carried both since before this phase.
 
-### 2. `shep-log-rotate` is not in this workspace
+### 2. `shep-log-rotate` is real, and is not in this workspace
 
-G11 argues from `shep-log-rotate` accepting `--print-config` and `--help` and refusing `--version`. No such binary exists here — `grep` finds the name nowhere outside the spec. The built-in dogs are `metrics` and `bark`, and they are `BUILT_IN_DOGS` in `crates/shep-cli/src/dog/mod.rs:46`.
+G11 argues from `shep-log-rotate` accepting `--print-config` and `--help` and refusing `--version`. `grep` finds the name nowhere in this tree outside the spec, and the built-in dogs are `metrics` and `bark` (`BUILT_IN_DOGS`, `crates/shep-cli/src/dog/mod.rs:46`).
 
-The argument survives; only its example is external. Do not go looking for that crate, and do not invent it.
+It is nonetheless a real published crate, at 0.1.3 as of 2026-08-31, and it is the adopted dog running against a production flock. So it is not a hypothetical to reason around — it is the reference third-party dog this phase should be driven against, and the one that exposed phase 3b's reporting defects. Expect to install it rather than to find it.
 
 ### 3. The two dog populations have opposite properties, and the spec treats them as one
 

--- a/docs/writing-plans/plans/2026-08-31-handover-phase4.md
+++ b/docs/writing-plans/plans/2026-08-31-handover-phase4.md
@@ -66,6 +66,23 @@ Note the tension this creates with a comment already in `dog_app`: *"an argv she
 
 ---
 
+## Measured on 2026-08-31, and it strengthens the case
+
+Both published dogs were found shipping lockfiles that pinned a protocol-1 `shep-core`: `shep-log-rotate` at 0.1.0 and `shep-deploy` at 0.1.10, against a current 0.1.24. Both repositories' CI had been red since 2026-08-30, failing on the exact sentence an operator hit in production, and nobody had connected a red dog repository to a stale dog in a flock.
+
+The install semantics are what this phase turns on, and they are not intuitive:
+
+| how the dog is built | which `shep-core` | so which protocol |
+|---|---|---|
+| `cargo install <dog>` | re-resolved, newest compatible | current |
+| `cargo install --locked`, and CI | whatever the shipped lockfile pins | whatever was pinned that day |
+
+Measured rather than reasoned: installing `shep-log-rotate` 0.1.3 to a throwaway root compiled `shep-core v0.1.24`, so the packaged lockfile was ignored. The same crate built `--locked` produced a protocol-1 dog, which is what CI had been doing for two days.
+
+**So a dog's crate version tells you nothing about its protocol, and neither does knowing that somebody installed it.** You would also need to know which flags they used and what the lockfile said at publish time. None of that is visible from outside the binary, which is the strongest argument available for G11: the binary is the only thing that can answer, so ask it.
+
+One more thing to carry into task 3. `RpcError` gained a public `daemon_version` field somewhere inside the 0.1.x range. Its fields are public and it has no constructor, so every literal built outside `shep-client` stopped compiling, and `shep-deploy` had eleven of them. Protocol equality is therefore necessary but not sufficient for "this dog still works", and a `--version` answer carrying only the protocol answers a narrower question than the operator is asking. Decide deliberately whether to close that gap here or defer it, and say which.
+
 ## The bug this found
 
 `dog_app` calls `std::env::current_exe()` unguarded (`dogs.rs:147`) and hands the result straight to `AppConfig::minimal`.

--- a/docs/writing-plans/plans/2026-08-31-handover-phase4.md
+++ b/docs/writing-plans/plans/2026-08-31-handover-phase4.md
@@ -1,0 +1,198 @@
+# Daemon handover, phase 4: the dog version axis
+
+> **For agentic workers:** REQUIRED SUB-SKILL: use `superpowers:subagent-driven-development` to implement this task-by-task. Steps use `- [ ]` for tracking.
+
+**Goal:** Let an operator find out that a dog's binary on disk cannot satisfy the running shepherd, before that dog is adopted or restarted into a state nobody can see.
+
+**Spec:** `docs/brainstorming/specs/2026-08-29-daemon-handover-design.md`, sections **G9**, **G10**, **G11**, **G12** and **G13**.
+
+**Base:** cut from `origin/main` after phase 3.
+
+## Global constraints
+
+- MSRV 1.88, edition 2024.
+- `PROTOCOL_VERSION` is 2 and does not move in this phase. Nothing here changes a wire frame.
+- The `shep-idiomatic-rust` skill fronts IR-1..IR-46. IR-11 (`# Errors`), IR-26 (named timing constants) and IR-41 (deliberate `Debug`) all apply.
+- The CLI's package is named `shep`. `-p shep-cli` matches nothing and exits 0 having run no tests.
+- `web/` is published. Every task in this phase changes what an operator types or sees, so every task regenerates the CLI reference and reads the prose pages.
+
+---
+
+## Three corrections the spec needs, found before any code
+
+Phase 3 was planned off G8-G13 and shipped clean. Re-reading the same sections against the tree found three places where the spec describes a system that is not this one. Each changes a design decision in this phase, so each is stated here and corrected in the commit that acts on it.
+
+### 1. G9 names the wrong field, and the right one was always there
+
+G9 closes: *"So `Hello.client_version`, which the daemon already receives and discards, is not a convenience. It is the only thing that knows."*
+
+That is wrong twice.
+
+`Hello` carries `client_version: String` and `protocol: u32` as separate fields. `server.rs:475` refuses on `hello.protocol != PROTOCOL_VERSION`; `client_version` is only ever logged. So the crate version is not what decides compatibility, and it is not the only thing that knows — the field that knows sits beside it.
+
+Phase 3's task 2 measured the first half directly: two builds differing only in `PROTOCOL_VERSION` both reported `0.1.22`.
+
+**But do not over-correct into "protocol replaces crate version".** The spec's own verification list asks for *"a version difference with NO protocol difference, which is the case a protocol-only check misses"*. Two builds can share a protocol and still be different code. So:
+
+| number | answers | on a mismatch |
+|---|---|---|
+| protocol | can this dog connect at all | hard: refuse |
+| crate version | is this dog the same build as everything else | soft: report |
+
+**A `--version` answer carries both.** Neither is sufficient, which is precisely why `Hello` has carried both since before this phase.
+
+### 2. `shep-log-rotate` is not in this workspace
+
+G11 argues from `shep-log-rotate` accepting `--print-config` and `--help` and refusing `--version`. No such binary exists here — `grep` finds the name nowhere outside the spec. The built-in dogs are `metrics` and `bark`, and they are `BUILT_IN_DOGS` in `crates/shep-cli/src/dog/mod.rs:46`.
+
+The argument survives; only its example is external. Do not go looking for that crate, and do not invent it.
+
+### 3. The two dog populations have opposite properties, and the spec treats them as one
+
+This is the finding that reshapes the phase. A built-in dog and an adopted dog get their program by different mechanisms (`dogs.rs:146-156`):
+
+| | built-in (`metrics`, `bark`) | adopted (third-party) |
+|---|---|---|
+| program | `current_exe()` + `["dog", name]` | the recorded path, **no argv at all** |
+| its binary on disk | *is* the shep binary | somebody else's crate |
+| can it skew from the shepherd? | only by being an older *running* image | yes, on both axes |
+| G12 rows reachable | 1 and 3 only | 1, 3, 4, 5 |
+
+**A built-in dog can never be G12 row 4 or 5.** Its disk binary is the shepherd's disk binary, so "reinstall the dog" is not a distinct action and a restart always reaches the same code the shepherd exec'd. Row 3 it can reach — a dog carried across a handover is an older image than the shepherd that adopted it, which is exactly what phase 3's one-restart rule already fixes.
+
+So **the `--version` contract is about adopted dogs.** Making `metrics` and `bark` answer a question whose answer is always "the same as the shepherd, by construction" adds a contract point carrying no information. `shep --version` already answers for both, because they are that binary.
+
+Note the tension this creates with a comment already in `dog_app`: *"an argv shep invented for it is one more thing it has to agree with before it can start"*, which is why an adopted dog gets no argv at run time. A `--version` vet is the same repo answering that question the other way. That is defensible — vetting spawns a throwaway process, running does not — but say so at the call site, because the next reader will find both.
+
+---
+
+## The bug this found
+
+`dog_app` calls `std::env::current_exe()` unguarded (`dogs.rs:147`) and hands the result straight to `AppConfig::minimal`.
+
+`handover/mod.rs:1148` documents at length why the handover must **not** do that, and `check_target` refuses a path containing `" (deleted)"`. `check_target` is private to that module and used nowhere else.
+
+So, on Linux only:
+
+1. Shepherd runs from inode A at some path on `PATH`.
+2. `cargo install shep` renames a new file over it (G10). Inode A is unlinked and still open.
+3. A built-in dog restarts before any handover — a crash, autorestart, or `shep restart metrics`.
+4. `current_exe()` reads `/proc/self/exe`, which is a symlink to the inode, and returns `"<path> (deleted)"`.
+5. That string becomes the dog's `script`. It cannot be spawned.
+
+macOS returns a clean path here, so no local run sees it — the handover module's own doc says the naive version "passes every local test", and CLAUDE.md says the same about the gate generally. CI's Linux legs are the only thing that can catch it.
+
+This is the same disk-versus-running axis as the rest of the phase, on the population the rest of the phase does not otherwise touch, so it belongs here. It is also independently shippable — if the phase runs long, task 1 is its own PR.
+
+---
+
+## Order
+
+Task 1 is independent and can land first or alone. Task 2 is the contract; 3 and 4 both depend on it and not on each other.
+
+---
+
+### Task 1: a built-in dog does not respawn from a deleted inode
+
+**Files:** `crates/shep-daemon/src/dogs.rs`, `crates/shep-daemon/src/handover/mod.rs`.
+
+The fix is to stop having two answers to "which file holds my binary" in one crate. `exec_target()` already resolves it correctly, preferring the recorded launch path and validating both arms. Decide whether `dog_app` should use it, use `check_target` alone, or grow its own guard, and argue the choice — `exec_target`'s fallback semantics were written for an exec that must reach the *new* binary, and a dog respawn may not want the same preference order.
+
+Whatever you pick, `DogError::NoBinary` gains a second way to happen, so its docs and `# Errors` section move with it (IR-11).
+
+- [ ] **Step 1: Write the failing test.** A `current_exe` answer carrying `" (deleted)"` does not become a dog's `script`. Pin the exact error text, per the spec's *"a message naming the fix is the feature"*.
+- [ ] **Step 2: Run it, watch it fail.**
+- [ ] **Step 3: Implement.**
+- [ ] **Step 4: Prove it non-vacuous.** Mutate the guard away and watch the test go red.
+- [ ] **Step 5: Drive it on Linux.** macOS cannot see this bug. Reproduce the rename-over-a-running-binary sequence from G10 and restart a built-in dog. If a Linux box is not to hand, say so and let CI's `ubuntu-latest` leg be the proof, rather than reporting a macOS run as evidence.
+- [ ] **Step 6: Commit.** No `web/` change — nothing an operator types moved.
+
+### Task 2: the `--version` contract, and G9 corrected
+
+**Files:** `docs/brainstorming/specs/2026-08-29-daemon-handover-design.md`, `docs/dogs.md`, `web/src/pages/docs/dogs.astro`.
+
+Write the contract down, correct G9 in the same commit, and decide the output format with an argument attached.
+
+The format is the whole of this task's design work. It carries two numbers (correction 1), third parties implement it from the published page, and shep parses it. Constraints worth weighing: a human runs `--version` far more often than shep does; a format that is easy to emit gets emitted correctly by strangers; and something has to be reserved for a future third number without breaking the parser.
+
+State explicitly that built-in dogs satisfy this through `shep --version` and why (correction 3), so nobody later reads the contract as a gap and "fixes" it.
+
+Measure what `shep --version` and `shep dog metrics --version` do today before writing about them.
+
+- [ ] **Step 1: Measure the current behaviour** of both invocations against a real build.
+- [ ] **Step 2: Write the contract** in `docs/dogs.md` and `web/`, with the format and its rationale.
+- [ ] **Step 3: Correct G9** — the field, not the conclusion. G9's actual finding, that nothing an operator reads tells them which protocol a dog speaks, is sound and stays.
+- [ ] **Step 4: Regenerate the CLI reference**, build and `astro check`.
+- [ ] **Step 5: Commit.**
+
+### Task 3: `adopt` vets the version
+
+**Files:** `crates/shep-cli/src/commands/dogs.rs`.
+
+`vet_binary` (reached at `dogs.rs:714`) already spawns the candidate to prove the kernel can exec it, so asking its version costs one more argument on a process that was going to start anyway.
+
+G11: *"A dog that cannot satisfy the running daemon is refused at adopt time rather than becoming a silent online-and-idle entry, which is what happens today."*
+
+**Backward compatibility is in the spec and is not optional.** *"Dogs predating the convention stay adoptable. One that does not answer is recorded as unknown rather than refused, and prediction degrades to G8's post-connection detection for that dog alone."* A dog that does not answer is adopted, recorded unknown. Refusing it would break every dog that exists.
+
+A protocol mismatch refuses; a crate-version difference with a matching protocol reports (correction 1). Do not collapse those into one branch.
+
+Keep the ordering `adopt` already documents and tests: a name collision is refused BEFORE the candidate is spawned, because a refusal running after the spawn has already run the thing it refuses.
+
+- [ ] **Step 1: Write the failing tests.** Refused on protocol mismatch; adopted-with-a-report on crate-version-only difference; adopted-as-unknown when it does not answer; the collision still refused before any spawn.
+- [ ] **Step 2: Run them, watch them fail.**
+- [ ] **Step 3: Implement.**
+- [ ] **Step 4: Prove each non-vacuous**, the unknown-not-refused case above all — it is the one that passes for the wrong reason if the vet silently no-ops.
+- [ ] **Step 5: Drive it.** Build a dog against a pinned old shep-core and adopt it; adopt one that does not answer at all.
+- [ ] **Step 6: `web/` and commit.**
+
+### Task 4: `shep restart <dog>` warns before creating row 5
+
+**Files:** `crates/shep-cli/src/commands/`, wherever a dog restart is issued.
+
+Row 5 is a working system that breaks at the next restart, days later, for an unrelated reason. G12: *"`shep restart <dog>` warns before creating that state."* The spec's verification list is specific about the ordering: *"the warning fires BEFORE the restart that breaks it."*
+
+Warn, do not refuse. The operator asked for the restart, the disk binary may be what they just installed, and refusing an explicit command on a prediction is worse than letting them watch it happen with warning in hand. Row 5's fix is *"upgrade the daemon, or reinstall the dog back"* — two options, so the message names both and picks neither.
+
+A built-in dog cannot reach row 5 (correction 3), so this applies to adopted dogs. Whether the check is silently skipped for built-ins or is structurally unreachable is a design choice — prefer the one a reader can see.
+
+- [ ] **Step 1: Write the failing tests.** The warning fires before the restart; a healthy restart stays silent; the message names both fixes.
+- [ ] **Step 2: Run them, watch them fail.**
+- [ ] **Step 3: Implement.**
+- [ ] **Step 4: Prove each non-vacuous**, including the silent-when-healthy case.
+- [ ] **Step 5: Drive row 5 end to end.** This is the phase's proof: a healthy flock, a dog upgraded on disk only, nothing yet wrong, and the warning arriving before the restart that would have broken it.
+- [ ] **Step 6: `web/` and commit.**
+
+---
+
+## Out of scope
+
+**Anything that carries more across the exec.** Phase 3 closed that. The gate's one remaining refusal, `PumpUnresponsive`, is permanent by design.
+
+**Bark's restart per reload.** Recorded in `deferred.md` after phase 3. Closing it needs a ruling on what an orphaned dog does, which is a question about every dog rather than about bark.
+
+**Sheep.** The spec's Part 4 exists to stop this guard being extended to them: a sheep is an arbitrary executable with no handshake and no version relationship to the daemon. The shepherd channel's `SHEP_CHANNEL_VERSION` is a third axis, set at spawn time, and a running sheep cannot be asked what it speaks.
+
+**The IR-35 byte-fixture debt.** Eight compatibility tests, recorded in `deferred.md`, unchanged by this phase.
+
+---
+
+## Verification
+
+Every phase of this work has found bugs by driving the real thing and none by reading code; phase 3 found four that way. **A green suite is not evidence here.**
+
+The reproduction, from G9 and worth getting right the first time: force an old protocol with `cargo update -p shep-core --precise <old>`, **not** by pinning `shep-client`. `PROTOCOL_VERSION` lives in shep-core and the client's dependency on it floats within 0.1.x. The spec records this as an experiment that was gotten wrong first.
+
+`$SHEP_HOME` stays under ~103 bytes or the control socket refuses the path.
+
+Task 1's drill is Linux-only and a macOS run is not evidence for it.
+
+## Gate
+
+Per `CLAUDE.md`. One cargo shape per task — `-p shep-daemon` for task 1, `-p shep` for tasks 3 and 4 — and never two shapes in one brief without a separate `CARGO_TARGET_DIR`.
+
+`web/` is in the gate for tasks 2, 3 and 4: `cargo build --release`, `./web/scripts/generate-cli-reference.sh`, then `astro build` **and** `astro check`. `check` is the one that catches a wrong prop; a build alone has shipped a broken page before.
+
+Counts at the branch point are a shape, not a checksum — take them from a real run rather than from this line.
+
+CI's process-spawning tiers flaked seven times across phases 2c and 3. A `slow`, `musl` or e2e failure gets read against `main`'s own history before it is treated as this branch's fault.

--- a/web/src/pages/docs/dogs.astro
+++ b/web/src/pages/docs/dogs.astro
@@ -591,8 +591,10 @@ the dog against protocol 2, and restart it again`}</CodeBlock>
         subscription, before the process is killed.
       </p>
       <p>
-        Every dog written before this contract is in that group. The trade is
-        deliberate: the command is about to restart that dog anyway, so the
+        Only dogs that ignore the flag are affected. A dog that recognises
+        <code>--version</code> and exits, even without naming a protocol,
+        does no work: its protocol is unknown and nothing overlaps. The
+        trade is deliberate: the command is about to restart that dog anyway, so the
         only question is whether it briefly overlaps itself, and the
         alternative is not asking at all. Adding <code>--version</code> to
         your dog removes the overlap, since a dog that answers exits

--- a/web/src/pages/docs/dogs.astro
+++ b/web/src/pages/docs/dogs.astro
@@ -435,6 +435,121 @@ watchdog  adopted  true      stopped`}</CodeBlock>
       the same index without leaving a terminal.
     </p>
 
+    <h2>Answering <code>--version</code></h2>
+    <p>
+      A dog answers <code>--version</code> on stdout and exits 0. Two
+      numbers come back, and they answer different questions.
+    </p>
+    <div class="metrics-table">
+      <div class="row header">
+        <span>What</span>
+        <span>Answers</span>
+      </div>
+      <div class="row"><span>the version on line 1</span> <span>Which build of the dog this is. A difference is reported, never refused.</span></div>
+      <div class="row"><span><code>shep-protocol</code></span> <span>Whether this dog can handshake with this shepherd at all. A difference means it can't connect until one side moves.</span></div>
+    </div>
+    <CodeBlock>{`shep-log-rotate 0.1.3
+shep-protocol: 2`}</CodeBlock>
+    <p>
+      Line 1 is <code>&lt;name&gt; &lt;version&gt;</code>. Shep takes the
+      last whitespace-separated field as the version and ignores the name,
+      so a crate whose name differs from the dog's registered name is fine.
+      That's the line clap already prints for free. Every later line is{" "}
+      <code>&lt;key&gt;: &lt;value&gt;</code>, one pair to a line, and{" "}
+      <code>shep-protocol</code> carries in decimal the{" "}
+      <code>PROTOCOL_VERSION</code> the binary was compiled against.
+    </p>
+    <p>
+      Unknown keys, blank lines and the order of the key lines are all
+      ignored. Keys beginning <code>shep-</code> are reserved, so a third
+      number can get its own line later without breaking a parser that
+      predates it. Put keys of your own under a prefix of your own.
+    </p>
+    <p>
+      Lines rather than JSON, because a human runs <code>--version</code>{" "}
+      far more often than shep does, and because a stranger writing a dog in
+      a language shep has never seen gets two <code>printf</code> calls
+      right on the first try. Hand written JSON is where the quoting and the
+      trailing comma go wrong, and nothing here nests.
+    </p>
+    <p>Emitting it needs no dependency a dog doesn't already have:</p>
+    <CodeBlock label="main.rs">{`if std::env::args().nth(1).as_deref() == Some("--version") {
+    println!("{} {}", env!("CARGO_PKG_NAME"), env!("CARGO_PKG_VERSION"));
+    println!("shep-protocol: {}", shep_client::shep_core::protocol::PROTOCOL_VERSION);
+    return;
+}`}</CodeBlock>
+    <Callout variant="note">
+      Answering is optional and stays optional. Dogs predating the
+      convention are still adoptable, and a dog that doesn't answer is never
+      refused for it: its protocol is simply unknown.
+    </Callout>
+
+    <h3>Why the binary is the only thing that can answer</h3>
+    <p>
+      A dog's crate version doesn't imply its protocol, and neither does
+      knowing that somebody installed it. Which{" "}
+      <code>shep-core</code> a dog ends up carrying depends on how it was
+      built:
+    </p>
+    <div class="metrics-table">
+      <div class="row header">
+        <span>How it was built</span>
+        <span>Which protocol</span>
+      </div>
+      <div class="row"><span><code>cargo install &lt;dog&gt;</code></span> <span><code>shep-core</code> is re-resolved to the newest compatible release, so the protocol is current.</span></div>
+      <div class="row"><span><code>cargo install --locked</code>, and most CI</span> <span>The shipped lockfile is honoured, so the protocol is whatever was pinned on publish day.</span></div>
+    </div>
+    <p class="fine">
+      Measured 2026-08-31: <code>shep-log-rotate</code> 0.1.3 installed
+      plain compiled <code>shep-core</code> 0.1.24, ignoring the packaged
+      lockfile, while the same crate built <code>--locked</code> produced a
+      protocol 1 dog. Both published dogs were shipping a lockfile pinning a
+      protocol 1 <code>shep-core</code> that day, and both repositories' CI
+      had been red on it for two days. The crate version was identical
+      either way. That's the whole argument for asking the binary: nothing
+      outside it knows.
+    </p>
+
+    <h3>The built-in dogs are outside this</h3>
+    <p>
+      <code>metrics</code> and <code>bark</code> are not separate binaries.
+      The shepherd starts them as{" "}
+      <code>&lt;its own binary&gt; dog &lt;name&gt;</code>, so a built-in
+      dog <strong>is</strong> the shep binary that spawned it and cannot
+      skew from it on disk. There's no question here for a contract to
+      answer:
+    </p>
+    <CodeBlock>{`$ shep --version
+shep 0.1.24
+$ shep dog metrics --version
+shep-dog 0.1.24`}</CodeBlock>
+    <p>
+      Neither prints a <code>shep-protocol</code> line, and that isn't a gap
+      to close. The protocol a built-in dog speaks is the shepherd's own,
+      because it is the shepherd's binary.
+    </p>
+
+    <h3>What this doesn't catch</h3>
+    <p>
+      Two dogs can agree on the protocol and still be different code.{" "}
+      <code>RpcError</code> gained a public <code>daemon_version</code>{" "}
+      field inside the 0.1.x range; its fields are public and it has no
+      constructor, so every literal built outside <code>shep-client</code>{" "}
+      stopped compiling while <code>PROTOCOL_VERSION</code> stood still.
+      Protocol equality is necessary and not sufficient.
+    </p>
+    <p>
+      Closing that is deferred, and the reason is that{" "}
+      <code>--version</code> can't close it. A break of that kind is source
+      level: it lands when the dog is compiled, in the dog's own repository,
+      and a dog nobody rebuilt keeps running. Shep has no table of which{" "}
+      <code>shep-client</code> versions build against which daemon, and a
+      version comparison standing in for one would report dogs that are
+      fine. What catches it is the dog's own CI building against a current{" "}
+      <code>shep-core</code>, which is where both published dogs' breakage
+      was already visible and unread.
+    </p>
+
     <h2>When a dog dies</h2>
     <p>
       If an enabled dog exhausts its own restart budget and lands on{" "}

--- a/web/src/pages/docs/dogs.astro
+++ b/web/src/pages/docs/dogs.astro
@@ -513,7 +513,9 @@ current shep-core, or run a shep that speaks 1`}</CodeBlock>
       the two would report every dog that exists.
     </p>
     <p>
-      A candidate gets one second to answer and is killed either way, so a
+      A candidate gets one second to exit and another to have its output
+      read, so two seconds is the worst case rather than one. It is killed
+      either way, so a
       dog that ignores <code>--version</code> and runs costs that second and
       is adopted with an unknown protocol. It can't hang the{" "}
       <code>adopt</code> that's vetting it.
@@ -575,9 +577,28 @@ the dog against protocol 2, and restart it again`}</CodeBlock>
       The cost is the same second <code>adopt</code> spends, and it's paid
       only by a restart that named an adopted dog. A binary that hangs is
       killed when the second is up and the restart goes ahead unwarned, so
-      the slowest a dog can make <code>shep restart</code> is one second,
+      the slowest a dog can make <code>shep restart</code> is two seconds,
       never indefinitely.
     </p>
+
+    <Callout variant="note">
+      <p>
+        A named restart briefly runs your dog twice. To read the binary on
+        disk, shep runs it with <code>--version</code>, and a dog that does
+        not recognise that flag ignores it and starts doing its ordinary job
+        instead, with <code>SHEP_HOME</code> pointing at the live shepherd.
+        So a rotator can rotate once, and a bark dog can open a second
+        subscription, before the process is killed.
+      </p>
+      <p>
+        Every dog written before this contract is in that group. The trade is
+        deliberate: the command is about to restart that dog anyway, so the
+        only question is whether it briefly overlaps itself, and the
+        alternative is not asking at all. Adding <code>--version</code> to
+        your dog removes the overlap, since a dog that answers exits
+        immediately.
+      </p>
+    </Callout>
 
     <h3>Why the binary is the only thing that can answer</h3>
     <p>

--- a/web/src/pages/docs/dogs.astro
+++ b/web/src/pages/docs/dogs.astro
@@ -484,6 +484,48 @@ shep-protocol: 2`}</CodeBlock>
       refused for it: its protocol is simply unknown.
     </Callout>
 
+    <h3>What <code>shep adopt</code> does with the answer</h3>
+    <p>
+      <code>shep adopt</code> asks the candidate before it records anything.
+      The vet was already spawning the binary to prove this kernel can exec
+      it, so the question costs one argument on a process that was going to
+      start anyway.
+    </p>
+    <div class="metrics-table">
+      <div class="row header">
+        <span>What the candidate answers</span>
+        <span>What adopt does</span>
+      </div>
+      <div class="row"><span>a <code>shep-protocol</code> this shep doesn't speak</span> <span>Refuses, before <code>shep.toml</code> is touched.</span></div>
+      <div class="row"><span>a protocol this shep speaks</span> <span>Adopts, and reports the version it gave.</span></div>
+      <div class="row"><span>a version and no protocol line</span> <span>Adopts, and says the protocol is unknown.</span></div>
+      <div class="row"><span>nothing, or a run that exits non-zero</span> <span>Adopts, protocol unknown, no notice.</span></div>
+    </div>
+    <p>The refusal names both numbers and both ways out:</p>
+    <CodeBlock>{`/usr/local/bin/shep-otel: this dog was built for shep protocol 1, and this
+shep speaks 2; reinstall the dog without --locked so it builds against the
+current shep-core, or run a shep that speaks 1`}</CodeBlock>
+    <p>
+      Only a stated protocol can refuse an adopt. The version is never
+      compared with anything, because a third-party dog's crate version has
+      no relationship to shep's own: <code>shep-log-rotate</code> 0.1.3
+      against shep 0.1.24 is the ordinary case, not a skew, and comparing
+      the two would report every dog that exists.
+    </p>
+    <p>
+      A candidate gets one second to answer and is killed either way, so a
+      dog that ignores <code>--version</code> and runs costs that second and
+      is adopted with an unknown protocol. It can't hang the{" "}
+      <code>adopt</code> that's vetting it.
+    </p>
+    <p>
+      None of the answer is written down. <code>[daemon] adopted_dogs</code>{" "}
+      records the path and nothing else, and a protocol stored at adopt time
+      would be a copy of a number that can change on disk with nothing
+      watching. Shep asks the binary again rather than remembering what it
+      said.
+    </p>
+
     <h3>Why the binary is the only thing that can answer</h3>
     <p>
       A dog's crate version doesn't imply its protocol, and neither does

--- a/web/src/pages/docs/dogs.astro
+++ b/web/src/pages/docs/dogs.astro
@@ -475,7 +475,7 @@ shep-protocol: 2`}</CodeBlock>
     <p>Emitting it needs no dependency a dog doesn't already have:</p>
     <CodeBlock label="main.rs">{`if std::env::args().nth(1).as_deref() == Some("--version") {
     println!("{} {}", env!("CARGO_PKG_NAME"), env!("CARGO_PKG_VERSION"));
-    println!("shep-protocol: {}", shep_client::shep_core::protocol::PROTOCOL_VERSION);
+    println!("shep-protocol: {}", shep_client::PROTOCOL_VERSION);
     return;
 }`}</CodeBlock>
     <Callout variant="note">

--- a/web/src/pages/docs/dogs.astro
+++ b/web/src/pages/docs/dogs.astro
@@ -526,6 +526,59 @@ current shep-core, or run a shep that speaks 1`}</CodeBlock>
       said.
     </p>
 
+    <h3>What <code>shep restart &lt;dog&gt;</code> does with the answer</h3>
+    <p>
+      <code>cargo install</code> replaces a file and never touches a
+      process, so a dog upgraded on disk leaves a working system: the dog
+      running now is the old binary, still connected, still doing its job.
+      The two only meet at the next restart, which may be days away and for
+      a reason that has nothing to do with the upgrade.
+    </p>
+    <p>
+      <code>shep restart &lt;name&gt;</code> is that restart, so it asks the
+      same question first:
+    </p>
+    <CodeBlock>{`notice[dog_binary_skew]: \`log-rotate\`'s binary at /usr/local/bin/shep-log-rotate
+was built for shep protocol 3, and this shep speaks 2; restarting it brings it
+back on that binary, unable to connect. Run a shep that speaks 3, or reinstall
+the dog against protocol 2, and restart it again`}</CodeBlock>
+    <p>
+      Then it restarts the dog. This is a warning and never a refusal: the
+      operator asked for the restart, the binary on disk may be exactly what
+      they just installed, and there are two ways out of the state rather
+      than one, so the message names both and picks neither.
+    </p>
+    <div class="metrics-table">
+      <div class="row header">
+        <span>What the binary answers</span>
+        <span>What restart does</span>
+      </div>
+      <div class="row"><span>a <code>shep-protocol</code> this shep doesn't speak</span> <span>Warns, then restarts.</span></div>
+      <div class="row"><span>a protocol this shep speaks</span> <span>Restarts, silently.</span></div>
+      <div class="row"><span>a version and no protocol line</span> <span>Restarts, silently.</span></div>
+      <div class="row"><span>nothing, or a run that exits non-zero</span> <span>Restarts, silently.</span></div>
+    </div>
+    <p>
+      Unknown is not stale. Every dog written before this contract is in the
+      last two rows, and a line on stderr for each of them is how an
+      operator learns to skip the one that matters.
+    </p>
+    <p>
+      Three things are never asked at all. A built-in dog has no binary of
+      its own, so there is nothing to be stale. A selector that sweeps
+      rather than names, <code>all</code> or a <code>/regex/</code>, doesn't
+      reach a dog in the first place. And a dog named by id rather than by
+      name is restarted without a check, because looking up its name would
+      cost a round trip before the restart the operator asked for.
+    </p>
+    <p>
+      The cost is the same second <code>adopt</code> spends, and it's paid
+      only by a restart that named an adopted dog. A binary that hangs is
+      killed when the second is up and the restart goes ahead unwarned, so
+      the slowest a dog can make <code>shep restart</code> is one second,
+      never indefinitely.
+    </p>
+
     <h3>Why the binary is the only thing that can answer</h3>
     <p>
       A dog's crate version doesn't imply its protocol, and neither does


### PR DESCRIPTION
Phase 4 of the daemon handover. A dog now says which protocol it was compiled against, `shep adopt` refuses one that cannot talk to this shepherd, and `shep restart <dog>` warns before bringing a dog back on a binary that will not connect.

The premise turned out to be true in production while this was being written. Both published dogs were shipping lockfiles pinning a protocol-1 `shep-core`, and both repositories' CI had been red for two days on the exact sentence an operator hit against a live flock. Nobody had connected a red dog repository to a stale dog in a flock, which is the gap this phase closes.

## Why a version number cannot answer this

| how the dog is built | which `shep-core` | so which protocol |
|---|---|---|
| `cargo install <dog>` | re-resolved, newest compatible | current |
| `cargo install --locked`, and CI | whatever the shipped lockfile pins | whatever was pinned that day |

Measured, not reasoned: installing `shep-log-rotate` 0.1.3 to a throwaway root compiled `shep-core` 0.1.24, so the packaged lockfile was ignored. The same crate built `--locked` produced a protocol-1 dog.

So a reader cannot deduce a dog's protocol from its version, and cannot deduce it from knowing somebody installed it either. They would also need the flags used and the lockfile as it stood at publish time. The binary is the only thing that can answer, which is the whole argument for asking it.

## The contract

```
shep-log-rotate 0.1.3
shep-protocol: 2
```

Line one is what clap already prints. Later lines are `key: value`. Keys beginning `shep-` are reserved so a third number can arrive later without breaking a parser that predates it. Answering is optional and stays optional: every dog that exists today predates this, and one that does not answer is adopted with its protocol recorded as unknown rather than refused.

## The four pieces

- a built-in dog no longer respawns from a deleted inode. `dog_app` resolved its program with an unguarded `current_exe()`, which on Linux returns `"<path> (deleted)"` after a package manager renames a new binary over a running one. The handover module has refused that string for phases, in a function private to itself
- `adopt` asks the candidate and refuses a protocol it cannot satisfy, naming both numbers and both ways out. A crate-version difference with a matching protocol is reported, not refused
- `shep restart <dog>` re-asks the binary on disk and warns before restarting, because a protocol recorded at adopt time is stale exactly when this needs it: G12 row 5 IS the binary changing after the adopt
- `shep_client::PROTOCOL_VERSION` at the crate root, so a dog author writing to a published contract does not have to reach through `shep_client::shep_core::protocol`

## A spec correction

G9 closed on `Hello.client_version` being "the only thing that knows" which protocol a dog speaks. `Hello` carries `client_version` and `protocol` as separate fields and `server.rs` refuses on the protocol, never on the version. Corrected in place, with the finding kept and sharpened: both fields only reach the daemon after the dog connects, so neither helps an operator holding a binary that has not started, which is what this phase exists for.

## Known gaps, all deliberate

A daemon-initiated restart gets no warning. The check is CLI-side, so a crash or an autorestart respawn walks into row 5 in silence, and "days later, for an unrelated reason" is more often a crash than a person. Closing it means the daemon running the probe, which is a wider design decision than G12 asks for here.

`shep restart <id>` on a dog is unwarned; only `restart <name>` is. A round trip to learn the name costs more than the rarer spelling is worth.

Protocol equality is necessary but not sufficient. `RpcError` gained a public field inside the 0.1.x range and, with public fields and no constructor, every literal built outside `shep-client` stopped compiling. That is a source break landing when a dog is rebuilt, and no `--version` answer can predict it. Written up under what this does not catch.

2238 tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adopted dogs now report available version and protocol details.
  * Adoption rejects binaries with incompatible protocols.
  * Restarting adopted dogs warns about potential protocol incompatibilities.
  * Binary checks safely handle timeouts, malformed responses, unknown details, and excess output.
  * Built-in dog resolution rejects invalid or deleted executable targets.
  * Restart continues safely after compatibility warnings.

* **Documentation**
  * Added guidance for version reporting, compatibility checks, warnings, limitations, and handover behavior.
  * Updated handover design and testing plans.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->