### PR TITLE
chore: release v0.1.25

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2058,7 +2058,7 @@ dependencies = [
 
 [[package]]
 name = "shep"
-version = "0.1.24"
+version = "0.1.25"
 dependencies = [
  "anstyle",
  "assert_cmd",
@@ -2096,11 +2096,11 @@ dependencies = [
 
 [[package]]
 name = "shep-cli"
-version = "0.1.24"
+version = "0.1.25"
 
 [[package]]
 name = "shep-client"
-version = "0.1.24"
+version = "0.1.25"
 dependencies = [
  "futures-util",
  "nix 0.29.0",
@@ -2113,7 +2113,7 @@ dependencies = [
 
 [[package]]
 name = "shep-core"
-version = "0.1.24"
+version = "0.1.25"
 dependencies = [
  "annotate-snippets",
  "anstyle",
@@ -2143,7 +2143,7 @@ dependencies = [
 
 [[package]]
 name = "shep-daemon"
-version = "0.1.24"
+version = "0.1.25"
 dependencies = [
  "bytes",
  "chrono",
@@ -2172,7 +2172,7 @@ dependencies = [
 
 [[package]]
 name = "shep-examples"
-version = "0.1.24"
+version = "0.1.25"
 dependencies = [
  "nix 0.29.0",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.24"
+version = "0.1.25"
 edition = "2024"
 # 1.88 forced by serde-saphyr (let-chains, stabilized 1.88) — a current dep,
 # not a future one. Also the floor for ratatui/sysinfo/rmcp in later phases.
@@ -31,9 +31,9 @@ license = "MIT OR Apache-2.0"
 # the `[package]` table — so this literal is not sourced from
 # `workspace.package.version` above and a release bump has to touch both
 # places by hand. If that drifts, `cargo-release` is the mechanical fix.
-shep-core = { path = "crates/shep-core", version = "0.1.24" }
-shep-daemon = { path = "crates/shep-daemon", version = "0.1.24" }
-shep-client = { path = "crates/shep-client", version = "0.1.24" }
+shep-core = { path = "crates/shep-core", version = "0.1.25" }
+shep-daemon = { path = "crates/shep-daemon", version = "0.1.25" }
+shep-client = { path = "crates/shep-client", version = "0.1.25" }
 serde = { version = "1", default-features = false, features = ["derive"] }
 serde_json = { version = "1", default-features = false, features = ["std"] }
 toml = { version = "0.8", default-features = false, features = ["parse", "display"] }

--- a/crates/shep-cli/CHANGELOG.md
+++ b/crates/shep-cli/CHANGELOG.md
@@ -13,6 +13,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.25] - 2026-09-01
+
+### Added
+
+- Ask a candidate dog what protocol it speaks, and refuse a mismatch
+- Warn before a restart brings a dog back on a binary that cannot connect
+
+### Fixed
+
+- Address review on the dog version probe
+- Probe with the daemon's environment, and let tests pick the budget
+
+
 ## [0.1.24] - 2026-08-31
 
 ### Added

--- a/crates/shep-client/CHANGELOG.md
+++ b/crates/shep-client/CHANGELOG.md
@@ -10,6 +10,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.25] - 2026-09-01
+
+### Added
+
+- Re-export PROTOCOL_VERSION from the crate root
+
+
 ## [0.1.24] - 2026-08-31
 
 

--- a/crates/shep-core/CHANGELOG.md
+++ b/crates/shep-core/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.25] - 2026-09-01
+
+
 ## [0.1.24] - 2026-08-31
 
 ### Added

--- a/crates/shep-daemon/CHANGELOG.md
+++ b/crates/shep-daemon/CHANGELOG.md
@@ -10,6 +10,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.25] - 2026-09-01
+
+### Fixed
+
+- Stop a built-in dog respawning from a deleted inode
+- Builtin_program has to compile where there is no handover
+
+
 ## [0.1.24] - 2026-08-31
 
 ### Added


### PR DESCRIPTION



## 🤖 New release

* `shep-core`: 0.1.24 -> 0.1.25
* `shep-daemon`: 0.1.24 -> 0.1.25 (✓ API compatible changes)
* `shep-client`: 0.1.24 -> 0.1.25 (✓ API compatible changes)
* `shep`: 0.1.24 -> 0.1.25 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>


## `shep-daemon`

<blockquote>

## [0.1.25] - 2026-09-01

### Fixed

- Stop a built-in dog respawning from a deleted inode
- Builtin_program has to compile where there is no handover
</blockquote>

## `shep-client`

<blockquote>

## [0.1.25] - 2026-09-01

### Added

- Re-export PROTOCOL_VERSION from the crate root
</blockquote>

## `shep`

<blockquote>

## [0.1.25] - 2026-09-01

### Added

- Ask a candidate dog what protocol it speaks, and refuse a mismatch
- Warn before a restart brings a dog back on a binary that cannot connect

### Fixed

- Address review on the dog version probe
- Probe with the daemon's environment, and let tests pick the budget
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).