### PR TITLE
fix(dogs): refuse `shep enable` of a name that is neither built-in nor adopted

### DIFF
--- a/crates/shep-cli/src/commands/dogs.rs
+++ b/crates/shep-cli/src/commands/dogs.rs
@@ -134,30 +134,123 @@ async fn connect_or_absent(
     }
 }
 
+/// [`enable`]'s own failure, so its `try_edit` closure can refuse from
+/// inside the lock: either the config layer's error, or a name that
+/// answers to no dog at all.
+///
+/// [`ShepToml::try_edit`] is generic over the closure's error precisely so
+/// a verb whose refusal is its own thing does not have to dress it up as a
+/// [`ShepTomlError`] it is not.
+enum EnableRefusal {
+    /// The read-modify-write underneath the closure failed; rendered by
+    /// [`fail_config`], exactly as [`ShepToml::edit`]'s `Err` always was.
+    Config(ShepTomlError),
+    /// The name is neither one of [`crate::dog::BUILT_IN_DOGS`] nor a key
+    /// of `[daemon] adopted_dogs`. `adopted` carries what that map did
+    /// hold, read under the same lock, so the refusal can name the
+    /// alternatives without a second read that a concurrent `shep adopt`
+    /// could invalidate.
+    UnknownDog { adopted: Vec<String> },
+}
+
+impl From<ShepTomlError> for EnableRefusal {
+    fn from(err: ShepTomlError) -> Self {
+        Self::Config(err)
+    }
+}
+
 /// `shep enable <name>`: writes the config, and starts the dog if a
 /// shepherd is running.
+///
+/// A name that is neither built-in nor adopted is refused before anything
+/// is written. [`dog_source`] reads that distinction as an absence — a
+/// name outside `[daemon] adopted_dogs` is [`DogSource::BuiltIn`] by
+/// construction — so without this check a typo is written into
+/// `enabled_dogs` as a built-in, and the shepherd then spawns `shep dog
+/// <typo>` on a restart ladder that cannot ever succeed: `dog::run_dog`
+/// refuses the name once per attempt until the budget is spent, while
+/// `shep dogs` reports the dog's `SOURCE` as `built-in`, which it is not.
 pub async fn enable(streams: &mut Streams<'_>, paths: &ShepPaths, name: &str) -> ExitCode {
-    // The read and the edit are one `edit` call because they are one
-    // transaction: the source below is read from the same document this
-    // then writes back, under the lock that keeps a concurrent `shep
-    // adopt` from landing between the two.
-    let source = match ShepToml::edit(&paths.daemon_config, |cfg| {
+    // `try_edit` rather than `edit`, and the check inside the closure
+    // rather than before the call: the refusal must skip `save` entirely
+    // (a refused enable leaves `shep.toml` untouched, down to its inode),
+    // and the adopted-name lookup it turns on must happen under the lock
+    // that keeps a concurrent `shep adopt` from landing between the check
+    // and the write.
+    // `result_large_err` on the closure, for the same reason and on the same
+    // platform as the module-wide allow in `commands::shep_toml` -- see the
+    // banner there. `EnableRefusal::Config` carries that module's error, so
+    // this closure is measured against the same 128-byte threshold the
+    // `try_edit` call in `lib.rs`'s `shep style` arm already allows for.
+    #[cfg_attr(windows, allow(clippy::result_large_err))]
+    let source = match ShepToml::try_edit(&paths.daemon_config, |cfg| {
         // Read from the config rather than assumed: `shep adopt` records
         // the binary and `shep enable` is what starts it afterwards, so a
         // hardcoded `BuiltIn` here sends the shepherd off to spawn `shep
         // dog <name>` and the adopted binary never runs at all.
         let source = dog_source(cfg, name);
+        if matches!(source, DogSource::BuiltIn) && !crate::dog::BUILT_IN_DOGS.contains(&name) {
+            return Err(EnableRefusal::UnknownDog {
+                adopted: cfg.adopted_dog_names(),
+            });
+        }
         cfg.enable_dog(name);
-        source
+        Ok(source)
     }) {
         Ok(source) => source,
-        Err(err) => return fail_config(streams, &err),
+        Err(EnableRefusal::Config(err)) => return fail_config(streams, &err),
+        Err(EnableRefusal::UnknownDog { adopted }) => {
+            return fail_enable_unknown_dog(streams, name, &adopted);
+        }
     };
     let client = match connect_or_absent(paths, streams).await {
         Ok(client) => client,
         Err(code) => return code,
     };
     enable_after_config(streams, name, &source, client.as_ref()).await
+}
+
+/// Renders [`enable`]'s refusal of a name that names no dog.
+///
+/// `adopted` is every key of `[daemon] adopted_dogs`, read under the same
+/// lock the refusal was decided under; it is empty on a `$SHEP_HOME` where
+/// nothing has ever been adopted, which is the common case for this typo.
+///
+/// [`ExitCode::InvalidConfig`] rather than [`ExitCode::Usage`]: the name
+/// is not a malformed argument, it is one the daemon config cannot
+/// resolve — the same code [`fail_adopt_name_collision`] gives the
+/// mirror-image refusal on `shep adopt`.
+fn fail_enable_unknown_dog(streams: &mut Streams<'_>, name: &str, adopted: &[String]) -> ExitCode {
+    let valid: Vec<String> = crate::dog::BUILT_IN_DOGS
+        .iter()
+        .map(|built_in| format!("{built_in:?}"))
+        .chain(adopted.iter().map(|dog| format!("{dog:?}")))
+        .collect();
+    let message = format!(
+        "`{name}` is not a dog; valid names are {} -- if you meant a third-party dog, \
+         run `shep adopt {name}` first",
+        join_with_and(&valid)
+    );
+    streams.fail(ExitCode::InvalidConfig, &message)
+}
+
+/// Joins `items` as an English list: `a`, `a and b`, `a, b, and c`.
+///
+/// Hand-rolled rather than pulled in: the whole of it is where the two
+/// commas go, and shep has one caller ([`fail_enable_unknown_dog`]).
+///
+/// The empty slice answers with the empty string. No caller can reach it —
+/// [`crate::dog::BUILT_IN_DOGS`] is never empty, so the one list this
+/// builds always has at least two entries — but a `match` on a slice owes
+/// the arm either way, and an empty string is the answer that degrades
+/// most quietly if a second caller ever does.
+fn join_with_and(items: &[String]) -> String {
+    match items {
+        [] => String::new(),
+        [only] => only.clone(),
+        [first, second] => format!("{first} and {second}"),
+        [rest @ .., last] => format!("{}, and {last}", rest.join(", ")),
+    }
 }
 
 /// `enable`'s daemon half, split out from [`enable`] so a test can drive it
@@ -1785,6 +1878,143 @@ mod tests {
             text.contains("next shepherd"),
             "the operator needs to know the dog is not running yet: {text}"
         );
+    }
+
+    /// fails if `shep enable` accepts a name that answers to no dog.
+    ///
+    /// `dog_source` reads built-in-ness as an ABSENCE from `[daemon]
+    /// adopted_dogs`, so before this guard a typo was written into
+    /// `enabled_dogs` as a built-in and exited zero. The shepherd then
+    /// spawned `shep dog <typo>` on the restart ladder, `dog::run_dog`
+    /// refused the name once per attempt until the budget was spent, and
+    /// `shep dogs` reported its `SOURCE` as `built-in` throughout -- a name
+    /// that is not one.
+    #[tokio::test]
+    async fn enable_refuses_a_name_that_is_neither_built_in_nor_adopted() {
+        let dir = tempfile::tempdir().unwrap();
+        let paths = ShepPaths::resolve(&|_| None, dir.path());
+        let mut out = Vec::new();
+        let mut err = Vec::new();
+        let code = enable(&mut streams(&mut out, &mut err), &paths, "pydog").await;
+
+        assert_eq!(code, ExitCode::InvalidConfig);
+        let text = String::from_utf8(err).unwrap();
+        assert!(
+            text.contains("pydog"),
+            "the refusal must name the name: {text}"
+        );
+        assert!(
+            text.contains("shep adopt pydog"),
+            "the refusal must name the way out, the way `shep adopt`'s own \
+             name-collision refusal does: {text}"
+        );
+        assert!(
+            !paths.daemon_config.exists(),
+            "a refused enable must leave the config untouched -- `try_edit` \
+             skips `save`, so a `$SHEP_HOME` that had no `shep.toml` still \
+             has none"
+        );
+    }
+
+    /// fails if the refusal names only the built-ins. An operator with dogs
+    /// adopted is the one likeliest to have mistyped one of THEIR names, so
+    /// the adopted set is the half of the list they need.
+    ///
+    /// Read inside `enable`'s own `try_edit` closure, under the lock, rather
+    /// than by a second read afterwards: a concurrent `shep adopt` landing
+    /// between the two would make the message name a set that was never the
+    /// one the refusal was decided against.
+    #[tokio::test]
+    async fn enable_refusal_names_the_adopted_dogs_alongside_the_built_ins() {
+        let dir = tempfile::tempdir().unwrap();
+        let paths = ShepPaths::resolve(&|_| None, dir.path());
+        ShepToml::edit(&paths.daemon_config, |cfg| {
+            cfg.adopt_dog("otel", Path::new("/usr/local/bin/shep-otel"));
+        })
+        .unwrap();
+
+        let mut out = Vec::new();
+        let mut err = Vec::new();
+        let code = enable(&mut streams(&mut out, &mut err), &paths, "pydog").await;
+
+        assert_eq!(code, ExitCode::InvalidConfig);
+        let text = String::from_utf8(err).unwrap();
+        for expected in ["\"metrics\"", "\"bark\"", "\"otel\""] {
+            assert!(
+                text.contains(expected),
+                "the refusal must name {expected} among the valid names: {text}"
+            );
+        }
+    }
+
+    /// fails if the guard swallows the case it exists to allow through: a
+    /// name `shep adopt` recorded is a dog, and `enable` must still take it.
+    #[tokio::test]
+    async fn enable_still_accepts_a_name_adopt_recorded() {
+        let dir = tempfile::tempdir().unwrap();
+        let paths = ShepPaths::resolve(&|_| None, dir.path());
+        ShepToml::edit(&paths.daemon_config, |cfg| {
+            cfg.adopt_dog("otel", Path::new("/usr/local/bin/shep-otel"));
+        })
+        .unwrap();
+
+        let mut out = Vec::new();
+        let mut err = Vec::new();
+        let code = enable(&mut streams(&mut out, &mut err), &paths, "otel").await;
+
+        assert_eq!(code, ExitCode::Success, "{}", String::from_utf8_lossy(&err));
+        let written = std::fs::read_to_string(&paths.daemon_config).unwrap();
+        assert!(written.contains("otel"), "{written}");
+    }
+
+    /// fails if `disable` grows the guard `enable` just did.
+    ///
+    /// It must not: a `shep.toml` written before that guard existed -- or by
+    /// hand -- can already carry a name that answers to no dog, and `shep
+    /// disable <name>` is the only way to get it back out of `enabled_dogs`.
+    /// A symmetrical check here would strand exactly the operators the
+    /// guard is meant to rescue, with a restart-looping dog and no verb that
+    /// will remove it.
+    #[tokio::test]
+    async fn disable_still_removes_a_name_enable_would_now_refuse() {
+        let dir = tempfile::tempdir().unwrap();
+        let paths = ShepPaths::resolve(&|_| None, dir.path());
+        std::fs::create_dir_all(paths.daemon_config.parent().unwrap()).unwrap();
+        std::fs::write(
+            &paths.daemon_config,
+            "[daemon]\nenabled_dogs = [\"pydog\", \"metrics\"]\n",
+        )
+        .unwrap();
+
+        let mut out = Vec::new();
+        let mut err = Vec::new();
+        let code = disable(&mut streams(&mut out, &mut err), &paths, "pydog").await;
+
+        assert_eq!(code, ExitCode::Success, "{}", String::from_utf8_lossy(&err));
+        let written = std::fs::read_to_string(&paths.daemon_config).unwrap();
+        assert!(
+            !written.contains("pydog"),
+            "disable is the escape hatch out of a config enable would now \
+             refuse to write: {written}"
+        );
+        assert!(
+            written.contains("metrics"),
+            "and it touches nothing else: {written}"
+        );
+    }
+
+    /// fails if the refusal's list grammar loses a comma or an `and`. The
+    /// two-name case is what every `$SHEP_HOME` with nothing adopted gets,
+    /// and the three-name case is the first one with an adopted dog in it.
+    #[test]
+    fn join_with_and_reads_as_an_english_list() {
+        let one = ["a".to_string()];
+        let two = ["a".to_string(), "b".to_string()];
+        let three = ["a".to_string(), "b".to_string(), "c".to_string()];
+        assert_eq!(join_with_and(&[]), "");
+        assert_eq!(join_with_and(&one), "a");
+        assert_eq!(join_with_and(&two), "a and b");
+        assert_eq!(join_with_and(&three), "a, b, and c");
     }
 
     /// The name-collision guard `shep-daemon/src/rpc.rs`'s `EnableDog` arm

--- a/crates/shep-cli/src/commands/shep_toml.rs
+++ b/crates/shep-cli/src/commands/shep_toml.rs
@@ -341,6 +341,23 @@ impl ShepToml {
             .map(PathBuf::from)
     }
 
+    /// Every name `[daemon] adopted_dogs` records, in TOML document order.
+    ///
+    /// Read by `commands::dogs::enable` to name the adopted dogs in its
+    /// refusal of a name that is neither adopted nor built in — a refusal
+    /// that lists the way out is worth the allocation, and this is the
+    /// only caller that wants the whole set rather than one lookup.
+    #[must_use]
+    pub fn adopted_dog_names(&self) -> Vec<String> {
+        self.doc
+            .get("daemon")
+            .and_then(Item::as_table)
+            .and_then(|daemon| daemon.get("adopted_dogs"))
+            .and_then(Item::as_table)
+            .map(|adopted| adopted.iter().map(|(name, _)| name.to_string()).collect())
+            .unwrap_or_default()
+    }
+
     /// [`Self::adopted_dog_path`] without [`Self::edit`]'s write side --
     /// for a caller that only wants the answer, such as `lib.rs`'s
     /// `dispatch_adopted_dog`, which runs on every unrecognized verb, most

--- a/crates/shep-cli/src/dog/mod.rs
+++ b/crates/shep-cli/src/dog/mod.rs
@@ -43,7 +43,7 @@ use crate::exit::ExitCode;
 /// `shep dog <name>` only ever reaches one of these two. Anything else in
 /// the config did not come from `enable`/`adopt`, however it got there, and
 /// [`run_dog`] refuses it before touching the socket.
-const BUILT_IN_DOGS: [&str; 2] = ["metrics", "bark"];
+pub(crate) const BUILT_IN_DOGS: [&str; 2] = ["metrics", "bark"];
 
 /// A dog's connection to the shepherd, and its own configuration.
 ///

--- a/docs/dogs.md
+++ b/docs/dogs.md
@@ -56,8 +56,31 @@ starts a shepherd on your behalf to act on its own edit — that would be a
 bigger side effect than a config change should cause, and `shep muster` is
 the one verb in this CLI that autostarts anything.
 
+`enable` takes a built-in name or one `shep adopt` has already recorded,
+and refuses anything else before it writes:
+
+```
+$ shep enable pydog
+error[invalid_config]: `pydog` is not a dog; valid names are "metrics"
+and "bark" -- if you meant a third-party dog, run `shep adopt pydog` first
+```
+
+A refused `enable` writes nothing at all: a `$SHEP_HOME` that had no
+`shep.toml` still has none afterwards. The check reads `[daemon]
+adopted_dogs`, not the shepherd, so it holds with nothing listening.
+
+The guard is on the verb, not on the file. Write a name into `[daemon]
+enabled_dogs` by hand and the shepherd still reads it at boot, still
+treats anything outside `[daemon] adopted_dogs` as built-in, and spawns
+`shep dog <name>` for it once per restart until the budget is spent. What
+that looks like from `shep dogs` is a climbing restart count against a
+`SOURCE` of `built-in`, for a name that is not one; `shep bleats <name>`
+is where the refusal itself shows up.
+
 `shep disable <name>` is the mirror: it stops the dog if one is running,
-and removes it from the boot list either way.
+and removes it from the boot list either way. It carries no name check of
+its own, deliberately, so it is what takes a hand-written entry back out
+of `enabled_dogs`.
 
 Running two of these at once is safe. A provisioning script that
 backgrounds `shep adopt` and `shep enable` together has each of them take

--- a/web/src/pages/docs/dogs.astro
+++ b/web/src/pages/docs/dogs.astro
@@ -73,11 +73,20 @@ WHEN                 RULE    SUBJECT  MESSAGE                                   
         behalf. Two verbs do, and neither is a dog verb:{" "}
         <code>shep start</code> and <code>shep muster</code>.
       </p>
+      <p>
+        Takes a built-in name or one <code>shep adopt</code> has recorded,
+        and refuses anything else before it writes. A refused enable leaves
+        <code>shep.toml</code> untouched. The check reads{" "}
+        <code>[daemon] adopted_dogs</code> rather than the shepherd, so it
+        holds with nothing listening.
+      </p>
     </VerbSignature>
     <VerbSignature verb="disable" usage="shep disable <name>">
       <p>
         The mirror: stops the dog if one is running and removes it from the
-        boot list either way.
+        boot list either way. It carries no name check of its own,
+        deliberately, so it is what takes a hand-written{" "}
+        <code>enabled_dogs</code> entry back out.
       </p>
     </VerbSignature>
     <CodeBlock>{`$ shep enable metrics
@@ -97,6 +106,17 @@ ID  NAME     STATUS  PID    RESTARTS  EXIT  CPU  MEM    UPTIME  SOURCE
 1   metrics  online  49313  0         -     -    10.9M  2s      built-in
 
 $ shep disable metrics`}</CodeBlock>
+    <p class="fine">
+      The guard is on the verb, not on the file. Write a name into{" "}
+      <code>[daemon] enabled_dogs</code> by hand and the shepherd still
+      reads it at boot, still treats anything outside{" "}
+      <code>[daemon] adopted_dogs</code> as built-in, and spawns{" "}
+      <code>shep dog &lt;name&gt;</code> for it once per restart until the
+      budget is spent. From <code>shep dogs</code> that reads as a climbing
+      restart count against a <code>SOURCE</code> of <code>built-in</code>,
+      for a name that is not one; <code>shep bleats &lt;name&gt;</code> is
+      where the refusal itself shows up.
+    </p>
     <p class="fine">
       The dogs table shares its column order with the sheep table above it,
       so a dog and a sheep read the same way. <code>SOURCE</code> is the one


### PR DESCRIPTION
`shep enable <name>` accepted any name at all. `dog_source` reads built-in-ness as an absence from `[daemon] adopted_dogs`, so a name nothing had adopted was written into `enabled_dogs` as built-in and exited 0. The next shepherd spawned `shep dog <name>` on the restart ladder until the budget was spent, while `shep dogs` reported `SOURCE` as `built-in` for a name that is not one. The only place the cause showed up was `shep bleats <name>`.

```
$ shep enable pydog
error[invalid_config]: `pydog` is not a dog; valid names are "metrics" and "bark" -- if you meant a third-party dog, run `shep adopt pydog` first
```

- Refuses a name that is neither built-in nor a key of `[daemon] adopted_dogs`
- Lists the built-ins plus every adopted name, so a mistyped adopted dog is in there
- `try_edit` instead of `edit`: a refused enable skips `save`, leaving `shep.toml` untouched rather than renaming a byte-identical copy over it
- The check runs inside the closure, under the lock, so a concurrent `shep adopt` cannot land between the check and the write
- `disable` deliberately gets no matching check: it is the only verb that removes such a name from a config written before this
- `BUILT_IN_DOGS` is now `pub(crate)`, and `ShepToml::adopted_dog_names` is new
- Five tests, plus `docs/dogs.md` and `web/src/pages/docs/dogs.astro`

Not covered: a hand-written `enabled_dogs` entry still restart-loops, since the daemon resolves the name the same way and has no list to check it against. Whether an unknown name there should skip with a warning or refuse the whole boot is its own call, because refusing takes a bad `shep.toml` from one looping dog to no sheep starting. Both docs pages say so.

2244 passed / 0 failed on `cargo test --workspace --all-features`. clippy and rustdoc clean with `-D warnings`, `astro build` and `astro check` green, and the generated CLI reference shows no drift since no help text changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * `shep enable` now rejects unknown dog names before changing configuration and provides valid-name guidance.
  * Existing configuration is preserved when enabling an invalid name.
  * `shep disable` continues to remove manually configured entries without validating their names.

* **Documentation**
  * Clarified dog-name validation, configuration behavior, and handling of manually enabled names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->