### PR TITLE
chore: release v0.1.28

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2058,7 +2058,7 @@ dependencies = [
 
 [[package]]
 name = "shep"
-version = "0.1.27"
+version = "0.1.28"
 dependencies = [
  "anstyle",
  "assert_cmd",
@@ -2096,11 +2096,11 @@ dependencies = [
 
 [[package]]
 name = "shep-cli"
-version = "0.1.27"
+version = "0.1.28"
 
 [[package]]
 name = "shep-client"
-version = "0.1.27"
+version = "0.1.28"
 dependencies = [
  "futures-util",
  "nix 0.29.0",
@@ -2113,7 +2113,7 @@ dependencies = [
 
 [[package]]
 name = "shep-core"
-version = "0.1.27"
+version = "0.1.28"
 dependencies = [
  "annotate-snippets",
  "anstyle",
@@ -2143,7 +2143,7 @@ dependencies = [
 
 [[package]]
 name = "shep-daemon"
-version = "0.1.27"
+version = "0.1.28"
 dependencies = [
  "bytes",
  "chrono",
@@ -2172,7 +2172,7 @@ dependencies = [
 
 [[package]]
 name = "shep-examples"
-version = "0.1.27"
+version = "0.1.28"
 dependencies = [
  "nix 0.29.0",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.27"
+version = "0.1.28"
 edition = "2024"
 # 1.88 forced by serde-saphyr (let-chains, stabilized 1.88) — a current dep,
 # not a future one. Also the floor for ratatui/sysinfo/rmcp in later phases.
@@ -31,9 +31,9 @@ license = "MIT OR Apache-2.0"
 # the `[package]` table — so this literal is not sourced from
 # `workspace.package.version` above and a release bump has to touch both
 # places by hand. If that drifts, `cargo-release` is the mechanical fix.
-shep-core = { path = "crates/shep-core", version = "0.1.27" }
-shep-daemon = { path = "crates/shep-daemon", version = "0.1.27" }
-shep-client = { path = "crates/shep-client", version = "0.1.27" }
+shep-core = { path = "crates/shep-core", version = "0.1.28" }
+shep-daemon = { path = "crates/shep-daemon", version = "0.1.28" }
+shep-client = { path = "crates/shep-client", version = "0.1.28" }
 serde = { version = "1", default-features = false, features = ["derive"] }
 serde_json = { version = "1", default-features = false, features = ["std"] }
 toml = { version = "0.8", default-features = false, features = ["parse", "display"] }

--- a/crates/shep-cli/CHANGELOG.md
+++ b/crates/shep-cli/CHANGELOG.md
@@ -13,6 +13,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.28] - 2026-09-03
+
+### Added
+
+- Stamp every log line with the time it was written
+- Make `silent` lead somewhere
+
+### Fixed
+
+- Keep a log line meaning one thing on both of its paths
+- Flush a narration line, or it can be lost outright
+- Stop prescribing a reinstall for every dog shep gave up on
+- Give `counting_lines` back the cfg its neighbour took
+- Stop the given-up note naming a cause it cannot know
+
+
 ### Added
 
 - `silent` leads somewhere. `shep flock` prints one line under the dogs table

--- a/crates/shep-client/CHANGELOG.md
+++ b/crates/shep-client/CHANGELOG.md
@@ -10,6 +10,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.28] - 2026-09-03
+
+### Fixed
+
+- Say what to do about a protocol mismatch
+
+
 ### Changed
 
 - `ConnectError::ProtocolMismatch`'s `Display` says what to do about the

--- a/crates/shep-core/CHANGELOG.md
+++ b/crates/shep-core/CHANGELOG.md
@@ -10,6 +10,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.28] - 2026-09-03
+
+### Added
+
+- Put the shepherd's give-up on a dog on the wire
+
+### Fixed
+
+- Keep a log line meaning one thing on both of its paths
+- Track_caller on stamp_into, as its Panics section requires
+
+
 ### Added
 
 - `ProcessInfo::dog_stale`: whether the shepherd has given up on a dog —

--- a/crates/shep-daemon/CHANGELOG.md
+++ b/crates/shep-daemon/CHANGELOG.md
@@ -10,6 +10,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.28] - 2026-09-03
+
+### Added
+
+- Stamp every log line with the time it was written
+- Write shep's own account of a dog into that dog's log
+- Report the give-up beside the handshake in every listing
+
+### Fixed
+
+- Say what this shepherd saw, not what it inferred, about a silent dog
+- Keep a log line meaning one thing on both of its paths
+- Flush a narration line, or it can be lost outright
+- Write a stamped line in one call, so narration cannot tear it
+- Stop telling an operator an anonymous dog is doing its job
+- Stop linking public docs at private items
+- A map that just started watching must not say a pid never called
+- Serialize a whole record across both writers on a log path
+- Make the ladder wait for attribution instead of racing it
+- Take the record lock in reopen, and name the lossy key it cannot cover
+
+
 ### Added
 
 - Shep writes its own account of a dog into that dog's log file, marked


### PR DESCRIPTION



## 🤖 New release

* `shep-core`: 0.1.27 -> 0.1.28 (✓ API compatible changes)
* `shep-daemon`: 0.1.27 -> 0.1.28 (✓ API compatible changes)
* `shep-client`: 0.1.27 -> 0.1.28 (✓ API compatible changes)
* `shep`: 0.1.27 -> 0.1.28 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `shep-core`

<blockquote>

## [0.1.28] - 2026-09-03

### Added

- Put the shepherd's give-up on a dog on the wire

### Fixed

- Keep a log line meaning one thing on both of its paths
- Track_caller on stamp_into, as its Panics section requires


### Added

- `ProcessInfo::dog_stale`: whether the shepherd has given up on a dog —
  restarted it once for never answering, watched that not help, and stopped
  restarting it. `None` for a sheep and for a peer daemon that predates the
  field, the same additive-optional rule `handshook` follows, so
  `PROTOCOL_VERSION` stays at 2. It is not derivable from `handshook`, which
  is the point: a dog spawned a second ago and a dog the shepherd will never
  touch again are both `handshook: Some(false)` with a live process, and the
  give-up was a latch inside the daemon that nothing on the wire could see.
- `logstamp`: the timestamp the daemon writes ahead of every line in a log
  file, its fixed 30-byte width, and `strip`, which takes it back off. One
  definition for the writer and every reader — the daemon stamps, and three
  separate file readers in `shep-cli` strip — so the two cannot drift.
</blockquote>

## `shep-daemon`

<blockquote>

## [0.1.28] - 2026-09-03

### Added

- Stamp every log line with the time it was written
- Write shep's own account of a dog into that dog's log
- Report the give-up beside the handshake in every listing

### Fixed

- Say what this shepherd saw, not what it inferred, about a silent dog
- Keep a log line meaning one thing on both of its paths
- Flush a narration line, or it can be lost outright
- Write a stamped line in one call, so narration cannot tear it
- Stop telling an operator an anonymous dog is doing its job
- Stop linking public docs at private items
- A map that just started watching must not say a pid never called
- Serialize a whole record across both writers on a log path
- Make the ladder wait for attribution instead of racing it
- Take the record lock in reopen, and name the lossy key it cannot cover


### Added

- Shep writes its own account of a dog into that dog's log file, marked
  `[shep]` so it cannot be read as the dog's own output: the spawn and the
  resolved binary path, an accepted handshake (once per episode, not per
  reconnect), a refused one with both protocol numbers, the silence warning,
  the stale verdict, and the exit code or signal. Every one of those used to
  go only to `shepd.err.log` — which is not the file shep's own error message
  tells the operator to read. `shep bleats --follow` sees the same lines live.

### Changed

- `ListFlock` and `Describe` now report `ProcessInfo::dog_stale` beside
  `handshook`, so a listing can tell a dog this shepherd is still waiting on
  from one it has permanently stopped restarting. Both were
  `handshook: false` with a live process before, and the give-up was visible
  nowhere outside this daemon's own memory.

### Fixed

- The stale verdict for a silent dog no longer asserts a cause the shepherd
  never observed. It now records which process each connection arrived from
  and whether that connection named a dog, and says one of three things: the
  dog has never reached the socket (rebuild or reinstall it), it reaches the
  socket and never names itself (a build against shep-client older than
  0.1.23, which reinstalling the same build will not fix), or the platform
  would not name the peer's process and so neither can be ruled out. Every
  one ends in a command to run. Previously all three got *the binary on disk
  cannot talk to this shep either*, which cost one operator two days of
  reinstalling a dog that was connected and serving requests the whole time.

### Changed

- Every line written to a sheep's or a dog's log file now starts with the
  time shep wrote it, RFC 3339 in local time with the offset spelled out
  (`2026-09-02T14:22:31.412+02:00 `). The stamp is a fixed 30 bytes
  (`shep_core::logstamp::LOG_STAMP_BYTES`), so `tail`, `less` and `grep` show
  the time and anything that wants the raw line strips a constant prefix.
  What a sheep is REPORTED to have said does not change: the bus carries its
  line verbatim, and `shep bleats` strips the stamp when it reads a file, so
  `--follow` and `--no-follow` still agree and `--format json`'s `line` means
  what it always did. That split is why this needs no opt-out.
</blockquote>

## `shep-client`

<blockquote>

## [0.1.28] - 2026-09-03

### Fixed

- Say what to do about a protocol mismatch


### Changed

- `ConnectError::ProtocolMismatch`'s `Display` says what to do about the
  skew instead of stating it twice and stopping. A refused dog is refused
  before it can issue a single request, so that one line is the entire
  account of the failure that reaches its log; it now names both remedies
  (rebuild this program against the daemon's version, or upgrade shep and
  reload) because the type cannot tell which of the two builds is the older
  one, and a line that guessed would send half its readers to reinstall the
  wrong thing. `daemon_version` is rendered now — it was deliberately left
  out while this was a bare statement of the skew, and a protocol number is
  not something anyone can install.
</blockquote>

## `shep`

<blockquote>

## [0.1.28] - 2026-09-03

### Added

- Stamp every log line with the time it was written
- Make `silent` lead somewhere

### Fixed

- Keep a log line meaning one thing on both of its paths
- Flush a narration line, or it can be lost outright
- Stop prescribing a reinstall for every dog shep gave up on
- Give `counting_lines` back the cfg its neighbour took
- Stop the given-up note naming a cause it cannot know


### Added

- `silent` leads somewhere. `shep flock` prints one line under the dogs table
  naming every silent dog, and `shep describe <dog>` carries the long form:
  whether the shepherd is still waiting on that dog or has given up on it,
  and which command answers the rest. The give-up had no surface at all
  before — an operator could watch a dog read `silent` forever with nothing
  telling them shep had stopped trying. Neither addition touches a column:
  the pointer is prose under the finished table. `--format json` carries
  `dog_stale` on every dog row.

### Fixed

- `shep daemon reload`'s report about dogs that could not come back no longer
  prescribes a reinstall. It is handed names and nothing else, and that
  population includes dogs a reinstall cannot fix — one of them cost an
  operator two days. It now says the shepherd gave up and sends the reader to
  `shep bleats <dog>`, which is where the shepherd wrote what it actually
  saw. The daemon's version is still named, as the thing a rebuild would
  target rather than as an instruction to rebuild.

- `shep bleats --no-follow` and `shep lookout`'s tail pane strip the daemon's
  new per-line timestamp before rendering, so a line means the same thing
  there as it does on the bus. Without this, `--follow` and `--no-follow`
  would report a sheep as having said two different things, and
  `--format json`'s `line` would have carried a prefix the sheep never wrote.
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).