### PR TITLE
fix(dogs): name --force in the reinstall advice, since plain install does nothing

### DIFF
--- a/crates/shep-daemon/src/dogs.rs
+++ b/crates/shep-daemon/src/dogs.rs
@@ -2650,14 +2650,16 @@ mod tests {
         );
 
         let unattributed = stale_verdict("metrics", Silence::Unattributed);
-        // Naming the flag is the point: `cargo install <dog>` on a dog whose
-        // version has not moved prints "already installed", builds nothing,
-        // and exits 0, so an operator following the advice sees success and
-        // gets the same stale binary back.
+        // The WHOLE command, not the flag on its own. `contains("--force")`
+        // would pass on any sentence that happened to mention it, and the
+        // point is that an operator can copy what they are shown: a plain
+        // `cargo install <crate>` on a dog whose version has not moved prints
+        // "already installed", builds nothing, and exits 0, so advice missing
+        // this is advice that silently does nothing.
         for verdict in [&unreachable, &anonymous] {
             assert!(
-                verdict.contains("--force"),
-                "reinstall advice that omits --force is advice that silently does nothing: {verdict}"
+                verdict.contains("`cargo install <crate> --force`"),
+                "an actionable verdict must carry the whole forced reinstall command: {verdict}"
             );
         }
         assert!(

--- a/crates/shep-daemon/src/dogs.rs
+++ b/crates/shep-daemon/src/dogs.rs
@@ -1273,7 +1273,10 @@ fn stale_verdict(name: &str, evidence: Silence) -> String {
             "{seen}, and nothing has ever connected to this shepherd's socket from its process (pid {pid}): \
              the binary on disk cannot reach this shep either, so this dog is stale and will not be \
              restarted again. Read its own log with `shep bleats {name}` for what it says about \
-             connecting, then rebuild or reinstall it and run `shep restart {name}`"
+             connecting, then rebuild or reinstall it and run `shep restart {name}`. A dog \
+             installed with cargo wants `cargo install <crate> --force`: its own version does \
+             not change when the shep it was built against does, so a plain `cargo install` \
+             reports the package already installed, builds nothing, and exits 0"
         ),
         Silence::Anonymous { pid } => format!(
             "{seen}, but its process (pid {pid}) HAS connected to this shepherd — every time without \
@@ -1281,8 +1284,10 @@ fn stale_verdict(name: &str, evidence: Silence) -> String {
              is reaching shep and may be serving every request it is asked; reinstalling the same \
              build will NOT change that. It is built against shep-client older than 0.1.23, or it \
              connects with `Client::connect` instead of `ReconnectingClient::connect_as_dog`. Rebuild \
-             it against shep-client 0.1.23 or newer, then run `shep restart {name}`. It will not be \
-             restarted again in the meantime, and it goes on running"
+             it against shep-client 0.1.23 or newer, then run `shep restart {name}`. With cargo \
+             that means `cargo install <crate> --force`: the dog's own version does not change \
+             when its shep-client does, so a plain `cargo install` builds nothing and exits 0. \
+             It will not be restarted again in the meantime, and it goes on running"
         ),
         Silence::Unattributed => format!(
             "{seen}, and this shepherd could not tell which process opened its connections, so it \
@@ -2645,6 +2650,16 @@ mod tests {
         );
 
         let unattributed = stale_verdict("metrics", Silence::Unattributed);
+        // Naming the flag is the point: `cargo install <dog>` on a dog whose
+        // version has not moved prints "already installed", builds nothing,
+        // and exits 0, so an operator following the advice sees success and
+        // gets the same stale binary back.
+        for verdict in [&unreachable, &anonymous] {
+            assert!(
+                verdict.contains("--force"),
+                "reinstall advice that omits --force is advice that silently does nothing: {verdict}"
+            );
+        }
         assert!(
             unattributed.contains("could not tell which process"),
             "not knowing has to be said rather than papered over: {unattributed}"

--- a/web/src/pages/docs/dogs.astro
+++ b/web/src/pages/docs/dogs.astro
@@ -638,11 +638,18 @@ the dog against protocol 2, and restart it again`}</CodeBlock>
         <span>How it was built</span>
         <span>Which protocol</span>
       </div>
-      <div class="row"><span><code>cargo install &lt;dog&gt;</code>, first time</span> <span><code>shep-core</code> is re-resolved to the newest compatible release, so the protocol is current.</span></div>
-      <div class="row"><span><code>cargo install &lt;dog&gt;</code>, already installed</span> <span>Nothing is built. Cargo prints <em>already installed, use --force to override</em> and exits 0, so the protocol stays exactly as stale as it was.</span></div>
-      <div class="row"><span><code>cargo install &lt;dog&gt; --force</code></span> <span>Rebuilt and re-resolved, so the protocol is current. This is the one that upgrades a dog after you upgrade shep.</span></div>
+      <div class="row"><span><code>cargo install &lt;crate&gt;</code>, first time</span> <span><code>shep-core</code> is re-resolved to the newest compatible release, so the protocol is current.</span></div>
+      <div class="row"><span><code>cargo install &lt;crate&gt;</code>, already installed</span> <span>Nothing is built. Cargo prints <em>already installed, use --force to override</em> and exits 0, so the protocol stays exactly as stale as it was.</span></div>
+      <div class="row"><span><code>cargo install &lt;crate&gt; --force</code></span> <span>Rebuilt and re-resolved, so the protocol is current. This is the one that upgrades a dog after you upgrade shep.</span></div>
       <div class="row"><span><code>cargo install --locked</code>, and most CI</span> <span>The shipped lockfile is honoured, so the protocol is whatever was pinned on publish day.</span></div>
     </div>
+    <p class="fine">
+      <code>&lt;crate&gt;</code> is the package name on crates.io, which is not
+      always what you call the dog. A dog's adopted name, its binary name and
+      its crate name are three separate things: <code>shep-log-rotate</code>
+      installs a binary of the same name that is usually adopted as{" "}
+      <code>log-rotate</code>. Cargo wants the crate.
+    </p>
     <p class="fine">
       The middle row is the one that catches people, because it looks like it
       worked. A dog's own version does not change when the shep it was built

--- a/web/src/pages/docs/dogs.astro
+++ b/web/src/pages/docs/dogs.astro
@@ -638,9 +638,19 @@ the dog against protocol 2, and restart it again`}</CodeBlock>
         <span>How it was built</span>
         <span>Which protocol</span>
       </div>
-      <div class="row"><span><code>cargo install &lt;dog&gt;</code></span> <span><code>shep-core</code> is re-resolved to the newest compatible release, so the protocol is current.</span></div>
+      <div class="row"><span><code>cargo install &lt;dog&gt;</code>, first time</span> <span><code>shep-core</code> is re-resolved to the newest compatible release, so the protocol is current.</span></div>
+      <div class="row"><span><code>cargo install &lt;dog&gt;</code>, already installed</span> <span>Nothing is built. Cargo prints <em>already installed, use --force to override</em> and exits 0, so the protocol stays exactly as stale as it was.</span></div>
+      <div class="row"><span><code>cargo install &lt;dog&gt; --force</code></span> <span>Rebuilt and re-resolved, so the protocol is current. This is the one that upgrades a dog after you upgrade shep.</span></div>
       <div class="row"><span><code>cargo install --locked</code>, and most CI</span> <span>The shipped lockfile is honoured, so the protocol is whatever was pinned on publish day.</span></div>
     </div>
+    <p class="fine">
+      The middle row is the one that catches people, because it looks like it
+      worked. A dog's own version does not change when the shep it was built
+      against does, so the rebuild you need after upgrading shep is exactly
+      the case cargo declines to do, and it says so in one line before exiting
+      successfully. Reach for <code>--force</code> whenever you are
+      reinstalling a dog rather than installing one.
+    </p>
     <p class="fine">
       Measured 2026-08-31: <code>shep-log-rotate</code> 0.1.3 installed
       plain compiled <code>shep-core</code> 0.1.24, ignoring the packaged


### PR DESCRIPTION
Both actionable stale verdicts told an operator to "rebuild or reinstall" the dog. Following that literally does nothing:

```
$ cargo install shep-log-rotate
Ignored package `shep-log-rotate v0.1.5` is already installed, use --force to override
```

One line, exit 0, no new binary, and the hint scrolls past in a build log.

- both verdicts now name `cargo install <crate> --force` and say why
- `<crate>` rather than a guessed name: this daemon knows the dog's adopted name and its binary path, and neither is reliably the crate
- the web protocol table listed `cargo install <dog>` as re-resolving `shep-core` to something current, which is true on a FIRST install and false on every reinstall. That row is now three: first install, already installed, and `--force`
- a note that the middle row is the one that catches people, because it looks like it worked
- the stale-verdict test asserts both actionable arms carry `--force`

The trap is structural rather than a slip, which is why the message has to name it. A dog's own version does not change when the `shep-client` it links does, so the rebuild needed after upgrading shep is exactly the case cargo declines to perform.

Reported from a live host, where the reinstall appeared to succeed several times over two days.

2100 passed under `cargo test --workspace --lib --bins`. Clippy, nightly docs and fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated installation guidance for unreachable or anonymous dogs.
  - Clarified when to use a standard installation versus `cargo install <crate> --force`.
  - Explained that standard reinstalls may leave a stale protocol, while forced reinstalls rebuild against current dependencies.
  - Added guidance distinguishing first-time installs, no-op installs, and forced rebuilds.

- **Bug Fixes**
  - Improved troubleshooting verdicts to include the force-reinstall command where appropriate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->