### PR TITLE
chore: release v0.1.30

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2058,7 +2058,7 @@ dependencies = [
 
 [[package]]
 name = "shep"
-version = "0.1.29"
+version = "0.1.30"
 dependencies = [
  "anstyle",
  "assert_cmd",
@@ -2096,11 +2096,11 @@ dependencies = [
 
 [[package]]
 name = "shep-cli"
-version = "0.1.29"
+version = "0.1.30"
 
 [[package]]
 name = "shep-client"
-version = "0.1.29"
+version = "0.1.30"
 dependencies = [
  "futures-util",
  "nix 0.29.0",
@@ -2113,7 +2113,7 @@ dependencies = [
 
 [[package]]
 name = "shep-core"
-version = "0.1.29"
+version = "0.1.30"
 dependencies = [
  "annotate-snippets",
  "anstyle",
@@ -2143,7 +2143,7 @@ dependencies = [
 
 [[package]]
 name = "shep-daemon"
-version = "0.1.29"
+version = "0.1.30"
 dependencies = [
  "bytes",
  "chrono",
@@ -2172,7 +2172,7 @@ dependencies = [
 
 [[package]]
 name = "shep-examples"
-version = "0.1.29"
+version = "0.1.30"
 dependencies = [
  "nix 0.29.0",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.29"
+version = "0.1.30"
 edition = "2024"
 # 1.88 forced by serde-saphyr (let-chains, stabilized 1.88) — a current dep,
 # not a future one. Also the floor for ratatui/sysinfo/rmcp in later phases.
@@ -31,9 +31,9 @@ license = "MIT OR Apache-2.0"
 # the `[package]` table — so this literal is not sourced from
 # `workspace.package.version` above and a release bump has to touch both
 # places by hand. If that drifts, `cargo-release` is the mechanical fix.
-shep-core = { path = "crates/shep-core", version = "0.1.29" }
-shep-daemon = { path = "crates/shep-daemon", version = "0.1.29" }
-shep-client = { path = "crates/shep-client", version = "0.1.29" }
+shep-core = { path = "crates/shep-core", version = "0.1.30" }
+shep-daemon = { path = "crates/shep-daemon", version = "0.1.30" }
+shep-client = { path = "crates/shep-client", version = "0.1.30" }
 serde = { version = "1", default-features = false, features = ["derive"] }
 serde_json = { version = "1", default-features = false, features = ["std"] }
 toml = { version = "0.8", default-features = false, features = ["parse", "display"] }

--- a/crates/shep-cli/CHANGELOG.md
+++ b/crates/shep-cli/CHANGELOG.md
@@ -13,6 +13,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.30] - 2026-09-03
+
+### Added
+
+- The override store, locked and owner-only like the KV store
+- Shep start <file> applies a template additively; shep start <name> reads nothing
+- --reset and --reset-all on a Flockfile load
+- A CFG column and a describe section, so pending config is visible
+- A Flockfile is a template, and a load applies it without killing anything ([#104](https://github.com/shep-pm/shep/pull/104))
+
+### Fixed
+
+- Validate shep.toml before a daemon reload, not after the predecessor is gone
+- Make the reload pre-flight file-only, not env-layered
+- Move the env-layer pin from an unfalsifiable unit test to a real e2e case
+- A Flockfile load that refused an app exits non-zero
+- Keep the overridden cache correct across reload, scale-up and restore
+- The pending clause is a gerund, so it agrees with one field or many
+- A reset resolves an undeclared key to the file, not to the default
+- A Flockfile that names a dog is refused, not merged onto it
+- A fresh start establishes the keys its Flockfile declared
+- A reset flag on a bare script target is refused, not ignored
+- Describe prints a clustered app's config sections once
+
+
 ## [0.1.29] - 2026-09-03
 
 

--- a/crates/shep-client/CHANGELOG.md
+++ b/crates/shep-client/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.30] - 2026-09-03
+
+
 ## [0.1.29] - 2026-09-03
 
 

--- a/crates/shep-core/CHANGELOG.md
+++ b/crates/shep-core/CHANGELOG.md
@@ -10,6 +10,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.30] - 2026-09-03
+
+### Added
+
+- A Flockfile is a template, and a load applies it without killing anything ([#104](https://github.com/shep-pm/shep/pull/104))
+
+
 ## [0.1.29] - 2026-09-03
 
 

--- a/crates/shep-daemon/CHANGELOG.md
+++ b/crates/shep-daemon/CHANGELOG.md
@@ -10,6 +10,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.30] - 2026-09-03
+
+### Added
+
+- Rearm_name, a force-replacing sibling to arm for config changes
+- The override store, locked and owner-only like the KV store
+- Apply a Flockfile onto a running flock additively, without killing anything
+- Reload and restart promote pending config, re-resolving identity only when it changed
+- Request::ApplyConfig on the wire, answered by Response::Applied
+- A CFG column and a describe section, so pending config is visible
+- A Flockfile is a template, and a load applies it without killing anything ([#104](https://github.com/shep-pm/shep/pull/104))
+
+### Fixed
+
+- Redact SpawnSpec's Debug, the one env-carrying type without it
+- Pin rearm_name's multi-instance path, move dead_code note out of rustdoc
+- An epoch, so a replaced liveness probe cannot restart the sheep it left
+- Correct guard ordinal in ExtraRestart epoch doc
+- Drop a memory breach measured against a ceiling a load has since changed
+- Four ways a Flockfile load could touch what it must not
+- A load must tear a group down even when it can arm nothing
+- Report a parked rebuild that failed with no field to name, and stop establishing refused keys
+- Decide a promotion's identity reset when the config is parked, and let a reload read what it is owed without taking it
+- A scale-up carries the parked config onto the instances it creates
+- Carry a parked config and its reset decision across a handover
+- Keep the overridden cache correct across reload, scale-up and restore
+- A reset resolves an undeclared key to the file, not to the default
+- A Flockfile that names a dog is refused, not merged onto it
+- A load during a reload reads the replacement, not the drainee
+- A reset no longer establishes env keys it never merged
+- A scale brings the count forward in the config it has parked
+- The two parking keys travel as a pair in both directions
+
+
 ## [0.1.29] - 2026-09-03
 
 ### Fixed


### PR DESCRIPTION



## 🤖 New release

* `shep-core`: 0.1.29 -> 0.1.30 (✓ API compatible changes)
* `shep-daemon`: 0.1.29 -> 0.1.30 (✓ API compatible changes)
* `shep-client`: 0.1.29 -> 0.1.30
* `shep`: 0.1.29 -> 0.1.30 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `shep-core`

<blockquote>

## [0.1.30] - 2026-09-03

### Added

- A Flockfile is a template, and a load applies it without killing anything ([#104](https://github.com/shep-pm/shep/pull/104))
</blockquote>

## `shep-daemon`

<blockquote>

## [0.1.30] - 2026-09-03

### Added

- Rearm_name, a force-replacing sibling to arm for config changes
- The override store, locked and owner-only like the KV store
- Apply a Flockfile onto a running flock additively, without killing anything
- Reload and restart promote pending config, re-resolving identity only when it changed
- Request::ApplyConfig on the wire, answered by Response::Applied
- A CFG column and a describe section, so pending config is visible
- A Flockfile is a template, and a load applies it without killing anything ([#104](https://github.com/shep-pm/shep/pull/104))

### Fixed

- Redact SpawnSpec's Debug, the one env-carrying type without it
- Pin rearm_name's multi-instance path, move dead_code note out of rustdoc
- An epoch, so a replaced liveness probe cannot restart the sheep it left
- Correct guard ordinal in ExtraRestart epoch doc
- Drop a memory breach measured against a ceiling a load has since changed
- Four ways a Flockfile load could touch what it must not
- A load must tear a group down even when it can arm nothing
- Report a parked rebuild that failed with no field to name, and stop establishing refused keys
- Decide a promotion's identity reset when the config is parked, and let a reload read what it is owed without taking it
- A scale-up carries the parked config onto the instances it creates
- Carry a parked config and its reset decision across a handover
- Keep the overridden cache correct across reload, scale-up and restore
- A reset resolves an undeclared key to the file, not to the default
- A Flockfile that names a dog is refused, not merged onto it
- A load during a reload reads the replacement, not the drainee
- A reset no longer establishes env keys it never merged
- A scale brings the count forward in the config it has parked
- The two parking keys travel as a pair in both directions
</blockquote>


## `shep`

<blockquote>

## [0.1.30] - 2026-09-03

### Added

- The override store, locked and owner-only like the KV store
- Shep start <file> applies a template additively; shep start <name> reads nothing
- --reset and --reset-all on a Flockfile load
- A CFG column and a describe section, so pending config is visible
- A Flockfile is a template, and a load applies it without killing anything ([#104](https://github.com/shep-pm/shep/pull/104))

### Fixed

- Validate shep.toml before a daemon reload, not after the predecessor is gone
- Make the reload pre-flight file-only, not env-layered
- Move the env-layer pin from an unfalsifiable unit test to a real e2e case
- A Flockfile load that refused an app exits non-zero
- Keep the overridden cache correct across reload, scale-up and restore
- The pending clause is a gerund, so it agrees with one field or many
- A reset resolves an undeclared key to the file, not to the default
- A Flockfile that names a dog is refused, not merged onto it
- A fresh start establishes the keys its Flockfile declared
- A reset flag on a bare script target is refused, not ignored
- Describe prints a clustered app's config sections once
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).