### PR TITLE
feat: shep add, which registers a sheep and starts nothing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -462,6 +462,25 @@ not guessed from field names: `kill_signal` is NextSpawn rather than Live,
 and `shutdown_with_message` needs a respawn. `web/src/pages/docs/overrides.astro`
 is the operator-facing account.
 
+**`shep add` is decision 7 of that same spec, and it is the verb that makes
+the template model usable.** It takes the targets `shep start` takes, runs the
+same load, and spawns nothing: the app lands registered and `Stopped`, its
+declared keys established, and `shep start <name>` brings it up. Without it
+the first thing an operator does with a template shipping `env = { DB_HOST =
+"", DB_PASSWORD = "" }` is start it, which spawns against an empty database
+URL, crash-loops through the restart budget, and has to be stopped before it
+can be configured. `start` and `add` are ONE code path (`lifecycle::load`,
+carrying a `Load`), because a document that registered differently depending
+on which verb read it is one nobody could reason about. Four places consult
+it: which request a fresh app goes out as, whether an app the flock already
+has is resumed after the merge, what a name target that resolves to a
+registered sheep does, and the notice code. `Request::Add` /
+`Response::Added` are additive, so `PROTOCOL_VERSION` stays at 2 and the
+paragraph below applies to `shep add` word for word. **The fill-in half of
+"register, fill in, start" does not exist yet**: an established `env` key
+today moves only through the file plus `--reset-all`, and editing one in
+place is a later slice (spec decisions 10 and 11).
+
 **Restart the shepherd after upgrading to it.** `PROTOCOL_VERSION` did NOT
 move (the variant is additive, and six precedents in shep-core's changelog
 agree), but the consequence is sharper than those precedents had: a CLI from
@@ -471,10 +490,10 @@ decode, so `shep start <Flockfile>` fails on a dead client rather than on a
 named version refusal. `shep daemon reload` is the whole fix, and
 `getting-started.astro` says so where an operator reads.
 
-**Verb count: 40 generated, 41 listed, and the difference is `help`.**
+**Verb count: 41 generated, 42 listed, and the difference is `help`.**
 `./web/scripts/generate-cli-reference.sh` prints its own number every time it
-runs, and its `VERBS` array holds 40 because it does not generate a page for
-`help`. `shep --help`'s grouped listing shows 41 because it does. Both are
+runs, and its `VERBS` array holds 41 because it does not generate a page for
+`help`. `shep --help`'s grouped listing shows 42 because it does. Both are
 right about different questions, so neither is a bug to fix; check which one is
 being asked before changing either. README.md deliberately quotes the grouping
 without a count, so there is no third number to keep in step.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -476,19 +476,35 @@ it: which request a fresh app goes out as, whether an app the flock already
 has is resumed after the merge, what a name target that resolves to a
 registered sheep does, and the notice code. `Request::Add` /
 `Response::Added` are additive, so `PROTOCOL_VERSION` stays at 2 and the
-paragraph below applies to `shep add` word for word. **The fill-in half of
+paragraph below applies to `shep add` too. **The fill-in half of
 "register, fill in, start" does not exist yet**: an established `env` key
 today moves only through the file plus `--reset-all`, and editing one in
 place is a later slice (spec decisions 10 and 11).
 
 **Restart the shepherd after upgrading to it.** `PROTOCOL_VERSION` did NOT
-move (the variant is additive, and six precedents in shep-core's changelog
-agree), but the consequence is sharper than those precedents had: a CLI from
-this commit against an older daemon passes the handshake, sends
-`ApplyConfig`, and the daemon ends the connection on an envelope it cannot
-decode, so `shep start <Flockfile>` fails on a dead client rather than on a
-named version refusal. `shep daemon reload` is the whole fix, and
-`getting-started.astro` says so where an operator reads.
+move for `ApplyConfig` or for `Add` (both variants are additive, and six
+precedents in shep-core's changelog agree), so an older shepherd cannot
+decode either one. **This paragraph said the operator meets a dead client,
+full stop, and that is wrong: it skips the skew guard, which fires first in
+the common case.** `refuse_version_skew` compares the shepherd's reported
+crate version against the client's own and refuses every verb but the three
+in `RECOVERY_VERBS` (`kill`, `ping`, `daemon reload`), at the connect site,
+before any request is sent. So the two cases are:
+
+- **Versions differ**, which is every release upgrade through cargo or brew:
+  `error[version_skew]`, naming `shep daemon reload` as the remedy. No
+  request is sent and nothing is ambiguous.
+- **Versions match**, which is a client built from a commit that added the
+  variant against a shepherd built from an earlier commit of the same
+  version, so every development build and every branch: the guard passes,
+  the request goes out, and the shepherd ends the connection on an envelope
+  it cannot decode. THAT is the dead client, and it is a working-tree
+  hazard rather than an operator one.
+
+`shep daemon reload` is the fix in both, and `getting-started.astro` says so
+where an operator reads. `every_exempt_verb_is_one_of_the_documented_recovery_verbs`
+pins `add` at `Enforce`, since it reaches that through the `_` arm rather
+than by being named.
 
 **Verb count: 41 generated, 42 listed, and the difference is `help`.**
 `./web/scripts/generate-cli-reference.sh` prints its own number every time it

--- a/crates/shep-cli/src/cli.rs
+++ b/crates/shep-cli/src/cli.rs
@@ -28,7 +28,7 @@ const HELP_GROUPS: &[(&str, &[&str])] = &[
     (
         "Run things",
         &[
-            "start", "serve", "stop", "restart", "reload", "delete", "stock",
+            "start", "add", "serve", "stop", "restart", "reload", "delete", "stock",
         ],
     ),
     (
@@ -71,7 +71,7 @@ Getting started
   shep save               remember this flock across reboots
   shep startup            bring it back after a reboot
 
-Run things       start serve stop restart reload delete stock
+Run things       start add serve stop restart reload delete stock
 See what's up    flock describe bleats lookout fold barks
 Survive reboots  save muster startup unstartup
 Talk to a sheep  trigger signal whisper
@@ -205,6 +205,22 @@ pub enum Init {
 pub enum Commands {
     /// Start a sheep from a script, a Flockfile, or stdin.
     Start(StartArgs),
+    /// Register a sheep without starting it.
+    ///
+    /// The same targets `shep start` takes and the same load path. The one
+    /// difference is that nothing spawns: the app lands registered and
+    /// stopped, and `shep start <name>` is what brings it up.
+    ///
+    /// It is here for the Flockfile a project commits with its secrets left
+    /// blank — `env = { DB_HOST = "", DB_PASSWORD = "" }`, the
+    /// `.env.example` convention. Starting that file spawns a process
+    /// against an empty database URL, which crashes, spends its restart
+    /// budget, and has to be stopped before anyone can configure it. This
+    /// registers it instead, so the order becomes register, fill in, start.
+    ///
+    /// An app the flock already has is merged into and left exactly as it
+    /// is, running or not.
+    Add(StartArgs),
     /// Serve a directory over plain HTTP, as a managed sheep.
     ///
     /// Registers a sheep whose command line is this invocation, canonicalized
@@ -589,7 +605,13 @@ pub enum Commands {
     Schema,
 }
 
-/// Arguments to `shep start`.
+/// Arguments to `shep start` and `shep add`.
+///
+/// One struct for both, the precedent [`SelectorArgs`] already sets for
+/// `stop`/`restart`/`reload`/`delete`: the two verbs take the same targets,
+/// resolve them the same way, and differ only in whether anything is spawned
+/// at the end. A second struct would be the same eight fields with the same
+/// meanings, and a flag added to one of them and not the other.
 #[derive(Debug, clap::Args)]
 pub struct StartArgs {
     /// Selectors, script paths, Flockfiles, or `-` to read Flockfile JSON
@@ -610,14 +632,17 @@ pub struct StartArgs {
     /// everywhere else: `all`, `/regex/`, and glob patterns such as
     /// `web-*`. They reach only sheep the flock already has, since there is
     /// nothing to register. A sheep already running is reported and left
-    /// alone; `restart` is the verb that replaces one.
+    /// alone; `restart` is the verb that replaces one, and `add` never
+    /// starts anything in the first place.
     ///
-    /// Omit the targets to start the Flockfile in the current directory, or,
-    /// when there is none, to bring a shepherd up with nothing running yet.
+    /// Omit the targets to read the Flockfile in the current directory. With
+    /// no Flockfile there, `shep start` brings a shepherd up with nothing
+    /// running yet, and `shep add` has nothing it could register.
     ///
-    /// Several are started in turn, not atomically: if the second fails the
-    /// first is already up, and the exit code is the first failure. `--name`
-    /// is refused with more than one, since a name is unique to one sheep.
+    /// Several are handled in turn, not atomically: if the second fails the
+    /// first has already landed, and the exit code is the first failure.
+    /// `--name` is refused with more than one, since a name is unique to one
+    /// sheep.
     #[arg(num_args = 0..)]
     pub targets: Vec<String>,
     /// Name for this sheep (script form only)

--- a/crates/shep-cli/src/cli.rs
+++ b/crates/shep-cli/src/cli.rs
@@ -212,7 +212,7 @@ pub enum Commands {
     /// stopped, and `shep start <name>` is what brings it up.
     ///
     /// It is here for the Flockfile a project commits with its secrets left
-    /// blank — `env = { DB_HOST = "", DB_PASSWORD = "" }`, the
+    /// blank: `env = { DB_HOST = "", DB_PASSWORD = "" }`, the
     /// `.env.example` convention. Starting that file spawns a process
     /// against an empty database URL, which crashes, spends its restart
     /// budget, and has to be stopped before anyone can configure it. This

--- a/crates/shep-cli/src/commands/lifecycle.rs
+++ b/crates/shep-cli/src/commands/lifecycle.rs
@@ -961,6 +961,43 @@ async fn resume_all(
     failure.unwrap_or(ExitCode::Success)
 }
 
+/// Reports the sheep `shep add` found already registered, and changes
+/// nothing.
+///
+/// `add`'s answer to what [`resume_all`] answers for `start`, and a much
+/// shorter one: `start` has to decide what to bring up, and `add` has
+/// nothing left to do at all. Registration is the whole of what the verb
+/// promises, and the flock already has these.
+///
+/// Always [`ExitCode::Success`]. Re-running a template against a flock that
+/// already holds its apps is the ordinary case, not an error, and a deploy
+/// script that ran `shep add Flockfile.toml` twice must not fail the second
+/// time.
+///
+/// ONE notice however large the set is, matching [`resume_all`]: `shep add
+/// all` against a thirteen-app flock would otherwise print thirteen lines
+/// saying the same thing.
+///
+/// No remedy is suggested, and that is deliberate rather than an omission.
+/// `shep start <name>` is the right next command for a row that is stopped
+/// and the wrong one for a row that is up, and this arm holds both -- so
+/// naming one would be advice that is wrong half the time, in the one place
+/// an operator has no reason to doubt it.
+fn already_registered(streams: &mut Streams<'_>, matched: &[ProcessInfo]) -> ExitCode {
+    let refs: Vec<&ProcessInfo> = matched.iter().collect();
+    let names = unique_names(&refs);
+    let message = match names.as_slice() {
+        [] => return ExitCode::Success,
+        [one] => format!("{one} is already registered; nothing to add."),
+        several => format!(
+            "{} are already registered; nothing to add.",
+            several.join(", ")
+        ),
+    };
+    streams.aside("add", &message);
+    ExitCode::Success
+}
+
 /// Every distinct name in `infos`, in the order they first appear.
 ///
 /// Feeds the already-running notice and nothing else -- never the respawn
@@ -1139,6 +1176,7 @@ async fn apply_declared(
     streams: &mut Streams<'_>,
     declared: &[DeclaredApp],
     reset: ResetDepth,
+    mode: Load,
 ) -> ExitCode {
     let apps: Vec<DeclaredApp> = declared
         .iter()
@@ -1198,7 +1236,7 @@ async fn apply_declared(
             // operator guessing about the rest of the file.
             failure = failure.or(Some(streams.fail(REFUSED_EXIT, &message)));
         } else {
-            streams.aside("start", &message);
+            streams.aside(mode.verb(), &message);
         }
     }
     failure.unwrap_or(ExitCode::Success)
@@ -1346,12 +1384,74 @@ fn reset_depth(args: &StartArgs) -> ResetDepth {
     }
 }
 
+/// Which of the two verbs that read a Flockfile is running.
+///
+/// They share everything: the same targets, the same four-tier resolution,
+/// the same merge into an app the flock already has, the same refusals. The
+/// whole difference is whether anything is spawned at the end, and it is one
+/// code path rather than two because a document that registered differently
+/// depending on which verb read it is a document nobody could reason about.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Load {
+    /// `shep start`: register what the flock does not have, and bring up what
+    /// it does.
+    Start,
+    /// `shep add`: register what the flock does not have, and stop there.
+    Add,
+}
+
+impl Load {
+    /// The verb's own name, for a notice's code and for the `--format json`
+    /// envelope's `command`.
+    fn verb(self) -> &'static str {
+        match self {
+            Self::Start => "start",
+            Self::Add => "add",
+        }
+    }
+}
+
+/// Registers what `args` resolves to and brings all of it up.
 pub async fn start(
     client: &Client,
     streams: &mut Streams<'_>,
     args: &StartArgs,
     discovered: Option<&Path>,
     interpreters: &BTreeMap<String, String>,
+) -> ExitCode {
+    load(client, streams, args, discovered, interpreters, Load::Start).await
+}
+
+/// Registers what `args` resolves to and starts none of it.
+///
+/// The app lands registered and stopped, which is what makes a Flockfile
+/// usable as a template. One shipping `env = { DB_HOST = "", DB_PASSWORD =
+/// "" }` cannot be started before it is configured -- the process comes up
+/// against an empty database URL, crashes, spends its restart budget, and has
+/// to be stopped before anybody can fix it. With this the order is register,
+/// fill in, start.
+///
+/// An app the flock already has is merged into and left exactly as it is,
+/// running or not. Re-running this after editing a template is the ordinary
+/// thing to do, so it must not be able to stop a service.
+pub async fn add(
+    client: &Client,
+    streams: &mut Streams<'_>,
+    args: &StartArgs,
+    discovered: Option<&Path>,
+    interpreters: &BTreeMap<String, String>,
+) -> ExitCode {
+    load(client, streams, args, discovered, interpreters, Load::Add).await
+}
+
+/// The body [`start`] and [`add`] share -- see [`Load`] for what they do not.
+async fn load(
+    client: &Client,
+    streams: &mut Streams<'_>,
+    args: &StartArgs,
+    discovered: Option<&Path>,
+    interpreters: &BTreeMap<String, String>,
+    mode: Load,
 ) -> ExitCode {
     // `--name` renames the sheep a target becomes, and a name is unique to
     // one sheep, so it cannot mean anything across several targets.
@@ -1361,7 +1461,7 @@ pub async fn start(
     }
     if args.targets.is_empty() {
         let mut started = Vec::new();
-        let code = start_one(
+        let code = load_one(
             client,
             streams,
             args,
@@ -1369,6 +1469,7 @@ pub async fn start(
             discovered,
             interpreters,
             &mut started,
+            mode,
         )
         .await;
         // Printed whenever the verb did its work, not only when it touched a row.
@@ -1378,7 +1479,7 @@ pub async fn start(
         // FAILED still leaves stdout empty, which is the discipline `cli_e2e`'s
         // `assert_json_error` pins crate-wide.
         if code == ExitCode::Success {
-            let wrote = render_outcome(client, streams, "start", FlockRows(started)).await;
+            let wrote = render_outcome(client, streams, mode.verb(), FlockRows(started)).await;
             if wrote != ExitCode::Success {
                 return wrote;
             }
@@ -1391,7 +1492,7 @@ pub async fn start(
     let mut failure: Option<ExitCode> = None;
     let mut started = Vec::new();
     for target in &args.targets {
-        let code = start_one(
+        let code = load_one(
             client,
             streams,
             args,
@@ -1399,6 +1500,7 @@ pub async fn start(
             discovered,
             interpreters,
             &mut started,
+            mode,
         )
         .await;
         if code != ExitCode::Success {
@@ -1423,7 +1525,7 @@ pub async fn start(
     // that is a data envelope beside an error envelope, which is two answers
     // to one question and what `cli_e2e`'s `assert_json_error` refuses.
     if failure.is_none() {
-        let wrote = render_outcome(client, streams, "start", FlockRows(started)).await;
+        let wrote = render_outcome(client, streams, mode.verb(), FlockRows(started)).await;
         if wrote != ExitCode::Success {
             return wrote;
         }
@@ -1431,20 +1533,20 @@ pub async fn start(
     failure.unwrap_or(ExitCode::Success)
 }
 
-/// One target's worth of [`start`].
+/// One target's worth of [`load`].
 ///
 /// Eight parameters, the same growth `lookout::frames::sheep`'s own
 /// `#[allow(clippy::too_many_arguments)]` already accepted for itself:
-/// `client`, `streams` and `fmt` are the RPC/rendering plumbing every verb
-/// in this file threads through; `args`, `target` and `discovered` are the
-/// three ways one invocation names what to start; `interpreters` is task
-/// 47's `shep.toml` mapping, read once by the caller rather than
-/// re-reading the file per target; and `started` is the caller's own
-/// accumulator. None of the eight groups naturally into a struct without
-/// inventing one used nowhere else, the same call that function's own doc
-/// makes.
+/// `client` and `streams` are the RPC/rendering plumbing every verb in this
+/// file threads through; `args`, `target` and `discovered` are the three ways
+/// one invocation names what to load; `interpreters` is task 47's
+/// `shep.toml` mapping, read once by the caller rather than re-reading the
+/// file per target; `started` is the caller's own accumulator; and `mode` is
+/// which of the two verbs is running. None of the eight groups naturally
+/// into a struct without inventing one used nowhere else, the same call that
+/// function's own doc makes.
 #[allow(clippy::too_many_arguments)]
-async fn start_one(
+async fn load_one(
     client: &Client,
     streams: &mut Streams<'_>,
     args: &StartArgs,
@@ -1452,6 +1554,7 @@ async fn start_one(
     discovered: Option<&Path>,
     interpreters: &BTreeMap<String, String>,
     started: &mut Vec<shep_core::protocol::ProcessInfo>,
+    mode: Load,
 ) -> ExitCode {
     // `args.target` is optional so bare `shep start` can mean "this
     // directory's Flockfile". The caller does the discovery, because the
@@ -1533,7 +1636,16 @@ async fn start_one(
                     );
                     return streams.fail(ExitCode::Usage, &message);
                 }
-                return resume_all(client, streams, Some(token), &matched, started).await;
+                return match mode {
+                    Load::Start => {
+                        resume_all(client, streams, Some(token), &matched, started).await
+                    }
+                    // Nothing to do and nothing to report as an error: the
+                    // sheep is registered, which is all `add` was asked for.
+                    // Saying so anyway, because a verb that printed a table
+                    // and no word would look like it had done something.
+                    Load::Add => already_registered(streams, &matched),
+                };
             }
             // Held for the failure path below rather than reported here: the
             // token may still name a Flockfile or a path, and only if it names
@@ -1654,9 +1766,17 @@ async fn start_one(
     // `start` was asked to do, they are what an operator running this in a
     // deploy needs to happen, and the refusal is reported the moment it
     // arrives either way. What it changes is what the verb EXITS with.
+    //
+    // The merge runs under `add` too, and only the resume below it does not.
+    // That is the whole of `shep add Flockfile.toml` against an app the flock
+    // already has: the file's new keys are appended, a field the running
+    // child holds parks for its next spawn, and nothing is replaced. Refusing
+    // instead would break re-running the file after a template edit, and
+    // stopping the app would be a config load that killed a process, which
+    // this design forbids outright.
     let declared: Vec<DeclaredApp> = resumed.iter().map(|(app, _)| app.clone()).collect();
-    let applied = apply_declared(client, streams, &declared, reset_depth(args)).await;
-    if !resumed.is_empty() {
+    let applied = apply_declared(client, streams, &declared, reset_depth(args), mode).await;
+    if !resumed.is_empty() && mode == Load::Start {
         // `None`, not the operator's token: this arm reached the flock through
         // a Flockfile or a path, so there is no selector to quote back in the
         // "already running" notice. `shep restart ./rotom.sh` is not a
@@ -1677,32 +1797,46 @@ async fn start_one(
 
     let (procs, failure) = request_each(
         client,
-        streams, // One request either way: `Start` carries the apps, so the "selector"
-        // here is a placeholder the body closure ignores. Reusing the looping
-        // helper keeps the collect-then-render shape in one place.
+        streams, // One request either way: `Start` and `Add` both carry the apps, so
+        // the "selector" here is a placeholder the body closure ignores.
+        // Reusing the looping helper keeps the collect-then-render shape in
+        // one place.
         &[SelectorSpec::All],
+        // `START_DEADLINE` for both, and it is not spare budget on the `Add`
+        // side. Nothing is spawned there, but the actor is single-threaded:
+        // an `Add` that arrives while the daemon is part way through a batch
+        // of cold spawns waits behind them, and the client's ordinary 5s
+        // would abandon a registration that was about to happen.
         Some(START_DEADLINE),
-        |_| Request::Start { apps: apps.clone() },
+        |_| match mode {
+            Load::Start => Request::Start { apps: apps.clone() },
+            Load::Add => Request::Add { apps: apps.clone() },
+        },
         |response| match response {
-            Response::Started(procs) => Some(procs),
+            Response::Started(procs) | Response::Added(procs) => Some(procs),
             _ => None,
         },
     )
     .await;
     // The load that establishes what a FRESH app's file declared, and the
     // whole of the spec's migration clause: "first load of an existing app
-    // establishes its current keys". `Request::Start` registers an app and
-    // writes nothing to the override store, so without this the app has an
-    // empty established set and the SECOND load of the same file treats every
-    // key as unestablished and overwrites the lot -- the one thing the
-    // additive default exists to prevent, arriving on the load after the one
-    // everybody tests.
+    // establishes its current keys". `Request::Start` and `Request::Add` both
+    // register an app and write nothing to the override store, so without
+    // this the app has an empty established set and the SECOND load of the
+    // same file treats every key as unestablished and overwrites the lot --
+    // the one thing the additive default exists to prevent, arriving on the
+    // load after the one everybody tests.
     //
     // `ResetDepth::None` whatever flag the operator passed, because there is
     // nothing to reset: the app was registered from this very file a moment
     // ago, so every declared key already holds the file's value and the merge
     // is a no-op that reports nothing. `--reset-all` would be worse than a
     // no-op, since it drops the record this call exists to write.
+    //
+    // `Request::Add` needs it for exactly the reason `Request::Start` does,
+    // and needs it more: `add` exists so an operator can fill in the empty
+    // `env` keys a template shipped, and a key that was never established is
+    // one the next load of that same template overwrites.
     //
     // Only the apps the daemon really registered. An app whose spawn failed
     // is not in `procs`, and sending its name here would earn an `is not
@@ -1713,7 +1847,7 @@ async fn start_one(
         .into_iter()
         .filter(|app| registered.contains(app.config.name.as_str()))
         .collect();
-    let recorded = apply_declared(client, streams, &established, ResetDepth::None).await;
+    let recorded = apply_declared(client, streams, &established, ResetDepth::None, mode).await;
     started.extend(procs);
     first_failure(
         applied,
@@ -4285,6 +4419,223 @@ mod tests {
         assert!(
             String::from_utf8(err).unwrap().contains("shep delete web"),
             "the daemon's own sentence has to reach the operator"
+        );
+    }
+
+    /// A daemon that registers what it is asked to register: an `Add`
+    /// answers one `Stopped` row per app, and a `Start` one `Online` row.
+    ///
+    /// A `Start` is ANSWERED rather than refused on purpose. A build that
+    /// sent one from `shep add` should fail on the assertion that names the
+    /// request it sent, not on a transport error that says only that
+    /// something went wrong.
+    fn a_daemon_that_registers(
+        flock: Vec<ProcessInfo>,
+    ) -> impl Fn(&Request) -> Response + Send + 'static {
+        use shep_core::status::ProcStatus;
+        let rows = |apps: &[AppConfig], status: ProcStatus| -> Vec<ProcessInfo> {
+            apps.iter()
+                .enumerate()
+                .map(|(i, app)| {
+                    ProcessInfo::builder(u32::try_from(i).unwrap(), &app.name, status).build()
+                })
+                .collect()
+        };
+        move |request| match request {
+            Request::ListFlock => Response::Flock(flock.clone()),
+            Request::ApplyConfig { apps, .. } => Response::Applied(
+                apps.iter()
+                    .map(|app| {
+                        SheepApplied::new(app.config.name.clone(), Vec::new(), Vec::new(), None)
+                    })
+                    .collect(),
+            ),
+            Request::Add { apps } => Response::Added(rows(apps, ProcStatus::Stopped)),
+            Request::Start { apps } => Response::Started(rows(apps, ProcStatus::Online)),
+            Request::Restart { .. } => Response::Restarted(Vec::new()),
+            _ => Response::Pong,
+        }
+    }
+
+    /// Every request body an invocation put on the wire, in order.
+    ///
+    /// One drain rather than a helper per request kind, unlike `applies` and
+    /// `respawns` above: a channel can only be emptied once, and every
+    /// assertion below is about what was sent AND what was not, which two
+    /// separate drains could not both see.
+    fn sent(
+        envelopes: &mut tokio::sync::mpsc::UnboundedReceiver<shep_core::protocol::Envelope>,
+    ) -> Vec<Request> {
+        let mut bodies = Vec::new();
+        while let Ok(envelope) = envelopes.try_recv() {
+            bodies.push(envelope.body);
+        }
+        bodies
+    }
+
+    /// Runs `shep add` against `target` and hands back its code and streams.
+    async fn add_against(client: &Client, target: &str) -> (ExitCode, String, String) {
+        let args = start_args(target);
+        let mut out = Vec::new();
+        let mut err = Vec::new();
+        let code = {
+            let mut streams = Streams {
+                out: &mut out,
+                err: &mut err,
+                style: crate::style::Presentation::BARE,
+                fmt: Format::Table,
+            };
+            add(client, &mut streams, &args, None, &BTreeMap::new()).await
+        };
+        (
+            code,
+            String::from_utf8(out).unwrap(),
+            String::from_utf8(err).unwrap(),
+        )
+    }
+
+    /// fails if `shep add` spawns the app it just registered.
+    ///
+    /// The whole of the verb, and the assertion that no `Start` was sent is
+    /// the half that matters: `add` and `start` are one code path, so the
+    /// failure this guards is not a missing feature but a mode that leaked.
+    #[tokio::test]
+    async fn add_registers_a_fresh_app_and_sends_no_start() {
+        let dir = tempfile::tempdir().unwrap();
+        let flockfile = dir.path().join("Flockfile.toml");
+        std::fs::write(
+            &flockfile,
+            "[[app]]\nname = \"demo\"\nscript = \"/bin/sleep\"\n",
+        )
+        .unwrap();
+        let path = shep_client::testing::control_address(dir.path());
+        let (client, mut envelopes) =
+            fake_client_answering(&path, a_daemon_that_registers(Vec::new())).await;
+
+        let (code, _out, _err) = add_against(&client, flockfile.to_str().unwrap()).await;
+
+        assert_eq!(code, ExitCode::Success);
+        let sent = sent(&mut envelopes);
+        let registered: Vec<&str> = sent
+            .iter()
+            .filter_map(|request| match request {
+                Request::Add { apps } => Some(apps[0].name.as_str()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(registered, vec!["demo"], "one registration, for the app");
+        assert!(
+            !sent.iter().any(|r| matches!(r, Request::Start { .. })),
+            "nothing was started"
+        );
+    }
+
+    /// fails if `shep add` leaves a fresh app with no established key set.
+    ///
+    /// The load that follows the registration is not bookkeeping: `add`
+    /// exists so an operator can fill in the empty `env` keys a template
+    /// shipped, and a key nothing established is one the NEXT load of that
+    /// same template overwrites. Without this the pattern the verb was built
+    /// for breaks on the second load rather than the first.
+    #[tokio::test]
+    async fn add_establishes_the_keys_the_template_declared() {
+        let dir = tempfile::tempdir().unwrap();
+        let flockfile = dir.path().join("Flockfile.toml");
+        std::fs::write(
+            &flockfile,
+            "[[app]]\nname = \"demo\"\nscript = \"/bin/sleep\"\n",
+        )
+        .unwrap();
+        let path = shep_client::testing::control_address(dir.path());
+        let (client, mut envelopes) =
+            fake_client_answering(&path, a_daemon_that_registers(Vec::new())).await;
+
+        let (code, _out, _err) = add_against(&client, flockfile.to_str().unwrap()).await;
+
+        assert_eq!(code, ExitCode::Success);
+        let sent = sent(&mut envelopes);
+        let add_at = sent
+            .iter()
+            .position(|r| matches!(r, Request::Add { .. }))
+            .expect("the app was registered");
+        let apply_at = sent
+            .iter()
+            .position(|r| matches!(r, Request::ApplyConfig { .. }))
+            .expect("its declared keys were established");
+        assert!(
+            add_at < apply_at,
+            "the app is registered before its keys are established"
+        );
+    }
+
+    /// fails if `shep add` restarts an app the flock already has.
+    ///
+    /// Re-running a template after editing it is the ordinary thing to do,
+    /// so the file's new keys have to be merged in -- and the running child
+    /// has to survive it. A config load that killed a process is the one
+    /// outcome this design forbids outright.
+    #[tokio::test]
+    async fn add_merges_into_a_running_app_without_replacing_it() {
+        let dir = tempfile::tempdir().unwrap();
+        let flockfile = dir.path().join("Flockfile.toml");
+        std::fs::write(
+            &flockfile,
+            "[[app]]\nname = \"zam\"\nscript = \"/bin/sleep\"\n",
+        )
+        .unwrap();
+        let path = shep_client::testing::control_address(dir.path());
+        let (client, mut envelopes) =
+            fake_client_answering(&path, a_daemon_that_registers(a_clustered_flock(&[0]))).await;
+
+        let (code, _out, _err) = add_against(&client, flockfile.to_str().unwrap()).await;
+
+        assert_eq!(code, ExitCode::Success);
+        let sent = sent(&mut envelopes);
+        assert!(
+            sent.iter()
+                .any(|r| matches!(r, Request::ApplyConfig { .. })),
+            "the template was merged in"
+        );
+        assert!(
+            !sent.iter().any(|r| matches!(r, Request::Restart { .. })),
+            "and nothing was replaced"
+        );
+        assert!(
+            !sent.iter().any(|r| matches!(r, Request::Add { .. })),
+            "the flock already has it, so there was nothing to register"
+        );
+    }
+
+    /// fails if `shep add <name>` reads a file or registers anything.
+    ///
+    /// A name target reads no Flockfile -- the security boundary the apply
+    /// design rests on, and `add` sits behind the same one. What is left for
+    /// the verb to do is nothing at all, so the one thing it owes the
+    /// operator is saying so.
+    #[tokio::test]
+    async fn add_by_name_registers_nothing_and_says_so() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = shep_client::testing::control_address(dir.path());
+        let (client, mut envelopes) =
+            fake_client_answering(&path, a_daemon_that_registers(a_clustered_flock(&[0]))).await;
+
+        let (code, _out, said) = add_against(&client, "zam").await;
+
+        assert_eq!(code, ExitCode::Success);
+        let sent = sent(&mut envelopes);
+        assert!(
+            !sent.iter().any(|r| matches!(r, Request::Add { .. })),
+            "the flock already has it"
+        );
+        assert!(
+            !sent
+                .iter()
+                .any(|r| matches!(r, Request::ApplyConfig { .. })),
+            "a name target reads no file, so there is nothing to apply"
+        );
+        assert!(
+            said.contains("already registered"),
+            "the operator is told why nothing happened: {said}"
         );
     }
 

--- a/crates/shep-cli/src/lib.rs
+++ b/crates/shep-cli/src/lib.rs
@@ -3169,6 +3169,21 @@ mod tests {
         assert!(err.is_empty(), "{}", String::from_utf8_lossy(&err));
     }
 
+    /// An empty [`StartArgs`], for asking which guard `add` gets. Its
+    /// fields do not reach the guard, which reads the verb alone.
+    fn add_args() -> StartArgs {
+        StartArgs {
+            targets: Vec::new(),
+            name: None,
+            fold: None,
+            cwd: None,
+            interpreter: None,
+            flockfile: false,
+            reset: false,
+            reset_all: false,
+        }
+    }
+
     /// A [`DaemonArgs`] carrying `cmd` and nothing else, for asking which
     /// guard the `daemon` verb's two shapes get.
     fn daemon_args(cmd: Option<cli::DaemonCmd>) -> DaemonArgs {
@@ -3218,6 +3233,17 @@ mod tests {
         assert_eq!(
             VersionGuard::for_command(&Commands::Kill),
             VersionGuard::Exempt
+        );
+        // `add` carries a request an older shepherd cannot decode
+        // (`Request::Add`, added without moving `PROTOCOL_VERSION`), so the
+        // skew refusal is the whole of what stands between an operator who
+        // upgraded and a client that dies on the reply. It reaches
+        // `Enforce` through the `_` arm rather than by being named, which
+        // is the right default and an easy one to lose: pinned here so a
+        // future exemption for `add` has to be argued rather than typed.
+        assert_eq!(
+            VersionGuard::for_command(&Commands::Add(add_args())),
+            VersionGuard::Enforce
         );
     }
 

--- a/crates/shep-cli/src/lib.rs
+++ b/crates/shep-cli/src/lib.rs
@@ -57,7 +57,7 @@ use std::path::PathBuf;
 
 use clap::Parser;
 
-use cli::{AdoptArgs, Commands, DaemonArgs, Format};
+use cli::{AdoptArgs, Commands, DaemonArgs, Format, StartArgs};
 use cli::{Cli, GlobalArgs};
 use commands::admin;
 use commands::bleats;
@@ -67,6 +67,7 @@ use commands::dogs;
 use commands::import;
 use commands::kv;
 use commands::lifecycle;
+use commands::lifecycle::Load;
 use commands::logs;
 use commands::muster;
 use commands::query;
@@ -1233,37 +1234,10 @@ async fn run(cli: Cli, style: style::Presentation) -> ExitCode {
                 ExitCode::Success
             }
         },
-        // Bare `shep start` means the Flockfile in this directory, the way
-        // `shep runtime` and `shep dev` already read one -- and when there is
-        // none, it means "bring a shepherd up", which is the only way to get
-        // one without also starting a process.
         Commands::Start(ref args) => {
-            let discovered = if args.targets.is_empty() {
-                std::env::current_dir()
-                    .ok()
-                    .and_then(|cwd| shep_core::config::flockfile::discover(&cwd))
-            } else {
-                None
-            };
-            if args.targets.is_empty() && discovered.is_none() {
-                return start_bare_shepherd(&mut streams, &paths, guard).await;
-            }
-            let shep_toml_text = std::fs::read_to_string(&paths.daemon_config).ok();
-            let interpreters = interpreters_from_config(shep_toml_text.as_deref());
-            match connect_or_spawn_client(&mut streams, &paths, guard).await {
-                Ok(client) => {
-                    lifecycle::start(
-                        &client,
-                        &mut streams,
-                        args,
-                        discovered.as_deref(),
-                        &interpreters,
-                    )
-                    .await
-                }
-                Err(code) => code,
-            }
+            load_command(&mut streams, &paths, guard, args, Load::Start).await
         }
+        Commands::Add(ref args) => load_command(&mut streams, &paths, guard, args, Load::Add).await,
         Commands::Stop(ref args) | Commands::Thatlldo(ref args) => {
             match connect_client(&mut streams, &paths, guard).await {
                 Ok(client) => lifecycle::stop(&client, &mut streams, args).await,
@@ -1495,6 +1469,60 @@ pub(crate) async fn connect_or_spawn_client(
         Err(err) => {
             let code = ExitCode::from(&err);
             Err(streams.fail(code, &err.to_string()))
+        }
+    }
+}
+
+/// `shep start` and `shep add`, which differ in one thing and share
+/// everything before it.
+///
+/// Bare, either verb means the Flockfile in this directory, the way `shep
+/// runtime` and `shep dev` already read one. What the two disagree about is
+/// what an EMPTY directory means, and the arm below is the whole of it.
+///
+/// Reading `shep.toml`'s interpreter mapping, discovering the file, and
+/// bringing a shepherd up to talk to are identical for both, which is why
+/// this is one function rather than two arms that would drift.
+async fn load_command(
+    streams: &mut Streams<'_>,
+    paths: &ShepPaths,
+    guard: VersionGuard,
+    args: &StartArgs,
+    mode: Load,
+) -> ExitCode {
+    let discovered = if args.targets.is_empty() {
+        std::env::current_dir()
+            .ok()
+            .and_then(|cwd| shep_core::config::flockfile::discover(&cwd))
+    } else {
+        None
+    };
+    if args.targets.is_empty() && discovered.is_none() {
+        // Bare `shep start` in an empty directory means "bring a shepherd
+        // up", the only way to get one without also starting a process.
+        // `shep add` cannot mean that: a shepherd holding nothing is what it
+        // would produce either way, so the operator has named something that
+        // is not there and the honest answer is to say so.
+        return match mode {
+            Load::Start => start_bare_shepherd(streams, paths, guard).await,
+            Load::Add => streams.fail(
+                ExitCode::Usage,
+                "no target and no Flockfile in this directory",
+            ),
+        };
+    }
+    let shep_toml_text = std::fs::read_to_string(&paths.daemon_config).ok();
+    let interpreters = interpreters_from_config(shep_toml_text.as_deref());
+    let client = match connect_or_spawn_client(streams, paths, guard).await {
+        Ok(client) => client,
+        Err(code) => return code,
+    };
+    match mode {
+        Load::Start => {
+            lifecycle::start(&client, streams, args, discovered.as_deref(), &interpreters).await
+        }
+        Load::Add => {
+            lifecycle::add(&client, streams, args, discovered.as_deref(), &interpreters).await
         }
     }
 }

--- a/crates/shep-cli/tests/cli_e2e.rs
+++ b/crates/shep-cli/tests/cli_e2e.rs
@@ -9062,3 +9062,140 @@ fn a_successor_inheriting_an_empty_flock_does_not_restore_the_roll() {
 
     graceful_kill(home);
 }
+
+/// `shep add` registers a sheep, starts nothing, and a later `shep start`
+/// brings that same sheep up.
+///
+/// The whole sequence the verb exists for. A Flockfile is a template, and one
+/// shipping `env = { DB_HOST = "", DB_PASSWORD = "" }` is the endorsed
+/// pattern -- the `.env.example` convention. Without `add`, the first thing an
+/// operator does with such a file is `shep start Flockfile.toml`, which spawns
+/// a process against an empty database URL: it crashes, `autorestart` spends
+/// the restart budget, and the app has to be stopped before it can be
+/// configured. With `add` the order is register, fill in, start.
+///
+/// The listing is read ONCE and not polled, deliberately. `Request::Add` is
+/// answered after the actor has registered, exactly as `Request::Start` is
+/// answered after the actor has spawned, so a build that routed `add` through
+/// the start path reports `online` on this very first read. Polling for
+/// `stopped` would spin out the deadline and reach the same assertion a lot
+/// later; a single read fails immediately and names the same cause.
+///
+/// What a broken implementation this catches: `add` wired to
+/// `Request::Start` (the row is `online`, and on unix the script's pid file
+/// exists); `add` registering nothing at all (the row is missing, and the
+/// `start` below cannot find it); the app registered under a status a later
+/// `start` cannot resume from (the final poll never reaches `online`).
+#[test]
+fn add_registers_a_stopped_sheep_that_a_later_start_brings_up() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path();
+    let script = write_test_script(&dir);
+    let flockfile = write_flockfile(
+        &dir,
+        &format!(
+            "[[app]]\nname = \"pending\"\nscript = '{}'\n",
+            script.display(),
+        ),
+    );
+    let mut guard = DaemonGuard::default();
+
+    let added = shep(home)
+        .arg("--format")
+        .arg("json")
+        .arg("add")
+        .arg(&flockfile)
+        .output()
+        .unwrap();
+    guard.adopt_home(home);
+    assert_success(&added);
+
+    let envelope: serde_json::Value = serde_json::from_slice(&added.stdout)
+        .unwrap_or_else(|e| panic!("add stdout was not JSON: {e}"));
+    assert_eq!(
+        envelope["command"], "add",
+        "the envelope names the verb the operator typed: {envelope}"
+    );
+    assert_eq!(
+        envelope["data"][0]["status"], "stopped",
+        "registered, not started: {envelope}"
+    );
+    assert!(
+        envelope["data"][0]["pid"].is_null(),
+        "a sheep that was never spawned has no pid: {envelope}"
+    );
+
+    // The strongest form of "nothing spawned" available here: the script
+    // itself appends its pid to this file on every run, so an empty one is
+    // the child's own evidence that it never executed. Unix only, because
+    // `record_pid_line` writes nothing on Windows and says why.
+    #[cfg(unix)]
+    assert!(
+        !dir.path().join(FIXTURE_PIDS).exists(),
+        "the script never ran, so it never recorded a pid"
+    );
+
+    // Registered rather than merely reported: a row `shep flock` cannot see
+    // is not a flock member, and `shep start pending` below would have
+    // nothing to name.
+    let listed = shep(home)
+        .arg("--format")
+        .arg("json")
+        .arg("flock")
+        .output()
+        .unwrap();
+    assert_success(&listed);
+    let flock: serde_json::Value = serde_json::from_slice(&listed.stdout).unwrap();
+    assert_eq!(flock["data"][0]["name"], "pending", "it is in the flock");
+    assert_eq!(flock["data"][0]["status"], "stopped", "and still at rest");
+
+    // By NAME, which is the half of the sequence that proves the
+    // registration was the real thing: a name reads no file, so this can only
+    // reach a sheep the flock already holds.
+    let started = shep(home).arg("start").arg("pending").output().unwrap();
+    assert_success(&started);
+    let running = poll_flock(home, |info| info["status"] == "online");
+    assert_eq!(
+        running["status"], "online",
+        "the registered sheep came up: {running}"
+    );
+
+    graceful_kill(home);
+}
+
+/// `shep add` with no target and no Flockfile in the current directory is a
+/// usage error, where bare `shep start` brings a shepherd up.
+///
+/// The one thing the two verbs disagree about. `start`'s empty-directory case
+/// means "give me a shepherd with nothing running yet", which is the only way
+/// to get one without also starting a process. `add` cannot mean that: a
+/// shepherd holding nothing is what it would produce either way, so the
+/// operator has named something that is not there.
+///
+/// The temporary directory is the working directory as well as the home, so
+/// there is genuinely no Flockfile to discover.
+///
+/// What a broken implementation this catches: `add` falling through to
+/// `start_bare_shepherd` (exit 0, and a daemon left running behind it).
+#[test]
+fn add_with_nothing_to_add_is_a_usage_error() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path();
+
+    let output = shep(home).arg("add").current_dir(home).output().unwrap();
+
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "clap's own code for bad arguments: {output:?}"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("no target and no Flockfile"),
+        "the refusal says what was missing: {stderr}"
+    );
+    assert!(
+        !home.join("run").join("shep.sock").exists(),
+        "and no shepherd was started to answer a request nobody made"
+    );
+}

--- a/crates/shep-core/CHANGELOG.md
+++ b/crates/shep-core/CHANGELOG.md
@@ -10,6 +10,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `Request::Add` and `Response::Added`: register apps as flock members
+  without starting any of them. Everything `Start` does to membership and
+  none of what it does to processes, so a Flockfile shipping empty `env`
+  keys can be registered and configured before anything spawns against
+  them. `PROTOCOL_VERSION` stays at 2, following the six additive
+  precedents below it: no existing variant moved, was renamed, or was
+  retyped. The consequence is the same one `Request::ApplyConfig` carried:
+  a CLI from this commit passes an older daemon's handshake, sends `add`,
+  and that daemon ends the connection on an envelope it cannot decode, so
+  the operator sees a dead client rather than a named version refusal.
+  `shep daemon reload` after upgrading is the fix.
+
 ## [0.1.30] - 2026-09-03
 
 ### Added

--- a/crates/shep-core/CHANGELOG.md
+++ b/crates/shep-core/CHANGELOG.md
@@ -18,11 +18,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   keys can be registered and configured before anything spawns against
   them. `PROTOCOL_VERSION` stays at 2, following the six additive
   precedents below it: no existing variant moved, was renamed, or was
-  retyped. The consequence is the same one `Request::ApplyConfig` carried:
-  a CLI from this commit passes an older daemon's handshake, sends `add`,
-  and that daemon ends the connection on an envelope it cannot decode, so
-  the operator sees a dead client rather than a named version refusal.
-  `shep daemon reload` after upgrading is the fix.
+  retyped. An older shepherd cannot decode the variant, and what an
+  operator meets depends on whether the crate version moved with it.
+  Across a release, `shep-cli`'s skew guard refuses first: it compares the
+  shepherd's reported version against the client's own and refuses every
+  verb but `kill`, `ping` and `daemon reload`, so `shep add` exits
+  `version_skew` naming `shep daemon reload` before the request is sent.
+  Within one version, a client built from this commit against a shepherd
+  built from an earlier one, the versions match, the guard passes, and the
+  shepherd ends the connection on an envelope it cannot decode. Restart the
+  shepherd either way.
 
 ## [0.1.30] - 2026-09-03
 

--- a/crates/shep-core/src/protocol/request.rs
+++ b/crates/shep-core/src/protocol/request.rs
@@ -277,7 +277,7 @@ pub enum Request {
     ///
     /// Idempotent by name, like the muster restore that shares its supervisor
     /// path: an app the flock already has is answered as it stands, running
-    /// or not, and nothing about it changes. Config is a separate request —
+    /// or not, and nothing about it changes. Config is a separate request:
     /// [`Self::ApplyConfig`] is what merges a template into an app the flock
     /// already has, and `shep add` sends both.
     ///
@@ -1520,7 +1520,7 @@ pub enum Response {
     ///
     /// A row here can still be `Online`. `Add` is idempotent by name, so an
     /// app the flock already had is answered as it stands rather than
-    /// replaced — the reply describes the membership the request leaves
+    /// replaced. The reply describes the membership the request leaves
     /// behind, not work it did.
     Added(Vec<ProcessInfo>),
     /// Answer to `ConfigDrift`: one entry per app that is registered under a

--- a/crates/shep-core/src/protocol/request.rs
+++ b/crates/shep-core/src/protocol/request.rs
@@ -263,6 +263,31 @@ pub enum Request {
         /// untrusted); failures return [`RpcErrorCode::InvalidConfig`]
         apps: Vec<AppConfig>,
     },
+    /// Register apps as flock members without starting any of them
+    ///
+    /// Everything [`Self::Start`] does to the flock's membership and none of
+    /// what it does to processes: each app lands `Stopped`, holds no pid, and
+    /// nothing is spawned. `shep add` is the verb.
+    ///
+    /// It exists because a Flockfile is a template. One shipping
+    /// `env = { DB_PASSWORD = "" }` would otherwise have to be STARTED before
+    /// it could be configured, and a process spawned against an empty
+    /// database URL crashes, spends its restart budget, and has to be stopped
+    /// before the operator can get anywhere near it.
+    ///
+    /// Idempotent by name, like the muster restore that shares its supervisor
+    /// path: an app the flock already has is answered as it stands, running
+    /// or not, and nothing about it changes. Config is a separate request —
+    /// [`Self::ApplyConfig`] is what merges a template into an app the flock
+    /// already has, and `shep add` sends both.
+    ///
+    /// Answers [`Response::Added`].
+    Add {
+        /// App configs, carried exactly as [`Self::Start`] carries them. The
+        /// daemon MUST re-normalize (peer input is untrusted); failures
+        /// return [`RpcErrorCode::InvalidConfig`]
+        apps: Vec<AppConfig>,
+    },
     /// Ask which of `apps` name a sheep the flock already has under a
     /// different config
     ///
@@ -1490,6 +1515,14 @@ pub enum Response {
     Described(Vec<ProcessInfo>),
     /// Answer to `Start`
     Started(Vec<ProcessInfo>),
+    /// Answer to `Add`: one row per app the request named, registered and
+    /// spawning nothing.
+    ///
+    /// A row here can still be `Online`. `Add` is idempotent by name, so an
+    /// app the flock already had is answered as it stands rather than
+    /// replaced — the reply describes the membership the request leaves
+    /// behind, not work it did.
+    Added(Vec<ProcessInfo>),
     /// Answer to `ConfigDrift`: one entry per app that is registered under a
     /// config different from the one asked about, and no entry for anything
     /// else. An empty vector means every app asked about either matches or
@@ -2150,6 +2183,28 @@ mod tests {
     /// `NotWritten` stops carrying its reason. That reason is the only thing that
     /// distinguishes "the app is not reading its stdin" from "the pipe broke", and
     /// the operator's next move differs between them.
+    /// fails if an `Add` decodes as anything but an `Add`.
+    ///
+    /// `Add` and `Start` carry byte-identical payloads and differ by their
+    /// `kind` alone, so the tag is the entire distinction between registering
+    /// an app and spawning it. The snapshot above pins what this ENCODES to;
+    /// this pins what a daemon reading those bytes gets back, which is the
+    /// half that decides whether a process starts.
+    #[test]
+    fn an_add_request_and_its_reply_round_trip() {
+        let request = Request::Add {
+            apps: vec![AppConfig::minimal("web", "./srv")],
+        };
+        let json = serde_json::to_string(&request).unwrap();
+        assert_eq!(serde_json::from_str::<Request>(&json).unwrap(), request);
+        assert!(json.contains(r#""kind":"add""#), "{json}");
+
+        let reply = Response::Added(vec![]);
+        let json = serde_json::to_string(&reply).unwrap();
+        assert_eq!(serde_json::from_str::<Response>(&json).unwrap(), reply);
+        assert!(json.contains(r#""kind":"added""#), "{json}");
+    }
+
     #[test]
     fn a_send_line_request_and_its_reply_round_trip() {
         let request = Request::SendLine {
@@ -2488,6 +2543,20 @@ mod tests {
                         declared_env: ["DATABASE_URL"].iter().map(|k| (*k).to_string()).collect(),
                     }],
                     reset: ResetDepth::Settings,
+                },
+            },
+            // The same app as the `start` row above, deliberately: the two
+            // requests carry identical payloads and differ by their `kind`
+            // alone, so an `add` that serialized under `start`'s tag -- the
+            // shape a copy-pasted variant takes -- shows up here as two
+            // identical objects rather than as a diff a reader has to
+            // compare field by field. The same trick the `reopen`/`flush`
+            // pair above plays.
+            Envelope {
+                id: 27,
+                deadline_ms: None,
+                body: Request::Add {
+                    apps: vec![AppConfig::minimal("web", "./srv")],
                 },
             },
         ];
@@ -2858,6 +2927,17 @@ mod tests {
                         Some("worker is not registered".to_string()),
                     ),
                 ])),
+            },
+            // `Added`'s tag. It is a `Vec<ProcessInfo>` like three of the
+            // rows above, so the tag is the only thing about it a fixture can
+            // prove, and empty is the shape that proves it -- the same
+            // reasoning the block of empty rows further up states for its
+            // own. Down here rather than beside `Started`, where it belongs
+            // by meaning, because every id in this vector is hand-written and
+            // an insertion in the middle renumbers twenty rows for nothing.
+            Reply {
+                id: 33,
+                result: Ok(Response::Added(vec![])),
             },
         ];
         insta::assert_json_snapshot!("reply_wire_v2", replies);

--- a/crates/shep-core/src/protocol/snapshots/shep_core__protocol__request__tests__reply_wire_v2.snap
+++ b/crates/shep-core/src/protocol/snapshots/shep_core__protocol__request__tests__reply_wire_v2.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/shep-core/src/protocol/request.rs
-assertion_line: 2604
 expression: replies
 ---
 [
@@ -651,6 +650,15 @@ expression: replies
             "refused": "worker is not registered"
           }
         ]
+      }
+    }
+  },
+  {
+    "id": 33,
+    "result": {
+      "Ok": {
+        "kind": "added",
+        "data": []
       }
     }
   }

--- a/crates/shep-core/src/protocol/snapshots/shep_core__protocol__request__tests__request_wire_v2.snap
+++ b/crates/shep-core/src/protocol/snapshots/shep_core__protocol__request__tests__request_wire_v2.snap
@@ -343,5 +343,56 @@ expression: requests
       ],
       "reset": "settings"
     }
+  },
+  {
+    "id": 27,
+    "deadline_ms": null,
+    "body": {
+      "kind": "add",
+      "apps": [
+        {
+          "name": "web",
+          "script": "./srv",
+          "args": [],
+          "cwd": null,
+          "interpreter": null,
+          "env": {},
+          "instances": 1,
+          "autorestart": true,
+          "autostart": true,
+          "stop_exit_codes": [],
+          "min_uptime": "1s",
+          "max_restarts": 16,
+          "restart_delay": null,
+          "exp_backoff_restart_delay": "100",
+          "kill_signal": null,
+          "kill_timeout": "1600",
+          "shutdown_with_message": false,
+          "listen_timeout": "3s",
+          "graceful_timeout": "8s",
+          "action_timeout": "3s",
+          "max_memory": null,
+          "watch": false,
+          "ignore_watch": [],
+          "watch_delay": null,
+          "cron_restart": null,
+          "fold": null,
+          "user": null,
+          "group": null,
+          "out_file": null,
+          "err_file": null,
+          "merge_logs": false,
+          "channel": false,
+          "stdin": false,
+          "wait_ready": false,
+          "reuse_port": false,
+          "readiness_probe": null,
+          "liveness_probe": null,
+          "watch_options": [],
+          "cron_timezone": null,
+          "increment_var": null
+        }
+      ]
+    }
   }
 ]

--- a/crates/shep-daemon/src/rpc.rs
+++ b/crates/shep-daemon/src/rpc.rs
@@ -294,6 +294,29 @@ async fn run(id: u64, conn: ConnId, request: Request, ctx: &RpcContext) -> Outco
                 }
             }
         },
+        // The membership half of `Start` with none of the spawning, and the
+        // same untrusted-peer rule: re-normalize before anything is
+        // registered.
+        //
+        // Recorded in the registry exactly as `Start` is. An added app is a
+        // flock member that happens to be stopped, so a `shep save` after a
+        // `shep add` has to write it -- without this the roll would forget an
+        // app that was registered and never started, which is the whole
+        // sequence this request exists to make possible.
+        Request::Add { apps } => match normalize_all(apps) {
+            Err(err) => reply(Err(RpcError {
+                code: RpcErrorCode::InvalidConfig,
+                message: err.to_string(),
+                daemon_version: None,
+            })),
+            Ok(resolved) => {
+                ctx.registry.record(&resolved);
+                match ctx.supervisor.register_at_rest(resolved).await {
+                    Ok(infos) => reply(Ok(Response::Added(infos))),
+                    Err(err) => reply(Err(rpc_error(&err))),
+                }
+            }
+        },
         // Re-normalized for the reason `Start` is, plus one of its own: an
         // unnormalized config would report every default it did not spell
         // out as a difference from the normalized copy the flock stores, so
@@ -1160,6 +1183,131 @@ mod tests {
             .await,
         );
         assert_eq!(reply.result.unwrap_err().code, RpcErrorCode::InvalidConfig);
+    }
+
+    /// fails if `Add` spawns anything.
+    ///
+    /// The harness is scripted with NO processes, which is the forcing
+    /// mechanism rather than a convenience: `ScriptedRunner::spawn` refuses
+    /// with `script exhausted` once the list is empty, so a build that routed
+    /// this at `do_start` cannot reach a row that is `Stopped` with no pid.
+    /// It would land `Errored`, and the two assertions below say which.
+    #[tokio::test(start_paused = true)]
+    async fn add_registers_a_stopped_member_and_spawns_nothing() {
+        let h = harness(vec![]);
+        let added = reply_of(
+            dispatch(
+                envelope(
+                    1,
+                    Request::Add {
+                        apps: vec![AppConfig::minimal("web", "./srv")],
+                    },
+                ),
+                &h.ctx,
+            )
+            .await,
+        );
+        let Response::Added(infos) = added.result.unwrap() else {
+            panic!("expected added")
+        };
+        assert_eq!(infos.len(), 1);
+        assert_eq!(infos[0].status, ProcStatus::Stopped);
+        assert_eq!(infos[0].pid, None, "nothing was spawned");
+
+        // The roll can only be built if `Add` recorded the config, and an app
+        // registered and never started is precisely the one a roll would
+        // otherwise forget.
+        let roll = h.ctx.registry.roll(&infos, 0);
+        assert_eq!(roll.apps.len(), 1);
+        assert_eq!(roll.apps[0].app.script, "./srv");
+        assert_eq!(roll.apps[0].instances_running, 0);
+
+        let listed = reply_of(dispatch(envelope(2, Request::ListFlock), &h.ctx).await);
+        let Response::Flock(flock) = listed.result.unwrap() else {
+            panic!("expected flock")
+        };
+        assert_eq!(
+            flock.len(),
+            1,
+            "it is a member of the flock, just a still one"
+        );
+    }
+
+    /// fails if `Add` trusts what a peer sent it. Same rule as `Start`: the
+    /// socket is the boundary, and an empty name is the shape `normalize`
+    /// refuses.
+    #[tokio::test(start_paused = true)]
+    async fn add_re_normalizes_untrusted_peer_config() {
+        let h = harness(vec![]);
+        let reply = reply_of(
+            dispatch(
+                envelope(
+                    1,
+                    Request::Add {
+                        apps: vec![AppConfig::minimal("", "./srv")],
+                    },
+                ),
+                &h.ctx,
+            )
+            .await,
+        );
+        assert_eq!(reply.result.unwrap_err().code, RpcErrorCode::InvalidConfig);
+    }
+
+    /// fails if a second `Add` of a name the flock already has registers a
+    /// second row, or disturbs the first.
+    ///
+    /// The sheep here is ONLINE, which is the case that matters: re-running
+    /// `shep add Flockfile.toml` after editing the file is the ordinary thing
+    /// to do, and it must not stop a service. One script, so a second spawn
+    /// would fail rather than pass quietly.
+    #[tokio::test(start_paused = true)]
+    async fn a_second_add_leaves_a_running_sheep_exactly_as_it_was() {
+        let h = harness(vec![ProcScript::never_exits()]);
+        let started = reply_of(
+            dispatch(
+                envelope(
+                    1,
+                    Request::Start {
+                        apps: vec![AppConfig::minimal("web", "./srv")],
+                    },
+                ),
+                &h.ctx,
+            )
+            .await,
+        );
+        let Response::Started(before) = started.result.unwrap() else {
+            panic!("expected started")
+        };
+
+        let added = reply_of(
+            dispatch(
+                envelope(
+                    2,
+                    Request::Add {
+                        apps: vec![AppConfig::minimal("web", "./srv")],
+                    },
+                ),
+                &h.ctx,
+            )
+            .await,
+        );
+        let Response::Added(after) = added.result.unwrap() else {
+            panic!("expected added")
+        };
+        assert_eq!(after.len(), 1);
+        assert_eq!(
+            after[0].id, before[0].id,
+            "the same sheep, not a second one"
+        );
+        assert_eq!(after[0].status, ProcStatus::Online, "still running");
+        assert_eq!(after[0].pid, before[0].pid, "the same process");
+
+        let listed = reply_of(dispatch(envelope(3, Request::ListFlock), &h.ctx).await);
+        let Response::Flock(flock) = listed.result.unwrap() else {
+            panic!("expected flock")
+        };
+        assert_eq!(flock.len(), 1, "one row, not two");
     }
 
     /// One app as a Flockfile would declare it: the config, plus the keys

--- a/crates/shep-daemon/src/supervisor.rs
+++ b/crates/shep-daemon/src/supervisor.rs
@@ -3150,8 +3150,11 @@ impl<R: ProcessRunner> Actor<R> {
             }
             // Not rejected while `shutting_down`, unlike Start: this
             // spawns nothing, so it can leave no child outside the shutdown
-            // aggregation. It is still pointless during a shutdown, and
-            // nothing calls it there.
+            // aggregation. `Request::Add` can now reach it at any moment a
+            // connection is still being served, a shutdown included, and that
+            // is safe for the same reason rather than for a new one: the
+            // worst it can do is register a member of a flock that is on its
+            // way out.
             Command::RegisterAtRest { apps, reply } => {
                 let registered = apps.iter().map(|app| self.register_at_rest(app)).collect();
                 let _ = reply.send(Ok(registered));

--- a/web/scripts/generate-cli-reference.sh
+++ b/web/scripts/generate-cli-reference.sh
@@ -49,10 +49,14 @@ fi
 # This list is hand-kept, and for a long time nothing checked it: `style`
 # and `welcome` shipped and were simply absent from the published
 # reference, because regenerating the file refreshes what is listed here
-# and can say nothing about what is not. `verbs_the_reference_generator_
-# misses` in `cli.rs` now compares it against the binary's own visible
-# subcommands, so a new verb fails a test rather than going quietly
-# undocumented. `help` is clap's own and is the one deliberate omission.
+# and can say nothing about what is not.
+# `every_visible_verb_reaches_the_docs_site_generator` in `cli.rs` now
+# compares it against the binary's own visible subcommands, so a new verb
+# fails a test rather than going quietly undocumented. (That name is the
+# real one. Both this comment and web/src/data/cliReference.ts called it
+# `verbs_the_reference_generator_misses`, which has never existed.)
+#
+# `help` is clap's own and is the one deliberate omission.
 VERBS=(
   start add serve stop restart reload delete stock flock dogs enable disable
   adopt rehome describe trigger signal whisper fold bleats lookout whistle

--- a/web/scripts/generate-cli-reference.sh
+++ b/web/scripts/generate-cli-reference.sh
@@ -54,7 +54,7 @@ fi
 # subcommands, so a new verb fails a test rather than going quietly
 # undocumented. `help` is clap's own and is the one deliberate omission.
 VERBS=(
-  start serve stop restart reload delete stock flock dogs enable disable
+  start add serve stop restart reload delete stock flock dogs enable disable
   adopt rehome describe trigger signal whisper fold bleats lookout whistle
   reopen flush barks set get unset ping kill save muster runtime dev
   import startup unstartup completions init style welcome

--- a/web/src/data/cli-reference.generated.txt
+++ b/web/src/data/cli-reference.generated.txt
@@ -10,7 +10,7 @@ Getting started
   shep save               remember this flock across reboots
   shep startup            bring it back after a reboot
 
-Run things       start serve stop restart reload delete stock
+Run things       start add serve stop restart reload delete stock
 See what's up    flock describe bleats lookout fold barks
 Survive reboots  save muster startup unstartup
 Talk to a sheep  trigger signal whisper
@@ -85,14 +85,145 @@ Arguments:
           The wildcard selectors work here too, and mean what they mean everywhere else: `all`,
           `/regex/`, and glob patterns such as `web-*`. They reach only sheep the flock already has,
           since there is nothing to register. A sheep already running is reported and left alone;
-          `restart` is the verb that replaces one.
+          `restart` is the verb that replaces one, and `add` never starts anything in the first
+          place.
           
-          Omit the targets to start the Flockfile in the current directory, or, when there is none,
-          to bring a shepherd up with nothing running yet.
+          Omit the targets to read the Flockfile in the current directory. With no Flockfile there,
+          `shep start` brings a shepherd up with nothing running yet, and `shep add` has nothing it
+          could register.
           
-          Several are started in turn, not atomically: if the second fails the first is already up,
-          and the exit code is the first failure. `--name` is refused with more than one, since a
-          name is unique to one sheep.
+          Several are handled in turn, not atomically: if the second fails the first has already
+          landed, and the exit code is the first failure. `--name` is refused with more than one,
+          since a name is unique to one sheep.
+
+Options:
+      --format <FORMAT>
+          Output format
+
+          Possible values:
+          - table: Human-readable columns (the default)
+          - json:  A versioned JSON envelope, one object per invocation
+          
+          [default: table]
+
+      --name <NAME>
+          Name for this sheep (script form only)
+
+      --fold <FOLD>
+          Fold to place this sheep in
+
+  -q, --quiet
+          Suppress non-essential output
+          
+          Currently narrows `bleats`' own notices (a dropped-events count, a daemon-shutdown notice,
+          ...): diagnostics distinct from a sheep's own line or a real error, both of which still
+          print regardless.
+
+      --cwd <CWD>
+          Working directory to run in (default: where you ran `shep start`)
+
+      --style <STYLE>
+          How much this invocation dresses up its output: `full`, `plain`, or `bare`
+          
+          Wins over `$SHEP_STYLE` and `shep.toml`'s `[style] level`. Omit to let those decide; `shep
+          style` reports which one answered.
+
+          Possible values:
+          - full:  Sheep, boxes and colour
+          - plain: Boxes and colour, no sheep
+          - bare:  Exactly what shep printed before any of this, and exactly what a pipe gets
+
+      --home <HOME>
+          Talk to a different shepherd
+          
+          Mostly plumbing: `shep dev` sessions, a system-wide flock, tests. You almost certainly
+          want the default, ~/.shep.
+          
+          [env: SHEP_HOME=]
+
+      --interpreter <INTERPRETER>
+          Interpreter to run the script with, overriding both shep.toml's extension mapping and a
+          Flockfile app's own interpreter field.
+          
+          The precedence, lowest to highest: shep.toml's interpreters table (matched against the
+          script's extension), then a Flockfile's own interpreter for that app, then this flag. shep
+          never guesses an interpreter on its own; every one of those three is something an operator
+          wrote down. Pass "none" to run the script directly, overriding a mapping or a Flockfile
+          that would otherwise pick one.
+
+      --flockfile
+          Read TARGET as a Flockfile rather than as a script path.
+          
+          Required for a `.js` Flockfile and the only way to reach one: shep reads a `.js` config by
+          running it through node, which is arbitrary code execution, so it never happens because a
+          file merely has that extension. Without this flag `shep start server.js` starts
+          `server.js` as a script, which is what it has always meant.
+
+      --reset
+          Put process settings back to what the Flockfile says, keeping env.
+          
+          Every setting goes back, whether the file declares it or not: a key the file is silent
+          about goes to the value a fresh `shep start` off that same file would give it. Without
+          this flag a load is additive: it appends keys nobody has set and overwrites nothing. `env`
+          is operator-supplied data and survives even this reset; everything else is operator-tuned
+          policy, and resetting policy is recoverable. Refused when the target supplies no template
+          to reset to: a sheep name reads no file, and a bare script path is a command line rather
+          than a file.
+
+      --reset-all
+          Put everything back to what the Flockfile says, including env, and drop the override
+          record.
+          
+          The wider of the two resets: `--reset` keeps `env` because it is operator-supplied data,
+          not policy, and losing it takes the app's database away. This flag drops it too. Refused
+          on the same targets `--reset` is: a sheep name reads no file, and a bare script path is a
+          command line rather than a file.
+
+  -h, --help
+          Print help (see a summary with '-h')
+
+  -V, --version
+          Print version
+@@VERB:add@@
+Register a sheep without starting it.
+
+The same targets `shep start` takes and the same load path. The one difference is that nothing
+spawns: the app lands registered and stopped, and `shep start <name>` is what brings it up.
+
+It is here for the Flockfile a project commits with its secrets left blank: `env = { DB_HOST = "",
+DB_PASSWORD = "" }`, the `.env.example` convention. Starting that file spawns a process against an
+empty database URL, which crashes, spends its restart budget, and has to be stopped before anyone
+can configure it. This registers it instead, so the order becomes register, fill in, start.
+
+An app the flock already has is merged into and left exactly as it is, running or not.
+
+Usage: shep add [OPTIONS] [TARGETS]...
+
+Arguments:
+  [TARGETS]...
+          Selectors, script paths, Flockfiles, or `-` to read Flockfile JSON from stdin
+          
+          A target is resolved in four tiers and the first one that matches wins: a sheep the flock
+          already has, by id or by name; then a fold, written either as `fold:<name>` or as the bare
+          fold name; then a Flockfile, by its extension; then a path on disk, started as a script.
+          
+          So `shep start backed` starts the fold `backed` even when a file called `backed` is
+          sitting in the current directory. Write `./backed` to mean the file: a sheep name may
+          never contain a path separator, so a target carrying one is always a path.
+          
+          The wildcard selectors work here too, and mean what they mean everywhere else: `all`,
+          `/regex/`, and glob patterns such as `web-*`. They reach only sheep the flock already has,
+          since there is nothing to register. A sheep already running is reported and left alone;
+          `restart` is the verb that replaces one, and `add` never starts anything in the first
+          place.
+          
+          Omit the targets to read the Flockfile in the current directory. With no Flockfile there,
+          `shep start` brings a shepherd up with nothing running yet, and `shep add` has nothing it
+          could register.
+          
+          Several are handled in turn, not atomically: if the second fails the first has already
+          landed, and the exit code is the first failure. `--name` is refused with more than one,
+          since a name is unique to one sheep.
 
 Options:
       --format <FORMAT>

--- a/web/src/data/cliReference.ts
+++ b/web/src/data/cliReference.ts
@@ -47,7 +47,8 @@ export interface CliReferenceData {
 // groups against this list rather than against the generated file, so the
 // two agreed with each other while both disagreed with the binary. The
 // generator's `VERBS` array has a Rust test holding it to the real command
-// tree (`verbs_the_reference_generator_misses`); this list has nothing, and
+// tree (`every_visible_verb_reaches_the_docs_site_generator` in
+// crates/shep-cli/src/cli.rs); this list has nothing, and
 // the only thing standing between it and the same drift is the build error
 // you get when the groups and this list disagree.
 const VERB_NAMES = [

--- a/web/src/data/cliReference.ts
+++ b/web/src/data/cliReference.ts
@@ -52,6 +52,7 @@ export interface CliReferenceData {
 // you get when the groups and this list disagree.
 const VERB_NAMES = [
   "start",
+  "add",
   "serve",
   "stop",
   "restart",

--- a/web/src/data/cliReference.ts
+++ b/web/src/data/cliReference.ts
@@ -39,6 +39,17 @@ export interface CliReferenceData {
 // Kept here (rather than re-derived from the generated file) so a missing
 // or misspelled `@@VERB:...@@` marker is a loud parse error, not a silently
 // short verb list.
+//
+// It was silently short by three anyway, from whenever `init`, `style` and
+// `welcome` shipped until 2026-09-03. Nothing caught it: this list is what
+// the page renders FROM, so a verb absent here is a verb the reference
+// simply does not have, and `cli.astro`'s own count check compares the
+// groups against this list rather than against the generated file, so the
+// two agreed with each other while both disagreed with the binary. The
+// generator's `VERBS` array has a Rust test holding it to the real command
+// tree (`verbs_the_reference_generator_misses`); this list has nothing, and
+// the only thing standing between it and the same drift is the build error
+// you get when the groups and this list disagree.
 const VERB_NAMES = [
   "start",
   "serve",
@@ -77,6 +88,9 @@ const VERB_NAMES = [
   "startup",
   "unstartup",
   "completions",
+  "init",
+  "style",
+  "welcome",
 ] as const;
 
 function fail(message: string): never {

--- a/web/src/pages/docs/cli.astro
+++ b/web/src/pages/docs/cli.astro
@@ -79,8 +79,12 @@ const groups = [
     verbs: ["import", "startup", "unstartup"],
   },
   {
-    title: "Shell completions",
-    verbs: ["completions"],
+    title: "Getting oriented",
+    verbs: ["welcome", "init"],
+  },
+  {
+    title: "Your shell and terminal",
+    verbs: ["completions", "style"],
   },
 ];
 

--- a/web/src/pages/docs/cli.astro
+++ b/web/src/pages/docs/cli.astro
@@ -40,7 +40,16 @@ const byName = new Map(cliReference.verbs.map((v) => [v.name, v]));
 const groups = [
   {
     title: "Managing a sheep",
-    verbs: ["start", "serve", "stop", "restart", "reload", "delete", "stock"],
+    verbs: [
+      "start",
+      "add",
+      "serve",
+      "stop",
+      "restart",
+      "reload",
+      "delete",
+      "stock",
+    ],
   },
   {
     title: "Inspecting the flock",

--- a/web/src/pages/docs/first-flockfile.astro
+++ b/web/src/pages/docs/first-flockfile.astro
@@ -194,6 +194,15 @@ script = "./server"`}</CodeBlock>
       whole story, including which settings change under a running process
       and which wait for the next spawn.
     </p>
+    <p>
+      A template that ships its secrets blank, <code>env = &#123; DB_HOST =
+      "", DB_PASSWORD = "" &#125;</code>, has one more problem:
+      <code>shep start</code> would spawn the app against those blanks and
+      leave it crash-looping. <code>shep add Flockfile.toml</code> takes the
+      same targets and the same load and spawns nothing, so the app lands
+      registered and stopped, and <code>shep start web</code> brings it up
+      once it has real values.
+    </p>
     <p class="fine">
       Naming a sheep reads no Flockfile at all. <code>shep start web</code>
       starts the sheep called <code>web</code> from the config the shepherd

--- a/web/src/pages/docs/overrides.astro
+++ b/web/src/pages/docs/overrides.astro
@@ -3,8 +3,8 @@
  * Overrides (crates/shep-core/src/overrides.rs, crates/shep-core/src/config/apply.rs
  * for ApplyGroup and ResetDepth, crates/shep-daemon/src/supervisor.rs for
  * merge_declared and handle_apply_config, `shep start --help`). Every
- * transcript below was run for real against target/release/shep on
- * 2026-09-02, one sheep in a throwaway $SHEP_HOME, and re-run there twice the
+ * transcript below was run for real against target/release/shep, one sheep in
+ * a throwaway $SHEP_HOME. All but one on 2026-09-02, re-run there twice the
  * same day: once when a fresh start began establishing the keys its file
  * declared, and again when a review found the reset-scales sample still
  * carrying a `cwd` clause the fixed binary does not print. The `cwd` the
@@ -12,6 +12,12 @@
  * it so the promotion can spawn. A `cwd` equal to where the app already runs
  * parks nothing, and on macOS a /tmp path and its /private/tmp resolution
  * differ enough to park one for a reason no reader could reproduce.
+ *
+ * `addFirst` is the exception: run on 2026-09-03, when `shep add` shipped,
+ * in a throwaway $SHEP_HOME of its own. Its RESTARTS column reads 1 on the
+ * third command and that is the real output, not a paste error. `shep start
+ * <name>` resumes a stopped sheep through `Request::Restart`, which counts
+ * a restart, and has since long before this verb.
  */
 import DocsLayout from "../../layouts/DocsLayout.astro";
 import ReferencePills from "../../components/docs/ReferencePills.astro";
@@ -73,6 +79,18 @@ notice[start]: web: env waiting on the next spawn (\`shep reload web\` promotes 
 notice[start]: web is already online; \`shep restart web\` replaces it.
 ID  NAME  STATUS  PID    RESTARTS  EXIT  CFG  CPU  MEM   UPTIME  FOLD  SMIT
 1   web   online  96368  0         -     !1   -    1.2M  3s      -     -`;
+
+const addFirst = `$ shep add Flockfile.toml
+ID  NAME  STATUS   PID  RESTARTS  EXIT  CFG  CPU  MEM  UPTIME  FOLD  SMIT
+0   web   stopped  -    0         -     -    -    -    0s      -     -
+
+$ shep flock
+ID  NAME  STATUS   PID  RESTARTS  EXIT  CFG  CPU  MEM  UPTIME  FOLD  SMIT
+0   web   stopped  -    0         -     -    -    -    0s      -     -
+
+$ shep start web
+ID  NAME  STATUS  PID   RESTARTS  EXIT  CFG  CPU  MEM    UPTIME  FOLD  SMIT
+0   web   online  4745  1         -     -    -    32.0K  0s      -     -`;
 
 const resetScales = `$ shep flock
 ID  NAME   STATUS  PID    RESTARTS  EXIT  CFG  CPU  MEM   UPTIME  FOLD  SMIT
@@ -318,6 +336,44 @@ const store = `$ cat $SHEP_HOME/overrides.json
       supposed to: the key was established, so the template no longer speaks
       for it. <code>--reset-all</code> is the only thing that hands
       <code>env</code> back to the file.
+    </p>
+
+    <h2>Registering before starting</h2>
+    <p>
+      <code>shep add</code> takes the targets <code>shep start</code> takes
+      and runs the same load. The one difference is that nothing spawns: the
+      app lands registered and stopped, with the keys its file declared
+      already established, and <code>shep start &lt;name&gt;</code> is what
+      brings it up.
+    </p>
+    <CodeBlock>{addFirst}</CodeBlock>
+    <p>
+      The empty values above are why it exists. Starting that file spawns a
+      process against an empty database URL: it crashes,
+      <code>autorestart</code> spends the restart budget on it, and the app
+      has to be stopped before anyone can configure it. Registering first
+      puts the steps in the order they belong.
+    </p>
+    <p class="fine">
+      The <code>1</code> under RESTARTS is not something <code>add</code>
+      did. <code>shep start &lt;name&gt;</code> brings a stopped sheep up
+      through the same request <code>shep restart</code> uses, and has
+      counted it that way since before this verb existed.
+    </p>
+    <Callout variant="careful">
+      The middle step is the one shep has no verb for yet. Filling in an
+      established key today means editing the Flockfile and loading it with
+      <code>--reset-all</code>, which hands <code>env</code> back to the file
+      and drops the override record with it. Read
+      <a href="#the-reset-flags-reshape-the-flock">the reset warning</a>
+      first if the app has been scaled.
+    </Callout>
+    <p>
+      Running <code>shep add</code> again changes nothing and prints nothing,
+      the way a second load of an unchanged file does. Naming a sheep instead
+      of a file says so out loud, because a name reads no Flockfile at all
+      and leaves nothing to register:
+      <code>notice[add]: web is already registered; nothing to add.</code>
     </p>
 
     <h2>A template may add, never overwrite</h2>


### PR DESCRIPTION
`shep add Flockfile.toml` and `shep add ./server` take the same targets `shep start` takes, run the same load path, and spawn nothing. The app lands registered and stopped. Decision 7 of `docs/brainstorming/specs/2026-09-02-config-overrides-design.md`.

- `Request::Add` / `Response::Added` wired to the existing `register_at_rest`, whose doc already anticipated a second caller, so no new supervisor machinery
- `start` and `add` are one code path (`lifecycle::load`, carrying a `Load`), differing in four places: which request a fresh app goes out as, whether an app the flock already has is resumed after the merge, what a name target that resolves to a registered sheep does, and the notice code
- an app the flock already has is merged into and left running, so re-running a file after a template edit cannot stop a service
- bare `shep add` in a directory with no Flockfile is a usage error, where bare `shep start` brings a shepherd up
- `web/`: regenerated CLI reference, `add` in the groups, a section on `overrides.astro` with a transcript run for real, a paragraph on `first-flockfile.astro`
- separate commit, unrelated: `init`, `style` and `welcome` have never appeared on the published CLI reference. The two hand-kept lists agreed with each other while both disagreed with the binary, so the count check passed at 37 the whole time. Easy to drop if you would rather it went on its own.

The fill-in half of "register, fill in, start" does not exist yet. An established `env` key today moves only through the Flockfile plus `--reset-all`, which hands `env` back to the file and drops the override record with it. Editing a value in place is a later slice (spec decisions 10 and 11). The overrides page says this where an operator reads it.

`PROTOCOL_VERSION` stays at 2, following the six additive precedents in shep-core's changelog. A CLI from this branch against an older daemon fails on a dead client rather than a named version refusal, exactly as `ApplyConfig` does, so `shep daemon reload` after upgrading.

One thing I left alone: `shep start <name>` on a stopped sheep reports 1 under RESTARTS, because it resumes through `Request::Restart`. That is pre-existing, confirmed by running the same sequence with no `add` in it, but `add` makes it the first thing you see. The docs page calls it out rather than hiding it.

Every new test proven non-vacuous by mutating what it protects and watching that one test go red: routing the arm through `do_start`, dropping the normalize refusal, removing the `AlreadyKnown` early return, renaming the wire tag to `start`, dropping the resume guard, and falling through to `start_bare_shepherd`.

Gate, each command's `$?` captured directly: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`, `cargo test --workspace --all-features` (2375 passed, 0 failed), `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features`, all EXIT=0. `astro build` and `astro check` EXIT=0, 0 errors and 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added `shep add` to register applications in a stopped state without launching them.
  - Supports Flockfile registration, configuration merging, and starting applications later by name.
  - Repeated additions are handled safely without changing already-running applications.
- **Documentation**
  - Updated CLI help, reference materials, and guides with `shep add` usage, behavior, and limitations.
- **Tests**
  - Added coverage for registration, stopped-state behavior, configuration handling, repeated additions, and invalid usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->