### PR TITLE
chore: release v0.1.31

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2058,7 +2058,7 @@ dependencies = [
 
 [[package]]
 name = "shep"
-version = "0.1.30"
+version = "0.1.31"
 dependencies = [
  "anstyle",
  "assert_cmd",
@@ -2096,11 +2096,11 @@ dependencies = [
 
 [[package]]
 name = "shep-cli"
-version = "0.1.30"
+version = "0.1.31"
 
 [[package]]
 name = "shep-client"
-version = "0.1.30"
+version = "0.1.31"
 dependencies = [
  "futures-util",
  "nix 0.29.0",
@@ -2113,7 +2113,7 @@ dependencies = [
 
 [[package]]
 name = "shep-core"
-version = "0.1.30"
+version = "0.1.31"
 dependencies = [
  "annotate-snippets",
  "anstyle",
@@ -2143,7 +2143,7 @@ dependencies = [
 
 [[package]]
 name = "shep-daemon"
-version = "0.1.30"
+version = "0.1.31"
 dependencies = [
  "bytes",
  "chrono",
@@ -2172,7 +2172,7 @@ dependencies = [
 
 [[package]]
 name = "shep-examples"
-version = "0.1.30"
+version = "0.1.31"
 dependencies = [
  "nix 0.29.0",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.30"
+version = "0.1.31"
 edition = "2024"
 # 1.88 forced by serde-saphyr (let-chains, stabilized 1.88) — a current dep,
 # not a future one. Also the floor for ratatui/sysinfo/rmcp in later phases.
@@ -31,9 +31,9 @@ license = "MIT OR Apache-2.0"
 # the `[package]` table — so this literal is not sourced from
 # `workspace.package.version` above and a release bump has to touch both
 # places by hand. If that drifts, `cargo-release` is the mechanical fix.
-shep-core = { path = "crates/shep-core", version = "0.1.30" }
-shep-daemon = { path = "crates/shep-daemon", version = "0.1.30" }
-shep-client = { path = "crates/shep-client", version = "0.1.30" }
+shep-core = { path = "crates/shep-core", version = "0.1.31" }
+shep-daemon = { path = "crates/shep-daemon", version = "0.1.31" }
+shep-client = { path = "crates/shep-client", version = "0.1.31" }
 serde = { version = "1", default-features = false, features = ["derive"] }
 serde_json = { version = "1", default-features = false, features = ["std"] }
 toml = { version = "0.8", default-features = false, features = ["parse", "display"] }

--- a/crates/shep-cli/CHANGELOG.md
+++ b/crates/shep-cli/CHANGELOG.md
@@ -13,6 +13,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.31] - 2026-09-03
+
+### Added
+
+- Shep add, which registers a sheep and starts nothing
+
+### Fixed
+
+- The skew guard already gates add, and say so accurately
+
+
 ## [0.1.30] - 2026-09-03
 
 ### Added

--- a/crates/shep-client/CHANGELOG.md
+++ b/crates/shep-client/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.31] - 2026-09-03
+
+
 ## [0.1.30] - 2026-09-03
 
 

--- a/crates/shep-core/CHANGELOG.md
+++ b/crates/shep-core/CHANGELOG.md
@@ -10,6 +10,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.31] - 2026-09-03
+
+### Added
+
+- A request that registers an app without starting it
+
+### Fixed
+
+- The skew guard already gates add, and say so accurately
+
+
 ### Added
 
 - `Request::Add` and `Response::Added`: register apps as flock members

--- a/crates/shep-daemon/CHANGELOG.md
+++ b/crates/shep-daemon/CHANGELOG.md
@@ -10,6 +10,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.31] - 2026-09-03
+
+### Added
+
+- A request that registers an app without starting it
+
+
 ## [0.1.30] - 2026-09-03
 
 ### Added


### PR DESCRIPTION



## 🤖 New release

* `shep-core`: 0.1.30 -> 0.1.31 (✓ API compatible changes)
* `shep-daemon`: 0.1.30 -> 0.1.31 (✓ API compatible changes)
* `shep-client`: 0.1.30 -> 0.1.31
* `shep`: 0.1.30 -> 0.1.31 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `shep-core`

<blockquote>

## [0.1.31] - 2026-09-03

### Added

- A request that registers an app without starting it

### Fixed

- The skew guard already gates add, and say so accurately


### Added

- `Request::Add` and `Response::Added`: register apps as flock members
  without starting any of them. Everything `Start` does to membership and
  none of what it does to processes, so a Flockfile shipping empty `env`
  keys can be registered and configured before anything spawns against
  them. `PROTOCOL_VERSION` stays at 2, following the six additive
  precedents below it: no existing variant moved, was renamed, or was
  retyped. An older shepherd cannot decode the variant, and what an
  operator meets depends on whether the crate version moved with it.
  Across a release, `shep-cli`'s skew guard refuses first: it compares the
  shepherd's reported version against the client's own and refuses every
  verb but `kill`, `ping` and `daemon reload`, so `shep add` exits
  `version_skew` naming `shep daemon reload` before the request is sent.
  Within one version, a client built from this commit against a shepherd
  built from an earlier one, the versions match, the guard passes, and the
  shepherd ends the connection on an envelope it cannot decode. Restart the
  shepherd either way.
</blockquote>

## `shep-daemon`

<blockquote>

## [0.1.31] - 2026-09-03

### Added

- A request that registers an app without starting it
</blockquote>


## `shep`

<blockquote>

## [0.1.31] - 2026-09-03

### Added

- Shep add, which registers a sheep and starts nothing

### Fixed

- The skew guard already gates add, and say so accurately
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).