### PR TITLE
feat: dog config moves out of shep.toml into dogs.toml

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -572,7 +572,13 @@ once per instance, and labels a multi-instance app's lines with their slot.
 used to live under `[dog.<name>]` in `shep.toml`; it now lives under
 `[<name>]` in a new, hand-editable `$SHEP_HOME/dogs.toml`. The daemon
 migrates any old sections once, at boot, and refuses to boot rather than
-guess when a name exists in both files. `RawDaemonConfig::dog` is kept on
+guess when a name holds VALUES in both files. **Not when a name merely
+exists in both**, which is what this line said and is the rule the branch
+removed: an empty section is a header, not a second value, so an empty
+`[dog.<name>]` in the source is skipped and an empty `[<name>]` in
+`dogs.toml` is written over. Every `shep enable` older than this branch
+scaffolds the first shape, and refusing on it took a mixed-version host to
+a shepherd that would not boot. `RawDaemonConfig::dog` is kept on
 purpose: removing it would turn an un-migrated `shep.toml` into a refused
 boot under `deny_unknown_fields`, so it stays as the thing the migration
 reads from. The migration itself lives in

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -568,5 +568,15 @@ on it reaches every instance behind a confirm naming the count. `shep
 bleats` now reads a log file shared by several instances once instead of
 once per instance, and labels a multi-instance app's lines with their slot.
 
+**A dog's config moved out of `shep.toml` on 2026-09-03.** A dog's section
+used to live under `[dog.<name>]` in `shep.toml`; it now lives under
+`[<name>]` in a new, hand-editable `$SHEP_HOME/dogs.toml`. The daemon
+migrates any old sections once, at boot, and refuses to boot rather than
+guess when a name exists in both files. `RawDaemonConfig::dog` is kept on
+purpose: removing it would turn an un-migrated `shep.toml` into a refused
+boot under `deny_unknown_fields`, so it stays as the thing the migration
+reads from. The migration itself lives in
+`crates/shep-cli/src/commands/dog_migration.rs`.
+
 Project memory (cross-session state) tracks decisions; docs above are the
 source of truth.

--- a/crates/shep-cli/src/cli.rs
+++ b/crates/shep-cli/src/cli.rs
@@ -335,9 +335,9 @@ pub enum Commands {
     /// Turn off a registered dog: removes it from `[daemon] enabled_dogs`,
     /// and stops it now if a shepherd is running.
     ///
-    /// Leaves `[dog.<name>]` in place — the dog's own configuration
-    /// survives a disable/enable cycle. `shep rehome` is the verb that
-    /// forgets a dog entirely.
+    /// Leaves `[<name>]` in `dogs.toml` in place: the dog's own
+    /// configuration survives a disable/enable cycle. `shep rehome` is the
+    /// verb that forgets a dog entirely.
     Disable(DogArgs),
     /// Vet a binary shep has never seen and register it as a dog: writes
     /// `[daemon] adopted_dogs` and `[daemon] enabled_dogs` in `shep.toml`,
@@ -356,7 +356,7 @@ pub enum Commands {
     Adopt(AdoptArgs),
     /// Forget an adopted dog entirely: stops it if a shepherd is running,
     /// and removes it from `[daemon] enabled_dogs`, `[daemon]
-    /// adopted_dogs`, and its own `[dog.<name>]` table.
+    /// adopted_dogs`, and its own `[<name>]` table in `dogs.toml`.
     ///
     /// `shep disable` stops a dog without forgetting its configuration;
     /// `rehome` is the verb that forgets it.
@@ -963,7 +963,7 @@ pub struct DogsArgs {
 /// would never touch the extra field.
 #[derive(Debug, clap::Args)]
 pub struct DogArgs {
-    /// The dog's name — the `[dog.<name>]` config key
+    /// The dog's name, the `[<name>]` config key in `dogs.toml`
     pub name: String,
 }
 
@@ -987,7 +987,7 @@ pub struct DogArgs {
 /// `the_hidden_pm2_spelling_reaches_adopt_with_the_arguments_the_right_way_round`.
 #[derive(Debug, clap::Args)]
 pub struct EnableArgs {
-    /// The dog's name — the `[dog.<name>]` config key
+    /// The dog's name, the `[<name>]` config key in `dogs.toml`
     pub name: String,
     /// Hidden pm2-spelling alias for `shep adopt`: routes to `adopt` with
     /// this flag's value as the binary path
@@ -1011,8 +1011,8 @@ pub struct AdoptArgs {
     /// Resolved before vetting: as given, with a leading `~/` expanded, or
     /// looked up on `$PATH` if it names no directory — first hit wins.
     pub path: PathBuf,
-    /// The dog's name — the `[dog.<name>]` config key. Defaults to the
-    /// binary's file stem with a leading `shep-` stripped.
+    /// The dog's name, the `[<name>]` config key in `dogs.toml`. Defaults
+    /// to the binary's file stem with a leading `shep-` stripped.
     #[arg(long)]
     pub name: Option<String>,
 }

--- a/crates/shep-cli/src/commands/daemon.rs
+++ b/crates/shep-cli/src/commands/daemon.rs
@@ -245,7 +245,10 @@ fn ansi_enabled(stderr_is_terminal: bool, no_color: Option<&OsStr>) -> bool {
 /// booted daemon in hand rather than a call that blocks until shutdown: it
 /// spawns `run()` as a task and then talks to the same supervisor over its
 /// own socket, like any other client. Nothing about the boot differs
-/// between the two callers, and the split is what keeps that true.
+/// between the two callers, and the split is what keeps that true -- which
+/// is why the dog-config migration is at the top of THIS function and not
+/// in [`run_daemon`]. It sat there for a release, and `shep runtime` spent
+/// it starting dogs against a `dogs.toml` nothing had written.
 ///
 /// `delete_flock_on_shutdown` becomes [`BootOptions::delete_flock_on_shutdown`]
 /// verbatim — see that field's own doc. `run_daemon` below always passes
@@ -260,11 +263,58 @@ fn ansi_enabled(stderr_is_terminal: bool, no_color: Option<&OsStr>) -> bool {
 /// - [`DaemonRunError::Boot`] — the config file itself could not be read
 ///   (any IO error other than "does not exist"), or the supervisor failed
 ///   to boot.
+/// - [`DaemonRunError::DogMigration`] — `[dog.<name>]` sections could not
+///   be moved out of `shep.toml` and into `dogs.toml`.
 pub async fn boot_supervisor(
     paths: ShepPaths,
     args: &DaemonArgs,
     delete_flock_on_shutdown: bool,
 ) -> Result<RunningDaemon, DaemonRunError> {
+    // Here rather than in `run_daemon`, because `run_daemon` is not the only
+    // caller that boots a supervisor and serves dogs. `commands::foreground`
+    // reaches this function directly for `shep runtime` and `shep dev`, and
+    // `boot_options` below builds their dogs out of `enabled_dogs` exactly as
+    // it does for the daemon -- so a `shep runtime` used to start a dog and
+    // then hand it a `dogs.toml` that would never exist. Measured: with
+    // `[dog.metrics] bind = "127.0.0.1:19616"` in shep.toml, nothing listened
+    // on 19616 and the compiled default 9615 served instead, with no warning
+    // and no file written. Permanent, since a container that only ever runs
+    // `shep runtime` never migrates. For bark it means every sink disappears
+    // and alerting stops silently.
+    //
+    // Before the config load and before the supervisor: `dog_section` reads
+    // the new file from the first request onward and a dog can connect as
+    // soon as the socket is up. A boot after the first finds nothing under
+    // `[dog]` and returns before it opens either file.
+    //
+    // This runs in more than one place on purpose. `reload_with_wait` runs
+    // the same call in the CLI process before it signals anything, so a
+    // handover successor is not the process that discovers a refusal (see
+    // that pre-flight's own comment). Both are safe because the migration is
+    // idempotent and takes both files' locks itself, in this crate's one
+    // order: shep.toml outer, dogs.toml inner. Two of them at once serialise
+    // rather than race, and the loser finds nothing left to move.
+    let moved =
+        dog_migration::migrate_dog_sections(&paths).map_err(DaemonRunError::DogMigration)?;
+    if !moved.is_empty() {
+        // Named individually: an operator who did not know this was coming
+        // needs to be able to find where their config went.
+        //
+        // `eprintln!` rather than `tracing::info!`, and only because of
+        // where this sits: `install_log_subscriber` runs a few lines below,
+        // so at this point in the boot there is no subscriber and a
+        // `tracing` record would be dropped on the floor. Stderr is the same
+        // destination that subscriber writes to (see `launch::launch_daemon`,
+        // which is what redirects it into the shepherd's own log), so the
+        // line lands where the rest of the boot's diagnostics do, one
+        // migration only, without a format the operator has to go looking
+        // for. `shep runtime` and `shep dev` are already streaming their
+        // flock's bleats to this same stderr, so it reaches them too.
+        eprintln!(
+            "shep: moved dog config out of shep.toml and into dogs.toml: {}",
+            moved.join(", ")
+        );
+    }
     let env = |key: &str| std::env::var(key).ok();
     let file_source = read_daemon_config_source(&paths)?;
     let overrides = daemon_overrides(args);
@@ -292,7 +342,8 @@ pub async fn boot_supervisor(
 ///
 /// [`boot_supervisor`] does everything up to and including the boot; this
 /// adds only `.run()` on top of it. See that function's own doc for the
-/// config-loading and log-subscriber detail this used to carry directly.
+/// config-loading, dog-migration and log-subscriber detail this used to
+/// carry directly.
 ///
 /// # Errors
 /// - [`DaemonRunError::Config`] — `shep.toml` failed to parse, or a
@@ -305,29 +356,6 @@ pub async fn boot_supervisor(
 /// - [`DaemonRunError::DogMigration`]: `[dog.<name>]` sections could not be
 ///   moved out of `shep.toml` and into `dogs.toml`.
 pub async fn run_daemon(paths: ShepPaths, args: &DaemonArgs) -> Result<(), DaemonRunError> {
-    // Before the supervisor, because `dog_section` reads the new file from
-    // the first request onward and a dog can connect as soon as the socket
-    // is up. A boot after the first finds nothing and returns immediately.
-    let moved =
-        dog_migration::migrate_dog_sections(&paths).map_err(DaemonRunError::DogMigration)?;
-    if !moved.is_empty() {
-        // Named individually: an operator who did not know this was coming
-        // needs to be able to find where their config went.
-        //
-        // `eprintln!` rather than `tracing::info!`, and only because of
-        // where this sits: `install_log_subscriber` runs inside
-        // `boot_supervisor`, so at this point in the boot there is no
-        // subscriber and a `tracing` record would be dropped on the floor.
-        // Stderr is the same destination that subscriber writes to (see
-        // `launch::launch_daemon`, which is what redirects it into the
-        // shepherd's own log), so the line lands where the rest of the
-        // boot's diagnostics do, one migration only, without a format the
-        // operator has to go looking for.
-        eprintln!(
-            "shep: moved dog config out of shep.toml and into dogs.toml: {}",
-            moved.join(", ")
-        );
-    }
     // A production daemon always keeps its final roll — `shep muster` after
     // a reboot is the entire reason it exists.
     boot_supervisor(paths, args, false)

--- a/crates/shep-cli/src/commands/daemon.rs
+++ b/crates/shep-cli/src/commands/daemon.rs
@@ -662,6 +662,52 @@ async fn reload_with_wait(
         return streams.fail(daemon_exit_code(&err), &err.to_string());
     }
 
+    // The same argument as the config check above, aimed at the other file
+    // the successor reads. The migration runs at the top of every boot
+    // (`boot_supervisor`), so on the handover arm it runs in a successor
+    // whose predecessor is already gone: a refusal there exits the
+    // successor and leaves the flock running with nothing supervising it.
+    // Reproduced before this line existed, with a dog named in both files:
+    // `shep daemon reload` failed, the sheep survived reparented to init,
+    // `shep flock` reported it stopped, and a recovering `shep muster`
+    // started a second copy alongside the orphan. `shep daemon reload` is
+    // the documented upgrade command, so for most operators the migration's
+    // first run happens inside a handover.
+    //
+    // RUN, not dry-run, and that is what makes this a pre-flight rather
+    // than a second opinion. The migration is idempotent -- a boot after
+    // the first finds nothing under `[dog]` and returns before it opens
+    // either file -- so doing the work here leaves the successor's own call
+    // with nothing to do, and there is no window in which a file changes
+    // between a check and the act it was checking. It takes both files'
+    // locks itself, in this crate's one order (`shep.toml` outer,
+    // `dogs.toml` inner), and this process holds neither, so the ordering
+    // is unchanged.
+    //
+    // This is the CLI process, and nothing below has signalled the
+    // predecessor yet, so a refusal here ends the verb with the running
+    // shepherd untouched -- which is the whole point.
+    match dog_migration::migrate_dog_sections(paths) {
+        Ok(moved) if moved.is_empty() => {}
+        Ok(moved) => {
+            // In front of the person who typed the verb, not in the
+            // daemon's log. Before this ran here the successor printed it
+            // to the shepherd's own stderr, where an operator who did not
+            // know the move was coming had no reason to look.
+            streams.aside(
+                "reload",
+                &format!(
+                    "moved dog config out of shep.toml and into dogs.toml: {}",
+                    moved.join(", ")
+                ),
+            );
+        }
+        Err(err) => {
+            let err = DaemonRunError::DogMigration(err);
+            return streams.fail(daemon_exit_code(&err), &err.to_string());
+        }
+    }
+
     // Connected to ask who is there, and, on the handover arm, whether
     // this flock can be carried. Dropped before anything is signalled: this
     // connection is to the process about to be replaced.

--- a/crates/shep-cli/src/commands/daemon.rs
+++ b/crates/shep-cli/src/commands/daemon.rs
@@ -263,7 +263,7 @@ fn ansi_enabled(stderr_is_terminal: bool, no_color: Option<&OsStr>) -> bool {
 /// - [`DaemonRunError::Boot`] — the config file itself could not be read
 ///   (any IO error other than "does not exist"), or the supervisor failed
 ///   to boot.
-/// - [`DaemonRunError::DogMigration`] — `[dog.<name>]` sections could not
+/// - [`DaemonRunError::DogMigration`]: `[dog.<name>]` sections could not
 ///   be moved out of `shep.toml` and into `dogs.toml`.
 pub async fn boot_supervisor(
     paths: ShepPaths,

--- a/crates/shep-cli/src/commands/daemon.rs
+++ b/crates/shep-cli/src/commands/daemon.rs
@@ -42,6 +42,7 @@ use shep_daemon::tokio_runner::TokioRunner;
 use tracing_subscriber::EnvFilter;
 
 use crate::cli::DaemonArgs;
+use crate::commands::dog_migration::{self, DogMigrationError};
 use crate::commands::{admin, muster};
 use crate::exit::ExitCode;
 use crate::output::Streams;
@@ -74,6 +75,10 @@ pub enum DaemonRunError {
     /// The supervisor came up and served, then failed during its run loop
     /// or teardown.
     Run(BootError),
+    /// `[dog.<name>]` sections could not be moved out of `shep.toml` and
+    /// into `dogs.toml`. Raised before the supervisor comes up, so no dog
+    /// has read a section from either file yet.
+    DogMigration(DogMigrationError),
 }
 
 impl core::fmt::Display for DaemonRunError {
@@ -82,6 +87,7 @@ impl core::fmt::Display for DaemonRunError {
             Self::Config(err) => write!(f, "invalid daemon configuration: {err}"),
             Self::Boot(err) => write!(f, "the daemon failed to boot: {err}"),
             Self::Run(err) => write!(f, "the daemon failed while running: {err}"),
+            Self::DogMigration(err) => write!(f, "invalid dog configuration: {err}"),
         }
     }
 }
@@ -91,6 +97,7 @@ impl core::error::Error for DaemonRunError {
         match self {
             Self::Config(err) => Some(err),
             Self::Boot(err) | Self::Run(err) => Some(err),
+            Self::DogMigration(err) => Some(err),
         }
     }
 }
@@ -295,7 +302,32 @@ pub async fn boot_supervisor(
 ///   to boot.
 /// - [`DaemonRunError::Run`] — the supervisor came up and served, then
 ///   failed during its run loop or teardown.
+/// - [`DaemonRunError::DogMigration`]: `[dog.<name>]` sections could not be
+///   moved out of `shep.toml` and into `dogs.toml`.
 pub async fn run_daemon(paths: ShepPaths, args: &DaemonArgs) -> Result<(), DaemonRunError> {
+    // Before the supervisor, because `dog_section` reads the new file from
+    // the first request onward and a dog can connect as soon as the socket
+    // is up. A boot after the first finds nothing and returns immediately.
+    let moved =
+        dog_migration::migrate_dog_sections(&paths).map_err(DaemonRunError::DogMigration)?;
+    if !moved.is_empty() {
+        // Named individually: an operator who did not know this was coming
+        // needs to be able to find where their config went.
+        //
+        // `eprintln!` rather than `tracing::info!`, and only because of
+        // where this sits: `install_log_subscriber` runs inside
+        // `boot_supervisor`, so at this point in the boot there is no
+        // subscriber and a `tracing` record would be dropped on the floor.
+        // Stderr is the same destination that subscriber writes to (see
+        // `launch::launch_daemon`, which is what redirects it into the
+        // shepherd's own log), so the line lands where the rest of the
+        // boot's diagnostics do, one migration only, without a format the
+        // operator has to go looking for.
+        eprintln!(
+            "shep: moved dog config out of shep.toml and into dogs.toml: {}",
+            moved.join(", ")
+        );
+    }
     // A production daemon always keeps its final roll — `shep muster` after
     // a reboot is the entire reason it exists.
     boot_supervisor(paths, args, false)
@@ -422,6 +454,17 @@ pub fn daemon_exit_code(err: &DaemonRunError) -> ExitCode {
             _ => ExitCode::Failure,
         },
         DaemonRunError::Run(_) => ExitCode::Failure,
+        // With `Config`, not with `Boot`. Every refusal this variant
+        // carries is a shep.toml or dogs.toml an operator has to edit
+        // before the daemon will come up (a name in both files, an entry
+        // under `[dog]` that is not a section, a dogs.toml that will not
+        // parse), which is the same fault `InvalidConfig` already names.
+        // Its two I/O arms are the imprecise half of that: a `dogs.toml`
+        // that cannot be written is a disk fault rather than a bad value,
+        // and it exits `InvalidConfig` all the same. One code per variant
+        // is what keeps the mapping readable, and the message on stderr is
+        // what tells the two apart.
+        DaemonRunError::DogMigration(_) => ExitCode::InvalidConfig,
     }
 }
 
@@ -1545,6 +1588,16 @@ otel = "/usr/local/bin/shep-otel"
                 "SHEP_LOG_JSON",
                 "maybe".into()
             ))),
+            ExitCode::InvalidConfig
+        );
+        // A refused dog migration is a file the operator has to edit, so it
+        // shares `Config`'s code rather than falling through to `Failure`.
+        assert_eq!(
+            daemon_exit_code(&DaemonRunError::DogMigration(
+                DogMigrationError::WouldOverwrite {
+                    name: "metrics".to_string(),
+                }
+            )),
             ExitCode::InvalidConfig
         );
     }

--- a/crates/shep-cli/src/commands/dog_migration.rs
+++ b/crates/shep-cli/src/commands/dog_migration.rs
@@ -1,0 +1,314 @@
+//! Moving `[dog.<name>]` out of `shep.toml` and into `dogs.toml`, once.
+//!
+//! Runs at the top of every daemon boot and does nothing on all but the
+//! first. `RawDaemonConfig` keeps its `dog` field so an un-migrated file
+//! still parses: deleting it would turn `deny_unknown_fields` into a
+//! refused boot for every operator carrying a dog section, with the flock
+//! left unsupervised at exactly the moment nobody is watching.
+
+use core::fmt;
+
+use shep_core::config::{DogsConfig, DogsConfigError};
+use shep_core::paths::ShepPaths;
+
+use super::shep_toml::{ShepToml, ShepTomlError};
+
+/// Moves every `[dog.<name>]` section into `dogs.toml`, returning the names
+/// moved
+///
+/// Empty when there was nothing to move, which is every boot after the
+/// first. Writes `dogs.toml` before striking `shep.toml`, so a crash
+/// between the two leaves the sections readable from the old file rather
+/// than from neither.
+///
+/// # Errors
+///
+/// - [`DogMigrationError::WouldOverwrite`] when a name is present in both
+///   files. Two values for one key is a question shep cannot answer, so it
+///   refuses and changes nothing.
+/// - [`DogMigrationError::SectionsUnreadable`] when `shep.toml` holds
+///   entries under `[dog]` and none of them came back as a section.
+/// - [`DogMigrationError::Parse`] when `dogs.toml` is not valid TOML,
+///   [`DogMigrationError::Render`] when the merged sections will not render
+///   back, and [`DogMigrationError::Read`], [`DogMigrationError::Write`]
+///   and [`DogMigrationError::Toml`] for the underlying I/O.
+pub(crate) fn migrate_dog_sections(paths: &ShepPaths) -> Result<Vec<String>, DogMigrationError> {
+    let existing_source = match std::fs::read_to_string(&paths.daemon_config) {
+        Ok(source) => source,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(err) => return Err(DogMigrationError::Read(err)),
+    };
+    // Cheap check first, and load-bearing rather than an optimisation.
+    // `ShepToml::edit` and `try_edit` both stage a temp file and rename it
+    // over the original whenever `save` runs, so opening the document at
+    // all would give an untouched `shep.toml` a fresh inode, force
+    // `CONFIG_FILE_MODE` on it, and replace a symlinked path with a plain
+    // file. A boot with nothing to do must not open it.
+    if !existing_source.contains("[dog.") && !existing_source.contains("[dog]") {
+        return Ok(Vec::new());
+    }
+    // The substring above answers "might there be sections"; this answers
+    // "are there". Both spellings can appear in a comment or inside a
+    // string, and `[dog]` on its own is a header with nothing under it: a
+    // section neither to move nor to lose. Getting that second case wrong
+    // in the other direction is what the refusal below would do to it, and
+    // an operator with a stray `[dog]` line would then be unable to boot at
+    // all. A source this parser rejects is not decided here: it falls
+    // through to `ShepToml`, whose own parse error names the file and the
+    // line.
+    let has_entries = match existing_source.parse::<toml::Table>() {
+        Ok(table) => {
+            matches!(table.get("dog"), Some(toml::Value::Table(dog)) if !dog.is_empty())
+        }
+        Err(_) => true,
+    };
+    if !has_entries {
+        return Ok(Vec::new());
+    }
+
+    let already = match std::fs::read_to_string(&paths.dogs_config) {
+        Ok(source) => DogsConfig::load(Some(&source)).map_err(DogMigrationError::Parse)?,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => DogsConfig::default(),
+        Err(err) => return Err(DogMigrationError::Read(err)),
+    };
+
+    // `try_edit`, never `edit`. `edit` calls `save` unconditionally
+    // (shep_toml.rs:173), so refusing from inside it would strike the
+    // sections from `shep.toml` and only then fail, leaving them in
+    // neither file. `try_edit`'s own `Err` skips `save` entirely and
+    // leaves `path` exactly as it was found.
+    ShepToml::try_edit(&paths.daemon_config, |doc| {
+        let incoming = doc.take_dog_sections();
+        // The document held entries a moment ago and none of them came
+        // back, so one of `take_dog_sections`' two lossy exits was taken:
+        // a failed internal reparse, or a value under `[dog]` that is not a
+        // table. It has already struck the sections from the document, and
+        // proceeding would write an empty `dogs.toml` over a `shep.toml`
+        // stripped of the only copy. Refusing here is what makes that a
+        // `save` that never happens.
+        if incoming.is_empty() {
+            return Err(DogMigrationError::SectionsUnreadable);
+        }
+        if let Some(name) = incoming.keys().find(|name| already.dog.contains_key(*name)) {
+            return Err(DogMigrationError::WouldOverwrite { name: name.clone() });
+        }
+        let mut moved: Vec<String> = incoming.keys().cloned().collect();
+        moved.sort();
+
+        let mut merged = already.dog.clone();
+        merged.extend(incoming);
+        let rendered = toml::to_string(&merged).map_err(DogMigrationError::Render)?;
+        // Written before this closure returns, so `save` strikes the old
+        // sections only once the new file already holds them. A crash
+        // between the two leaves them readable from `shep.toml`, which is
+        // the direction that loses nothing.
+        std::fs::write(&paths.dogs_config, rendered).map_err(DogMigrationError::Write)?;
+        Ok(moved)
+    })
+}
+
+/// Why `[dog.<name>]` could not be moved into `dogs.toml`
+///
+/// Derived `Debug`, deliberately (IR-41): every variant carries a dog name,
+/// an I/O error, or a serializer's complaint, and never a section's
+/// contents, so there is nothing here to redact. The one wrapped type that
+/// could carry the file, [`ShepTomlError`], redacts its own `Debug` for
+/// exactly that reason.
+#[derive(Debug)]
+// `#[non_exhaustive]`: the migration is the one writer of `dogs.toml` and
+// will grow refusals as operators meet shapes nobody predicted, so a
+// seventh variant should be additive rather than breaking (IR-20).
+#[non_exhaustive]
+pub(crate) enum DogMigrationError {
+    /// `shep.toml` itself could not be read.
+    Read(std::io::Error),
+    /// `dogs.toml` already exists and is not valid TOML.
+    Parse(DogsConfigError),
+    /// `name` has a section in both files, so the move would silently pick
+    /// one of two values for it.
+    WouldOverwrite {
+        /// The dog named in both `shep.toml` and `dogs.toml`.
+        name: String,
+    },
+    /// `shep.toml` holds entries under `[dog]` and none of them came back
+    /// as a section to move.
+    SectionsUnreadable,
+    /// The merged sections would not render back to TOML.
+    Render(toml::ser::Error),
+    /// `dogs.toml` could not be written.
+    Write(std::io::Error),
+    /// Reading, locking or rewriting `shep.toml` failed.
+    Toml(ShepTomlError),
+}
+
+impl fmt::Display for DogMigrationError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Read(err) => write!(f, "shep.toml could not be read: {err}"),
+            Self::Parse(err) => write!(f, "dogs.toml could not be read: {err}"),
+            Self::WouldOverwrite { name } => write!(
+                f,
+                "dog '{name}' is configured in both shep.toml and dogs.toml; \
+                 delete one of the two sections and start the daemon again"
+            ),
+            Self::SectionsUnreadable => write!(
+                f,
+                "shep.toml has entries under [dog] that are not dog sections; \
+                 give each dog a table of its own, or delete them"
+            ),
+            Self::Render(err) => write!(f, "dogs.toml could not be rendered: {err}"),
+            Self::Write(err) => write!(f, "dogs.toml could not be written: {err}"),
+            Self::Toml(err) => write!(f, "shep.toml could not be rewritten: {err}"),
+        }
+    }
+}
+
+impl core::error::Error for DogMigrationError {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
+        match self {
+            Self::Read(err) | Self::Write(err) => Some(err),
+            Self::Parse(err) => Some(err),
+            Self::Render(err) => Some(err),
+            Self::Toml(err) => Some(err),
+            Self::WouldOverwrite { .. } | Self::SectionsUnreadable => None,
+        }
+    }
+}
+
+// `ShepToml::try_edit` is generic as `E: From<ShepTomlError>`: this is what
+// lets its own setup failures (home dir, lock, parse) reach the caller as
+// this module's error without a second wrapping layer.
+impl From<ShepTomlError> for DogMigrationError {
+    fn from(source: ShepTomlError) -> Self {
+        Self::Toml(source)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn home_with(shep_toml: &str) -> (tempfile::TempDir, ShepPaths) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        // `ShepPaths` has no temp-directory constructor and does not grow
+        // one for a test's convenience: `resolve` with an empty environment
+        // puts the home under `dir` and every other test in this crate
+        // builds one the same way.
+        let paths = ShepPaths::resolve(&|_| None, dir.path());
+        std::fs::create_dir_all(&paths.home).expect("home");
+        std::fs::write(&paths.daemon_config, shep_toml).expect("write");
+        (dir, paths)
+    }
+
+    #[test]
+    fn sections_move_and_the_original_loses_them() {
+        let (_dir, paths) = home_with(
+            "# mine\n[daemon]\nenabled_dogs = [\"metrics\"]\n\n[dog.metrics]\nbind = \"127.0.0.1:9615\"\n",
+        );
+
+        let moved = migrate_dog_sections(&paths).expect("migrate");
+
+        assert_eq!(moved, vec!["metrics".to_string()]);
+        assert_eq!(
+            std::fs::read_to_string(&paths.daemon_config).expect("read"),
+            "# mine\n[daemon]\nenabled_dogs = [\"metrics\"]\n"
+        );
+        let written = std::fs::read_to_string(&paths.dogs_config).expect("read");
+        let parsed = DogsConfig::load(Some(&written)).expect("valid");
+        assert_eq!(
+            parsed.dog["metrics"]["bind"].as_str(),
+            Some("127.0.0.1:9615")
+        );
+    }
+
+    #[test]
+    fn a_file_with_no_dog_sections_is_not_rewritten() {
+        let before = "[daemon]\nlog_level = \"info\"\n";
+        let (_dir, paths) = home_with(before);
+
+        let moved = migrate_dog_sections(&paths).expect("migrate");
+
+        assert!(moved.is_empty());
+        assert_eq!(
+            std::fs::read_to_string(&paths.daemon_config).expect("read"),
+            before
+        );
+        assert!(!paths.dogs_config.exists(), "no sections means no file");
+    }
+
+    #[test]
+    fn a_second_boot_writes_nothing() {
+        let (_dir, paths) = home_with("[dog.metrics]\nbind = \"127.0.0.1:9615\"\n");
+        migrate_dog_sections(&paths).expect("first");
+        let after_first = std::fs::read_to_string(&paths.dogs_config).expect("read");
+
+        let moved = migrate_dog_sections(&paths).expect("second");
+
+        assert!(moved.is_empty());
+        assert_eq!(
+            std::fs::read_to_string(&paths.dogs_config).expect("read"),
+            after_first
+        );
+    }
+
+    // `take_dog_sections` answers an empty map on two paths that have
+    // already struck the sections from the document: a failed internal
+    // reparse, and a value under `[dog]` that is not a table. Both are
+    // close to unreachable, and treating either as "nothing to move" would
+    // write an empty `dogs.toml` over a `shep.toml` it had just stripped.
+    // `metrics = 5` is the reachable half: legal TOML, a non-table under
+    // `[dog]`, and dropped by that method's own filter.
+    #[test]
+    fn entries_under_dog_that_come_back_as_nothing_make_the_migration_refuse() {
+        let (_dir, paths) = home_with("[dog]\nmetrics = 5\n");
+
+        let err = migrate_dog_sections(&paths).expect_err("a section that will not travel");
+
+        assert!(matches!(err, DogMigrationError::SectionsUnreadable));
+        assert_eq!(
+            std::fs::read_to_string(&paths.daemon_config).expect("read"),
+            "[dog]\nmetrics = 5\n",
+            "a refused migration strikes nothing"
+        );
+        assert!(!paths.dogs_config.exists(), "nor writes anything");
+    }
+
+    // The counterpart to the refusal above, and the reason it is keyed on
+    // what the file actually holds rather than on the substring gate: a
+    // header with nothing under it has no section to move and no section to
+    // lose, so it is neither migrated nor refused. Refusing it would leave
+    // an operator with a `[dog]` line unable to boot at all.
+    #[test]
+    fn an_empty_dog_table_is_left_exactly_as_it_was() {
+        let before = "[daemon]\nlog_level = \"info\"\n\n[dog]\n";
+        let (_dir, paths) = home_with(before);
+
+        let moved = migrate_dog_sections(&paths).expect("migrate");
+
+        assert!(moved.is_empty());
+        assert_eq!(
+            std::fs::read_to_string(&paths.daemon_config).expect("read"),
+            before
+        );
+        assert!(!paths.dogs_config.exists(), "no sections means no file");
+    }
+
+    // The one case that must never silently merge: an operator who already
+    // hand-wrote dogs.toml and still has a stale section in shep.toml. Two
+    // values for one key, and picking either would be shep guessing.
+    #[test]
+    fn an_existing_dogs_file_makes_the_migration_refuse() {
+        let (_dir, paths) = home_with("[dog.metrics]\nbind = \"127.0.0.1:9615\"\n");
+        std::fs::write(&paths.dogs_config, "[metrics]\nbind = \"0.0.0.0:9615\"\n").expect("write");
+
+        let err = migrate_dog_sections(&paths).expect_err("both files hold metrics");
+
+        assert!(matches!(err, DogMigrationError::WouldOverwrite { .. }));
+        assert!(
+            std::fs::read_to_string(&paths.daemon_config)
+                .expect("read")
+                .contains("[dog.metrics]"),
+            "a refused migration strikes nothing"
+        );
+    }
+}

--- a/crates/shep-cli/src/commands/dog_migration.rs
+++ b/crates/shep-cli/src/commands/dog_migration.rs
@@ -22,13 +22,13 @@
 //! left unsupervised at exactly the moment nobody is watching.
 
 use core::fmt;
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::io::Write as _;
 use std::path::Path;
 
 use shep_core::config::{DogsConfig, DogsConfigError};
 use shep_core::paths::ShepPaths;
-use toml_edit::{DocumentMut, Item, Table};
+use toml_edit::{DocumentMut, Item, Table, TableLike};
 
 use super::shep_toml::{ConfigLock, ShepToml, ShepTomlError, create_config_file};
 
@@ -42,9 +42,10 @@ use super::shep_toml::{ConfigLock, ShepToml, ShepTomlError, create_config_file};
 ///
 /// # Errors
 ///
-/// - [`DogMigrationError::WouldOverwrite`] when a name is present in both
-///   files. Two values for one key is a question shep cannot answer, so it
-///   refuses and changes nothing.
+/// - [`DogMigrationError::WouldOverwrite`] when a name holding VALUES is
+///   present in both files. Two values for one key is a question shep
+///   cannot answer, so it refuses and changes nothing. An empty
+///   `[dog.<name>]` is not one of the two -- see [`declared_dog_names`].
 /// - [`DogMigrationError::SectionsUnreadable`] when `shep.toml` declares a
 ///   name under `[dog]` that did not come back as a section to move.
 ///   Refused rather than skipped: `take_dog_sections` has already struck
@@ -75,7 +76,9 @@ pub(crate) fn migrate_dog_sections(paths: &ShepPaths) -> Result<Vec<String>, Dog
     // spelling can appear in a comment or inside a string, and `[dog]` on
     // its own is a header with nothing under it: a section neither to move
     // nor to lose, and refusing on it would leave an operator with a stray
-    // `[dog]` line unable to boot at all.
+    // `[dog]` line unable to boot at all. A `[dog.metrics]` holding no
+    // values is the same shape one level down and is skipped for the same
+    // reason -- see [`declared_dog_names`].
     //
     // `None` means this parser could not read the source. That is not
     // decided here: it falls through to `ShepToml`, whose own parse error
@@ -92,7 +95,19 @@ pub(crate) fn migrate_dog_sections(paths: &ShepPaths) -> Result<Vec<String>, Dog
     // neither file. `try_edit`'s own `Err` skips `save` entirely and
     // leaves `path` exactly as it was found.
     ShepToml::try_edit(&paths.daemon_config, |doc| {
-        let incoming = doc.take_dog_sections();
+        // Empty sections dropped here, matching what [`declared_dog_names`]
+        // already left out of `declared`, so the two agree on what there
+        // was to move. An empty one is not moved and not counted as
+        // missing: there is nothing in it to arrive at the other end. It
+        // does still go, because `take_dog_sections` removes the whole
+        // `[dog]` table, and striking an empty header an older `shep
+        // enable` scaffolded is the right outcome anyway. Only the sections
+        // beside it are what made this boot open the file at all.
+        let incoming: BTreeMap<String, Item> = doc
+            .take_dog_sections()
+            .into_iter()
+            .filter(|(_, section)| !section.as_table_like().is_some_and(TableLike::is_empty))
+            .collect();
         // `take_dog_sections` removes the WHOLE `[dog]` table and then
         // decides what to hand back, so anything it drops on the way is
         // gone from the document with nothing written in its place: a
@@ -262,22 +277,57 @@ fn read_dogs_document(path: &Path) -> Result<DocumentMut, DogMigrationError> {
     })
 }
 
-/// Every name `source` declares under `[dog]`, or `None` when `source` is
-/// not TOML this parser can read.
+/// Every name `source` declares a VALUE for under `[dog]`, or `None` when
+/// `source` is not TOML this parser can read.
 ///
 /// A second parse of a file [`ShepToml`] is about to parse again, and
 /// deliberately so: it is the only record of what was there BEFORE
 /// [`ShepToml::take_dog_sections`] struck the table, which is what the
 /// guard inside [`migrate_dog_sections`] compares against. Read-only, over
 /// a string already in memory, and it never opens the file.
+///
+/// A name holding nothing is left out, and that is the whole of
+/// [`declares_nothing`]'s reason to exist. `shep enable metrics` on any
+/// binary older than this branch scaffolds an EMPTY `[dog.metrics]`, and
+/// this branch's own `enable` no longer does -- but a mixed-version host is
+/// ordinary, so the shape keeps arriving. Counting it as a declared name
+/// made the new binary refuse to boot against a `dogs.toml` that already
+/// held `metrics`, on a `WouldOverwrite` whose own doc says "two values for
+/// one key". An empty table is not a value.
 fn declared_dog_names(source: &str) -> Option<BTreeSet<String>> {
     let table = source.parse::<toml::Table>().ok()?;
     match table.get("dog") {
-        Some(toml::Value::Table(dog)) => Some(dog.keys().cloned().collect()),
+        Some(toml::Value::Table(dog)) => Some(
+            dog.iter()
+                .filter(|(_, value)| !declares_nothing(value))
+                .map(|(name, _)| name.clone())
+                .collect(),
+        ),
         // No `[dog]` at all, or a `dog` that is not a table: either way it
         // declares no dog, and the substring gate that let us this far was
         // matching a comment or a string.
         _ => Some(BTreeSet::new()),
+    }
+}
+
+/// Whether `value` holds nothing an operator could lose by not moving it.
+///
+/// An empty table, an empty array, and an array of tables that are all
+/// empty. That last one is why this recurses rather than testing
+/// `Table::is_empty` directly: `[[dog.metrics]]` with nothing under it used
+/// to reach [`DogMigrationError::SectionsUnreadable`], because the name was
+/// declared and [`ShepToml::take_dog_sections`] hands back no array. Under
+/// the pre-flight that refusal is a boot the operator has to repair by
+/// hand, over a header holding nothing.
+///
+/// A `[[dog.metrics]]` that DOES carry values is a different question and
+/// still refuses: there is no one section for it to become, and dropping it
+/// silently is the outcome the name guard exists to prevent.
+fn declares_nothing(value: &toml::Value) -> bool {
+    match value {
+        toml::Value::Table(table) => table.is_empty(),
+        toml::Value::Array(items) => items.iter().all(declares_nothing),
+        _ => false,
     }
 }
 
@@ -371,8 +421,12 @@ pub(crate) enum DogMigrationError {
     ReadDogs(std::io::Error),
     /// `dogs.toml` already exists and is not valid TOML.
     Parse(DogsConfigError),
-    /// `name` has a section in both files, so the move would silently pick
-    /// one of two values for it.
+    /// `name` has a section carrying values in both files, so the move
+    /// would silently pick one of the two.
+    ///
+    /// An empty `[dog.<name>]` never raises this. It is not a value, it is
+    /// what every `shep enable` before this branch scaffolded, and refusing
+    /// on it took a mixed-version host to a shepherd that would not boot.
     WouldOverwrite {
         /// The dog named in both `shep.toml` and `dogs.toml`.
         name: String,
@@ -816,6 +870,101 @@ mod tests {
             headers,
             vec!["[a]", "[b]", "[c]", "[bark.sinks]", "[[bark.rules]]"],
             "the migration appends; it does not interleave: {written}"
+        );
+    }
+
+    /// Fails if an empty `[dog.<name>]` can stop a shepherd booting.
+    ///
+    /// Reproduced with a pre-branch `0.1.30` binary: its `shep enable
+    /// metrics` scaffolds an empty `[dog.metrics]`, and the new binary then
+    /// refused the whole migration on `WouldOverwrite` against a
+    /// `dogs.toml` that already held `metrics` -- so `shep start` exited 5
+    /// on a daemon that exited 4. This branch stopped the new `enable` from
+    /// scaffolding, but every older binary still on a box does it and a
+    /// mixed-version host is ordinary.
+    ///
+    /// Nothing written on either side is the assertion: the configured
+    /// `dogs.toml` is the one that wins, untouched, and `shep.toml` keeps
+    /// its stray header rather than being rewritten to strike it.
+    #[test]
+    fn an_empty_section_colliding_with_a_configured_one_is_not_a_refusal() {
+        let before = "[daemon]\nenabled_dogs = [\"metrics\"]\n\n[dog.metrics]\n";
+        let (_dir, paths) = home_with(before);
+        let dogs = "[metrics]\nbind = \"127.0.0.1:19616\"\n";
+        std::fs::write(&paths.dogs_config, dogs).expect("write");
+
+        let moved = migrate_dog_sections(&paths).expect("an empty table is not a second value");
+
+        assert!(moved.is_empty());
+        assert_eq!(
+            std::fs::read_to_string(&paths.daemon_config).expect("read"),
+            before
+        );
+        assert_eq!(
+            std::fs::read_to_string(&paths.dogs_config).expect("read"),
+            dogs
+        );
+    }
+
+    /// The item this subsumes: `[[dog.metrics]]` with nothing under it.
+    ///
+    /// `take_dog_sections` hands back no array, so the name guard used to
+    /// call it `SectionsUnreadable` -- which under the reload pre-flight is
+    /// a refused boot over a header holding nothing.
+    #[test]
+    fn an_empty_array_of_tables_under_dog_is_skipped_rather_than_refused() {
+        let before = "[[dog.metrics]]\n";
+        let (_dir, paths) = home_with(before);
+
+        let moved = migrate_dog_sections(&paths).expect("nothing declared, nothing to lose");
+
+        assert!(moved.is_empty());
+        assert_eq!(
+            std::fs::read_to_string(&paths.daemon_config).expect("read"),
+            before
+        );
+    }
+
+    /// The other half of the same ruling, and the reason the skip is over
+    /// values rather than over the spelling: an array of tables that DOES
+    /// carry values has no one section to become, and dropping it silently
+    /// is what the name guard exists to prevent.
+    #[test]
+    fn an_array_of_tables_with_values_still_makes_the_migration_refuse() {
+        let before = "[[dog.metrics]]\nbind = \"127.0.0.1:9615\"\n";
+        let (_dir, paths) = home_with(before);
+
+        let err = migrate_dog_sections(&paths).expect_err("values with nowhere to go");
+
+        assert!(matches!(
+            err,
+            DogMigrationError::SectionsUnreadable { ref names } if names == &["metrics".to_string()]
+        ));
+        assert_eq!(
+            std::fs::read_to_string(&paths.daemon_config).expect("read"),
+            before
+        );
+    }
+
+    /// An empty section beside a real one still lets the real one move, and
+    /// the empty header goes with it: `take_dog_sections` strikes the whole
+    /// `[dog]` table, and an empty scaffold is not something to preserve.
+    #[test]
+    fn an_empty_section_beside_a_real_one_does_not_block_it() {
+        let (_dir, paths) =
+            home_with("[dog.metrics]\n\n[dog.bark.sinks]\noncall = { url = \"u\" }\n");
+
+        let moved = migrate_dog_sections(&paths).expect("migrate");
+
+        assert_eq!(moved, vec!["bark".to_string()]);
+        assert_eq!(
+            std::fs::read_to_string(&paths.daemon_config).expect("read"),
+            ""
+        );
+        let written = std::fs::read_to_string(&paths.dogs_config).expect("read");
+        assert!(
+            !written.contains("metrics"),
+            "an empty scaffold is not carried across: {written}"
         );
     }
 

--- a/crates/shep-cli/src/commands/dog_migration.rs
+++ b/crates/shep-cli/src/commands/dog_migration.rs
@@ -28,6 +28,7 @@ use std::path::Path;
 
 use shep_core::config::{DogsConfig, DogsConfigError};
 use shep_core::paths::ShepPaths;
+use toml_edit::{DocumentMut, Item, Table};
 
 use super::shep_toml::{ConfigLock, ShepToml, ShepTomlError, create_config_file};
 
@@ -49,12 +50,11 @@ use super::shep_toml::{ConfigLock, ShepToml, ShepTomlError, create_config_file};
 ///   Refused rather than skipped: `take_dog_sections` has already struck
 ///   the whole `[dog]` table by then, so moving what came back would drop
 ///   what did not.
-/// - [`DogMigrationError::Parse`] when `dogs.toml` is not valid TOML,
-///   [`DogMigrationError::Render`] when the merged sections will not render
-///   back, and [`DogMigrationError::Read`],
-///   [`DogMigrationError::ReadDogs`], [`DogMigrationError::Lock`],
-///   [`DogMigrationError::Write`] and [`DogMigrationError::Toml`] for the
-///   underlying I/O.
+/// - [`DogMigrationError::Parse`] when `dogs.toml` is not valid TOML, and
+///   [`DogMigrationError::Read`], [`DogMigrationError::ReadDogs`],
+///   [`DogMigrationError::Lock`], [`DogMigrationError::Write`] and
+///   [`DogMigrationError::Toml`] for the underlying I/O. There is no
+///   rendering failure to report: a [`DocumentMut`] always renders.
 pub(crate) fn migrate_dog_sections(paths: &ShepPaths) -> Result<Vec<String>, DogMigrationError> {
     let existing_source = match std::fs::read_to_string(&paths.daemon_config) {
         Ok(source) => source,
@@ -128,21 +128,42 @@ pub(crate) fn migrate_dog_sections(paths: &ShepPaths) -> Result<Vec<String>, Dog
         // never takes them the other way round.
         let _dogs_lock =
             ConfigLock::acquire(&paths.dogs_config).map_err(DogMigrationError::Lock)?;
-        let already = read_dogs_config(&paths.dogs_config)?;
-        if let Some(name) = incoming.keys().find(|name| already.dog.contains_key(*name)) {
+        // The destination as a live document, not a `toml::Table`: a
+        // second migration writes into a `dogs.toml` an operator has been
+        // hand-editing since the first one, and a `toml::to_string` of a
+        // parsed map hands that file back with every comment gone (spec
+        // decision 1 calls this file hand-editable, and decision 9 promises
+        // `toml_edit` for exactly this reason).
+        let mut merged = read_dogs_document(&paths.dogs_config)?;
+        if let Some(name) = incoming.keys().find(|name| merged.contains_key(name)) {
             return Err(DogMigrationError::WouldOverwrite { name: name.clone() });
         }
         let mut moved: Vec<String> = incoming.keys().cloned().collect();
         moved.sort();
 
-        let mut merged = already.dog.clone();
-        merged.extend(incoming);
-        let rendered = toml::to_string(&merged).map_err(DogMigrationError::Render)?;
+        // Appended, never wedged into the middle. A table taken out of
+        // `shep.toml` still carries the position it held THERE, and
+        // `toml_edit` renders tables in position order, so a
+        // `[dog.metrics]` that was the first table in `shep.toml` lands
+        // between the first and second tables of an operator's `dogs.toml`
+        // -- inside the blank line that separated them. Renumbering from
+        // one past the destination's own last table is what makes a
+        // migration read like an append.
+        let mut next = merged
+            .iter()
+            .filter_map(|(_, item)| item.as_table().and_then(Table::position))
+            .max()
+            .map_or(0, |last| last + 1);
+        for (name, mut section) in incoming {
+            renumber_tables(&mut section, &mut next);
+            merged.insert(&name, section);
+        }
         // Written before this closure returns, so `save` strikes the old
         // sections only once the new file already holds them. A crash
         // between the two leaves them readable from `shep.toml`, which is
         // the direction that loses nothing.
-        write_dogs_config(&paths.dogs_config, &rendered).map_err(DogMigrationError::Write)?;
+        write_dogs_config(&paths.dogs_config, &merged.to_string())
+            .map_err(DogMigrationError::Write)?;
         Ok(moved)
     })
 }
@@ -170,8 +191,7 @@ pub(crate) fn migrate_dog_sections(paths: &ShepPaths) -> Result<Vec<String>, Dog
 ///   Refused rather than replaced: a file this verb cannot understand is
 ///   not one it may overwrite.
 /// - [`DogMigrationError::Lock`] when this file's sibling lock could not be
-///   taken, [`DogMigrationError::Render`] when what is left will not render
-///   back, and [`DogMigrationError::Write`] when the staged replacement
+///   taken, and [`DogMigrationError::Write`] when the staged replacement
 ///   fails.
 ///
 /// The error type is shared with [`migrate_dog_sections`] rather than
@@ -188,32 +208,58 @@ pub(crate) fn forget_dog_section(path: &Path, name: &str) -> Result<bool, DogMig
     // never be the half of a deadlock that holds `dogs.toml` and waits on
     // `shep.toml`.
     let _lock = ConfigLock::acquire(path).map_err(DogMigrationError::Lock)?;
-    let mut config = read_dogs_config(path)?;
-    if config.dog.remove(name).is_none() {
+    let mut doc = read_dogs_document(path)?;
+    if doc.remove(name).is_none() {
         return Ok(false);
     }
-    let rendered = toml::to_string(&config.dog).map_err(DogMigrationError::Render)?;
-    write_dogs_config(path, &rendered).map_err(DogMigrationError::Write)?;
+    write_dogs_config(path, &doc.to_string()).map_err(DogMigrationError::Write)?;
     Ok(true)
 }
 
-/// Reads `path` as a [`DogsConfig`], treating a missing file as an empty
-/// one.
+/// Reads `path` as an editable document, treating a missing file as an
+/// empty one.
 ///
 /// Both writers of `dogs.toml` read it this way, and both call this with
 /// that file's [`ConfigLock`] already held: a read outside the lock is the
 /// first half of a lost update, not a cheap shortcut.
 ///
+/// A [`DocumentMut`] rather than a [`DogsConfig`], because both writers
+/// rewrite the whole file and an operator is invited to hand-edit it. Every
+/// comment, key order and inline table survives a `toml_edit` round trip
+/// and none of them survives a `toml::to_string` of a parsed map, which is
+/// what one `shep rehome` used to do to a commented file.
+///
+/// [`DogsConfig::load`] stays as the gate in front of that, unconditional
+/// and first. It is strictly the stricter of the two parses -- a stray
+/// top-level scalar is a valid document and not a valid `DogsConfig` -- and
+/// it is the same call `shep_daemon::dogs` reads this file with, so a file
+/// this gate refuses is one the daemon could not have served either.
+/// Refusing it here is the rule both writers already followed: a file this
+/// verb cannot understand is not one it may overwrite.
+///
 /// # Errors
 ///
 /// - [`DogMigrationError::ReadDogs`] when the file exists and could not be
 ///   read, and [`DogMigrationError::Parse`] when it is not valid TOML.
-fn read_dogs_config(path: &Path) -> Result<DogsConfig, DogMigrationError> {
-    match std::fs::read_to_string(path) {
-        Ok(source) => DogsConfig::load(Some(&source)).map_err(DogMigrationError::Parse),
-        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(DogsConfig::default()),
-        Err(err) => Err(DogMigrationError::ReadDogs(err)),
-    }
+fn read_dogs_document(path: &Path) -> Result<DocumentMut, DogMigrationError> {
+    let source = match std::fs::read_to_string(path) {
+        Ok(source) => source,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+            return Ok(DocumentMut::new());
+        }
+        Err(err) => return Err(DogMigrationError::ReadDogs(err)),
+    };
+    DogsConfig::load(Some(&source)).map_err(DogMigrationError::Parse)?;
+    source.parse::<DocumentMut>().map_err(|_| {
+        // No input reaches this. `toml` 0.8 is a thin layer over
+        // `toml_edit`, so a source the gate above accepted parses here as
+        // well. Reported rather than `expect`ed all the same: this runs at
+        // the top of every daemon boot, and a boot is not a place to
+        // panic on a disagreement between two parsers.
+        DogMigrationError::ReadDogs(std::io::Error::other(
+            "dogs.toml parses as TOML values and not as an editable document",
+        ))
+    })
 }
 
 /// Every name `source` declares under `[dog]`, or `None` when `source` is
@@ -232,6 +278,41 @@ fn declared_dog_names(source: &str) -> Option<BTreeSet<String>> {
         // declares no dog, and the substring gate that let us this far was
         // matching a comment or a string.
         _ => Some(BTreeSet::new()),
+    }
+}
+
+/// Walks `item` depth-first and gives every table it holds the next
+/// document position, so a section moved out of `shep.toml` renders after
+/// everything already in `dogs.toml` rather than at the index it happened
+/// to hold in the file it came from.
+///
+/// Depth-first and over sub-tables too, because `toml_edit` renders every
+/// table by its own position and not by its parent's: renumbering only the
+/// top-level `bark` would leave `[bark.sinks]` back at `shep.toml`'s
+/// index, split away from the header it belongs under.
+///
+/// [`Item::Value`] and [`Item::None`] hold no positioned table --- an
+/// inline `metrics = { .. }` is a key/value pair and renders with the
+/// others, above the tables --- so both are left alone.
+fn renumber_tables(item: &mut Item, next: &mut usize) {
+    match item {
+        Item::Table(table) => {
+            table.set_position(*next);
+            *next += 1;
+            for (_, child) in table.iter_mut() {
+                renumber_tables(child, next);
+            }
+        }
+        Item::ArrayOfTables(array) => {
+            for table in array.iter_mut() {
+                table.set_position(*next);
+                *next += 1;
+                for (_, child) in table.iter_mut() {
+                    renumber_tables(child, next);
+                }
+            }
+        }
+        Item::Value(_) | Item::None => {}
     }
 }
 
@@ -305,8 +386,6 @@ pub(crate) enum DogMigrationError {
         /// section header, and it is already what `WouldOverwrite` carries.
         names: Vec<String>,
     },
-    /// The merged sections would not render back to TOML.
-    Render(toml::ser::Error),
     /// `dogs.toml` could not be written.
     Write(std::io::Error),
     /// `dogs.toml`'s sibling lock file could not be created or locked.
@@ -342,7 +421,6 @@ impl fmt::Display for DogMigrationError {
                  give each dog a table of its own, or delete them",
                 names.join(", ")
             ),
-            Self::Render(err) => write!(f, "dogs.toml could not be rendered: {err}"),
             Self::Write(err) => write!(f, "dogs.toml could not be written: {err}"),
             Self::Lock(err) => write!(f, "dogs.toml could not be locked: {err}"),
             Self::Toml(err) => write!(f, "shep.toml could not be rewritten: {err}"),
@@ -355,7 +433,6 @@ impl core::error::Error for DogMigrationError {
         match self {
             Self::Read(err) | Self::ReadDogs(err) | Self::Write(err) | Self::Lock(err) => Some(err),
             Self::Parse(err) => Some(err),
-            Self::Render(err) => Some(err),
             Self::Toml(err) => Some(err),
             Self::WouldOverwrite { .. } | Self::SectionsUnreadable { .. } => None,
         }
@@ -578,11 +655,11 @@ mod tests {
                 assert!(removal.join().expect("thread"), "each found its own dog");
             }
 
-            let left = read_dogs_config(&paths.dogs_config).expect("read");
+            let left = read_dogs_document(&paths.dogs_config).expect("read");
             assert!(
-                left.dog.is_empty(),
+                left.is_empty(),
                 "round {round}: both removals must survive, {:?} came back",
-                left.dog.keys().collect::<Vec<_>>()
+                left.iter().map(|(name, _)| name).collect::<Vec<_>>()
             );
         }
     }
@@ -632,7 +709,7 @@ mod tests {
             // on; the file left behind is the same either way.
             let _removed = rehoming.join().expect("thread");
 
-            let left = read_dogs_config(&paths.dogs_config).expect("read");
+            let left = read_dogs_document(&paths.dogs_config).expect("read");
             // Which of the two ran first is genuinely undecided, and only
             // one ordering has a section for the rehome to find: if it
             // went first, `otel` was struck before the migration merged
@@ -640,11 +717,106 @@ mod tests {
             // file that has to be left behind, which is the property.
             assert_eq!(moved, vec!["metrics".to_string()], "round {round}");
             assert_eq!(
-                left.dog.keys().collect::<Vec<_>>(),
+                left.iter().map(|(name, _)| name).collect::<Vec<_>>(),
                 vec!["metrics"],
                 "round {round}: the migrated section stays and the rehomed one goes"
             );
         }
+    }
+
+    /// The whole of spec decision 9, at the writer that reproduced its
+    /// absence: `shep rehome` used to turn a commented `dogs.toml` with
+    /// inline tables into header-per-key output with every comment gone.
+    ///
+    /// Exact string, not a parse-and-compare, for the same reason
+    /// `taking_dog_sections_leaves_every_other_section_alone` pins one: a
+    /// reparse agrees on the values, which is precisely what a wrecked
+    /// file also does. The comments, the inline table and the blank lines
+    /// are the assertion.
+    #[test]
+    fn forgetting_a_dog_keeps_every_other_comment_and_shape() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("dogs.toml");
+        std::fs::write(
+            &path,
+            "# hand-written, do not clobber\n[otel]\nendpoint = \"127.0.0.1:4317\"\nheaders = { auth = \"x\" }\n\n[metrics]\nbind = \"127.0.0.1:9615\"\n",
+        )
+        .expect("write");
+
+        assert!(forget_dog_section(&path, "metrics").expect("forget"));
+
+        assert_eq!(
+            std::fs::read_to_string(&path).expect("read"),
+            "# hand-written, do not clobber\n[otel]\nendpoint = \"127.0.0.1:4317\"\nheaders = { auth = \"x\" }\n"
+        );
+    }
+
+    /// The same promise at the other writer, and the case that says the
+    /// migration's first write is not the only one it makes: a second
+    /// `[dog.<name>]` appearing in `shep.toml` after an operator has spent
+    /// months hand-editing the `dogs.toml` the first migration created.
+    ///
+    /// Two properties in one exact string, because they are two halves of
+    /// the same round trip. The destination keeps its own comment and its
+    /// inline table, and the moved section arrives carrying the comments
+    /// an operator wrote around it in `shep.toml` -- both of which a
+    /// `toml::to_string` of a parsed map dropped.
+    ///
+    /// The moved section lands AFTER everything already there, which is
+    /// what `renumber_tables` is for: without it `[metrics]` carries the
+    /// position it held in `shep.toml` and renders between the
+    /// destination's first and second tables.
+    #[test]
+    fn migrating_into_a_hand_edited_file_keeps_both_files_comments() {
+        let (_dir, paths) = home_with(
+            "[daemon]\nlog_level = \"info\"\n\n# scrape target\n[dog.metrics]\nbind = \"127.0.0.1:9615\" # loopback only\n",
+        );
+        std::fs::write(
+            &paths.dogs_config,
+            "# hand-written, do not clobber\n[otel]\nendpoint = \"127.0.0.1:4317\"\nheaders = { auth = \"x\" }\n",
+        )
+        .expect("write");
+
+        let moved = migrate_dog_sections(&paths).expect("migrate");
+
+        assert_eq!(moved, vec!["metrics".to_string()]);
+        assert_eq!(
+            std::fs::read_to_string(&paths.dogs_config).expect("read"),
+            "# hand-written, do not clobber\n[otel]\nendpoint = \"127.0.0.1:4317\"\nheaders = { auth = \"x\" }\n\n# scrape target\n[metrics]\nbind = \"127.0.0.1:9615\" # loopback only\n"
+        );
+    }
+
+    /// Fails if a moved dog with sub-tables and an array of tables is
+    /// split across the destination's own sections.
+    ///
+    /// `toml_edit` renders every table by its own position, not by its
+    /// parent's, so renumbering only the top-level `bark` would leave
+    /// `[bark.sinks]` and `[[bark.rules]]` at the indices they held in
+    /// `shep.toml` -- interleaved with `[a]`, `[b]` and `[c]` here. The
+    /// three destination sections staying consecutive is the property.
+    #[test]
+    fn a_moved_dog_with_sub_tables_lands_in_one_piece_at_the_end() {
+        let (_dir, paths) = home_with(
+            "[dog.bark.sinks]\noncall = { url = \"u\" }\n\n[[dog.bark.rules]]\non = \"gave_up\"\n",
+        );
+        std::fs::write(
+            &paths.dogs_config,
+            "[a]\nk = 1\n\n[b]\nk = 2\n\n[c]\nk = 3\n",
+        )
+        .expect("write");
+
+        migrate_dog_sections(&paths).expect("migrate");
+
+        let written = std::fs::read_to_string(&paths.dogs_config).expect("read");
+        let headers: Vec<&str> = written
+            .lines()
+            .filter(|line| line.starts_with('['))
+            .collect();
+        assert_eq!(
+            headers,
+            vec!["[a]", "[b]", "[c]", "[bark.sinks]", "[[bark.rules]]"],
+            "the migration appends; it does not interleave: {written}"
+        );
     }
 
     // The one case that must never silently merge: an operator who already

--- a/crates/shep-cli/src/commands/dog_migration.rs
+++ b/crates/shep-cli/src/commands/dog_migration.rs
@@ -62,29 +62,42 @@ pub(crate) fn migrate_dog_sections(paths: &ShepPaths) -> Result<Vec<String>, Dog
         Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
         Err(err) => return Err(DogMigrationError::Read(err)),
     };
-    // Cheap check first, and load-bearing rather than an optimisation.
-    // `ShepToml::edit` and `try_edit` both stage a temp file and rename it
-    // over the original whenever `save` runs, so opening the document at
-    // all would give an untouched `shep.toml` a fresh inode, force
-    // `CONFIG_FILE_MODE` on it, and replace a symlinked path with a plain
-    // file. A boot with nothing to do must not open it.
-    if !existing_source.contains("[dog.") && !existing_source.contains("[dog]") {
-        return Ok(Vec::new());
-    }
-    // The substring above answers "might there be sections"; this answers
-    // "which ones", by name, and both questions have to be asked. Either
-    // spelling can appear in a comment or inside a string, and `[dog]` on
-    // its own is a header with nothing under it: a section neither to move
-    // nor to lose, and refusing on it would leave an operator with a stray
-    // `[dog]` line unable to boot at all. A `[dog.metrics]` holding no
-    // values is the same shape one level down and is skipped for the same
-    // reason -- see [`declared_dog_names`].
+    // One parse of the string already in memory, answering both questions
+    // this function has to ask before it may open the document: is there
+    // anything to move, and which names. A read-only `toml::Table` parse
+    // opens no file and costs nothing next to the boot around it.
     //
-    // `None` means this parser could not read the source. That is not
-    // decided here: it falls through to `ShepToml`, whose own parse error
-    // names the file and the line, and the guard inside the closure falls
-    // back to the only question it can still answer.
-    let declared = declared_dog_names(&existing_source);
+    // Not a substring test, which is what this was. `[dog.` and `[dog]`
+    // are two of the spellings a `[dog]` header has and TOML allows the
+    // others: `[ dog.metrics ]` and `[dog . metrics]` are the same section
+    // and matched neither, so the migration reported nothing to do, the
+    // section stayed in a file nothing reads any more, and the dog came up
+    // on compiled defaults with no warning on any surface. For bark that
+    // is every sink gone. A parse knows the spellings; a substring cannot.
+    //
+    // Skipping the open when there is nothing to move is load-bearing
+    // rather than an optimisation. `ShepToml::edit` and `try_edit` both
+    // stage a temp file and rename it over the original whenever `save`
+    // runs, so opening the document at all would give an untouched
+    // `shep.toml` a fresh inode, force `CONFIG_FILE_MODE` on it, and
+    // replace a symlinked path with a plain file. Every boot after the
+    // first reaches this line, so that cost would land on everyone.
+    //
+    // `[dog]` on its own is a header with nothing under it: a section
+    // neither to move nor to lose, and refusing on it would leave an
+    // operator with a stray `[dog]` line unable to boot at all. A
+    // `[dog.metrics]` holding no values is the same shape one level down
+    // and is skipped for the same reason -- see [`declared_dog_names`].
+    //
+    // `None` means this parser could not read the source at all. That is
+    // not decided here: the document is opened and it falls through to
+    // `ShepToml`, whose own parse error names the file and the line, and
+    // the guard inside the closure falls back to the only question it can
+    // still answer.
+    let declared = existing_source
+        .parse::<toml::Table>()
+        .ok()
+        .map(|table| declared_dog_names(&table));
     if declared.as_ref().is_some_and(BTreeSet::is_empty) {
         return Ok(Vec::new());
     }
@@ -277,14 +290,15 @@ fn read_dogs_document(path: &Path) -> Result<DocumentMut, DogMigrationError> {
     })
 }
 
-/// Every name `source` declares a VALUE for under `[dog]`, or `None` when
-/// `source` is not TOML this parser can read.
+/// Every name `table` declares a VALUE for under `[dog]`.
 ///
-/// A second parse of a file [`ShepToml`] is about to parse again, and
-/// deliberately so: it is the only record of what was there BEFORE
-/// [`ShepToml::take_dog_sections`] struck the table, which is what the
-/// guard inside [`migrate_dog_sections`] compares against. Read-only, over
-/// a string already in memory, and it never opens the file.
+/// Read from a second parse of a file [`ShepToml`] is about to parse
+/// again, and deliberately so: it is the only record of what was there
+/// BEFORE [`ShepToml::take_dog_sections`] struck the table, which is what
+/// the guard inside [`migrate_dog_sections`] compares against. Read-only,
+/// over a string already in memory, and it never opens the file. Empty
+/// also means "do not open the file at all", so this is the whole of that
+/// caller's gate as well as its record.
 ///
 /// A name holding nothing is left out, and that is the whole of
 /// [`declares_nothing`]'s reason to exist. `shep enable metrics` on any
@@ -294,19 +308,17 @@ fn read_dogs_document(path: &Path) -> Result<DocumentMut, DogMigrationError> {
 /// made the new binary refuse to boot against a `dogs.toml` that already
 /// held `metrics`, on a `WouldOverwrite` whose own doc says "two values for
 /// one key". An empty table is not a value.
-fn declared_dog_names(source: &str) -> Option<BTreeSet<String>> {
-    let table = source.parse::<toml::Table>().ok()?;
+fn declared_dog_names(table: &toml::Table) -> BTreeSet<String> {
     match table.get("dog") {
-        Some(toml::Value::Table(dog)) => Some(
-            dog.iter()
-                .filter(|(_, value)| !declares_nothing(value))
-                .map(|(name, _)| name.clone())
-                .collect(),
-        ),
+        Some(toml::Value::Table(dog)) => dog
+            .iter()
+            .filter(|(_, value)| !declares_nothing(value))
+            .map(|(name, _)| name.clone())
+            .collect(),
         // No `[dog]` at all, or a `dog` that is not a table: either way it
-        // declares no dog, and the substring gate that let us this far was
-        // matching a comment or a string.
-        _ => Some(BTreeSet::new()),
+        // declares no dog and there is nothing here to open the document
+        // for.
+        _ => BTreeSet::new(),
     }
 }
 
@@ -966,6 +978,61 @@ mod tests {
             !written.contains("metrics"),
             "an empty scaffold is not carried across: {written}"
         );
+    }
+
+    /// Fails if a header an operator spelled with spaces inside the
+    /// brackets strands its section in `shep.toml` forever.
+    ///
+    /// `[ dog.metrics ]` is ordinary TOML and means exactly what
+    /// `[dog.metrics]` means. A substring test for `"[dog."` matched
+    /// neither it nor `[dog . metrics]`, so the migration returned "nothing
+    /// to do", the section stayed where nothing reads it any more, and the
+    /// dog came up on its compiled defaults with no warning on any surface.
+    /// For bark that is every sink gone and alerting silently off.
+    #[test]
+    fn a_header_spelled_with_whitespace_still_migrates() {
+        let (_dir, paths) = home_with(
+            "[daemon]\nenabled_dogs = [\"metrics\"]\n\n[ dog.metrics ]\nbind = \"127.0.0.1:19615\"\n",
+        );
+
+        let moved = migrate_dog_sections(&paths).expect("migrate");
+
+        assert_eq!(moved, vec!["metrics".to_string()]);
+        assert_eq!(
+            std::fs::read_to_string(&paths.daemon_config).expect("read"),
+            "[daemon]\nenabled_dogs = [\"metrics\"]\n",
+            "the section leaves shep.toml"
+        );
+        let written = std::fs::read_to_string(&paths.dogs_config).expect("read");
+        let parsed = DogsConfig::load(Some(&written)).expect("valid");
+        assert_eq!(
+            parsed.dog["metrics"]["bind"].as_str(),
+            Some("127.0.0.1:19615")
+        );
+    }
+
+    /// Fails if a boot with nothing to migrate opens `shep.toml` for
+    /// editing anyway.
+    ///
+    /// The inode is the assertion, not the bytes, because the bytes are
+    /// identical either way. `ShepToml::edit` and `try_edit` stage a temp
+    /// file and rename it over the original whenever `save` runs, so
+    /// opening the document on an idle boot would hand an untouched
+    /// `shep.toml` a fresh inode, force `CONFIG_FILE_MODE` onto it, and
+    /// turn a symlinked path into a plain file. Every boot after the first
+    /// takes this path, so the cost lands on every operator.
+    #[cfg(unix)]
+    #[test]
+    fn a_boot_with_nothing_to_move_never_reopens_the_file() {
+        use std::os::unix::fs::MetadataExt as _;
+
+        let (_dir, paths) = home_with("[daemon]\nlog_level = \"info\"\n\n[dog]\n");
+        let before = std::fs::metadata(&paths.daemon_config).expect("stat").ino();
+
+        assert!(migrate_dog_sections(&paths).expect("migrate").is_empty());
+
+        let after = std::fs::metadata(&paths.daemon_config).expect("stat").ino();
+        assert_eq!(before, after, "an idle boot must not rewrite shep.toml");
     }
 
     // The one case that must never silently merge: an operator who already

--- a/crates/shep-cli/src/commands/dog_migration.rs
+++ b/crates/shep-cli/src/commands/dog_migration.rs
@@ -7,11 +7,13 @@
 //! left unsupervised at exactly the moment nobody is watching.
 
 use core::fmt;
+use std::io::Write as _;
+use std::path::Path;
 
 use shep_core::config::{DogsConfig, DogsConfigError};
 use shep_core::paths::ShepPaths;
 
-use super::shep_toml::{ShepToml, ShepTomlError};
+use super::shep_toml::{ShepToml, ShepTomlError, create_config_file};
 
 /// Moves every `[dog.<name>]` section into `dogs.toml`, returning the names
 /// moved
@@ -102,9 +104,36 @@ pub(crate) fn migrate_dog_sections(paths: &ShepPaths) -> Result<Vec<String>, Dog
         // sections only once the new file already holds them. A crash
         // between the two leaves them readable from `shep.toml`, which is
         // the direction that loses nothing.
-        std::fs::write(&paths.dogs_config, rendered).map_err(DogMigrationError::Write)?;
+        write_dogs_config(&paths.dogs_config, &rendered).map_err(DogMigrationError::Write)?;
         Ok(moved)
     })
+}
+
+/// Writes `rendered` to `path`: staged in a sibling temp file at
+/// `CONFIG_FILE_MODE`, `fsync`ed, then `rename`d over `path`.
+///
+/// The same three steps, through the same helper, that
+/// [`ShepToml::save`] writes `shep.toml` with, and for the same two
+/// reasons. **Mode**: these bytes are the ones that used to sit inside
+/// `shep.toml` at `0600`, and they are where `docs/dogs.md` tells an
+/// operator to paste a Discord or Slack webhook URL, which is a bearer
+/// token in a path. A `std::fs::write` here would create the file at the
+/// ambient umask, typically `0644`, so the migration itself would be the
+/// downgrade. `$SHEP_HOME` being `0700` does not answer it: a `tar`, a
+/// `cp -p` or a backup carries a file's own mode somewhere no directory
+/// mode follows. **Atomicity**: `std::fs::write` opens `O_TRUNC`, so a
+/// crash between the truncate and the write leaves a half-written
+/// `dogs.toml` behind; the rename installs the whole file or none of it.
+fn write_dogs_config(path: &Path, rendered: &str) -> std::io::Result<()> {
+    let parent = path.parent().unwrap_or_else(|| Path::new("."));
+    let mut tmp = create_config_file(parent)?;
+    tmp.write_all(rendered.as_bytes())?;
+    tmp.as_file().sync_all()?;
+    // `persist` is `rename(2)`. On failure the `NamedTempFile` comes back
+    // inside the error and its `Drop` removes the staging file, so a failed
+    // replace leaves nothing behind in `$SHEP_HOME`.
+    tmp.persist(path).map_err(|err| err.error)?;
+    Ok(())
 }
 
 /// Why `[dog.<name>]` could not be moved into `dogs.toml`
@@ -291,6 +320,27 @@ mod tests {
             before
         );
         assert!(!paths.dogs_config.exists(), "no sections means no file");
+    }
+
+    /// `dogs.toml` holds the webhook URLs that used to sit inside
+    /// `shep.toml` at `0600`, so it is created at `0600` too, at the `open`
+    /// rather than by a later `chmod`. Fails if the migration goes back to
+    /// `std::fs::write`, which would leave it at the ambient umask.
+    #[cfg(unix)]
+    #[test]
+    fn the_written_file_is_owner_only() {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let (_dir, paths) = home_with("[dog.metrics]\nbind = \"127.0.0.1:9615\"\n");
+
+        migrate_dog_sections(&paths).expect("migrate");
+
+        let mode = std::fs::metadata(&paths.dogs_config)
+            .expect("stat")
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(mode, 0o600, "mode was {mode:o}");
     }
 
     // The one case that must never silently merge: an operator who already

--- a/crates/shep-cli/src/commands/dog_migration.rs
+++ b/crates/shep-cli/src/commands/dog_migration.rs
@@ -7,6 +7,7 @@
 //! left unsupervised at exactly the moment nobody is watching.
 
 use core::fmt;
+use std::collections::BTreeSet;
 use std::io::Write as _;
 use std::path::Path;
 
@@ -28,8 +29,11 @@ use super::shep_toml::{ShepToml, ShepTomlError, create_config_file};
 /// - [`DogMigrationError::WouldOverwrite`] when a name is present in both
 ///   files. Two values for one key is a question shep cannot answer, so it
 ///   refuses and changes nothing.
-/// - [`DogMigrationError::SectionsUnreadable`] when `shep.toml` holds
-///   entries under `[dog]` and none of them came back as a section.
+/// - [`DogMigrationError::SectionsUnreadable`] when `shep.toml` declares a
+///   name under `[dog]` that did not come back as a section to move.
+///   Refused rather than skipped: `take_dog_sections` has already struck
+///   the whole `[dog]` table by then, so moving what came back would drop
+///   what did not.
 /// - [`DogMigrationError::Parse`] when `dogs.toml` is not valid TOML,
 ///   [`DogMigrationError::Render`] when the merged sections will not render
 ///   back, and [`DogMigrationError::Read`], [`DogMigrationError::Write`]
@@ -50,21 +54,18 @@ pub(crate) fn migrate_dog_sections(paths: &ShepPaths) -> Result<Vec<String>, Dog
         return Ok(Vec::new());
     }
     // The substring above answers "might there be sections"; this answers
-    // "are there". Both spellings can appear in a comment or inside a
-    // string, and `[dog]` on its own is a header with nothing under it: a
-    // section neither to move nor to lose. Getting that second case wrong
-    // in the other direction is what the refusal below would do to it, and
-    // an operator with a stray `[dog]` line would then be unable to boot at
-    // all. A source this parser rejects is not decided here: it falls
-    // through to `ShepToml`, whose own parse error names the file and the
-    // line.
-    let has_entries = match existing_source.parse::<toml::Table>() {
-        Ok(table) => {
-            matches!(table.get("dog"), Some(toml::Value::Table(dog)) if !dog.is_empty())
-        }
-        Err(_) => true,
-    };
-    if !has_entries {
+    // "which ones", by name, and both questions have to be asked. Either
+    // spelling can appear in a comment or inside a string, and `[dog]` on
+    // its own is a header with nothing under it: a section neither to move
+    // nor to lose, and refusing on it would leave an operator with a stray
+    // `[dog]` line unable to boot at all.
+    //
+    // `None` means this parser could not read the source. That is not
+    // decided here: it falls through to `ShepToml`, whose own parse error
+    // names the file and the line, and the guard inside the closure falls
+    // back to the only question it can still answer.
+    let declared = declared_dog_names(&existing_source);
+    if declared.as_ref().is_some_and(BTreeSet::is_empty) {
         return Ok(Vec::new());
     }
 
@@ -81,15 +82,30 @@ pub(crate) fn migrate_dog_sections(paths: &ShepPaths) -> Result<Vec<String>, Dog
     // leaves `path` exactly as it was found.
     ShepToml::try_edit(&paths.daemon_config, |doc| {
         let incoming = doc.take_dog_sections();
-        // The document held entries a moment ago and none of them came
-        // back, so one of `take_dog_sections`' two lossy exits was taken:
-        // a failed internal reparse, or a value under `[dog]` that is not a
-        // table. It has already struck the sections from the document, and
-        // proceeding would write an empty `dogs.toml` over a `shep.toml`
-        // stripped of the only copy. Refusing here is what makes that a
-        // `save` that never happens.
-        if incoming.is_empty() {
-            return Err(DogMigrationError::SectionsUnreadable);
+        // `take_dog_sections` removes the WHOLE `[dog]` table and then
+        // decides what to hand back, so anything it drops on the way is
+        // gone from the document with nothing written in its place: a
+        // failed internal reparse hands back nothing at all, and its filter
+        // drops a non-table entry while keeping the tables beside it. That
+        // second shape is the one a count cannot see, since `[dog] stray =
+        // 5` next to `[dog.metrics]` comes back one entry long and not
+        // empty. So the guard is over NAMES, comparing what the source
+        // declared against what came back, and it refuses before anything
+        // is written: `try_edit`'s own `Err` is what makes that a `save`
+        // that never happens.
+        //
+        // With no readable source there are no names to compare, and the
+        // fallback is the weaker question: did anything come back at all.
+        let missing: Vec<String> = match &declared {
+            Some(names) => names
+                .iter()
+                .filter(|name| !incoming.contains_key(*name))
+                .cloned()
+                .collect(),
+            None => Vec::new(),
+        };
+        if !missing.is_empty() || incoming.is_empty() {
+            return Err(DogMigrationError::SectionsUnreadable { names: missing });
         }
         if let Some(name) = incoming.keys().find(|name| already.dog.contains_key(*name)) {
             return Err(DogMigrationError::WouldOverwrite { name: name.clone() });
@@ -107,6 +123,25 @@ pub(crate) fn migrate_dog_sections(paths: &ShepPaths) -> Result<Vec<String>, Dog
         write_dogs_config(&paths.dogs_config, &rendered).map_err(DogMigrationError::Write)?;
         Ok(moved)
     })
+}
+
+/// Every name `source` declares under `[dog]`, or `None` when `source` is
+/// not TOML this parser can read.
+///
+/// A second parse of a file [`ShepToml`] is about to parse again, and
+/// deliberately so: it is the only record of what was there BEFORE
+/// [`ShepToml::take_dog_sections`] struck the table, which is what the
+/// guard inside [`migrate_dog_sections`] compares against. Read-only, over
+/// a string already in memory, and it never opens the file.
+fn declared_dog_names(source: &str) -> Option<BTreeSet<String>> {
+    let table = source.parse::<toml::Table>().ok()?;
+    match table.get("dog") {
+        Some(toml::Value::Table(dog)) => Some(dog.keys().cloned().collect()),
+        // No `[dog]` at all, or a `dog` that is not a table: either way it
+        // declares no dog, and the substring gate that let us this far was
+        // matching a comment or a string.
+        _ => Some(BTreeSet::new()),
+    }
 }
 
 /// Writes `rendered` to `path`: staged in a sibling temp file at
@@ -159,9 +194,15 @@ pub(crate) enum DogMigrationError {
         /// The dog named in both `shep.toml` and `dogs.toml`.
         name: String,
     },
-    /// `shep.toml` holds entries under `[dog]` and none of them came back
-    /// as a section to move.
-    SectionsUnreadable,
+    /// `shep.toml` declares names under `[dog]` that did not come back as
+    /// sections to move.
+    SectionsUnreadable {
+        /// The names that were declared and did not come back, empty when
+        /// the source could not be parsed closely enough to name them.
+        /// Keys, never values: a dog's name is what an operator typed as a
+        /// section header, and it is already what `WouldOverwrite` carries.
+        names: Vec<String>,
+    },
     /// The merged sections would not render back to TOML.
     Render(toml::ser::Error),
     /// `dogs.toml` could not be written.
@@ -180,10 +221,16 @@ impl fmt::Display for DogMigrationError {
                 "dog '{name}' is configured in both shep.toml and dogs.toml; \
                  delete one of the two sections and start the daemon again"
             ),
-            Self::SectionsUnreadable => write!(
+            Self::SectionsUnreadable { names } if names.is_empty() => write!(
                 f,
                 "shep.toml has entries under [dog] that are not dog sections; \
                  give each dog a table of its own, or delete them"
+            ),
+            Self::SectionsUnreadable { names } => write!(
+                f,
+                "shep.toml has entries under [dog] that are not dog sections ({}); \
+                 give each dog a table of its own, or delete them",
+                names.join(", ")
             ),
             Self::Render(err) => write!(f, "dogs.toml could not be rendered: {err}"),
             Self::Write(err) => write!(f, "dogs.toml could not be written: {err}"),
@@ -199,7 +246,7 @@ impl core::error::Error for DogMigrationError {
             Self::Parse(err) => Some(err),
             Self::Render(err) => Some(err),
             Self::Toml(err) => Some(err),
-            Self::WouldOverwrite { .. } | Self::SectionsUnreadable => None,
+            Self::WouldOverwrite { .. } | Self::SectionsUnreadable { .. } => None,
         }
     }
 }
@@ -293,7 +340,7 @@ mod tests {
 
         let err = migrate_dog_sections(&paths).expect_err("a section that will not travel");
 
-        assert!(matches!(err, DogMigrationError::SectionsUnreadable));
+        assert!(matches!(err, DogMigrationError::SectionsUnreadable { .. }));
         assert_eq!(
             std::fs::read_to_string(&paths.daemon_config).expect("read"),
             "[dog]\nmetrics = 5\n",
@@ -320,6 +367,32 @@ mod tests {
             before
         );
         assert!(!paths.dogs_config.exists(), "no sections means no file");
+    }
+
+    // Partial loss, which a count cannot see and a name can: the whole
+    // `[dog]` table is struck, `metrics` comes back, `stray` does not, and
+    // a migration that shipped what came back would drop `stray` from disk
+    // with no error and no warning. Refused instead, with the name in the
+    // message, because nothing else on the machine holds that line.
+    #[test]
+    fn an_entry_that_comes_back_beside_a_section_but_not_as_one_makes_the_migration_refuse() {
+        let (_dir, paths) =
+            home_with("[dog]\nstray = 5\n\n[dog.metrics]\nbind = \"127.0.0.1:9615\"\n");
+
+        let err = migrate_dog_sections(&paths).expect_err("stray would be dropped");
+
+        let DogMigrationError::SectionsUnreadable { names } = &err else {
+            panic!("expected a refusal naming what would be lost, got {err:?}");
+        };
+        assert_eq!(names, &vec!["stray".to_string()]);
+        assert!(err.to_string().contains("stray"), "{err}");
+        assert!(
+            std::fs::read_to_string(&paths.daemon_config)
+                .expect("read")
+                .contains("stray = 5"),
+            "a refused migration strikes nothing"
+        );
+        assert!(!paths.dogs_config.exists(), "nor writes anything");
     }
 
     /// `dogs.toml` holds the webhook URLs that used to sit inside

--- a/crates/shep-cli/src/commands/dog_migration.rs
+++ b/crates/shep-cli/src/commands/dog_migration.rs
@@ -7,7 +7,16 @@
 //! rather than beside that verb because both go through
 //! [`write_dogs_config`]: that file holds webhook credentials at `0600`,
 //! and one staged-temp-`fsync`-`rename` helper with the reasoning attached
-//! is what keeps a second writer from reaching for `std::fs::write`. `RawDaemonConfig` keeps its `dog` field so an un-migrated file
+//! is what keeps a second writer from reaching for `std::fs::write`.
+//!
+//! **Both hold `dogs.toml`'s own [`ConfigLock`] across the whole
+//! read-modify-write**, the same discipline [`ShepToml::edit`] applies to
+//! `shep.toml` and for the same reason: each rewrites the entire file, so
+//! two unserialised writers lose one of each other's edits rather than
+//! colliding visibly. Two `shep rehome` calls for two different dogs, out
+//! of the sort of provisioning script `docs/dogs.md` tells operators is
+//! safe, is the ordinary way to reach that. When both locks are held,
+//! `shep.toml`'s is always the outer one. `RawDaemonConfig` keeps its `dog` field so an un-migrated file
 //! still parses: deleting it would turn `deny_unknown_fields` into a
 //! refused boot for every operator carrying a dog section, with the flock
 //! left unsupervised at exactly the moment nobody is watching.
@@ -20,7 +29,7 @@ use std::path::Path;
 use shep_core::config::{DogsConfig, DogsConfigError};
 use shep_core::paths::ShepPaths;
 
-use super::shep_toml::{ShepToml, ShepTomlError, create_config_file};
+use super::shep_toml::{ConfigLock, ShepToml, ShepTomlError, create_config_file};
 
 /// Moves every `[dog.<name>]` section into `dogs.toml`, returning the names
 /// moved
@@ -42,8 +51,10 @@ use super::shep_toml::{ShepToml, ShepTomlError, create_config_file};
 ///   what did not.
 /// - [`DogMigrationError::Parse`] when `dogs.toml` is not valid TOML,
 ///   [`DogMigrationError::Render`] when the merged sections will not render
-///   back, and [`DogMigrationError::Read`], [`DogMigrationError::Write`]
-///   and [`DogMigrationError::Toml`] for the underlying I/O.
+///   back, and [`DogMigrationError::Read`],
+///   [`DogMigrationError::ReadDogs`], [`DogMigrationError::Lock`],
+///   [`DogMigrationError::Write`] and [`DogMigrationError::Toml`] for the
+///   underlying I/O.
 pub(crate) fn migrate_dog_sections(paths: &ShepPaths) -> Result<Vec<String>, DogMigrationError> {
     let existing_source = match std::fs::read_to_string(&paths.daemon_config) {
         Ok(source) => source,
@@ -74,12 +85,6 @@ pub(crate) fn migrate_dog_sections(paths: &ShepPaths) -> Result<Vec<String>, Dog
     if declared.as_ref().is_some_and(BTreeSet::is_empty) {
         return Ok(Vec::new());
     }
-
-    let already = match std::fs::read_to_string(&paths.dogs_config) {
-        Ok(source) => DogsConfig::load(Some(&source)).map_err(DogMigrationError::Parse)?,
-        Err(err) if err.kind() == std::io::ErrorKind::NotFound => DogsConfig::default(),
-        Err(err) => return Err(DogMigrationError::Read(err)),
-    };
 
     // `try_edit`, never `edit`. `edit` calls `save` unconditionally
     // (shep_toml.rs:173), so refusing from inside it would strike the
@@ -113,6 +118,17 @@ pub(crate) fn migrate_dog_sections(paths: &ShepPaths) -> Result<Vec<String>, Dog
         if !missing.is_empty() || incoming.is_empty() {
             return Err(DogMigrationError::SectionsUnreadable { names: missing });
         }
+        // `dogs.toml`'s own lock, taken here rather than at the top of the
+        // function so that this whole read-and-merge is one transaction
+        // against the other writer of that file,
+        // [`forget_dog_section`]. Nested INSIDE `shep.toml`'s lock, which
+        // `try_edit` already holds: that is the ordering both call sites
+        // keep, and the reason a deadlock is not reachable. This is the
+        // only place either lock is nested in the other at all, and it
+        // never takes them the other way round.
+        let _dogs_lock =
+            ConfigLock::acquire(&paths.dogs_config).map_err(DogMigrationError::Lock)?;
+        let already = read_dogs_config(&paths.dogs_config)?;
         if let Some(name) = incoming.keys().find(|name| already.dog.contains_key(*name)) {
             return Err(DogMigrationError::WouldOverwrite { name: name.clone() });
         }
@@ -153,25 +169,51 @@ pub(crate) fn migrate_dog_sections(paths: &ShepPaths) -> Result<Vec<String>, Dog
 ///   read, and [`DogMigrationError::Parse`] when it is not valid TOML.
 ///   Refused rather than replaced: a file this verb cannot understand is
 ///   not one it may overwrite.
-/// - [`DogMigrationError::Render`] when what is left will not render back,
-///   and [`DogMigrationError::Write`] when the staged replacement fails.
+/// - [`DogMigrationError::Lock`] when this file's sibling lock could not be
+///   taken, [`DogMigrationError::Render`] when what is left will not render
+///   back, and [`DogMigrationError::Write`] when the staged replacement
+///   fails.
 ///
 /// The error type is shared with [`migrate_dog_sections`] rather than
 /// split: every variant either half can produce says which of the two
 /// files failed and how, which is what an operator needs from both.
 pub(crate) fn forget_dog_section(path: &Path, name: &str) -> Result<bool, DogMigrationError> {
-    let source = match std::fs::read_to_string(path) {
-        Ok(source) => source,
-        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(false),
-        Err(err) => return Err(DogMigrationError::ReadDogs(err)),
-    };
-    let mut config = DogsConfig::load(Some(&source)).map_err(DogMigrationError::Parse)?;
+    // Held across the read, the removal and the rename, and dropped on the
+    // way out of this function. Without it, two `shep rehome` calls for two
+    // different dogs, backgrounded together out of a provisioning script,
+    // both read the file before either writes and the second rename puts
+    // one of the two removals back: a whole-file read-modify-write with
+    // nothing serialising it. `docs/dogs.md` promises a provisioning script
+    // exactly this guarantee. This function takes no other lock, so it can
+    // never be the half of a deadlock that holds `dogs.toml` and waits on
+    // `shep.toml`.
+    let _lock = ConfigLock::acquire(path).map_err(DogMigrationError::Lock)?;
+    let mut config = read_dogs_config(path)?;
     if config.dog.remove(name).is_none() {
         return Ok(false);
     }
     let rendered = toml::to_string(&config.dog).map_err(DogMigrationError::Render)?;
     write_dogs_config(path, &rendered).map_err(DogMigrationError::Write)?;
     Ok(true)
+}
+
+/// Reads `path` as a [`DogsConfig`], treating a missing file as an empty
+/// one.
+///
+/// Both writers of `dogs.toml` read it this way, and both call this with
+/// that file's [`ConfigLock`] already held: a read outside the lock is the
+/// first half of a lost update, not a cheap shortcut.
+///
+/// # Errors
+///
+/// - [`DogMigrationError::ReadDogs`] when the file exists and could not be
+///   read, and [`DogMigrationError::Parse`] when it is not valid TOML.
+fn read_dogs_config(path: &Path) -> Result<DogsConfig, DogMigrationError> {
+    match std::fs::read_to_string(path) {
+        Ok(source) => DogsConfig::load(Some(&source)).map_err(DogMigrationError::Parse),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(DogsConfig::default()),
+        Err(err) => Err(DogMigrationError::ReadDogs(err)),
+    }
 }
 
 /// Every name `source` declares under `[dog]`, or `None` when `source` is
@@ -262,6 +304,13 @@ pub(crate) enum DogMigrationError {
     Render(toml::ser::Error),
     /// `dogs.toml` could not be written.
     Write(std::io::Error),
+    /// `dogs.toml`'s sibling lock file could not be created or locked.
+    ///
+    /// Refused rather than pressed on without the lock: the guarantee the
+    /// dogs page makes to a provisioning script is the whole reason the
+    /// lock is taken, and a write that skips it quietly is worse than one
+    /// that says it could not run.
+    Lock(std::io::Error),
     /// Reading, locking or rewriting `shep.toml` failed.
     Toml(ShepTomlError),
 }
@@ -290,6 +339,7 @@ impl fmt::Display for DogMigrationError {
             ),
             Self::Render(err) => write!(f, "dogs.toml could not be rendered: {err}"),
             Self::Write(err) => write!(f, "dogs.toml could not be written: {err}"),
+            Self::Lock(err) => write!(f, "dogs.toml could not be locked: {err}"),
             Self::Toml(err) => write!(f, "shep.toml could not be rewritten: {err}"),
         }
     }
@@ -298,7 +348,7 @@ impl fmt::Display for DogMigrationError {
 impl core::error::Error for DogMigrationError {
     fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
         match self {
-            Self::Read(err) | Self::ReadDogs(err) | Self::Write(err) => Some(err),
+            Self::Read(err) | Self::ReadDogs(err) | Self::Write(err) | Self::Lock(err) => Some(err),
             Self::Parse(err) => Some(err),
             Self::Render(err) => Some(err),
             Self::Toml(err) => Some(err),
@@ -319,6 +369,15 @@ impl From<ShepTomlError> for DogMigrationError {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// How many times [`two_rehomes_at_once_both_land`] re-runs its race.
+    ///
+    /// A lost update needs both threads to read before either renames, and
+    /// on this write path (stage, `fsync`, rename) that window is wide, so
+    /// one round is usually enough. Twenty costs a few milliseconds and
+    /// makes the failure a certainty rather than a likelihood, which is
+    /// what a test guarding a race has to be to be worth having.
+    const ROUNDS_OF_CONTENTION: u32 = 20;
 
     fn home_with(shep_toml: &str) -> (tempfile::TempDir, ShepPaths) {
         let dir = tempfile::tempdir().expect("tempdir");
@@ -470,6 +529,117 @@ mod tests {
             .mode()
             & 0o777;
         assert_eq!(mode, 0o600, "mode was {mode:o}");
+    }
+
+    /// The bug the lock exists for, forced rather than hoped for: two
+    /// `shep rehome` calls for two DIFFERENT dogs, started together the way
+    /// a provisioning script backgrounds them, and both removals have to
+    /// land. Each call is a whole-file read, remove, rename, so without a
+    /// lock both threads read the two-dog file and the second rename puts
+    /// the first one's dog back, with nothing anywhere reporting it.
+    ///
+    /// Two threads and a barrier, not two processes: `flock(2)` is
+    /// per-open-file-description rather than per-process, so two threads
+    /// that each open the lock file contend exactly as two `shep`
+    /// invocations do, and this needs no re-exec harness to prove it.
+    /// Repeated over fresh homes because the losing interleaving is a
+    /// race, and one round of a race that happens to serialise itself
+    /// proves nothing.
+    #[test]
+    fn two_rehomes_at_once_both_land() {
+        use std::sync::{Arc, Barrier};
+
+        for round in 0..ROUNDS_OF_CONTENTION {
+            let (_dir, paths) = home_with("");
+            std::fs::write(
+                &paths.dogs_config,
+                "[otel]\nendpoint = \"127.0.0.1:4317\"\n\n[watchdog]\nevery = \"30s\"\n",
+            )
+            .expect("write");
+
+            let gate = Arc::new(Barrier::new(2));
+            let removals: Vec<_> = ["otel", "watchdog"]
+                .into_iter()
+                .map(|name| {
+                    let gate = Arc::clone(&gate);
+                    let path = paths.dogs_config.clone();
+                    std::thread::spawn(move || {
+                        gate.wait();
+                        forget_dog_section(&path, name).expect("rehome")
+                    })
+                })
+                .collect();
+            for removal in removals {
+                assert!(removal.join().expect("thread"), "each found its own dog");
+            }
+
+            let left = read_dogs_config(&paths.dogs_config).expect("read");
+            assert!(
+                left.dog.is_empty(),
+                "round {round}: both removals must survive, {:?} came back",
+                left.dog.keys().collect::<Vec<_>>()
+            );
+        }
+    }
+
+    /// The other pair of writers, and the reason the migration takes the
+    /// same lock rather than only the verb that races itself: a boot
+    /// migrating a section INTO `dogs.toml` while an operator's `shep
+    /// rehome` takes a different dog's section out. Whoever renames second
+    /// wins the whole file, so an unlocked pair either resurrects the
+    /// rehomed dog or drops the migrated one, and both are silent.
+    ///
+    /// The migration holds `shep.toml`'s lock while it takes `dogs.toml`'s.
+    /// The rehome half takes only `dogs.toml`'s and holds nothing else, so
+    /// there is no second ordering for the two to deadlock across.
+    #[test]
+    fn a_boot_migration_and_a_rehome_at_once_both_land() {
+        use std::sync::{Arc, Barrier};
+
+        for round in 0..ROUNDS_OF_CONTENTION {
+            let (_dir, paths) = home_with("[dog.metrics]\nbind = \"127.0.0.1:9615\"\n");
+            std::fs::write(
+                &paths.dogs_config,
+                "[otel]\nendpoint = \"127.0.0.1:4317\"\n",
+            )
+            .expect("write");
+
+            let gate = Arc::new(Barrier::new(2));
+            let migrating = {
+                let gate = Arc::clone(&gate);
+                let paths = paths.clone();
+                std::thread::spawn(move || {
+                    gate.wait();
+                    migrate_dog_sections(&paths).expect("migrate")
+                })
+            };
+            let rehoming = {
+                let gate = Arc::clone(&gate);
+                let path = paths.dogs_config.clone();
+                std::thread::spawn(move || {
+                    gate.wait();
+                    forget_dog_section(&path, "otel").expect("rehome")
+                })
+            };
+            let moved = migrating.join().expect("thread");
+            // Whether the rehome found a section to strike is the one
+            // thing the ordering genuinely decides, so it is not asserted
+            // on; the file left behind is the same either way.
+            let _removed = rehoming.join().expect("thread");
+
+            let left = read_dogs_config(&paths.dogs_config).expect("read");
+            // Which of the two ran first is genuinely undecided, and only
+            // one ordering has a section for the rehome to find: if it
+            // went first, `otel` was struck before the migration merged
+            // `metrics` in beside nothing. Both orderings agree on the
+            // file that has to be left behind, which is the property.
+            assert_eq!(moved, vec!["metrics".to_string()], "round {round}");
+            assert_eq!(
+                left.dog.keys().collect::<Vec<_>>(),
+                vec!["metrics"],
+                "round {round}: the migrated section stays and the rehomed one goes"
+            );
+        }
     }
 
     // The one case that must never silently merge: an operator who already

--- a/crates/shep-cli/src/commands/dog_migration.rs
+++ b/crates/shep-cli/src/commands/dog_migration.rs
@@ -1,7 +1,13 @@
-//! Moving `[dog.<name>]` out of `shep.toml` and into `dogs.toml`, once.
+//! Moving `[dog.<name>]` out of `shep.toml` and into `dogs.toml`, once,
+//! and the one write path `dogs.toml` has.
 //!
-//! Runs at the top of every daemon boot and does nothing on all but the
-//! first. `RawDaemonConfig` keeps its `dog` field so an un-migrated file
+//! [`migrate_dog_sections`] runs at the top of every daemon boot and does
+//! nothing on all but the first. [`forget_dog_section`] is the other
+//! writer, `shep rehome`'s half of forgetting a dog, and it lives here
+//! rather than beside that verb because both go through
+//! [`write_dogs_config`]: that file holds webhook credentials at `0600`,
+//! and one staged-temp-`fsync`-`rename` helper with the reasoning attached
+//! is what keeps a second writer from reaching for `std::fs::write`. `RawDaemonConfig` keeps its `dog` field so an un-migrated file
 //! still parses: deleting it would turn `deny_unknown_fields` into a
 //! refused boot for every operator carrying a dog section, with the flock
 //! left unsupervised at exactly the moment nobody is watching.
@@ -125,6 +131,49 @@ pub(crate) fn migrate_dog_sections(paths: &ShepPaths) -> Result<Vec<String>, Dog
     })
 }
 
+/// Removes `name`'s section from `dogs.toml`, answering whether there was
+/// one to remove.
+///
+/// `shep rehome <name>`'s half of the cross-file forget: [`ShepToml`] owns
+/// `shep.toml` alone, so `rehome_dog` strikes the registration and this
+/// strikes the configuration. A missing `dogs.toml`, or one with no
+/// section under `name`, is `Ok(false)` and writes nothing: rehoming a dog
+/// that was never configured is an ordinary thing to do, not a fault.
+///
+/// Called after `shep.toml` has already been rewritten, deliberately. The
+/// two writes are not one transaction, and of the two ways a crash between
+/// them can land, this is the harmless one: a section nothing reads, since
+/// the name is out of `enabled_dogs` and `adopted_dogs` by then. The other
+/// order loses an operator's webhook URLs while the dog is still enabled
+/// and still running, and says nothing about it.
+///
+/// # Errors
+///
+/// - [`DogMigrationError::ReadDogs`] when `dogs.toml` exists and cannot be
+///   read, and [`DogMigrationError::Parse`] when it is not valid TOML.
+///   Refused rather than replaced: a file this verb cannot understand is
+///   not one it may overwrite.
+/// - [`DogMigrationError::Render`] when what is left will not render back,
+///   and [`DogMigrationError::Write`] when the staged replacement fails.
+///
+/// The error type is shared with [`migrate_dog_sections`] rather than
+/// split: every variant either half can produce says which of the two
+/// files failed and how, which is what an operator needs from both.
+pub(crate) fn forget_dog_section(path: &Path, name: &str) -> Result<bool, DogMigrationError> {
+    let source = match std::fs::read_to_string(path) {
+        Ok(source) => source,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+        Err(err) => return Err(DogMigrationError::ReadDogs(err)),
+    };
+    let mut config = DogsConfig::load(Some(&source)).map_err(DogMigrationError::Parse)?;
+    if config.dog.remove(name).is_none() {
+        return Ok(false);
+    }
+    let rendered = toml::to_string(&config.dog).map_err(DogMigrationError::Render)?;
+    write_dogs_config(path, &rendered).map_err(DogMigrationError::Write)?;
+    Ok(true)
+}
+
 /// Every name `source` declares under `[dog]`, or `None` when `source` is
 /// not TOML this parser can read.
 ///
@@ -186,6 +235,12 @@ fn write_dogs_config(path: &Path, rendered: &str) -> std::io::Result<()> {
 pub(crate) enum DogMigrationError {
     /// `shep.toml` itself could not be read.
     Read(std::io::Error),
+    /// `dogs.toml` exists and could not be read.
+    ///
+    /// Its own variant rather than [`Self::Read`]: both are the same I/O
+    /// failure, and an operator's next move depends entirely on which of
+    /// the two files it was.
+    ReadDogs(std::io::Error),
     /// `dogs.toml` already exists and is not valid TOML.
     Parse(DogsConfigError),
     /// `name` has a section in both files, so the move would silently pick
@@ -215,6 +270,7 @@ impl fmt::Display for DogMigrationError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Read(err) => write!(f, "shep.toml could not be read: {err}"),
+            Self::ReadDogs(err) => write!(f, "dogs.toml could not be read: {err}"),
             Self::Parse(err) => write!(f, "dogs.toml could not be read: {err}"),
             Self::WouldOverwrite { name } => write!(
                 f,
@@ -242,7 +298,7 @@ impl fmt::Display for DogMigrationError {
 impl core::error::Error for DogMigrationError {
     fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
         match self {
-            Self::Read(err) | Self::Write(err) => Some(err),
+            Self::Read(err) | Self::ReadDogs(err) | Self::Write(err) => Some(err),
             Self::Parse(err) => Some(err),
             Self::Render(err) => Some(err),
             Self::Toml(err) => Some(err),

--- a/crates/shep-cli/src/commands/dog_migration.rs
+++ b/crates/shep-cli/src/commands/dog_migration.rs
@@ -266,9 +266,14 @@ fn write_dogs_config(path: &Path, rendered: &str) -> std::io::Result<()> {
 ///
 /// Derived `Debug`, deliberately (IR-41): every variant carries a dog name,
 /// an I/O error, or a serializer's complaint, and never a section's
-/// contents, so there is nothing here to redact. The one wrapped type that
-/// could carry the file, [`ShepTomlError`], redacts its own `Debug` for
-/// exactly that reason.
+/// contents, so there is nothing here to redact. That is a claim about the
+/// two wrapped types that COULD carry a file, and both of them redact their
+/// own `Debug` for exactly that reason: [`ShepTomlError`] for `shep.toml`,
+/// and [`DogsConfigError`] for `dogs.toml`. The second one did not, for a
+/// while, and this comment asserted it anyway -- a derive over
+/// `toml::de::Error` prints the parser's `raw` field, which is the whole
+/// source document. A derive here is only ever as safe as what it forwards
+/// to, so a new variant wrapping a parse error needs the same check.
 #[derive(Debug)]
 // `#[non_exhaustive]`: the migration is the one writer of `dogs.toml` and
 // will grow refusals as operators meet shapes nobody predicted, so a

--- a/crates/shep-cli/src/commands/dog_migration.rs
+++ b/crates/shep-cli/src/commands/dog_migration.rs
@@ -28,7 +28,7 @@ use std::path::Path;
 
 use shep_core::config::{DogsConfig, DogsConfigError};
 use shep_core::paths::ShepPaths;
-use toml_edit::{DocumentMut, Item, Table, TableLike};
+use toml_edit::{DocumentMut, Item, TableLike};
 
 use super::shep_toml::{ConfigLock, ShepToml, ShepTomlError, create_config_file};
 
@@ -197,9 +197,19 @@ pub(crate) fn migrate_dog_sections(paths: &ShepPaths) -> Result<Vec<String>, Dog
         // -- inside the blank line that separated them. Renumbering from
         // one past the destination's own last table is what makes a
         // migration read like an append.
+        //
+        // Over EVERY positioned table in the destination, not the
+        // top-level `Item::Table`s alone, which is what this counted. A
+        // `dogs.toml` whose own sections are `[bark.sinks]` (nested under
+        // an implicit `bark` that holds no position of its own) and
+        // `[[bark.rules]]` (an array of tables, never an `Item::Table`)
+        // answered "no positions at all", so the scan said 0, the moved
+        // section took 0, and it rendered FIRST and jammed against the
+        // section it was supposed to follow. That is the shape a real
+        // `dogs.toml` has as soon as bark is configured.
         let mut next = merged
             .iter()
-            .filter_map(|(_, item)| item.as_table().and_then(Table::position))
+            .filter_map(|(_, item)| last_position(item))
             .max()
             .map_or(0, |last| last + 1);
         for (name, mut section) in incoming {
@@ -360,6 +370,42 @@ fn declares_nothing(value: &toml::Value) -> bool {
         toml::Value::Table(table) => table.is_empty(),
         toml::Value::Array(items) => items.iter().all(declares_nothing),
         _ => false,
+    }
+}
+
+/// The highest render position any table inside `item` holds, or `None`
+/// when it holds no positioned table at all.
+///
+/// [`renumber_tables`]'s read-only twin, and it walks the same three
+/// shapes for the same reason: `toml_edit` positions every table
+/// individually, so a nested `[bark.sinks]` and an `[[bark.rules]]` entry
+/// each carry one and neither is an `Item::Table` at the top level. A scan
+/// that looked only there reported no positions for a `dogs.toml` made
+/// entirely of those, and the migration then appended at 0.
+///
+/// An implicit parent (`bark` itself, when the file only ever wrote
+/// `[bark.sinks]`) has no position of its own, hence the descent into
+/// children rather than a test on the parent alone.
+fn last_position(item: &Item) -> Option<usize> {
+    match item {
+        Item::Table(table) => table
+            .position()
+            .into_iter()
+            .chain(table.iter().filter_map(|(_, child)| last_position(child)))
+            .max(),
+        Item::ArrayOfTables(array) => array
+            .iter()
+            .flat_map(|table| {
+                table
+                    .position()
+                    .into_iter()
+                    .chain(table.iter().filter_map(|(_, child)| last_position(child)))
+            })
+            .max(),
+        // Neither holds a positioned table: an inline `metrics = { .. }`
+        // is a key/value pair and renders above the tables, with the other
+        // pairs.
+        Item::Value(_) | Item::None => None,
     }
 }
 
@@ -904,6 +950,46 @@ mod tests {
             headers,
             vec!["[a]", "[b]", "[c]", "[bark.sinks]", "[[bark.rules]]"],
             "the migration appends; it does not interleave: {written}"
+        );
+    }
+
+    /// Fails if a destination whose own sections are nested or an array of
+    /// tables sends the moved section to the FRONT of the file.
+    ///
+    /// The counterpart to
+    /// [`a_moved_dog_with_sub_tables_lands_in_one_piece_at_the_end`], which
+    /// puts the shapes in the source. Here they are in `dogs.toml`, which
+    /// is where the scan for "one past the last table" had to see them and
+    /// did not: it read `Item::Table` positions at the top level only, so
+    /// `[bark.sinks]` (nested one level under an implicit `bark`) and
+    /// `[[bark.rules]]` (an array of tables) both counted as position
+    /// nothing. The scan answered 0, the moved `[metrics]` took position 0,
+    /// and `toml_edit` rendered it first and jammed against `[bark.sinks]`
+    /// with no blank line between them. Reproduced against a real flock on
+    /// exactly this fixture.
+    ///
+    /// TWO `[[bark.rules]]` entries, not one, and that is what makes the
+    /// array arm of the scan load-bearing rather than decorative: with one
+    /// entry a scan that saw only the nested table answered 1, tied with
+    /// the array's own 1, and happened to render correctly anyway. With
+    /// two, the same blind scan wedges `[metrics]` between them.
+    ///
+    /// The exact string is the assertion, blank lines and all: nothing
+    /// here is lost either way, so a reparse agrees with a wrecked file
+    /// and only the rendering tells them apart.
+    #[test]
+    fn a_moved_dog_lands_after_a_destination_of_nested_and_array_tables() {
+        let (_dir, paths) = home_with(
+            "[daemon]\nlog_level = \"info\"\n\n[dog.metrics]\nbind = \"127.0.0.1:19615\"\n",
+        );
+        let before = "[bark.sinks]\noncall = { url = \"u\" }\n\n[[bark.rules]]\non = \"gave_up\"\n\n[[bark.rules]]\non = \"restarted\"\n";
+        std::fs::write(&paths.dogs_config, before).expect("write");
+
+        migrate_dog_sections(&paths).expect("migrate");
+
+        assert_eq!(
+            std::fs::read_to_string(&paths.dogs_config).expect("read"),
+            format!("{before}\n[metrics]\nbind = \"127.0.0.1:19615\"\n")
         );
     }
 

--- a/crates/shep-cli/src/commands/dog_migration.rs
+++ b/crates/shep-cli/src/commands/dog_migration.rs
@@ -42,10 +42,12 @@ use super::shep_toml::{ConfigLock, ShepToml, ShepTomlError, create_config_file};
 ///
 /// # Errors
 ///
-/// - [`DogMigrationError::WouldOverwrite`] when a name holding VALUES is
-///   present in both files. Two values for one key is a question shep
-///   cannot answer, so it refuses and changes nothing. An empty
-///   `[dog.<name>]` is not one of the two -- see [`declared_dog_names`].
+/// - [`DogMigrationError::WouldOverwrite`] when a name holds VALUES in
+///   BOTH files. Two values for one key is a question shep cannot answer,
+///   so it refuses and changes nothing. An empty section is not one of the
+///   two on either side: an empty `[dog.<name>]` in the source is skipped
+///   (see [`declared_dog_names`]) and an empty `[<name>]` in the
+///   destination is written over.
 /// - [`DogMigrationError::SectionsUnreadable`] when `shep.toml` declares a
 ///   name under `[dog]` that did not come back as a section to move.
 ///   Refused rather than skipped: `take_dog_sections` has already struck
@@ -163,7 +165,25 @@ pub(crate) fn migrate_dog_sections(paths: &ShepPaths) -> Result<Vec<String>, Dog
         // decision 1 calls this file hand-editable, and decision 9 promises
         // `toml_edit` for exactly this reason).
         let mut merged = read_dogs_document(&paths.dogs_config)?;
-        if let Some(name) = incoming.keys().find(|name| merged.contains_key(name)) {
+        // Over VALUES on both sides, the same rule `incoming`'s own filter
+        // and [`declared_dog_names`] apply to the source. `WouldOverwrite`
+        // exists because two values for one key is a question shep cannot
+        // answer, and a bare `[metrics]` in `dogs.toml` is not one of the
+        // two: there is no second value to guess between, so the section
+        // carrying values wins and the header it lands on held nothing to
+        // lose. Refusing on it took a boot down over an empty header, the
+        // same way the source side did before
+        // `an_empty_section_colliding_with_a_configured_one_is_not_a_refusal`.
+        //
+        // Table-like only, deliberately. A destination `[[metrics]]` is an
+        // array of tables and not a section this migration could merge
+        // into, so it still refuses rather than being quietly replaced.
+        let collides = |name: &String| {
+            merged
+                .get(name)
+                .is_some_and(|item| !item.as_table_like().is_some_and(TableLike::is_empty))
+        };
+        if let Some(name) = incoming.keys().find(|name| collides(name)) {
             return Err(DogMigrationError::WouldOverwrite { name: name.clone() });
         }
         let mut moved: Vec<String> = incoming.keys().cloned().collect();
@@ -436,9 +456,11 @@ pub(crate) enum DogMigrationError {
     /// `name` has a section carrying values in both files, so the move
     /// would silently pick one of the two.
     ///
-    /// An empty `[dog.<name>]` never raises this. It is not a value, it is
-    /// what every `shep enable` before this branch scaffolded, and refusing
-    /// on it took a mixed-version host to a shepherd that would not boot.
+    /// An empty section never raises this, on either side. It is not a
+    /// value, it is what every `shep enable` before this branch
+    /// scaffolded, and refusing on it took a mixed-version host to a
+    /// shepherd that would not boot. In the source it is skipped; in
+    /// `dogs.toml` it is the header the moved section lands on.
     WouldOverwrite {
         /// The dog named in both `shep.toml` and `dogs.toml`.
         name: String,
@@ -980,6 +1002,33 @@ mod tests {
         );
     }
 
+    /// Fails if a bare header in `dogs.toml` can refuse a section that
+    /// carries values.
+    ///
+    /// The mirror of
+    /// [`an_empty_section_colliding_with_a_configured_one_is_not_a_refusal`],
+    /// which made this exemption on the source side and left the
+    /// destination side alone. `WouldOverwrite` exists because two values
+    /// for one key is a question shep cannot answer; a bare `[metrics]`
+    /// holds no value, so there is no second answer and nothing to guess
+    /// between. Refusing on it took a boot down over a header.
+    #[test]
+    fn a_bare_header_in_dogs_toml_does_not_refuse_a_configured_section() {
+        let (_dir, paths) = home_with("[dog.metrics]\nbind = \"127.0.0.1:19615\"\n");
+        std::fs::write(&paths.dogs_config, "[metrics]\n").expect("write");
+
+        let moved = migrate_dog_sections(&paths).expect("an empty destination is not a value");
+
+        assert_eq!(moved, vec!["metrics".to_string()]);
+        let written = std::fs::read_to_string(&paths.dogs_config).expect("read");
+        let parsed = DogsConfig::load(Some(&written)).expect("valid");
+        assert_eq!(
+            parsed.dog["metrics"]["bind"].as_str(),
+            Some("127.0.0.1:19615"),
+            "the section that had values is the one left standing: {written}"
+        );
+    }
+
     /// Fails if a header an operator spelled with spaces inside the
     /// brackets strands its section in `shep.toml` forever.
     ///
@@ -1037,7 +1086,10 @@ mod tests {
 
     // The one case that must never silently merge: an operator who already
     // hand-wrote dogs.toml and still has a stale section in shep.toml. Two
-    // values for one key, and picking either would be shep guessing.
+    // values for one key, and picking either would be shep guessing. The
+    // destination holding a VALUE is what makes it two, which is the half
+    // `a_bare_header_in_dogs_toml_does_not_refuse_a_configured_section`
+    // does not have.
     #[test]
     fn an_existing_dogs_file_makes_the_migration_refuse() {
         let (_dir, paths) = home_with("[dog.metrics]\nbind = \"127.0.0.1:9615\"\n");
@@ -1045,7 +1097,10 @@ mod tests {
 
         let err = migrate_dog_sections(&paths).expect_err("both files hold metrics");
 
-        assert!(matches!(err, DogMigrationError::WouldOverwrite { .. }));
+        assert!(matches!(
+            err,
+            DogMigrationError::WouldOverwrite { ref name } if name == "metrics"
+        ));
         assert!(
             std::fs::read_to_string(&paths.daemon_config)
                 .expect("read")

--- a/crates/shep-cli/src/commands/dogs.rs
+++ b/crates/shep-cli/src/commands/dogs.rs
@@ -1824,6 +1824,35 @@ mod tests {
         );
     }
 
+    /// The bug this test exists for: `shep enable` scaffolded `[dog.<name>]`
+    /// into `shep.toml` while a dog's config had already moved to
+    /// `dogs.toml`, so an operator who enabled a dog and then configured it
+    /// where the docs say to had a name in both files. The migration refuses
+    /// that, correctly, and the daemon exits 4 with the flock unsupervised.
+    /// Enabling must leave nothing behind that a later boot can collide with.
+    #[tokio::test]
+    async fn enabling_a_dog_does_not_leave_a_section_that_refuses_the_next_boot() {
+        let dir = tempfile::tempdir().unwrap();
+        let paths = ShepPaths::resolve(&|_| None, dir.path());
+
+        let mut out = Vec::new();
+        let mut err = Vec::new();
+        let code = enable(&mut streams(&mut out, &mut err), &paths, "metrics").await;
+
+        assert_eq!(code, ExitCode::Success);
+        let written = std::fs::read_to_string(&paths.daemon_config).unwrap();
+        assert!(
+            !written.contains("[dog"),
+            "enable must write no dog section into shep.toml: {written}"
+        );
+
+        // The operator then configures the dog where `docs/dogs.md` now
+        // tells them to, and the next `shep muster` runs the migration.
+        std::fs::write(&paths.dogs_config, "[metrics]\nbind = \"127.0.0.1:9615\"\n").unwrap();
+        crate::commands::dog_migration::migrate_dog_sections(&paths)
+            .expect("a boot after an enable must not refuse over a section enable wrote");
+    }
+
     /// Task 6 / spec G4, the `dogs.rs` spelling of the same bug `shep flock`
     /// had: `Client::connect(..).ok()` folded a handshake REFUSAL into
     /// `None`, exactly as it folds a genuine absence into `None` — so a live

--- a/crates/shep-cli/src/commands/dogs.rs
+++ b/crates/shep-cli/src/commands/dogs.rs
@@ -43,6 +43,7 @@ use shep_core::paths::ShepPaths;
 use shep_core::protocol::{DogSource, Request, Response, SelectorSpec};
 
 use crate::cli::{AdoptArgs, BarksArgs};
+use crate::commands::dog_migration::{self, DogMigrationError};
 use crate::commands::shep_toml::{ShepToml, ShepTomlError};
 use crate::exit::ExitCode;
 use crate::output::{
@@ -79,6 +80,25 @@ fn fail_config(streams: &mut Streams<'_>, err: &ShepTomlError) -> ExitCode {
     let code = match err {
         ShepTomlError::Io { .. } => ExitCode::Failure,
         ShepTomlError::Parse { .. } | ShepTomlError::WrongShape { .. } => ExitCode::InvalidConfig,
+    };
+    streams.fail(code, &err.to_string())
+}
+
+/// [`fail_config`] for the other file: renders a `dogs.toml` failure and
+/// picks its exit code.
+///
+/// The same split `fail_config` makes, and for the same reason. A file
+/// that will not parse is the operator's to fix
+/// ([`ExitCode::InvalidConfig`]); everything else is I/O this process
+/// could not complete ([`ExitCode::Failure`]). Wildcarded rather than
+/// matched arm by arm: [`DogMigrationError`] is `#[non_exhaustive]`
+/// because the migration keeps meeting shapes nobody predicted, and a new
+/// variant should land as a plain failure here rather than as a compile
+/// error in a verb that does not know what it means.
+fn fail_dogs_config(streams: &mut Streams<'_>, err: &DogMigrationError) -> ExitCode {
+    let code = match err {
+        DogMigrationError::Parse(_) => ExitCode::InvalidConfig,
+        _ => ExitCode::Failure,
     };
     streams.fail(code, &err.to_string())
 }
@@ -1600,6 +1620,14 @@ async fn adopt_after_config(
 }
 
 /// `shep rehome <name>`: stops an adopted dog and forgets it entirely.
+///
+/// Two files, in this order. [`ShepToml::rehome_dog`] strikes the
+/// registration from `shep.toml`, then
+/// [`dog_migration::forget_dog_section`] strikes the configuration from
+/// `dogs.toml`. The cross-file half is here rather than inside
+/// `rehome_dog` because [`ShepToml`] owns one file and writing the other
+/// needs the staged-temp, `fsync` and `rename` path that keeps webhook
+/// credentials at `0600`.
 pub async fn rehome(streams: &mut Streams<'_>, paths: &ShepPaths, name: &str) -> ExitCode {
     let source = match ShepToml::edit(&paths.daemon_config, |cfg| {
         // Read before `rehome_dog` erases it — the row below reports what
@@ -1614,6 +1642,13 @@ pub async fn rehome(streams: &mut Streams<'_>, paths: &ShepPaths, name: &str) ->
         Ok(source) => source,
         Err(err) => return fail_config(streams, &err),
     };
+    // Reported and non-zero rather than pressed on with: the dog is out of
+    // `shep.toml` by now, so the daemon half below would stop it and the
+    // operator would be told it was forgotten while its configuration, and
+    // the webhook URLs in it, were still on disk.
+    if let Err(err) = dog_migration::forget_dog_section(&paths.dogs_config, name) {
+        return fail_dogs_config(streams, &err);
+    }
     let client = match connect_or_absent(paths, streams).await {
         Ok(client) => client,
         Err(code) => return code,
@@ -2991,10 +3026,15 @@ mod tests {
     }
 
     /// fails if `rehome` behaves as `disable` does — the whole difference
-    /// between the two verbs is that this one forgets the registration,
-    /// including the `[dog.<name>]` table and the `adopted_dogs` entry
-    /// `disable` deliberately keeps (`disable_with_no_shepherd_writes_the_config_and_exits_zero`
+    /// between the two verbs is that this one forgets the registration and
+    /// the configuration, including the `adopted_dogs` entry `disable`
+    /// deliberately keeps (`disable_with_no_shepherd_writes_the_config_and_exits_zero`
     /// pins the keeping half of that contrast).
+    ///
+    /// The configuration half is two files: a `[dog.otel]` an un-migrated
+    /// `shep.toml` still carries, and the `[otel]` in `dogs.toml` that is
+    /// where one lives now. `metrics` is beside it to catch a rewrite that
+    /// forgets more than it was asked to.
     #[tokio::test]
     async fn rehome_forgets_everything_disable_deliberately_keeps() {
         let dir = tempfile::tempdir().unwrap();
@@ -3002,6 +3042,11 @@ mod tests {
         ShepToml::edit(&paths.daemon_config, |seed| {
             seed.adopt_dog("otel", Path::new("/usr/local/bin/shep-otel"));
         })
+        .unwrap();
+        std::fs::write(
+            &paths.dogs_config,
+            "[otel]\nendpoint = \"127.0.0.1:4317\"\n\n[metrics]\nbind = \"127.0.0.1:9615\"\n",
+        )
         .unwrap();
 
         let mut out = Vec::new();
@@ -3022,6 +3067,78 @@ mod tests {
         assert!(
             !cfg.dog.contains_key("otel"),
             "rehome must remove [dog.otel] too, unlike disable: {written}"
+        );
+        let dogs = std::fs::read_to_string(&paths.dogs_config).unwrap();
+        let dogs = shep_core::config::DogsConfig::load(Some(&dogs)).unwrap();
+        assert!(
+            !dogs.dog.contains_key("otel"),
+            "rehome must strike the section from dogs.toml, where a dog's config lives now"
+        );
+        assert!(
+            dogs.dog.contains_key("metrics"),
+            "and must leave every other dog's section exactly where it was"
+        );
+    }
+
+    /// fails if the `dogs.toml` rewrite goes back to `std::fs::write`.
+    /// That file is where an operator pastes a Discord or Slack webhook
+    /// URL, which is a bearer token in a path, so it is `0600` and the
+    /// rewrite installs a staged inode carrying that mode rather than
+    /// trusting the mode it found. A file an older shep (or an operator's
+    /// own `touch`) left wide comes back narrow, the same property
+    /// `shep_toml`'s `editing_a_world_readable_config_leaves_it_owner_only`
+    /// pins for the other file.
+    #[tokio::test]
+    async fn rehoming_narrows_a_world_readable_dogs_toml() {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let dir = tempfile::tempdir().unwrap();
+        let paths = ShepPaths::resolve(&|_| None, dir.path());
+        ShepToml::edit(&paths.daemon_config, |seed| {
+            seed.adopt_dog("otel", Path::new("/usr/local/bin/shep-otel"));
+        })
+        .unwrap();
+        std::fs::write(
+            &paths.dogs_config,
+            "[otel]\nendpoint = \"127.0.0.1:4317\"\n",
+        )
+        .unwrap();
+        std::fs::set_permissions(&paths.dogs_config, std::fs::Permissions::from_mode(0o644))
+            .unwrap();
+
+        let mut out = Vec::new();
+        let mut err = Vec::new();
+        let code = rehome(&mut streams(&mut out, &mut err), &paths, "otel").await;
+
+        assert_eq!(code, ExitCode::Success);
+        let mode = std::fs::metadata(&paths.dogs_config)
+            .unwrap()
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(mode, 0o600, "mode was {mode:o}");
+    }
+
+    /// Rehoming a dog nobody ever configured is an ordinary thing to do:
+    /// no `dogs.toml` exists, and this verb must not invent an empty one
+    /// or fail over its absence.
+    #[tokio::test]
+    async fn rehoming_with_no_dogs_toml_at_all_writes_none() {
+        let dir = tempfile::tempdir().unwrap();
+        let paths = ShepPaths::resolve(&|_| None, dir.path());
+        ShepToml::edit(&paths.daemon_config, |seed| {
+            seed.adopt_dog("otel", Path::new("/usr/local/bin/shep-otel"));
+        })
+        .unwrap();
+
+        let mut out = Vec::new();
+        let mut err = Vec::new();
+        let code = rehome(&mut streams(&mut out, &mut err), &paths, "otel").await;
+
+        assert_eq!(code, ExitCode::Success);
+        assert!(
+            !paths.dogs_config.exists(),
+            "nothing to strike, nothing written"
         );
     }
 

--- a/crates/shep-cli/src/commands/mod.rs
+++ b/crates/shep-cli/src/commands/mod.rs
@@ -9,6 +9,7 @@ pub mod bleats;
 pub(crate) mod bounded;
 pub mod daemon;
 pub mod dev;
+pub(crate) mod dog_migration;
 pub mod dogs;
 pub(crate) mod empty;
 pub(crate) mod foreground;

--- a/crates/shep-cli/src/commands/shep_toml.rs
+++ b/crates/shep-cli/src/commands/shep_toml.rs
@@ -51,8 +51,10 @@ use toml_edit::{Array, DocumentMut, Item, Table, Value};
 
 use crate::style::StyleLevel;
 
-/// Mode `shep.toml` — and the sibling lock file and staging file it is
-/// written through — is created with: owner read/write, nobody else.
+/// Mode `shep.toml` (and the sibling lock file and staging file it is
+/// written through, and `dogs.toml`, which
+/// `commands::dog_migration` stages through the same helper) is created
+/// with: owner read/write, nobody else.
 ///
 /// Unlike `barks.jsonl`'s own `0600`, this is not belt-and-braces. This
 /// file is where `docs/dogs.md` tells an operator to paste a Discord or
@@ -612,7 +614,7 @@ fn create_home_dir(dir: &Path) -> std::io::Result<()> {
     builder.create(dir)
 }
 
-/// Creates the staging file the config is written through, in `parent` so
+/// Creates the staging file a config is written through, in `parent` so
 /// the later `rename` stays within one filesystem.
 ///
 /// Mode-at-creation rather than a separate `chmod` pass (`tempfile` passes
@@ -620,7 +622,14 @@ fn create_home_dir(dir: &Path) -> std::io::Result<()> {
 /// which the file holding a webhook token sits at whatever the process
 /// umask leaves it. Same shape, and same reasoning, as
 /// `barks::create_ring_file`.
-fn create_config_file(parent: &Path) -> std::io::Result<tempfile::NamedTempFile> {
+///
+/// `pub(super)` rather than private, and deliberately shared rather than
+/// copied: `commands::dog_migration` writes `dogs.toml`, which holds the
+/// webhook URLs that used to live in this file and needs the same
+/// [`CONFIG_FILE_MODE`] at the same `open`. A second implementation of
+/// create-at-mode plus `fsync` plus `rename` is how the two would drift,
+/// and the one that drifted would be the one nobody was reading.
+pub(super) fn create_config_file(parent: &Path) -> std::io::Result<tempfile::NamedTempFile> {
     let mut builder = tempfile::Builder::new();
     builder.prefix("shep").suffix(".toml.tmp");
     // `shep.toml` can hold a webhook token, so on unix it is created `0600`

--- a/crates/shep-cli/src/commands/shep_toml.rs
+++ b/crates/shep-cli/src/commands/shep_toml.rs
@@ -273,12 +273,29 @@ impl ShepToml {
         })
     }
 
-    /// Adds `name` to `[daemon] enabled_dogs` (idempotently) and ensures a
-    /// `[dog.<name>]` table exists for the dog to be configured through.
+    /// Adds `name` to `[daemon] enabled_dogs` (idempotently), and writes
+    /// nothing else anywhere.
     ///
-    /// Never truncates a `[dog.<name>]` table that already exists — a
-    /// dog's own configuration is not this writer's to touch, only its
-    /// existence.
+    /// **It used to scaffold an empty `[dog.<name>]` here, and that is now
+    /// a boot-breaking bug rather than a nicety.** A dog's configuration
+    /// lives in `dogs.toml`, so an operator who enabled a dog and then
+    /// configured it where `docs/dogs.md` says to had that name in both
+    /// files, and `commands::dog_migration` refuses on exactly that: two
+    /// values for one key is a question shep cannot answer. The daemon
+    /// exits 4 and the flock is left unsupervised, over a table nobody
+    /// asked for.
+    ///
+    /// Scaffolding into `dogs.toml` instead would keep the nicety, and is
+    /// the wrong trade. It puts this type, which owns `shep.toml` and only
+    /// that, in the business of writing a second file behind a second lock,
+    /// and every write of that file has to hold the staged-temp, `fsync`
+    /// and `rename` discipline `dog_migration::write_dogs_config` carries
+    /// because webhook credentials live there at `0600`. The nicety it
+    /// buys is thin: `shep-daemon`'s `dog_section` already documents an
+    /// absent section as legitimate and answers an empty string, so a dog
+    /// enabled with no section runs on its defaults, and an empty table
+    /// tells an operator nothing a documented example does not tell them
+    /// better. Writing nothing cannot collide with anything.
     pub fn enable_dog(&mut self, name: &str) {
         let daemon = self.daemon_table_mut();
         let enabled_dogs = daemon
@@ -289,12 +306,18 @@ impl ShepToml {
         if !enabled_dogs.iter().any(|v| v.as_str() == Some(name)) {
             enabled_dogs.push(name);
         }
-        self.dog_table_mut(name);
     }
 
-    /// Removes `name` from `[daemon] enabled_dogs`, leaving `[dog.<name>]`
-    /// in place: an operator who disables a dog to restart it must not lose
-    /// the configuration they wrote for it.
+    /// Removes `name` from `[daemon] enabled_dogs` and touches nothing
+    /// else: an operator who disables a dog to restart it must not lose the
+    /// configuration they wrote for it.
+    ///
+    /// That configuration lives in `dogs.toml` now, so keeping it is
+    /// something this method achieves by doing nothing at all rather than
+    /// by leaving a `[dog.<name>]` table alone. The behaviour is unchanged;
+    /// only the file the promise is about moved. [`Self::rehome_dog`] is
+    /// the half that forgets a dog for real, and `commands::dogs::rehome`
+    /// is where the other file is reached.
     pub fn disable_dog(&mut self, name: &str) {
         if let Some(enabled_dogs) = self
             .doc
@@ -569,21 +592,6 @@ impl ShepToml {
             .or_insert_with(|| Item::Table(Table::new()))
             .as_table_mut()
             .expect("daemon is only ever written as a table")
-    }
-
-    /// `[dog.<name>]`, creating it (empty) if it does not exist yet — never
-    /// touched again once it does, per [`Self::enable_dog`]'s own doc.
-    fn dog_table_mut(&mut self, name: &str) -> &mut Table {
-        let dog = self
-            .doc
-            .entry("dog")
-            .or_insert_with(|| Item::Table(Table::new()))
-            .as_table_mut()
-            .expect("dog is only ever written as a table");
-        dog.entry(name)
-            .or_insert_with(|| Item::Table(Table::new()))
-            .as_table_mut()
-            .expect("a dog's own section is only ever written as a table")
     }
 }
 
@@ -878,8 +886,9 @@ mod tests {
         let cfg = DaemonConfig::load(Some(&written), &|_| None).unwrap();
         assert_eq!(cfg.daemon.enabled_dogs, vec!["metrics"]);
         assert!(
-            cfg.dog.contains_key("metrics"),
-            "a table to configure it through"
+            cfg.dog.is_empty(),
+            "enable writes no dog section at all; the next boot refuses a \
+             name held in both files: {written}"
         );
     }
 
@@ -937,6 +946,10 @@ mod tests {
     fn rehoming_a_dog_forgets_it_entirely() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("shep.toml");
+        // Seeded by hand, since no writer here creates one any more: a
+        // `[dog.<name>]` in `shep.toml` is what an un-migrated file carries,
+        // and striking it is still this method's job.
+        std::fs::write(&path, "[dog.otel]\ndebounce = \"30s\"\n").unwrap();
         ShepToml::edit(&path, |doc| {
             doc.adopt_dog("otel", Path::new("/usr/local/bin/shep-otel"));
         })

--- a/crates/shep-cli/src/commands/shep_toml.rs
+++ b/crates/shep-cli/src/commands/shep_toml.rs
@@ -41,6 +41,7 @@
 // a genuinely large variant, which is a different fact from the one here.
 #![allow(clippy::result_large_err)]
 
+use std::collections::BTreeMap;
 use std::io::Write as _;
 #[cfg(unix)]
 use std::os::unix::fs::{DirBuilderExt as _, OpenOptionsExt as _, PermissionsExt as _};
@@ -321,6 +322,33 @@ impl ShepToml {
             Item::Value(exec.to_string_lossy().into_owned().into()),
         );
         self.enable_dog(name);
+    }
+
+    /// Removes the whole `[dog]` table and hands back what was under it.
+    ///
+    /// Keyed by dog name with the `dog.` prefix dropped, which is the shape
+    /// `dogs.toml` wants. A document with no `[dog]` table yields an empty
+    /// map and is left byte-identical, so a second call after a migration
+    /// writes nothing.
+    ///
+    /// The one caller is the boot migration. This is not a general editing
+    /// primitive: it takes everything, because a partial move would leave
+    /// the same key readable from two files.
+    pub fn take_dog_sections(&mut self) -> BTreeMap<String, toml::Table> {
+        let Some(item) = self.doc.remove("dog") else {
+            return BTreeMap::new();
+        };
+        let Some(table) = item.as_table() else {
+            return BTreeMap::new();
+        };
+        table
+            .iter()
+            .filter_map(|(name, value)| {
+                let section = value.as_table()?;
+                let parsed = section.to_string().parse::<toml::Table>().ok()?;
+                Some((name.to_string(), parsed))
+            })
+            .collect()
     }
 
     /// The binary path recorded for `name` in `[daemon] adopted_dogs`, if
@@ -1363,5 +1391,59 @@ mod tests {
             2 * EDITS_PER_WRITER,
             "the config enables dogs nobody asked for"
         );
+    }
+
+    #[test]
+    fn taking_dog_sections_returns_them_keyed_by_name() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("shep.toml");
+        std::fs::write(
+            &path,
+            "[daemon]\nenabled_dogs = [\"metrics\"]\n\n[dog.metrics]\nbind = \"127.0.0.1:9615\"\n\n[dog.bark.sinks]\noncall = { kind = \"discord\" }\n",
+        )
+        .expect("write");
+
+        let taken = ShepToml::edit(&path, ShepToml::take_dog_sections).expect("edit");
+
+        assert_eq!(taken.keys().collect::<Vec<_>>(), vec!["bark", "metrics"]);
+        assert_eq!(taken["metrics"]["bind"].as_str(), Some("127.0.0.1:9615"));
+    }
+
+    #[test]
+    fn taking_dog_sections_leaves_every_other_section_alone() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("shep.toml");
+        std::fs::write(
+            &path,
+            "# keep me\n[daemon]\nenabled_dogs = [\"metrics\"]\n\n[dog.metrics]\nbind = \"127.0.0.1:9615\"\n\n[style]\nlevel = \"full\"\n",
+        )
+        .expect("write");
+
+        ShepToml::edit(&path, ShepToml::take_dog_sections).expect("edit");
+
+        // Exact string: the whole reason this goes through `toml_edit` rather
+        // than a `toml::Table` round-trip is that a comment or a reordered key
+        // would be a reason not to run the upgrade.
+        assert_eq!(
+            std::fs::read_to_string(&path).expect("read"),
+            "# keep me\n[daemon]\nenabled_dogs = [\"metrics\"]\n\n[style]\nlevel = \"full\"\n"
+        );
+    }
+
+    #[test]
+    fn taking_from_a_file_with_no_dog_sections_changes_nothing() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("shep.toml");
+        let before = "[daemon]\nlog_level = \"info\"\n";
+        std::fs::write(&path, before).expect("write");
+
+        let taken = ShepToml::edit(&path, ShepToml::take_dog_sections).expect("edit");
+
+        assert!(taken.is_empty());
+        // Content identity, not proof that nothing was written: `edit` always
+        // stages and renames, so the file has a new inode either way. Not
+        // writing at all is the migration's job, and its own early return is
+        // where that is tested.
+        assert_eq!(std::fs::read_to_string(&path).expect("read"), before);
     }
 }

--- a/crates/shep-cli/src/commands/shep_toml.rs
+++ b/crates/shep-cli/src/commands/shep_toml.rs
@@ -449,11 +449,16 @@ impl ShepToml {
         Ok(Self::open(path)?.adopted_dog_path(name))
     }
 
-    /// Forgets `name` entirely: out of `enabled_dogs`, out of
-    /// `adopted_dogs`, and `[dog.<name>]` removed. The difference between
-    /// `rehome` and `disable`, and the reason they are two verbs.
+    /// Forgets `name` in this file: out of `enabled_dogs`, out of
+    /// `adopted_dogs`, and `[dog.<name>]` removed if an un-migrated
+    /// `shep.toml` still carries one. The difference between `rehome` and
+    /// `disable`, and the reason they are two verbs.
     ///
-    /// Called by `commands::dogs::rehome`.
+    /// **This is half of a rehome.** A dog's configuration lives in
+    /// `dogs.toml` now, and striking it there is
+    /// `commands::dog_migration::forget_dog_section`, called by
+    /// `commands::dogs::rehome` immediately after this: one file per
+    /// writer, since this type owns `shep.toml` and only that.
     pub fn rehome_dog(&mut self, name: &str) {
         self.disable_dog(name);
         if let Some(adopted_dogs) = self

--- a/crates/shep-cli/src/commands/shep_toml.rs
+++ b/crates/shep-cli/src/commands/shep_toml.rs
@@ -649,11 +649,19 @@ pub(super) fn create_config_file(parent: &Path) -> std::io::Result<tempfile::Nam
     builder.tempfile_in(parent)
 }
 
-/// An exclusive advisory lock over one `shep.toml`, held for as long as
+/// An exclusive advisory lock over one config file, held for as long as
 /// the value lives and released when it drops (including on an early `?`,
 /// and by the kernel if the process dies holding it).
 ///
-/// The lock is on a sibling `shep.toml.lock`, never on the config itself,
+/// Keyed on the path it is given rather than on `shep.toml` specifically:
+/// [`ShepToml::edit`] takes one over `shep.toml`, and
+/// `commands::dog_migration` takes one over `dogs.toml`, which has two
+/// writers of its own. **Whenever both are held at once, `shep.toml`'s is
+/// taken first**, which is the whole of what keeps the two orderings from
+/// deadlocking; `migrate_dog_sections` is the one caller that holds both,
+/// and it says so at the point it nests them.
+///
+/// The lock is on a sibling `<name>.lock`, never on the config itself,
 /// and that is the whole design decision — the same one `barks::RingLock`
 /// records: [`ShepToml::save`] finishes by `rename`ing a new file over the
 /// config, which replaces the inode. A lock taken on the config would be a
@@ -663,7 +671,7 @@ pub(super) fn create_config_file(parent: &Path) -> std::io::Result<tempfile::Nam
 /// never read; it exists only to be an inode with a stable identity, and
 /// it is left on disk between edits on purpose so both writers keep
 /// agreeing on which one it is.
-struct ConfigLock {
+pub(super) struct ConfigLock {
     /// `flock(2)` is released by this handle's `Drop`. Named with a
     /// leading underscore because it is held, never read.
     #[cfg(unix)]
@@ -683,7 +691,7 @@ impl ConfigLock {
     /// for a reason other than contention (contention blocks rather than
     /// failing).
     #[cfg(windows)]
-    fn acquire(path: &Path) -> std::io::Result<Self> {
+    pub(super) fn acquire(path: &Path) -> std::io::Result<Self> {
         use std::os::windows::fs::OpenOptionsExt as _;
 
         /// Another handle already holds share access this open denies.
@@ -711,7 +719,7 @@ impl ConfigLock {
     }
 
     #[cfg(unix)]
-    fn acquire(path: &Path) -> std::io::Result<Self> {
+    pub(super) fn acquire(path: &Path) -> std::io::Result<Self> {
         use nix::fcntl::{Flock, FlockArg};
 
         let file = std::fs::OpenOptions::new()

--- a/crates/shep-cli/src/commands/shep_toml.rs
+++ b/crates/shep-cli/src/commands/shep_toml.rs
@@ -352,42 +352,41 @@ impl ShepToml {
     /// Removes the whole `[dog]` table and hands back what was under it.
     ///
     /// Keyed by dog name with the `dog.` prefix dropped, which is the shape
-    /// `dogs.toml` wants. A document with no `[dog]` table yields an empty
-    /// map and is left byte-identical, so a second call after a migration
-    /// writes nothing.
+    /// `dogs.toml` wants, and handed back as live [`Item`]s rather than
+    /// `toml::Table` values. That is what lets the migration write the
+    /// destination through `toml_edit` as well: an `Item` carries its own
+    /// decor, so a comment an operator wrote above or inside
+    /// `[dog.metrics]` travels with the section instead of being dropped at
+    /// this boundary, and the header re-renders under whatever key the
+    /// section is inserted at, with nothing here rewriting it. Going
+    /// through `toml::Table` used to lose both.
+    ///
+    /// Only table-like entries come back, which covers `[dog.metrics]`, a
+    /// dotted `metrics.bind = ...` under `[dog]`, and an inline
+    /// `metrics = { .. }` alike. `[dog] stray = 5` and `[[dog.x]]` are
+    /// neither, and are dropped here rather than moved. That is not a
+    /// silent loss: the migration's own guard compares these keys against
+    /// what the source declared under `[dog]` and refuses the whole move
+    /// when one does not come back.
+    ///
+    /// A document with no `[dog]` table yields an empty map and is left
+    /// byte-identical, so a second call after a migration writes nothing.
     ///
     /// The one caller is the boot migration. This is not a general editing
     /// primitive: it takes everything, because a partial move would leave
     /// the same key readable from two files.
-    pub fn take_dog_sections(&mut self) -> BTreeMap<String, toml::Table> {
+    pub fn take_dog_sections(&mut self) -> BTreeMap<String, Item> {
         let Some(item) = self.doc.remove("dog") else {
             return BTreeMap::new();
         };
-
-        // A `Table`'s own `to_string()` renders only its direct key/value
-        // pairs -- a nested sub-table, an array of tables, or an inline
-        // table underneath it does not survive that round trip once the
-        // table is detached from the document root. Re-attaching `item`
-        // under a fresh document and rendering THAT is what keeps every
-        // header and array-of-tables marker: the fresh document is exactly
-        // as capable of printing `[dog.bark.sinks]` and `[[dog.bark.rules]]`
-        // as the original one was. Parsing the result with `toml` (not
-        // `toml_edit`) rather than walking `item` by hand is what also
-        // catches the inline-table shape, since `toml`'s deserializer does
-        // not care how a table was spelled.
-        let mut wrapper = DocumentMut::new();
-        wrapper.insert("dog", item);
-        let Ok(mut parsed) = wrapper.to_string().parse::<toml::Table>() else {
+        // `[[dog]]` itself, the one shape with nothing table-like under it
+        // to iterate.
+        let Some(dog) = item.as_table_like() else {
             return BTreeMap::new();
         };
-        let Some(toml::Value::Table(dog)) = parsed.remove("dog") else {
-            return BTreeMap::new();
-        };
-        dog.into_iter()
-            .filter_map(|(name, value)| match value {
-                toml::Value::Table(section) => Some((name, section)),
-                _ => None,
-            })
+        dog.iter()
+            .filter(|(_, value)| value.as_table_like().is_some())
+            .map(|(name, value)| (name.to_owned(), value.clone()))
             .collect()
     }
 
@@ -1515,13 +1514,20 @@ mod tests {
             Some("https://discord.com/api/webhooks/x"),
             "a nested sub-table's own values must survive the take"
         );
+        // `as_array_of_tables`, not `as_array`: `[[dog.bark.rules]]` is a
+        // `toml_edit::ArrayOfTables`, a document construct, where `sinks =
+        // ["oncall"]` below is a `Value::Array`.
         let rules = bark["rules"]
-            .as_array()
+            .as_array_of_tables()
             .expect("rules is an array of tables");
         assert_eq!(rules.len(), 1);
-        assert_eq!(rules[0]["on"].as_str(), Some("gave_up"));
+        let rule = rules.get(0).expect("one rule");
+        assert_eq!(rule["on"].as_str(), Some("gave_up"));
         assert_eq!(
-            rules[0]["sinks"][0].as_str(),
+            rule["sinks"]
+                .as_array()
+                .and_then(|sinks| sinks.get(0))
+                .and_then(toml_edit::Value::as_str),
             Some("oncall"),
             "the array-of-tables entry keeps its own array field"
         );

--- a/crates/shep-cli/src/commands/shep_toml.rs
+++ b/crates/shep-cli/src/commands/shep_toml.rs
@@ -338,15 +338,30 @@ impl ShepToml {
         let Some(item) = self.doc.remove("dog") else {
             return BTreeMap::new();
         };
-        let Some(table) = item.as_table() else {
+
+        // A `Table`'s own `to_string()` renders only its direct key/value
+        // pairs -- a nested sub-table, an array of tables, or an inline
+        // table underneath it does not survive that round trip once the
+        // table is detached from the document root. Re-attaching `item`
+        // under a fresh document and rendering THAT is what keeps every
+        // header and array-of-tables marker: the fresh document is exactly
+        // as capable of printing `[dog.bark.sinks]` and `[[dog.bark.rules]]`
+        // as the original one was. Parsing the result with `toml` (not
+        // `toml_edit`) rather than walking `item` by hand is what also
+        // catches the inline-table shape, since `toml`'s deserializer does
+        // not care how a table was spelled.
+        let mut wrapper = DocumentMut::new();
+        wrapper.insert("dog", item);
+        let Ok(mut parsed) = wrapper.to_string().parse::<toml::Table>() else {
             return BTreeMap::new();
         };
-        table
-            .iter()
-            .filter_map(|(name, value)| {
-                let section = value.as_table()?;
-                let parsed = section.to_string().parse::<toml::Table>().ok()?;
-                Some((name.to_string(), parsed))
+        let Some(toml::Value::Table(dog)) = parsed.remove("dog") else {
+            return BTreeMap::new();
+        };
+        dog.into_iter()
+            .filter_map(|(name, value)| match value {
+                toml::Value::Table(section) => Some((name, section)),
+                _ => None,
             })
             .collect()
     }
@@ -1445,5 +1460,50 @@ mod tests {
         // writing at all is the migration's job, and its own early return is
         // where that is tested.
         assert_eq!(std::fs::read_to_string(&path).expect("read"), before);
+    }
+
+    #[test]
+    fn taking_dog_sections_keeps_nested_tables_and_arrays_of_tables() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("shep.toml");
+        std::fs::write(
+            &path,
+            "[dog.bark.sinks]\noncall = { kind = \"discord\", url = \"https://discord.com/api/webhooks/x\" }\n\n[[dog.bark.rules]]\non = \"gave_up\"\nsinks = [\"oncall\"]\n",
+        )
+        .expect("write");
+
+        let taken = ShepToml::edit(&path, ShepToml::take_dog_sections).expect("edit");
+
+        let bark = &taken["bark"];
+        assert_eq!(
+            bark["sinks"]["oncall"]["url"].as_str(),
+            Some("https://discord.com/api/webhooks/x"),
+            "a nested sub-table's own values must survive the take"
+        );
+        let rules = bark["rules"]
+            .as_array()
+            .expect("rules is an array of tables");
+        assert_eq!(rules.len(), 1);
+        assert_eq!(rules[0]["on"].as_str(), Some("gave_up"));
+        assert_eq!(
+            rules[0]["sinks"][0].as_str(),
+            Some("oncall"),
+            "the array-of-tables entry keeps its own array field"
+        );
+    }
+
+    #[test]
+    fn taking_dog_sections_keeps_an_inline_table_dog() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("shep.toml");
+        std::fs::write(&path, "[dog]\nmetrics = { bind = \"127.0.0.1:9615\" }\n").expect("write");
+
+        let taken = ShepToml::edit(&path, ShepToml::take_dog_sections).expect("edit");
+
+        assert_eq!(
+            taken["metrics"]["bind"].as_str(),
+            Some("127.0.0.1:9615"),
+            "an inline-table dog under [dog] must not be dropped"
+        );
     }
 }

--- a/crates/shep-cli/src/dog/bark/rules.rs
+++ b/crates/shep-cli/src/dog/bark/rules.rs
@@ -161,7 +161,7 @@ fn is_known_kind(kind: &str) -> bool {
 #[derive(Debug)]
 pub enum RulesError {
     /// Rule at position `index` (0-based, in configuration order) routes
-    /// to a sink name `[dog.bark.sinks]` does not define.
+    /// to a sink name `[bark.sinks]` does not define.
     UnknownSink {
         /// Position in the configured rule list.
         index: usize,
@@ -181,7 +181,7 @@ pub enum RulesError {
         /// The kind string that matches no [`ProcessEventKind`].
         kind: String,
     },
-    /// A `[dog.bark.sinks]` entry is a Discord or Slack webhook configured
+    /// A `[bark.sinks]` entry is a Discord or Slack webhook configured
     /// with `http://`. See [`sinks::require_secure_scheme`].
     InsecureSink(SinkConfigError),
 }
@@ -191,7 +191,8 @@ impl fmt::Display for RulesError {
         match self {
             Self::UnknownSink { index, sink } => write!(
                 f,
-                "rule {index} routes to sink \"{sink}\", which [dog.bark.sinks] does not define"
+                "rule {index} routes to sink \"{sink}\", which [bark.sinks] in dogs.toml does \
+                 not define"
             ),
             Self::NoSinks { index } => write!(f, "rule {index} routes to no sink at all"),
             Self::UnknownKind { index, kind } => write!(
@@ -618,7 +619,16 @@ mod tests {
     fn a_rule_routed_at_a_sink_that_does_not_exist_is_refused_at_startup() {
         let err = Rules::new(vec![rule_to("pager")], &BTreeMap::new()).unwrap_err();
         assert!(matches!(err, RulesError::UnknownSink { .. }));
-        assert!(err.to_string().contains("pager"));
+        // Exact, not a `contains`, because the sink name is not the part
+        // that drifted. This sentence reaches an operator's terminal
+        // through `Display` rather than through an `eprintln!` literal,
+        // which is how it kept sending them to `[dog.bark.sinks]` for a
+        // whole branch after that section moved to `[bark.sinks]` in
+        // dogs.toml: the sweep that fixed the literals could not see it.
+        assert_eq!(
+            err.to_string(),
+            "rule 0 routes to sink \"pager\", which [bark.sinks] in dogs.toml does not define"
+        );
     }
 
     /// fails if `[dog.bark]` with sinks and no rules alerts on nothing.

--- a/crates/shep-cli/src/dog/bark/rules.rs
+++ b/crates/shep-cli/src/dog/bark/rules.rs
@@ -43,7 +43,7 @@ fn default_debounce() -> UpDuration {
     UpDuration::from_millis(5 * 60 * 1_000)
 }
 
-/// One entry under `[dog.bark.rules]`.
+/// One entry under `[[bark.rules]]` in `dogs.toml`.
 ///
 /// A misspelled key anywhere in a rule is a startup error naming the bad
 /// key, never a silently ignored setting. See
@@ -63,9 +63,9 @@ pub struct Rule {
     /// What fires it.
     #[serde(flatten)]
     pub when: Trigger,
-    /// Sinks by name, from `[dog.bark.sinks]`. At least one; a rule
-    /// routing nowhere is a rule that fires into a file and is refused at
-    /// startup rather than discovered during an incident.
+    /// Sinks by name, from `[bark.sinks]` in `dogs.toml`. At least one; a
+    /// rule routing nowhere is a rule that fires into a file and is
+    /// refused at startup rather than discovered during an incident.
     pub sinks: Vec<String>,
     /// How long after one firing this rule stays quiet FOR THE SAME
     /// SUBJECT. Per-subject, never global: a flock where one sheep flaps
@@ -631,7 +631,7 @@ mod tests {
         );
     }
 
-    /// fails if `[dog.bark]` with sinks and no rules alerts on nothing.
+    /// fails if a `[bark]` with sinks and no rules alerts on nothing.
     /// "The shepherd gave up" is on by default with nothing to tune — that
     /// is what makes it the alert that cannot be missed.
     #[test]
@@ -919,9 +919,9 @@ sinks = ["oncall"]
     }
 
     /// fails if an `event` rule cannot be parsed from TOML — not shown in
-    /// the published docs, but a real `Trigger` variant a `[[dog.bark.
-    /// rules]]` entry can name, and the same flatten mechanism the docs'
-    /// two forms exercise.
+    /// the published docs, but a real `Trigger` variant a `[[bark.rules]]`
+    /// entry can name, and the same flatten mechanism the docs' two forms
+    /// exercise.
     #[test]
     fn an_event_rule_parses_from_toml() {
         let rule: Rule = toml::from_str(

--- a/crates/shep-cli/src/dog/metrics/mod.rs
+++ b/crates/shep-cli/src/dog/metrics/mod.rs
@@ -169,7 +169,7 @@ pub async fn run(runtime: DogRuntime) -> ExitCode {
             // fact, never the value, and that rule does not carve out an
             // exception for a config shape (like this one) that happens not
             // to carry a secret today.
-            eprintln!("shep dog metrics: [dog.metrics] does not parse; see `shep dogs`");
+            eprintln!("shep dog metrics: [metrics] in dogs.toml does not parse; see `shep dogs`");
             return ExitCode::InvalidConfig;
         }
     };

--- a/crates/shep-cli/src/dog/mod.rs
+++ b/crates/shep-cli/src/dog/mod.rs
@@ -320,12 +320,12 @@ async fn run_bark(runtime: DogRuntime) -> ExitCode {
     let config = match runtime.config::<bark::BarkConfig>() {
         Ok(config) => config,
         Err(_err) => {
-            // The fact, not the value: a `[dog.bark]` section routinely
+            // The fact, not the value: a `[bark]` section routinely
             // carries a webhook URL with a bearer token in its path, and
             // `DogRunError::Section`'s own message can quote it — see that
             // type's redacted `Debug`. `metrics::run`'s own diagnostic
             // takes the same posture for the same reason.
-            eprintln!("shep dog bark: [dog.bark] does not parse; see `shep dogs`");
+            eprintln!("shep dog bark: [bark] in dogs.toml does not parse; see `shep dogs`");
             return ExitCode::InvalidConfig;
         }
     };

--- a/crates/shep-cli/src/dog/mod.rs
+++ b/crates/shep-cli/src/dog/mod.rs
@@ -416,6 +416,7 @@ mod tests {
         let home = dir.to_path_buf();
         ShepPaths {
             daemon_config: home.join("shep.toml"),
+            dogs_config: home.join("dogs.toml"),
             snapshot: home.join("flock.json"),
             logs: home.join("logs"),
             pids: home.join("pids"),

--- a/crates/shep-cli/src/lib.rs
+++ b/crates/shep-cli/src/lib.rs
@@ -322,9 +322,9 @@ fn home_before(prefix: &[OsString]) -> Option<PathBuf> {
 /// Runs `path` — an adopted dog's binary — the way an operator invoking it
 /// by name expects: `extra_args` passed through exactly as typed, the two
 /// environment variables every dog is promised (`$SHEP_HOME` to find the
-/// shepherd, `$SHEP_DOG_NAME` to name its own `[dog.<name>]` section),
-/// stdio inherited so an interactive dog behaves like any other program run
-/// directly from a shell.
+/// shepherd, `$SHEP_DOG_NAME` to name its own `[<name>]` section in
+/// `dogs.toml`), stdio inherited so an interactive dog behaves like any
+/// other program run directly from a shell.
 ///
 /// `name` is the token the operator typed, which is what
 /// [`dispatch_adopted_dog`] resolved `path` from, so a dog run this way and
@@ -2177,8 +2177,8 @@ mod tests {
     /// shepherd does. Both channels promise the same two variables
     /// (`shep_daemon::dogs::dog_app`), and this is the half an operator
     /// drives by hand -- a dog invoked here to print or check its own
-    /// configuration would otherwise read a different `[dog.<name>]` section
-    /// than the one it runs under, which is the whole failure
+    /// configuration would otherwise read a different `[<name>]` section in
+    /// `dogs.toml` than the one it runs under, which is the whole failure
     /// `SHEP_DOG_NAME` exists to end.
     ///
     /// The name asserted is the token the operator typed, never the script's

--- a/crates/shep-cli/src/whistle/control.rs
+++ b/crates/shep-cli/src/whistle/control.rs
@@ -237,6 +237,7 @@ mod tests {
         let paths = ShepPaths {
             home: std::path::PathBuf::new(),
             daemon_config: std::path::PathBuf::new(),
+            dogs_config: std::path::PathBuf::new(),
             snapshot: std::path::PathBuf::new(),
             logs: std::path::PathBuf::new(),
             pids: std::path::PathBuf::new(),

--- a/crates/shep-cli/src/whistle/read.rs
+++ b/crates/shep-cli/src/whistle/read.rs
@@ -253,6 +253,7 @@ mod tests {
         ShepPaths {
             home: std::path::PathBuf::new(),
             daemon_config: std::path::PathBuf::new(),
+            dogs_config: std::path::PathBuf::new(),
             snapshot: std::path::PathBuf::new(),
             logs: std::path::PathBuf::new(),
             pids: std::path::PathBuf::new(),

--- a/crates/shep-cli/tests/cli_e2e.rs
+++ b/crates/shep-cli/tests/cli_e2e.rs
@@ -7655,6 +7655,84 @@ fn a_bad_shep_toml_refuses_the_reload_and_leaves_the_flock_supervised() {
     graceful_kill(dir.path());
 }
 
+/// Fails if a dog section shep cannot move can orphan a running flock.
+///
+/// The dog-config migration runs at the top of every boot, so on the
+/// handover arm it runs in a successor whose predecessor is already gone: a
+/// refusal there used to exit the successor with the flock still running
+/// and nothing supervising it. Measured before the fix, with exactly this
+/// setup: the reload failed, the sheep survived reparented to init, `shep
+/// flock` reported it stopped, and a recovering `shep muster` started a
+/// second copy alongside the orphan.
+///
+/// `metrics` configured in both `shep.toml` and `dogs.toml` is the refusal
+/// with the fewest moving parts (`DogMigrationError::WouldOverwrite`), and
+/// it is one an operator reaches by hand-writing `dogs.toml` before
+/// upgrading. No `#[cfg(unix)]`, for the same reason the bad-`shep.toml`
+/// case above carries none: the pre-flight runs before the arm is chosen.
+#[test]
+fn a_refused_dog_migration_refuses_the_reload_and_leaves_the_flock_supervised() {
+    let dir = tempfile::tempdir().unwrap();
+    let script = write_test_script(&dir);
+    let mut guard = DaemonGuard::default();
+
+    let started = shep(dir.path())
+        .arg("--format")
+        .arg("json")
+        .arg("start")
+        .arg(&script)
+        .arg("--name")
+        .arg("sheep")
+        .output()
+        .unwrap();
+    guard.adopt_home(dir.path());
+    assert_success(&started);
+
+    let before = poll_flock(dir.path(), |info| {
+        info["status"] == "online" && !info["pid"].is_null()
+    });
+    let pid_before = before["pid"]
+        .as_u64()
+        .unwrap_or_else(|| panic!("an online sheep reports a pid: {before}"));
+
+    write_shep_toml(&dir, "[dog.metrics]\nbind = \"127.0.0.1:19616\"\n");
+    std::fs::write(
+        dir.path().join("dogs.toml"),
+        "[metrics]\nbind = \"127.0.0.1:19617\"\n",
+    )
+    .unwrap();
+
+    let reloaded = shep(dir.path())
+        .arg("daemon")
+        .arg("reload")
+        .output()
+        .unwrap();
+    assert_eq!(
+        reloaded.status.code(),
+        Some(4),
+        "InvalidConfig; stderr={}",
+        String::from_utf8_lossy(&reloaded.stderr)
+    );
+
+    let after = shep(dir.path())
+        .arg("--format")
+        .arg("json")
+        .arg("flock")
+        .output()
+        .unwrap();
+    assert_success(&after);
+    let envelope: serde_json::Value = serde_json::from_slice(&after.stdout).unwrap();
+    let sheep = &envelope["data"][0];
+    assert_eq!(sheep["status"], "online", "still supervised: {sheep}");
+    assert_eq!(
+        sheep["pid"].as_u64(),
+        Some(pid_before),
+        "the refusal must happen before anything is signalled: {sheep}"
+    );
+
+    graceful_kill(dir.path());
+}
+
 /// Pins the ruling behind the file-only pre-flight: an env var set on the
 /// `shep daemon reload` invocation itself must not rescue a file that is
 /// invalid on its own, because a handover successor execs with the OLD

--- a/crates/shep-cli/tests/cli_e2e.rs
+++ b/crates/shep-cli/tests/cli_e2e.rs
@@ -6238,6 +6238,97 @@ fn runtime_exits_when_the_flock_empties_with_a_code_that_says_why() {
     );
 }
 
+#[cfg(unix)]
+/// Fails if `shep runtime` serves a dog the compiled default instead of the
+/// bind an operator wrote.
+///
+/// `runtime` reaches `boot_supervisor` directly, never `run_daemon`, and
+/// the dog-config migration used to live in the latter -- so `runtime`
+/// started dogs out of a `dogs.toml` that would never exist. Measured
+/// before the fix, with exactly this shep.toml: nothing listened on the
+/// configured port and the compiled default 9615 served instead, with no
+/// warning and no file written. Permanent, since a container that only ever
+/// runs `shep runtime` never migrates; for bark it would mean every sink
+/// disappearing and alerting stopping silently.
+///
+/// The port is the assertion rather than the file, because the file is the
+/// mechanism and the port is what an operator loses. `dogs.toml` is
+/// asserted too, as the cheap direct evidence of which of the two ran.
+///
+/// `#[cfg(unix)]`, like the other cases that scrape a real dog process:
+/// they share [`wait_for_dog_pid`]'s `nix::unistd::Pid` and
+/// [`DaemonGuard`]'s dog sweep.
+#[test]
+fn runtime_migrates_dog_config_and_serves_the_bind_an_operator_wrote() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path();
+    let port = free_port();
+    write_shep_toml(
+        &dir,
+        &format!(
+            "[daemon]\nenabled_dogs = [\"metrics\"]\n\n[dog.metrics]\nbind = \"127.0.0.1:{port}\"\n"
+        ),
+    );
+    let script = write_test_script(&dir);
+    let flockfile = write_flockfile(
+        &dir,
+        &format!("[[app]]\nname = \"web\"\nscript = '{}'\n", script.display()),
+    );
+    let mut guard = DaemonGuard::default();
+    // Before the spawn, not after: `runtime` boots its shepherd in its own
+    // process, so there is a supervisor to reap from the moment it starts.
+    guard.adopt_home(home);
+
+    let mut child = std::process::Command::cargo_bin("shep")
+        .expect("locate the built shep binary")
+        .arg("--home")
+        .arg(home)
+        .arg("runtime")
+        .arg(&flockfile)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn shep runtime");
+    // `runtime` streams the flock's bleats to its own stdout for as long as
+    // it runs; nothing draining those pipes wedges the child once they fill.
+    discard_in_background(child.stdout.take().expect("piped stdout"));
+    discard_in_background(child.stderr.take().expect("piped stderr"));
+
+    // `wait_for_dog_pid` shells out to `shep flock` and asserts success on
+    // the first try, so it cannot be the first thing aimed at a shepherd
+    // booting inside a process this test only just spawned. Every other
+    // case in this file reaches its daemon through a `shep start` that has
+    // already returned; `runtime` gives no such moment.
+    let start = Instant::now();
+    while !shep(home).arg("flock").output().unwrap().status.success() {
+        assert!(
+            start.elapsed() < FLOCK_DEADLINE,
+            "`shep runtime` never brought a shepherd up at {}",
+            home.display()
+        );
+        std::thread::sleep(Duration::from_millis(50));
+    }
+
+    let dog_pid = wait_for_dog_pid(home, "metrics");
+    guard.adopt_dog_pid(dog_pid);
+
+    let addr = std::net::SocketAddr::from(([127, 0, 0, 1], port));
+    let body = poll_metrics(addr);
+    assert!(
+        body.contains("HTTP/1.1 200"),
+        "the metrics dog must answer at the bind shep.toml asked for, not at \
+         the compiled default: {body}"
+    );
+    assert!(
+        home.join("dogs.toml").is_file(),
+        "`shep runtime` must migrate `[dog.metrics]` out of shep.toml"
+    );
+
+    graceful_kill(home);
+    let _ = child.wait();
+}
+
 // --- `shep dev` -------------------------------------------------------
 
 /// A `shep dev` invocation with `$SHEP_DEV_HOME` set to `dev_home`, timeout

--- a/crates/shep-core/src/config/daemon.rs
+++ b/crates/shep-core/src/config/daemon.rs
@@ -188,12 +188,15 @@ pub struct StyleSection {
 /// `ResolvedApp` protects a property of travel — the supervisor is handed one
 /// and must trust normalization it cannot see. Every production site loads a
 /// `DaemonConfig` and consumes it within a few lines (`run_daemon` renders it
-/// straight into `BootOptions`; shep-daemon's `dogs` reads one
-/// `[dog.<name>]` table; shep-cli's `whistle::gate` reads one boolean), and
-/// the daemon holds a `BootOptions`, not this. Guarding the one
-/// `max_cron_sleep` floor against a caller who is already out of contract
-/// would cost accessors for every field of every section, including a
-/// `BTreeMap<String, toml::Table>` two crates legitimately read. If an
+/// straight into `BootOptions`; shep-cli's `whistle::gate` reads one
+/// boolean), and the daemon holds a `BootOptions`, not this. A dog's own
+/// table is no longer among them: it lives in `dogs.toml` now, and
+/// shep-daemon's `dog_section` reads it out of a
+/// [`DogsConfig`](crate::config::DogsConfig), so
+/// [`Self::dog`] is what an un-migrated file parses into and nothing in
+/// production reads. Guarding the one `max_cron_sleep` floor against a
+/// caller who is already out of contract would cost accessors for every
+/// field of every section, that `BTreeMap<String, toml::Table>` included. If an
 /// out-of-tree caller ever does need to mutate and re-check, the answer is to
 /// make `validate` public — one line, non-breaking — not to privatise the
 /// fields. `docs/specs/deferred.md` records this as resolved.

--- a/crates/shep-core/src/config/dogs.rs
+++ b/crates/shep-core/src/config/dogs.rs
@@ -49,7 +49,6 @@ impl DogsConfig {
 }
 
 /// Why `dogs.toml` could not be read
-#[derive(Debug)]
 // One variant today. `#[non_exhaustive]` so a second reading failure (a
 // permissions error, once this type learns to open the file itself) is
 // additive rather than breaking.
@@ -57,6 +56,30 @@ impl DogsConfig {
 pub enum DogsConfigError {
     /// The file is not valid TOML
     Toml(toml::de::Error),
+}
+
+/// Manual, not derived (IR-41): `toml::de::Error`'s own `Debug` forwards to
+/// `toml_edit::TomlError`, which keeps the ENTIRE source document in a `raw`
+/// field so `Display` can quote a line of context. A derived `Debug` here
+/// prints all of it, and this is the one type in the workspace whose source
+/// document is `dogs.toml` -- the file `docs/dogs.md` tells an operator to
+/// paste a Discord or Slack webhook URL into. Measured against `toml`
+/// 0.8.23: a derived `Debug` emitted the whole file, webhook and all, five
+/// lines below the redacted `Debug` [`DogsConfig`] carries for the same
+/// secret.
+///
+/// The redaction is the parser's short `message()`, never the line it
+/// quotes -- the same posture, for the same reason, that
+/// `ShepTomlError::Parse` takes in shep-cli. `Display` below still shows the
+/// full line-and-column rendering: that is the deliberate surface, meant for
+/// the operator who broke their own file to read. `Debug` is not that
+/// surface, it is what a log captures.
+impl fmt::Debug for DogsConfigError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Toml(err) => f.debug_tuple("Toml").field(&err.message()).finish(),
+        }
+    }
 }
 
 impl fmt::Display for DogsConfigError {
@@ -109,6 +132,34 @@ mod tests {
     // path. `Debug` is the one thing between such a token and any future
     // `tracing::debug!("{config:?}")`, so the exact string is pinned rather
     // than the shape.
+    // IR-41 again, and this is the leak the redaction above defeated by
+    // being five lines away from it: `DogsConfig`'s own `Debug` says
+    // `<1 tables>`, and the error returned when the same file will not
+    // parse used to print every byte of it. The exact string is pinned,
+    // not the shape, because a shape assertion passes on a `Debug` that
+    // appended the raw source after the message.
+    #[test]
+    fn debug_redacts_the_source_a_parse_error_carries() {
+        let source =
+            "[bark.sinks]\noncall = { url = \"https://discord.com/api/webhooks/SECRET\" }\n[oops\n";
+        let err = DogsConfig::load(Some(source)).expect_err("unterminated table header");
+        assert_eq!(
+            format!("{err:?}"),
+            "Toml(\"invalid table header\\nexpected `.`, `]`\")"
+        );
+        // The operator's own surface is untouched: `Display` still quotes
+        // the line that failed, which is the one line of the file this type
+        // is meant to show.
+        assert!(
+            err.to_string().contains("line 3, column 6"),
+            "Display keeps its line-and-column context: {err}"
+        );
+        assert!(
+            !err.to_string().contains("SECRET"),
+            "and it quotes only the line that failed: {err}"
+        );
+    }
+
     #[test]
     fn debug_redacts_every_dog_section() {
         let source =

--- a/crates/shep-core/src/config/dogs.rs
+++ b/crates/shep-core/src/config/dogs.rs
@@ -1,0 +1,119 @@
+//! `$SHEP_HOME/dogs.toml`, a dog's own settings.
+//!
+//! One table per dog, keyed by the name the dog was registered under, with
+//! no prefix: `[metrics]` here is what `[dog.metrics]` was in `shep.toml`
+//! before the move. The daemon serves a section verbatim over the socket as
+//! `Response::DogSection` and never interprets it, so this type parses
+//! exactly far enough to find the right table and no further.
+//!
+//! Hand-editable on purpose, and deliberately not a locked shep-owned store
+//! like `overrides.json`. A dog's config is authored intent rather than
+//! derived state, and an operator on a box with only a shell has to be able
+//! to set one without a dashboard.
+
+use core::fmt;
+use std::collections::BTreeMap;
+
+/// Every `[<dog>]` table in `dogs.toml`
+///
+/// `Debug` is redacted (IR-41): a dog section routinely carries a webhook
+/// URL with a bearer token in it, and this type exists to be logged near
+/// the boot path.
+#[derive(Clone, Default, PartialEq)]
+pub struct DogsConfig {
+    /// Raw `[<name>]` tables keyed by dog name
+    pub dog: BTreeMap<String, toml::Table>,
+}
+
+impl fmt::Debug for DogsConfig {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("DogsConfig")
+            .field("dog", &format_args!("<{} tables>", self.dog.len()))
+            .finish()
+    }
+}
+
+impl DogsConfig {
+    /// Parses `dogs.toml`, or answers empty when there is no file
+    ///
+    /// # Errors
+    ///
+    /// - [`DogsConfigError::Toml`] when `source` is not valid TOML.
+    pub fn load(source: Option<&str>) -> Result<Self, DogsConfigError> {
+        let Some(source) = source else {
+            return Ok(Self::default());
+        };
+        let dog = toml::from_str(source).map_err(DogsConfigError::Toml)?;
+        Ok(Self { dog })
+    }
+}
+
+/// Why `dogs.toml` could not be read
+#[derive(Debug)]
+// One variant today. `#[non_exhaustive]` so a second reading failure (a
+// permissions error, once this type learns to open the file itself) is
+// additive rather than breaking.
+#[non_exhaustive]
+pub enum DogsConfigError {
+    /// The file is not valid TOML
+    Toml(toml::de::Error),
+}
+
+impl fmt::Display for DogsConfigError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Toml(err) => write!(f, "invalid TOML in dogs.toml: {err}"),
+        }
+    }
+}
+
+impl core::error::Error for DogsConfigError {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
+        match self {
+            Self::Toml(err) => Some(err),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_missing_file_loads_as_an_empty_map() {
+        let config = DogsConfig::load(None).expect("None is not an error");
+        assert!(config.dog.is_empty());
+    }
+
+    #[test]
+    fn sections_are_keyed_by_name_with_no_prefix() {
+        let source = "[metrics]\nbind = \"127.0.0.1:9615\"\n\n[bark.sinks]\noncall = { kind = \"discord\" }\n";
+        let config = DogsConfig::load(Some(source)).expect("valid TOML");
+        assert_eq!(
+            config.dog.keys().collect::<Vec<_>>(),
+            vec!["bark", "metrics"]
+        );
+        assert_eq!(
+            config.dog["metrics"]["bind"].as_str(),
+            Some("127.0.0.1:9615")
+        );
+    }
+
+    #[test]
+    fn invalid_toml_is_a_named_error() {
+        let err = DogsConfig::load(Some("[metrics")).expect_err("unterminated table header");
+        assert!(matches!(err, DogsConfigError::Toml(_)));
+    }
+
+    // IR-41: this map routinely holds webhook URLs with a bearer token in the
+    // path. `Debug` is the one thing between such a token and any future
+    // `tracing::debug!("{config:?}")`, so the exact string is pinned rather
+    // than the shape.
+    #[test]
+    fn debug_redacts_every_dog_section() {
+        let source =
+            "[bark.sinks]\noncall = { url = \"https://discord.com/api/webhooks/SECRET\" }\n";
+        let config = DogsConfig::load(Some(source)).expect("valid TOML");
+        assert_eq!(format!("{config:?}"), "DogsConfig { dog: <1 tables> }");
+    }
+}

--- a/crates/shep-core/src/config/mod.rs
+++ b/crates/shep-core/src/config/mod.rs
@@ -5,6 +5,7 @@ pub mod app;
 pub mod apply;
 pub mod cron;
 pub mod daemon;
+pub mod dogs;
 pub mod flockfile;
 pub mod kill_signal;
 pub mod normalize;
@@ -17,6 +18,7 @@ pub use app::{AppConfig, ProbeConfig, ProbeKind};
 pub use apply::{ApplyGroup, ResetDepth, apply_group};
 pub use cron::{CronParseError, CronSchedule, CronScheduleError};
 pub use daemon::{DaemonConfig, DaemonConfigError, DaemonOverrides, LogLevel, parse_daemon_bool};
+pub use dogs::{DogsConfig, DogsConfigError};
 pub use flockfile::{DeclaredApp, FlockFormat, Flockfile, FlockfileError, discover};
 #[cfg(feature = "schema")]
 pub use flockfile::{flockfile_schema_json, flockfile_schema_string};

--- a/crates/shep-core/src/paths.rs
+++ b/crates/shep-core/src/paths.rs
@@ -72,6 +72,12 @@ pub struct ShepPaths {
     pub home: PathBuf,
     /// Daemon config: `shep.toml`
     pub daemon_config: PathBuf,
+    /// A dog's own settings: `dogs.toml`
+    ///
+    /// Separate from [`Self::daemon_config`] rather than a section inside
+    /// it, so lookout can write a dog's config without writing into the
+    /// daemon's own hand-authored file.
+    pub dogs_config: PathBuf,
     /// Flock snapshot (muster roll): `flock.json`
     pub snapshot: PathBuf,
     /// Log directory
@@ -173,6 +179,7 @@ impl ShepPaths {
         #[cfg_attr(not(windows), allow(unused_mut))]
         let mut paths = Self {
             daemon_config: home.join("shep.toml"),
+            dogs_config: home.join("dogs.toml"),
             snapshot: home.join("flock.json"),
             logs: home.join("logs"),
             pids: home.join("pids"),
@@ -272,6 +279,7 @@ mod tests {
         let p = ShepPaths::resolve(&no_env, Path::new("/home/ada"));
         assert_eq!(p.home, Path::new("/home/ada/.shep"));
         assert_eq!(p.daemon_config, Path::new("/home/ada/.shep/shep.toml"));
+        assert_eq!(p.dogs_config, Path::new("/home/ada/.shep/dogs.toml"));
         assert_eq!(p.snapshot, Path::new("/home/ada/.shep/flock.json"));
         assert_eq!(p.logs, Path::new("/home/ada/.shep/logs"));
         assert_eq!(p.pids, Path::new("/home/ada/.shep/pids"));

--- a/crates/shep-daemon/src/assemble.rs
+++ b/crates/shep-daemon/src/assemble.rs
@@ -280,6 +280,7 @@ mod tests {
         ShepPaths {
             home: PathBuf::from("/home/ada/.shep"),
             daemon_config: PathBuf::from("/home/ada/.shep/shep.toml"),
+            dogs_config: PathBuf::from("/home/ada/.shep/dogs.toml"),
             snapshot: PathBuf::from("/home/ada/.shep/flock.json"),
             logs: PathBuf::from("/home/ada/.shep/logs"),
             pids: PathBuf::from("/home/ada/.shep/pids"),

--- a/crates/shep-daemon/src/boot.rs
+++ b/crates/shep-daemon/src/boot.rs
@@ -1376,7 +1376,7 @@ pub async fn boot<R: ProcessRunner>(
         events,
         registry,
         snapshot_path: paths.snapshot.clone(),
-        daemon_config: paths.daemon_config.clone(),
+        dogs_config: paths.dogs_config.clone(),
         paths: paths.clone(),
         daemon_version: env!("CARGO_PKG_VERSION").to_string(),
         dog_refusals,

--- a/crates/shep-daemon/src/dogs.rs
+++ b/crates/shep-daemon/src/dogs.rs
@@ -53,7 +53,7 @@ use crate::supervisor::SupervisorHandle;
 /// One dog the daemon knows about: its name, and where its binary comes from.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DogSpec {
-    /// The dog's name — the `[<name>]` key and the entry's name.
+    /// The dog's name: the `[<name>]` key and the entry's name.
     pub name: String,
     /// Where its binary comes from.
     pub source: DogSource,
@@ -63,7 +63,7 @@ pub struct DogSpec {
 ///
 /// `Debug` is derived and needs no redaction: the variants carry a path, a
 /// normalizer complaint about a config this module assembled itself, or a
-/// TOML parser message — never a value read out of a parsed `[<name>]`
+/// TOML parser message, never a value read out of a parsed `[<name>]`
 /// table. The one way a section's own text can reach a message is a *syntax*
 /// error, where the parser quotes the line it failed on; that is the same
 /// exposure [`DogsConfigError`](shep_core::config::DogsConfigError)
@@ -231,7 +231,7 @@ pub fn dog_app(spec: &DogSpec, paths: &ShepPaths) -> Result<ResolvedApp, DogErro
     config
         .env
         .insert("SHEP_HOME".to_string(), paths.home.display().to_string());
-    // The name the operator registered this dog under — the `[<name>]`
+    // The name the operator registered this dog under: the `[<name>]`
     // key its own section lives beneath, and so the `name` it has to put in
     // `Request::DogConfig`. A built-in dog reads it out of its argv; an
     // adopted one has no argv at all, so it needs another way to learn it —
@@ -249,7 +249,7 @@ pub fn dog_app(spec: &DogSpec, paths: &ShepPaths) -> Result<ResolvedApp, DogErro
     //
     // Safe to place here for the same reason `SHEP_HOME` is, and for no
     // other: a name is not a secret. The rule this does not break is that
-    // no `[<name>]` VALUE travels in the environment — that is the key,
+    // no `[<name>]` VALUE travels in the environment. That is the key,
     // not the section.
     config
         .env
@@ -292,9 +292,9 @@ pub async fn spawn_enabled_dogs(
             }
         };
         // Read before `start_dog` takes the app. This is the one place that
-        // knows which file a dog's spawn actually resolved to — a built-in
+        // knows which file a dog's spawn actually resolved to (a built-in
         // dog's is this shep's own binary, an adopted one's is whatever the
-        // operator's `[<name>]` named — and an operator reading the
+        // operator's `[<name>]` named), and an operator reading the
         // dog's log during an upgrade is usually asking exactly that.
         let script = app.config().script.clone();
         match supervisor.start_dog(app, spec.source.clone()).await {
@@ -335,7 +335,7 @@ pub async fn spawn_enabled_dogs(
 /// simply has no file.
 ///
 /// # Errors
-/// - [`DogError::Config`] — the file exists and is not valid `dogs.toml`,
+/// - [`DogError::Config`]: the file exists and is not valid `dogs.toml`,
 ///   or its section will not render back to TOML.
 /// - [`DogError::Io`] — the file exists and could not be read.
 pub fn dog_section(path: &Path, name: &str) -> Result<String, DogError> {

--- a/crates/shep-daemon/src/dogs.rs
+++ b/crates/shep-daemon/src/dogs.rs
@@ -18,7 +18,7 @@
 //! the socket as `Request::DogConfig`. A dog inherits `$SHEP_HOME` and
 //! `$SHEP_DOG_NAME` and nothing else it did not already need in order to
 //! exec: it connects to the socket the first names, handshakes, and asks for
-//! the `[dog.<name>]` section the second names. The reply is opaque text the
+//! its `[<name>]` section of `dogs.toml`, which the second names. The reply is opaque text the
 //! dog parses, so a third-party dog is bound to the shape of its own section
 //! and not to shep's config model, file discovery, or layering rules.
 //!
@@ -39,7 +39,7 @@ use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex, PoisonError};
 
 use shep_core::barks::{self, Bark};
-use shep_core::config::{AppConfig, DaemonConfig, ResolvedApp, normalize};
+use shep_core::config::{AppConfig, DogsConfig, ResolvedApp, normalize};
 use shep_core::paths::ShepPaths;
 use shep_core::protocol::{BusEvent, DogSource, ProcessEventKind, ProcessInfo};
 use shep_core::selector::ProcessSelector;
@@ -53,7 +53,7 @@ use crate::supervisor::SupervisorHandle;
 /// One dog the daemon knows about: its name, and where its binary comes from.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DogSpec {
-    /// The dog's name — the `[dog.<name>]` key and the entry's name.
+    /// The dog's name — the `[<name>]` key and the entry's name.
     pub name: String,
     /// Where its binary comes from.
     pub source: DogSource,
@@ -63,10 +63,10 @@ pub struct DogSpec {
 ///
 /// `Debug` is derived and needs no redaction: the variants carry a path, a
 /// normalizer complaint about a config this module assembled itself, or a
-/// TOML parser message — never a value read out of a parsed `[dog.<name>]`
+/// TOML parser message — never a value read out of a parsed `[<name>]`
 /// table. The one way a section's own text can reach a message is a *syntax*
 /// error, where the parser quotes the line it failed on; that is the same
-/// exposure [`DaemonConfigError`](shep_core::config::DaemonConfigError)
+/// exposure [`DogsConfigError`](shep_core::config::DogsConfigError)
 /// already carries, and it reaches only the peer that asked, which
 /// peer-cred auth has already established owns the file.
 ///
@@ -194,7 +194,7 @@ fn builtin_program() -> Result<PathBuf, DogError> {
 /// carries exactly two things it did not already need in order to exec:
 /// `SHEP_HOME`, which is how every client locates the socket, and
 /// `SHEP_DOG_NAME`, which is the name this dog was registered under and so
-/// the `name` its `Request::DogConfig` has to carry. No `[dog.<name>]`
+/// the `name` its `Request::DogConfig` has to carry. No `[<name>]`
 /// value is ever placed here — a dog asks for its section over the socket,
 /// because the environment is readable from the process table, inherited by
 /// every child, and captured into crash dumps. The section's KEY is not one
@@ -231,7 +231,7 @@ pub fn dog_app(spec: &DogSpec, paths: &ShepPaths) -> Result<ResolvedApp, DogErro
     config
         .env
         .insert("SHEP_HOME".to_string(), paths.home.display().to_string());
-    // The name the operator registered this dog under — the `[dog.<name>]`
+    // The name the operator registered this dog under — the `[<name>]`
     // key its own section lives beneath, and so the `name` it has to put in
     // `Request::DogConfig`. A built-in dog reads it out of its argv; an
     // adopted one has no argv at all, so it needs another way to learn it —
@@ -249,7 +249,7 @@ pub fn dog_app(spec: &DogSpec, paths: &ShepPaths) -> Result<ResolvedApp, DogErro
     //
     // Safe to place here for the same reason `SHEP_HOME` is, and for no
     // other: a name is not a secret. The rule this does not break is that
-    // no `[dog.<name>]` VALUE travels in the environment — that is the key,
+    // no `[<name>]` VALUE travels in the environment — that is the key,
     // not the section.
     config
         .env
@@ -294,7 +294,7 @@ pub async fn spawn_enabled_dogs(
         // Read before `start_dog` takes the app. This is the one place that
         // knows which file a dog's spawn actually resolved to — a built-in
         // dog's is this shep's own binary, an adopted one's is whatever the
-        // operator's `[dog.<name>]` named — and an operator reading the
+        // operator's `[<name>]` named — and an operator reading the
         // dog's log during an upgrade is usually asking exactly that.
         let script = app.config().script.clone();
         match supervisor.start_dog(app, spec.source.clone()).await {
@@ -321,17 +321,21 @@ pub async fn spawn_enabled_dogs(
     }
 }
 
-/// The `[dog.<name>]` section of `path`, rendered back to TOML text.
+/// The `[<name>]` section of `path`, a `dogs.toml`, rendered back to TOML
+/// text.
 ///
 /// Reads the file on every call rather than serving a copy cached at boot:
 /// one reader can never be stale, and it is what makes
 /// `shep disable X && shep enable X` re-read an edited section.
 ///
 /// A missing file, or a file with no such section, is `Ok(String::new())` —
-/// a dog with no configuration is the ordinary case, not a fault.
+/// a dog with no configuration is the ordinary case, not a fault. That
+/// covers every home that has never had a dog configured: `dogs.toml` is
+/// written by the boot-time migration or by hand, so a home with neither
+/// simply has no file.
 ///
 /// # Errors
-/// - [`DogError::Config`] — the file exists and is not valid `shep.toml`,
+/// - [`DogError::Config`] — the file exists and is not valid `dogs.toml`,
 ///   or its section will not render back to TOML.
 /// - [`DogError::Io`] — the file exists and could not be read.
 pub fn dog_section(path: &Path, name: &str) -> Result<String, DogError> {
@@ -340,13 +344,13 @@ pub fn dog_section(path: &Path, name: &str) -> Result<String, DogError> {
         Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(String::new()),
         Err(err) => return Err(DogError::Io(err)),
     };
-    // Loaded through the daemon's own config loader rather than parsed here,
-    // so a broken `shep.toml` is one named error and not a second parser's
-    // opinion of the same file. No environment closure: `SHEP_*` overrides
-    // govern the daemon's own knobs and have nothing to say about a dog's
-    // section.
-    let config = DaemonConfig::load(Some(&source), &|_| None)
-        .map_err(|err| DogError::Config(err.to_string()))?;
+    // Loaded through shep-core's own type rather than parsed here, so a
+    // broken `dogs.toml` is one named error and not a second parser's
+    // opinion of the same file. The keys are dog names with no prefix:
+    // `[metrics]` here is what `[dog.metrics]` was in `shep.toml` before
+    // the boot-time migration moved it.
+    let config =
+        DogsConfig::load(Some(&source)).map_err(|err| DogError::Config(err.to_string()))?;
     match config.dog.get(name) {
         None => Ok(String::new()),
         Some(table) => toml::to_string(table).map_err(|err| DogError::Config(err.to_string())),
@@ -404,7 +408,7 @@ pub enum Refusal {
 /// a dog it can talk to is not stale by any definition it could apply.
 ///
 /// `Debug` is derived and needs no redaction (IR-41): the map holds dog
-/// names and counts. A dog's name is the `[dog.<name>]` key an operator
+/// names and counts. A dog's name is the `[<name>]` key an operator
 /// typed, which `dogs.rs` already places in the child's environment for the
 /// reason its module doc gives — the section's KEY is not one of its
 /// VALUES, and no value ever reaches this type.
@@ -995,7 +999,7 @@ pub(crate) fn silent_dogs(infos: &[ProcessInfo], refusals: &DogRefusals) -> Vec<
 ///
 /// `Debug` is derived and needs no redaction (IR-41), for the same reason
 /// [`DogRefusals`]'s is: the map holds dog names and instants, and a dog's
-/// name is a `[dog.<name>]` KEY rather than one of its values.
+/// name is a `[<name>]` KEY rather than one of its values.
 #[derive(Debug, Default)]
 pub(crate) struct SilentDogs {
     /// One instant per dog currently silent. A name absent from the map is a
@@ -1680,7 +1684,7 @@ mod tests {
         );
     }
 
-    /// fails if a `[dog.<name>]` value is folded into the child's
+    /// fails if a `[<name>]` value is folded into the child's
     /// environment. That is the design's whole reason for putting config on
     /// the socket: a webhook URL in the environment is readable from the
     /// process table on some systems, inherited by every child the dog
@@ -1698,8 +1702,8 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let paths = test_paths(&dir);
         std::fs::write(
-            &paths.daemon_config,
-            "[dog.bark]\nwebhook = \"https://example.invalid/hook\"\n",
+            &paths.dogs_config,
+            "[bark]\nwebhook = \"https://example.invalid/hook\"\n",
         )
         .unwrap();
         let spec = DogSpec {
@@ -1813,10 +1817,10 @@ mod tests {
     #[test]
     fn a_dogs_section_comes_back_as_its_own_table_and_nothing_else() {
         let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("shep.toml");
+        let path = dir.path().join("dogs.toml");
         std::fs::write(
             &path,
-            "[daemon]\nlog_json = true\n\n[dog.bark]\ndebounce = \"30s\"\n\n[dog.metrics]\nport = 9615\n",
+            "[bark]\ndebounce = \"30s\"\n\n[metrics]\nport = 9615\n",
         )
         .unwrap();
 
@@ -1826,7 +1830,6 @@ mod tests {
             !bark.contains("9615"),
             "one dog never sees another's config"
         );
-        assert!(!bark.contains("log_json"), "nor the daemon's own");
         // Round-trips as TOML, since that is the contract the dog parses under.
         let parsed: toml::Table = toml::from_str(&bark).unwrap();
         assert_eq!(parsed["debounce"].as_str(), Some("30s"));
@@ -1836,6 +1839,32 @@ mod tests {
             dog_section(&dir.path().join("gone.toml"), "bark").unwrap(),
             ""
         );
+    }
+
+    /// fails if the read that moved to `dogs.toml` changed what a dog is
+    /// served.
+    #[test]
+    fn a_section_reaches_the_wire_exactly_as_it_did_from_shep_toml() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("dogs.toml");
+        std::fs::write(&path, "[bark]\ndebounce = \"30s\"\n").expect("write");
+
+        // Byte-for-byte what the old `[dog.bark]` read produced. The
+        // dog-facing contract not moving is the whole of decision 3, so it
+        // is pinned as a string rather than as a parse.
+        assert_eq!(
+            dog_section(&path, "bark").expect("section"),
+            "debounce = \"30s\"\n"
+        );
+    }
+
+    #[test]
+    fn a_dog_with_no_section_still_gets_an_empty_string() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("dogs.toml");
+        std::fs::write(&path, "[bark]\ndebounce = \"30s\"\n").expect("write");
+
+        assert_eq!(dog_section(&path, "metrics").expect("section"), "");
     }
 
     /// A minimal `Process` bus event, `name` carrying either a sheep's or a

--- a/crates/shep-daemon/src/lib.rs
+++ b/crates/shep-daemon/src/lib.rs
@@ -58,8 +58,9 @@
 //! - `bus`: the daemon-wide event bus — topic-glob filtering, per-subscriber forwarder tasks
 //! - [`rpc`]: request dispatch — verb routing onto [`SupervisorHandle`](supervisor::SupervisorHandle), typed errors, per-call deadlines
 //! - [`dogs`]: the dog contract — what a dog is spawned as
-//!   ([`dog_app`](dogs::dog_app)) and the `[dog.<name>]` section served back
-//!   to it over the socket ([`dog_section`](dogs::dog_section))
+//!   ([`dog_app`](dogs::dog_app)) and the `[<name>]` section, read from
+//!   `dogs.toml`, served back to it over the socket
+//!   ([`dog_section`](dogs::dog_section))
 //! - `server`: the unix-socket connection layer — peer-cred auth, handshake, subscriptions (unix-only)
 //! - [`snapshot`]: the muster roll — debounced atomic `flock.json` writes, restart-survival restore
 //! - [`boot`]: daemon boot — `0700` layout dirs, pidfile, socket bind with stale-socket

--- a/crates/shep-daemon/src/rpc.rs
+++ b/crates/shep-daemon/src/rpc.rs
@@ -66,12 +66,14 @@ pub struct RpcContext {
     pub(crate) registry: FlockRegistry,
     /// Where [`Self::snapshot_now`] writes the muster roll.
     pub(crate) snapshot_path: PathBuf,
-    /// Where `DogConfig` reads a dog's `[dog.<name>]` section from.
+    /// Where `DogConfig` reads a dog's `[<name>]` section from: this home's
+    /// `dogs.toml`, not `shep.toml`. The key carries no prefix, and the
+    /// boot-time migration is what put it there.
     ///
     /// Re-read per request rather than held as parsed config: that is what
     /// makes `shep disable X && shep enable X` pick up an edited section
     /// (`crate::dogs::dog_section`).
-    pub(crate) daemon_config: PathBuf,
+    pub(crate) dogs_config: PathBuf,
     /// This daemon's `$SHEP_HOME` layout, for assembling a dog's app config.
     pub(crate) paths: ShepPaths,
     /// This daemon's crate version, echoed in the handshake.
@@ -504,7 +506,7 @@ async fn run(id: u64, conn: ConnId, request: Request, ctx: &RpcContext) -> Outco
         // Re-read per request, never cached: `shep disable X && shep enable X`
         // is the supported way to reload a dog's configuration, and a copy
         // taken at boot would answer that with the section as it was.
-        Request::DogConfig { name } => match crate::dogs::dog_section(&ctx.daemon_config, &name) {
+        Request::DogConfig { name } => match crate::dogs::dog_section(&ctx.dogs_config, &name) {
             Ok(toml) => reply(Ok(Response::DogSection { toml: toml.into() })),
             Err(err) => reply(Err(RpcError {
                 code: RpcErrorCode::InvalidConfig,
@@ -2600,7 +2602,7 @@ mod tests {
     #[tokio::test(start_paused = true)]
     async fn a_dog_config_request_reads_the_file_as_it_stands_now() {
         let h = harness(vec![]);
-        std::fs::write(&h.ctx.daemon_config, "[dog.bark]\ndebounce = \"30s\"\n").unwrap();
+        std::fs::write(&h.ctx.dogs_config, "[bark]\ndebounce = \"30s\"\n").unwrap();
         let reply = reply_of(
             dispatch(
                 envelope(

--- a/crates/shep-daemon/src/testing.rs
+++ b/crates/shep-daemon/src/testing.rs
@@ -534,7 +534,7 @@ pub(crate) fn harness_with_runner(
             events,
             registry: FlockRegistry::new(),
             snapshot_path: paths.snapshot.clone(),
-            daemon_config: paths.daemon_config.clone(),
+            dogs_config: paths.dogs_config.clone(),
             paths: paths.clone(),
             daemon_version: "0.1.0".to_string(),
             dog_refusals: crate::dogs::DogRefusals::new(),

--- a/crates/shep-daemon/tests/real_runner.rs
+++ b/crates/shep-daemon/tests/real_runner.rs
@@ -898,6 +898,7 @@ async fn a_bare_interpreter_resolves_via_the_seeded_path() {
     let paths = ShepPaths {
         home: dir.path().to_path_buf(),
         daemon_config: dir.path().join("shep.toml"),
+        dogs_config: dir.path().join("dogs.toml"),
         snapshot: dir.path().join("flock.json"),
         logs: dir.path().join("logs"),
         pids: dir.path().join("pids"),

--- a/docs/brainstorming/specs/2026-09-03-dog-config-design.md
+++ b/docs/brainstorming/specs/2026-09-03-dog-config-design.md
@@ -1,0 +1,315 @@
+# Design: dog config, and making it editable
+
+Status: designed 2026-09-03, not yet implemented.
+
+This moves a dog's settings out of `shep.toml`, gives a dog a way to describe
+its own config, and gives lookout enough to render an editor for it. The store
+move is breaking for operators and is deliberately sequenced first, before
+anything that depends on it.
+
+## The problem
+
+A dog's settings live under `[dog.<name>]` in `shep.toml` and shep has no idea
+what any of it means. `DaemonConfig` carries `pub dog: BTreeMap<String,
+toml::Table>`, parsed only because `RawDaemonConfig` denies unknown top-level
+keys and an unregistered section would otherwise be a hard boot error. One read
+site, `dog_section`, re-reads the file per request and passes the table through
+as TOML text.
+
+So shep sees the keys an operator wrote and their values, and nothing else. Not
+the fields a dog defaults internally, not their types, not whether a key is
+even valid for that dog, and not whether a value is a bearer credential.
+`[dog.bark.sinks]` routinely holds a webhook URL, which is why the whole
+section is treated as sensitive rather than any part of it.
+
+That is the reason decision 11 of the overrides spec excluded `[dog.<name>]`
+from lookout: "a third-party dog's opaque schema". The exclusion was correct
+and this spec removes the thing that made it necessary.
+
+Two smaller consequences fall out of the same gap. An operator editing
+`[dog.metrics]` gets no hint of what else could be set, because a dog that
+defaults everything has an empty section. And a change never reaches a running
+dog, so `docs/dogs.md` documents `shep disable <name> && shep enable <name>` as
+the way to apply one.
+
+## What already exists
+
+More than expected, which is why little of this is breaking.
+
+`shep adopt` already spawns a dog binary, asks it a question, and tolerates
+silence. It runs the binary with `--version`, reads two lines, and a dog that
+does not answer is adopted with its protocol unknown rather than refused. The
+pattern for asking a stranger's binary something is settled.
+
+The bus already pushes. `Request::Subscribe` takes topic globs and `shep
+bleats` uses it today. No dog subscribes yet, but nothing in the wire has to
+change for one to start.
+
+A dog can already restart itself. `hello.dog_name` is bookkeeping (it records
+who named themselves, and narrates the reconnect transition) and gates no
+requests, so a dog connection can issue `Request::Restart` exactly like the CLI
+can.
+
+`ShepToml` already does careful writes to `shep.toml`: `toml_edit` so comments
+and key order survive, an advisory lock on a sibling file, a staged temp file,
+`fsync`, atomic rename. `shep style`, `shep enable` and `shep adopt` all go
+through it, so shep writing an operator's config file is established practice
+rather than a new liberty.
+
+schemars is already a workspace dependency at 1.2.2, and field-level
+`#[schemars(extend(...))]` works in that version.
+
+## Decisions
+
+### 1. Dog config leaves `shep.toml` for its own file
+
+`$SHEP_HOME/dogs.toml`, holding what `[dog.*]` holds today with the `dog.`
+prefix dropped: `[metrics]`, `[bark.sinks]`.
+
+Decision 11's objection was never to dog config being in a file. It was to
+lookout writing into free-form maps inside the daemon's own hand-written
+config, which is the same reason decision 8 of that spec put shared env in its
+own store. A separate file answers the objection without taking anything away.
+
+Hand-editable, and deliberately not a locked shep-owned store like
+`overrides.json`. A dog's config is authored intent, not derived state, and an
+operator on a box with only a shell has to be able to set `bind =
+"0.0.0.0:9615"` without waiting for a dashboard. shep tolerates a human having
+edited it badly exactly as it does for `shep.toml`.
+
+### 2. Migrate on first boot, then strike the section
+
+`RawDaemonConfig` keeps its `dog` field, so an old `shep.toml` never fails to
+parse. This is not optional politeness: delete that field and every existing
+file with a `[dog.bark]` section stops parsing, the daemon refuses to boot, and
+the flock goes unsupervised at upgrade time.
+
+On boot, any `[dog.*]` section present is moved into `dogs.toml` and struck
+from `shep.toml` in one `ShepToml::edit`, and shep reports what moved. One
+transition, one source of truth after it, no window where both files hold a
+value for the same key.
+
+After that boot the `dog` field is a recognized key that is always empty.
+Removing it from the struct is a later breaking change with its own
+deprecation window, not part of this.
+
+### 3. The dog-facing wire does not change
+
+`Response::DogSection` keeps carrying the section as TOML text in
+`DogSectionToml`, and `dog_section` just reads a different file. Every dog ever
+written keeps working, so the breakage stays operator-side: one file, migrated
+automatically.
+
+The newtype's manual `Debug` and its exact-string test survive untouched, which
+matters more than the format seam it creates against a schema that is JSON.
+
+### 4. A dog publishes its schema, and answering is optional
+
+`--schema` on the binary, printing JSON Schema on stdout. Same shape as the
+`--version` probe adopt already runs: spawn, read, kill.
+
+Asked of the binary rather than over the socket because the dog most in need of
+configuring is the one that is disabled or has never started, and it has no
+connection to answer on. Configure then enable is the sequence an operator
+wants.
+
+A dog that answers nothing is recorded as having no schema and is refused
+nothing, matching `--version`. A dog that answers invalid JSON gets one warning
+at adopt and is otherwise treated as silence, because a dog with a broken
+`--schema` may still scrape perfectly well.
+
+This is a new expectation on dog authors, which is why it belongs in the dog
+contract now rather than after more dogs exist.
+
+### 5. shep owns the probe, and the strings both sides parse
+
+One entry point on the dog side, handling every probe rather than one function
+per flag:
+
+```rust
+fn main() {
+    shep_client::dogs::probe::<MyDogConfig>();  // answers --version and --schema
+    // ...normal startup
+}
+```
+
+`--version`'s answer format is parsed by shep and is currently hand-typed in
+every dog from a snippet in the docs. A typo there reads as "protocol unknown"
+and nothing says so. `--schema` would create the same bug on day one, so both
+move behind one call that shep can extend later without every dog needing an
+edit.
+
+Three homes, and no crate depends on another's half:
+
+| what | where |
+| --- | --- |
+| flag names, the `shep-protocol:` line's grammar, the secret marker key | `shep-core` |
+| `dogs::probe`, the dog side | `shep-client`, which already re-exports `shep_core` |
+| spawning the binary and reading the answer | `shep-cli`, beside the vetting adopt already does |
+
+The asker stays in `shep-cli` deliberately. It is the code that executes an
+untrusted third-party binary, and it belongs next to the rules that go with
+that (execute bit, world-writable refusal, canonicalized path, spawn and kill).
+Putting it in `shep-client` would make every dog compile it and would split
+adopt's vetting across two crates.
+
+### 6. The secret marker is a derive macro, not a documented extension
+
+```rust
+#[derive(Deserialize, DogConfig)]
+struct Sink {
+    kind: SinkKind,
+    #[shep(secret)]
+    url: String,
+}
+```
+
+schemars can express this without shep shipping anything:
+`#[schemars(extend("x-shep-secret" = true))]` works at field level in 1.2. On
+ergonomics that is twenty-three characters and not worth a proc-macro crate.
+
+The reason to ship one anyway is that `x-shep-secret` is a string shep parses,
+hand-typed by the author. Spell it `x-shep-secert` and it compiles, the schema
+validates, the field is not marked, and lookout paints a webhook credential on
+screen. Nothing fails and nothing warns. It cannot be linted either, because
+schemars takes a string literal for the extension key, so a shep-exported const
+cannot go in that position.
+
+That is the same bug class decision 5 removes for `--version`, and the marker
+is the one field where getting it wrong has a security consequence rather than
+a cosmetic one.
+
+### 7. The schema is asked fresh, never stored
+
+`docs/dogs.md` already refuses to store a dog's protocol version, on the
+grounds that `cargo install` replaces a binary with nothing watching, so a
+stored copy "would be wrong exactly when it mattered". A schema is the same
+claim about the same file and gets the same rule.
+
+A stale schema is worse than a stale version number, because it mislabels which
+field is a credential. The cost is a process spawn when a pane opens, which is
+a keystroke rather than a loop.
+
+### 8. A change reaches a running dog over the bus, and the dog decides
+
+shep publishes on `config.dog.<name>` when a dog's config changes. A dog that
+subscribed re-asks with `Request::DogConfig` and does whatever suits it: swap
+values in place, rebind a listener, or send `Request::Restart` on itself.
+
+shep says that it changed and nothing about what it means. Putting the live
+versus needs-restart axis in the schema would have made lookout able to show
+dogs the same pending marker sheep get, at the cost of shep knowing what a
+third-party dog's fields mean, which every other decision here refuses.
+
+The two built-in dogs need no contract at all, since shep owns their source.
+They are not the same case: bark's config is sinks and rules, pure data with no
+OS resource attached, swappable in place. `[dog.metrics]` has exactly one key,
+`bind`, which is a listening socket, so metrics has real work to do on a change
+even though its process never has to exit.
+
+Published on writes shep made, and on a rescan at `shep daemon reload`. Not on
+a file watcher: a hand edit takes effect the way an edit to `shep.toml` does
+today, on a path a human deliberately triggered.
+
+A dog that restarts itself on a config change must say so in its own log. The
+restart count cannot tell that apart from a crash loop, and that column is what
+an operator reads as instability.
+
+### 9. No schema means no pane
+
+Lookout renders from the schema: field list, types, defaults, and descriptions,
+which schemars takes from doc comments. A field marked `#[shep(secret)]`
+renders as `<set>` and can be replaced, never read back, which is decision 12
+of the overrides spec applied per field instead of per section. Behind
+`--allow-control`, per decision 11. Writes go through `toml_edit`, so a
+hand-written `dogs.toml` keeps its comments.
+
+A dog with no schema gets no pane and needs no fallback, because decision 1
+already provides one. A raw TOML buffer inside a TUI would be worse than
+`$EDITOR`, and it would show bark's webhook URL in the clear for every dog that
+has not adopted the contract yet, bark included until it does.
+
+## Wire
+
+`Request` and `Response` are unchanged. `Subscribe` and `DogConfig` already
+exist and `config.dog.<name>` is a topic, not a variant. `PROTOCOL_VERSION`
+stays at 2 and `SCHEMA_VERSION` stays at 1.
+
+The new contract is entirely outside the socket: two flags on a binary and what
+they print.
+
+## Surfacing
+
+`shep describe <dog>` gains the schema's field list where one exists, so the
+information is reachable without lookout. `shep flock` gains nothing: it is for
+critical state, and a dog's config is not that.
+
+## Rollout
+
+Three releases, because the breaking half is independent of everything else and
+should ship small.
+
+1. **The store move.** Decisions 1, 2, 3. No new features, nothing for a dog
+   author to read. The change that touches every operator's file ships alone
+   and is easy to revert.
+2. **The contract.** Decisions 4, 5, 6, 7, 8, plus schemas on both built-in
+   dogs and bark subscribing to its own topic.
+3. **The pane.** Decision 9.
+
+## Out of scope
+
+- **Encrypting `dogs.toml`.** It holds webhook credentials and is plaintext,
+  exactly as `shep.toml` is today. Spec 2 of the overrides work owns the
+  encrypted store and this file should join it there rather than grow its own
+  scheme.
+- **A live versus needs-restart axis in the schema.** Argued at decision 8.
+  Additive later if a dog author asks for it.
+- **Removing `dog` from `RawDaemonConfig`.** Its own breaking change, after a
+  deprecation window.
+- **Validating a dog's config against its own schema.** shep has the schema and
+  the values and could reject a bad edit, but the dog is the authority on its
+  own config and a shep that disagreed would be wrong in the direction that
+  breaks a working dog.
+
+## Testing
+
+- A `shep.toml` carrying `[dog.*]` parses on the new binary, migrates on boot,
+  and the file afterwards has the section gone and every other section, comment
+  and key order intact. Exact string.
+- A `shep.toml` with no dog sections is not rewritten at all.
+- A second boot after a migration writes nothing.
+- `dog_section` serves byte-identical TOML from `dogs.toml` as it did from
+  `shep.toml`, so the dog-facing contract is pinned rather than assumed.
+- `probe` answers both flags and returns for anything else, including no
+  arguments at all.
+- A dog binary that exits non-zero, prints nothing, or prints invalid JSON on
+  `--schema` is recorded as having no schema and refused nothing. One test per
+  shape.
+- A schema with a `#[shep(secret)]` field round-trips the marker, and a pane
+  built from it renders `<set>` rather than the value. Exact string, since this
+  is the assertion standing between a webhook token and a screen.
+- Editing a dog's config publishes on `config.dog.<name>` exactly once.
+- `shep daemon reload` rescans `dogs.toml` and publishes for a dog whose
+  section changed, and not for one whose section did not.
+
+Every await needs a forcing mechanism rather than a sleep, and every new test
+gets proved non-vacuous by mutating what it protects and watching that test go
+red.
+
+## Docs
+
+`docs/dogs.md` is the dog contract and needs the most of this: the new file,
+the migration, `--schema`, `probe`, the secret marker, and the bus topic with
+the self-restart logging rule. Its Configuration section currently documents
+the disable-and-enable dance and that paragraph is replaced.
+
+`web/src/pages/docs/` needs the store move on any page naming `[dog.<name>]`,
+and the CLI reference regenerated if any verb's help text moves.
+
+`CLAUDE.md` records that dog config no longer lives in `shep.toml`.
+
+## Migration
+
+Covered at decision 2. The operator does nothing: they upgrade, the daemon
+boots, the sections move, and shep says what it did. An operator who never
+opens `shep.toml` again never learns this happened, which is the goal.

--- a/docs/brainstorming/specs/2026-09-03-dog-config-design.md
+++ b/docs/brainstorming/specs/2026-09-03-dog-config-design.md
@@ -84,10 +84,19 @@ parse. This is not optional politeness: delete that field and every existing
 file with a `[dog.bark]` section stops parsing, the daemon refuses to boot, and
 the flock goes unsupervised at upgrade time.
 
-On boot, any `[dog.*]` section present is moved into `dogs.toml` and struck
-from `shep.toml` in one `ShepToml::edit`, and shep reports what moved. One
-transition, one source of truth after it, no window where both files hold a
-value for the same key.
+On boot, any `[dog.*]` section carrying values is moved into `dogs.toml` and
+struck from `shep.toml` in one `ShepToml::edit`, and shep reports what moved.
+One transition, one source of truth after it, no window where both files hold
+a value for the same key.
+
+An EMPTY `[dog.<name>]` is skipped rather than moved, and an empty `[<name>]`
+already in `dogs.toml` is written over rather than refused. Every `shep enable`
+older than this change scaffolds the first shape, so a mixed-version host keeps
+producing it; counting a header as a value made the new binary refuse the whole
+migration and the daemon exited 4. The refusal is for two VALUES under one
+name, which is the only case shep would have to guess between. A header holds
+nothing to guess about, and it goes with the rest of the `[dog]` table when the
+migration strikes it.
 
 After that boot the `dog` field is a recognized key that is always empty.
 Removing it from the struct is a later breaking change with its own

--- a/docs/brainstorming/specs/2026-09-03-dog-config-design.md
+++ b/docs/brainstorming/specs/2026-09-03-dog-config-design.md
@@ -169,9 +169,9 @@ schemars can express this without shep shipping anything:
 ergonomics that is twenty-three characters and not worth a proc-macro crate.
 
 The reason to ship one anyway is that `x-shep-secret` is a string shep parses,
-hand-typed by the author. Spell it `x-shep-secert` and it compiles, the schema
-validates, the field is not marked, and lookout paints a webhook credential on
-screen. Nothing fails and nothing warns. It cannot be linted either, because
+hand-typed by the author. Transpose two of its letters and it compiles, the
+schema validates, the field is not marked, and lookout paints a webhook
+credential on screen. Nothing fails and nothing warns. It cannot be linted either, because
 schemars takes a string literal for the extension key, so a shep-exported const
 cannot go in that position.
 

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -1750,3 +1750,13 @@ A config change to a lifecycle extra rebuilds the whole name-group's tasks throu
 **Why:** Recorded explicitly because this is the confusion most likely to produce a wrong doc later: two entries with the word "reload" in the heading, asserting that a reload reads no config, sitting a search away from anybody asking whether the shepherd re-reads its own config file. It does. Nothing in this work changed that, and nothing about the Flockfile side is evidence about it. `getting-started.astro`'s upgrading section now says so where an operator reads rather than only here.
 
 `verified crates/shep-cli/src/commands/daemon.rs (the pre-flight validates shep.toml before the reload) and web/src/pages/docs/getting-started.astro`
+
+## Dog config store
+
+### A dog's section moved out of `shep.toml` into a hand-editable `dogs.toml`, migrated once at boot, and a name in both files is a refusal rather than a merge
+
+A dog's own settings now live under `[<name>]` in `$SHEP_HOME/dogs.toml` instead of under `[dog.<name>]` in `shep.toml`. The daemon migrates any old sections into the new file once, on the first boot that carries the change, and prints which dogs moved. `RawDaemonConfig::dog` stays on the old type on purpose, so an un-migrated `shep.toml` still parses instead of refusing to boot under `deny_unknown_fields`.
+
+**Why:** Making `dogs.toml` hand-editable, the same way `shep.toml` is, means an operator can write a section into it before ever upgrading, so a migration that merged silently would have to pick a winner between two values for the same key with nothing to go on. Refusing is the only answer that does not guess, and it costs nothing but an edit: the fix is deleting one of the two sections and starting the daemon again. This was not in the original spec for the move; it came out of writing the migration itself, once the hand-editable file made the collision possible.
+
+`verified crates/shep-core/src/config/dogs.rs (DogsConfig) and crates/shep-cli/src/commands/dog_migration.rs (migrate_dog_sections, DogMigrationError::WouldOverwrite)`

--- a/docs/dogs.md
+++ b/docs/dogs.md
@@ -90,26 +90,37 @@ the first one's edit landed.
 
 ## Configuration
 
-A dog's settings live under `[dog.<name>]` in `shep.toml`, and they never
-travel through the dog's environment. Instead the dog connects to the
-socket and asks for its own section over the wire
-(`Request::DogConfig`) — the daemon reads the file fresh for every such
-request rather than serving a copy it cached at boot.
+A dog's settings live under `[<name>]` in `$SHEP_HOME/dogs.toml`, hand-editable
+and separate from `shep.toml`, and they never travel through the dog's
+environment. Instead the dog connects to the socket and asks for its own
+section over the wire (`Request::DogConfig`), the daemon reads the file
+fresh for every such request rather than serving a copy it cached at boot.
 
-**Editing `[dog.<name>]` in `shep.toml` does not reach a dog that is
-already running.** A running dog asked for its section once, at startup,
-and nothing pushes it a new one. `shep disable <name> && shep enable
-<name>` is what re-reads it: that stop/start cycle is a fresh process
-asking a fresh question, and the daemon answers off the file as it stands
-at that moment.
+**Editing `[<name>]` in `dogs.toml` does not reach a dog that is already
+running.** A running dog asked for its section once, at startup, and
+nothing pushes it a new one. `shep disable <name> && shep enable <name>`
+is what re-reads it: that stop/start cycle is a fresh process asking a
+fresh question, and the daemon answers off the file as it stands at that
+moment.
 
 The reason the section rides the socket instead of the environment is the
 same reason it applies to every dog and not just the ones with obvious
 secrets: an environment variable is readable from the process table,
 inherited by every child the dog spawns, and captured into a crash dump.
-`[dog.bark.sinks]` routinely holds a webhook URL, and a webhook URL is a
-bearer credential — keeping the whole section off the environment means
+`[bark.sinks]` routinely holds a webhook URL, and a webhook URL is a
+bearer credential, keeping the whole section off the environment means
 nobody has to remember which dog's config is sensitive.
+
+**A section that used to live in `shep.toml` migrates to `dogs.toml`
+automatically.** The first boot of a shep carrying this move reads any
+`[dog.<name>]` sections still in `shep.toml`, writes them into `dogs.toml`
+under their bare name, strikes them from `shep.toml`, and prints which
+dogs moved. Every boot after that finds nothing to do. If a name already
+exists in both files, the daemon refuses to boot rather than guess which
+value is right; the fix is to delete one of the two sections and start it
+again. The likeliest way to hit that is hand-writing `[dog.metrics]` back
+into `shep.toml` after it already migrated, so check `dogs.toml` first. A
+dog present in only one file migrates or starts normally either way.
 
 ## The metrics dog
 
@@ -117,7 +128,7 @@ nobody has to remember which dog's config is sensitive.
 bound to `127.0.0.1:9615` by default:
 
 ```toml
-[dog.metrics]
+[metrics]
 bind = "127.0.0.1:9615"
 ```
 
@@ -156,22 +167,22 @@ decision for you by shipping wide and asking you to lock it down.
 the things worth paging someone about, delivering to named webhook sinks:
 
 ```toml
-[dog.bark.sinks]
+[bark.sinks]
 oncall = { kind = "discord", url = "https://discord.com/api/webhooks/..." }
 audit = { kind = "json", url = "https://example.internal/hook" }
 
-[[dog.bark.rules]]
+[[bark.rules]]
 on = "gave_up"
 sinks = ["oncall", "audit"]
 
-[[dog.bark.rules]]
+[[bark.rules]]
 on = "restart_rate"
 restarts = 5
 within = "2m"
 sinks = ["oncall"]
 ```
 
-Leave `[dog.bark.rules]` out entirely and the bark dog does not stay
+Leave `[bark.rules]` out entirely and the bark dog does not stay
 silent — one rule is built in by default, firing on every configured sink
 whenever a sheep reaches `Errored`. That is deliberate: it is the alert
 that must not be missed, keyed to the shepherd's own decision that it has
@@ -261,11 +272,11 @@ The wire a third-party dog speaks is the same client protocol
 [§6](specs/shep-v1.md#6-wire-protocol-v1--protocol-version-1) pins for
 every other client of this daemon: connect to the Unix socket at
 `$SHEP_HOME/run/shep.sock`, send `Hello`, wait for `HelloAck`, then send
-`Request::DogConfig { name }` to fetch your own `[dog.<name>]` section as
+`Request::DogConfig { name }` to fetch your own `[<name>]` section as
 opaque text — parse it however your own config shape wants. Shep sets two
 variables of its own on a dog: `$SHEP_HOME`, which is how it finds that
 socket in the first place, and `$SHEP_DOG_NAME`, which is the `name` to put
-in that request. No `[dog.<name>]` value ever rides along beside them, for
+in that request. No `[<name>]` value ever rides along beside them, for
 the reason given above. A section's key is not one of its values.
 
 **Put that name in the `Hello` too, as `dog_name`.** Optional, and nothing
@@ -306,7 +317,7 @@ that reads wrong rather than an outage.
 Those two are what shep ADDS, not the whole environment. A dog is a
 supervised process like any other, so it also starts from the small base
 every sheep gets: `PATH`, plus whichever of `HOME`, `USER`, `LANG` and `TZ`
-the shepherd itself has, plus `SHEP_INSTANCE`. Nothing from `[dog.<name>]`
+the shepherd itself has, plus `SHEP_INSTANCE`. Nothing from `[<name>]`
 is in there.
 
 **Read `$SHEP_DOG_NAME` rather than hardcoding a name.** It holds the name

--- a/docs/dogs.md
+++ b/docs/dogs.md
@@ -88,6 +88,14 @@ an exclusive lock on `shep.toml` for its whole read-edit-write, so the
 second waits its turn instead of writing back a document it read before
 the first one's edit landed.
 
+`dogs.toml` has a lock of its own on the same terms, and it needs one for
+the same reason: its writers rewrite the whole file rather than a line of
+it. Two of them exist, `shep rehome` and the once-per-home migration a
+boot runs, and each holds that lock across its whole read-edit-write. So
+two backgrounded `shep rehome` calls for two different dogs both land,
+and a rehome that overlaps a boot does not undo the migration or get
+undone by it. A boot that holds both locks takes `shep.toml`'s first.
+
 ## Configuration
 
 A dog's settings live under `[<name>]` in `$SHEP_HOME/dogs.toml`, hand-editable

--- a/docs/dogs.md
+++ b/docs/dogs.md
@@ -194,7 +194,7 @@ within = "2m"
 sinks = ["oncall"]
 ```
 
-Leave `[bark.rules]` out entirely and the bark dog does not stay
+Leave `[[bark.rules]]` out entirely and the bark dog does not stay
 silent — one rule is built in by default, firing on every configured sink
 whenever a sheep reaches `Errored`. That is deliberate: it is the alert
 that must not be missed, keyed to the shepherd's own decision that it has

--- a/docs/dogs.md
+++ b/docs/dogs.md
@@ -123,12 +123,16 @@ nobody has to remember which dog's config is sensitive.
 automatically.** The first boot of a shep carrying this move reads any
 `[dog.<name>]` sections still in `shep.toml`, writes them into `dogs.toml`
 under their bare name, strikes them from `shep.toml`, and prints which
-dogs moved. Every boot after that finds nothing to do. If a name already
-exists in both files, the daemon refuses to boot rather than guess which
-value is right; the fix is to delete one of the two sections and start it
-again. The likeliest way to hit that is hand-writing `[dog.metrics]` back
-into `shep.toml` after it already migrated, so check `dogs.toml` first. A
-dog present in only one file migrates or starts normally either way.
+dogs moved. Every boot after that finds nothing to do. `shep runtime` and
+`shep dev` migrate too: any boot does. If a name carries values in both
+files, the daemon refuses to boot rather than guess which is right, and
+`shep daemon reload` refuses before it signals the shepherd it was going
+to replace. Delete one of the two sections. The likeliest way to hit that
+is hand-writing `[dog.metrics]` back into `shep.toml` after it already
+migrated, so check `dogs.toml` first. An empty `[dog.<name>]`, which
+`shep enable` scaffolded before this move, is not a value and refuses
+nothing. A dog present in only one file migrates or starts normally
+either way.
 
 ## The metrics dog
 

--- a/docs/dogs.md
+++ b/docs/dogs.md
@@ -265,8 +265,11 @@ started as `shep dog <name>` and read their own name from that argv, but
 neither is a dog anybody writes: they ship inside the binary.
 
 `rehome <name>` is `disable`'s counterpart for a third-party dog: it stops
-it if running and forgets the registration in `shep.toml` entirely, rather
-than leaving it disabled-but-known the way plain `disable` would.
+it if running and forgets the dog entirely, rather than leaving it
+disabled-but-known the way plain `disable` would. Both files: the
+registration in `shep.toml`, and the dog's own `[<name>]` section in
+`dogs.toml`, webhook URLs and all. `disable` keeps that section on
+purpose; `rehome` is the verb that does not.
 
 The wire a third-party dog speaks is the same client protocol
 [§6](specs/shep-v1.md#6-wire-protocol-v1--protocol-version-1) pins for

--- a/docs/kv.md
+++ b/docs/kv.md
@@ -8,18 +8,18 @@ of that sentence.
 
 ## What this is for, and what it is not
 
-Two other files already configure everything shep runs: a **Flockfile**
-configures a sheep (its script, its instances, its restart policy), and
-`shep.toml` configures the shepherd itself and its dogs. Neither has a
-field for "the port the last on-call engineer picked" or "a feature flag a
-provisioning script wants to leave a note about." That is what this store
-is for — ad-hoc operator notes and runtime tweaks a dog reads, not
-anything that shapes how a sheep is supervised.
+Three other files already configure everything shep runs: a **Flockfile**
+configures a sheep (its script, its instances, its restart policy),
+`shep.toml` configures the shepherd itself, and `dogs.toml` configures its
+dogs. None has a field for "the port the last on-call engineer picked" or
+"a feature flag a provisioning script wants to leave a note about." That
+is what this store is for: ad-hoc operator notes and runtime tweaks a dog
+reads, not anything that shapes how a sheep is supervised.
 
 If you are reaching for this store to configure a *sheep*, put it in the
 Flockfile instead. If you are reaching for it to configure a *dog*, put it
-under `[dog.<name>]` in `shep.toml`. This store is what is left over —
-small, flat, and explicitly not the primary config path.
+under `[<name>]` in `dogs.toml`. This store is what is left over: small,
+flat, and explicitly not the primary config path.
 
 ## The three verbs
 

--- a/docs/specs/deferred.md
+++ b/docs/specs/deferred.md
@@ -240,9 +240,9 @@ job was to find the friction rather than resolve it.
 
 Raised 2026-08-20 while designing `shep-log-rotate`, the first fully external
 dog. `shep adopt <name> <path>` vets, registers, enables and starts in one
-command, and then the operator has an adopted dog with no `[dog.<name>]`
-section and nothing telling them what its knobs are. The README is the only
-answer today.
+command, and then the operator has an adopted dog with no `[<name>]`
+section in `dogs.toml` and nothing telling them what its knobs are. The
+README is the only answer today.
 
 The maintainer asked whether a dog's repo could ship a `Flockfile.toml` that `shep adopt`
 reads. It cannot: `RawFlockfile` is `deny_unknown_fields` over exactly

--- a/docs/writing-plans/plans/2026-09-03-dog-config-store-move.md
+++ b/docs/writing-plans/plans/2026-09-03-dog-config-store-move.md
@@ -506,8 +506,9 @@ Expected: FAIL, `cannot find function 'migrate_dog_sections'`.
 ///   TOML, and [`DogMigrationError::Render`] when the merged map will not
 ///   serialize.
 /// - [`DogMigrationError::Read`] and [`DogMigrationError::Write`] for the
-///   underlying I/O, and [`DogMigrationError::Toml`] for whatever
-///   `ShepToml` failed at.
+///   underlying I/O, [`DogMigrationError::Lock`] when `dogs.toml`'s
+///   sibling lock could not be taken, and [`DogMigrationError::Toml`] for
+///   whatever `ShepToml` failed at.
 pub fn migrate_dog_sections(paths: &ShepPaths) -> Result<Vec<String>, DogMigrationError> {
     let existing_source = match std::fs::read_to_string(&paths.daemon_config) {
         Ok(source) => source,
@@ -536,6 +537,8 @@ pub fn migrate_dog_sections(paths: &ShepPaths) -> Result<Vec<String>, DogMigrati
     // neither file. `try_edit`'s own `Err` skips `save` entirely and
     // leaves `path` exactly as it was found.
     ShepToml::try_edit(&paths.daemon_config, |doc| {
+        let _dogs_lock =
+            ConfigLock::acquire(&paths.dogs_config).map_err(DogMigrationError::Lock)?;
         let incoming = doc.take_dog_sections();
         if let Some(name) = incoming.keys().find(|name| already.dog.contains_key(*name)) {
             return Err(DogMigrationError::WouldOverwrite { name: name.clone() });
@@ -550,7 +553,16 @@ pub fn migrate_dog_sections(paths: &ShepPaths) -> Result<Vec<String>, DogMigrati
         // sections only once the new file already holds them. A crash
         // between the two leaves them readable from `shep.toml`, which is
         // the direction that loses nothing.
-        std::fs::write(&paths.dogs_config, rendered).map_err(DogMigrationError::Write)?;
+        //
+        // Through `write_dogs_config`, never `std::fs::write`. That file
+        // holds webhook URLs, which are bearer tokens in a path, so it is
+        // staged in a sibling temp at `CONFIG_FILE_MODE`, `fsync`ed and
+        // `rename`d: a bare write would create it at the ambient umask and
+        // leave a half-written file behind on a crash. The lock above is
+        // the other half, serialising this against `shep rehome`'s write
+        // to the same file. `shep.toml`'s lock is the outer one and this
+        // is the only place either is nested in the other.
+        write_dogs_config(&paths.dogs_config, &rendered).map_err(DogMigrationError::Write)?;
         Ok(moved)
     })
 }

--- a/docs/writing-plans/plans/2026-09-03-dog-config-store-move.md
+++ b/docs/writing-plans/plans/2026-09-03-dog-config-store-move.md
@@ -499,11 +499,15 @@ Expected: FAIL, `cannot find function 'migrate_dog_sections'`.
 ///
 /// # Errors
 ///
-/// - [`DogMigrationError::WouldOverwrite`] when a name is present in both
-///   files. Two values for one key is a question shep cannot answer, so it
-///   refuses and changes nothing.
-/// - [`DogMigrationError::Read`], [`DogMigrationError::Write`] and
-///   [`DogMigrationError::Edit`] for the underlying I/O.
+/// - [`DogMigrationError::WouldOverwrite`] when a name holds values in
+///   both files. Two values for one key is a question shep cannot answer,
+///   so it refuses and changes nothing.
+/// - [`DogMigrationError::Parse`] when `dogs.toml` exists and is not valid
+///   TOML, and [`DogMigrationError::Render`] when the merged map will not
+///   serialize.
+/// - [`DogMigrationError::Read`] and [`DogMigrationError::Write`] for the
+///   underlying I/O, and [`DogMigrationError::Toml`] for whatever
+///   `ShepToml` failed at.
 pub fn migrate_dog_sections(paths: &ShepPaths) -> Result<Vec<String>, DogMigrationError> {
     let existing_source = match std::fs::read_to_string(&paths.daemon_config) {
         Ok(source) => source,

--- a/docs/writing-plans/plans/2026-09-03-dog-config-store-move.md
+++ b/docs/writing-plans/plans/2026-09-03-dog-config-store-move.md
@@ -766,12 +766,12 @@ Expected: FAIL, the enable leaves a `[dog.<name>]` table behind.
 
 - [ ] **Step 3: Decide where a scaffold belongs, and say why in the code**
 
-`enable_dog` must stop writing into `shep.toml`'s `[dog]` table. Two defensible destinations and the choice is yours to argue at the call site:
+`enable_dog` must stop writing into `shep.toml`'s `[dog]` table, and it scaffolds nothing in its place. Two destinations were defensible when this was written and the implementation picked the first:
 
-- Scaffold nothing. `dog_section` already documents an absent section as legitimate and answers an empty string, so a dog enables and runs on its defaults until someone configures it.
-- Scaffold `[<name>]` into `dogs.toml` instead, keeping the original intent that enabling a dog gives an operator somewhere to write.
+- **Scaffold nothing, which is what shipped.** `dog_section` already documents an absent section as legitimate and answers an empty string, so a dog enables and runs on its defaults until someone configures it. Smaller, and it cannot collide.
+- Scaffold `[<name>]` into `dogs.toml` instead. Rejected: it preserves a nicety at the cost of putting `ShepToml`, which owns one file, in the position of writing another.
 
-The first is smaller and cannot collide. The second preserves a nicety and puts `ShepToml`, which owns one file, in the position of writing another. Whichever you pick, the doc comment says which and why.
+The doc comment on `enable_dog` says which and why. The empty tables an older `shep enable` already scaffolded are a separate matter and the migration handles them: skipped on the source side, written over on the destination side, never a refusal.
 
 - [ ] **Step 4: Make `rehome` forget both files**
 

--- a/docs/writing-plans/plans/2026-09-03-dog-config-store-move.md
+++ b/docs/writing-plans/plans/2026-09-03-dog-config-store-move.md
@@ -714,6 +714,87 @@ git commit -m "docs: dog config lives in dogs.toml now"
 
 ---
 
+---
+
+### Task 5: the writers the plan forgot
+
+**Added after Task 4's review found a boot-breaking bug this plan had no task for.** Tasks 1 to 3 moved every READER of a dog's config to `dogs.toml` and left three WRITERS pointed at `shep.toml`. The file list for this plan never asked what else touches `[dog.*]`, and Task 2 added a method to the very file holding them.
+
+**Files:**
+- Modify: `crates/shep-cli/src/commands/shep_toml.rs` (`enable_dog` around line 282, `rehome_dog` around line 434, and the doc comments on both plus `disable_dog`)
+- Modify: `crates/shep-cli/src/commands/dogs.rs` (the `rehome` verb, which coordinates across both files)
+- Modify: `crates/shep-cli/src/dog/mod.rs:328` and `crates/shep-cli/src/dog/metrics/mod.rs:172` (operator-facing `eprintln!` strings)
+- Modify: `crates/shep-core/src/config/daemon.rs:192`
+
+**Interfaces:**
+- Consumes: `DogsConfig`, `ShepPaths::dogs_config`, and `dog_migration`'s write path from Tasks 1 and 3.
+- Produces: nothing new for later tasks; this is the last one.
+
+**The bug, reproduced with the release binary:**
+
+```
+shep enable metrics     # writes an empty [dog.metrics] into shep.toml
+# operator configures metrics in dogs.toml, as docs/dogs.md now instructs
+shep muster             # daemon exits 4: configured in both shep.toml and dogs.toml
+```
+
+The flock goes down over a scaffold nobody meant to write. `enable_dog` ends with `self.dog_table_mut(name)`, which creates that table. `rehome_dog` strikes `[dog.<name>]` from `shep.toml` and never touches `dogs.toml`, so rehoming a dog now leaves its config orphaned in a file nothing will clean up.
+
+`disable_dog` is already correct: it deliberately leaves a dog's config alone so it survives a disable and enable cycle, and post-move that means not touching `dogs.toml`, which it does by doing nothing. Only its doc comment is stale.
+
+- [ ] **Step 1: Write the failing test**
+
+The regression test is the sequence above, not a unit assertion. Put it where the CLI's other end-to-end dog tests live and drive the real verbs:
+
+```rust
+#[test]
+fn enabling_a_dog_does_not_leave_a_section_that_refuses_the_next_boot() {
+    // The bug this test exists for: `shep enable` scaffolded `[dog.<name>]`
+    // into `shep.toml` while a dog's config had already moved to
+    // `dogs.toml`, so an operator who enabled a dog and then configured it
+    // where the docs say to had a name in both files. The migration refuses
+    // that, correctly, and the daemon exits 4 with the flock unsupervised.
+    // Enabling must leave nothing behind that a later boot can collide with.
+}
+```
+
+Write the body against whatever harness the neighbouring dog tests already use. Assert on `shep.toml`'s content after `shep enable`, then that a boot with a configured `dogs.toml` succeeds rather than refusing.
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Expected: FAIL, the enable leaves a `[dog.<name>]` table behind.
+
+- [ ] **Step 3: Decide where a scaffold belongs, and say why in the code**
+
+`enable_dog` must stop writing into `shep.toml`'s `[dog]` table. Two defensible destinations and the choice is yours to argue at the call site:
+
+- Scaffold nothing. `dog_section` already documents an absent section as legitimate and answers an empty string, so a dog enables and runs on its defaults until someone configures it.
+- Scaffold `[<name>]` into `dogs.toml` instead, keeping the original intent that enabling a dog gives an operator somewhere to write.
+
+The first is smaller and cannot collide. The second preserves a nicety and puts `ShepToml`, which owns one file, in the position of writing another. Whichever you pick, the doc comment says which and why.
+
+- [ ] **Step 4: Make `rehome` forget both files**
+
+`ShepToml` owns `shep.toml` alone, so the cross-file part belongs in the `rehome` verb rather than inside `rehome_dog`. Removing a dog's section from `dogs.toml` must go through the same staged temp, `fsync` and rename path Task 3 built, never a bare `std::fs::write`: that file holds webhook credentials and is `0600`.
+
+- [ ] **Step 5: Fix the operator-facing strings**
+
+`crates/shep-cli/src/dog/mod.rs:328` and `crates/shep-cli/src/dog/metrics/mod.rs:172` print `[dog.bark]` and `[dog.metrics]` at runtime. `crates/shep-core/src/config/daemon.rs:192` says shep-daemon reads a `[dog.<name>]` table from `DaemonConfig`, which is wrong about the struct and not only the notation: `dog_section` reads `DogsConfig` now.
+
+- [ ] **Step 6: Run the tests**
+
+Run: `cargo test --workspace --lib --bins --all-features -- --skip ::slow::`
+Expected: PASS.
+
+- [ ] **Step 7: Prove the regression test is not vacuous**
+
+Restore the `self.dog_table_mut(name)` call in `enable_dog`, watch the new test go red, remove it again.
+
+- [ ] **Step 8: Commit**
+
+One commit per item, per this repository's convention: the enable fix, the rehome fix, and the strings are three separable changes.
+
+
 ## Self-Review
 
 **Spec coverage.** Decision 1 is Tasks 1 and 3. Decision 2 is Task 3, with `RawDaemonConfig::dog` deliberately retained and that argued in the File Structure table. Decision 3 is Task 3 step 6, pinned as an exact string rather than assumed. The spec's Testing section lists eight cases: the migration exact-string, the no-sections no-rewrite, the second-boot no-op, and the byte-identical `dog_section` are Tasks 2 and 3. The remaining four (`probe` answering both flags, the three bad-`--schema` shapes, the secret marker round-trip, and the bus topic publishing once) all belong to decisions 4 through 9 and are releases 2 and 3, correctly absent here. The spec's Docs section is Task 4.

--- a/docs/writing-plans/plans/2026-09-03-dog-config-store-move.md
+++ b/docs/writing-plans/plans/2026-09-03-dog-config-store-move.md
@@ -505,6 +505,10 @@ Expected: FAIL, `cannot find function 'migrate_dog_sections'`.
 /// - [`DogMigrationError::Parse`] when `dogs.toml` exists and is not valid
 ///   TOML, and [`DogMigrationError::Render`] when the merged map will not
 ///   serialize.
+/// - [`DogMigrationError::SectionsUnreadable`] when the source declared a
+///   dog under `[dog]` that `take_dog_sections` did not hand back. The
+///   sections are struck by then, so refusing is the only answer that
+///   does not lose them. It reaches an operator as a refused boot.
 /// - [`DogMigrationError::Read`] and [`DogMigrationError::Write`] for the
 ///   underlying I/O, [`DogMigrationError::Lock`] when `dogs.toml`'s
 ///   sibling lock could not be taken, and [`DogMigrationError::Toml`] for

--- a/docs/writing-plans/plans/2026-09-03-dog-config-store-move.md
+++ b/docs/writing-plans/plans/2026-09-03-dog-config-store-move.md
@@ -121,8 +121,8 @@ Expected: FAIL, `unresolved module or unlinked crate 'dogs'` or `cannot find typ
 //! derived state, and an operator on a box with only a shell has to be able
 //! to set one without a dashboard.
 
-use alloc::collections::BTreeMap;
 use core::fmt;
+use std::collections::BTreeMap;
 
 /// Every `[<dog>]` table in `dogs.toml`
 ///
@@ -183,13 +183,13 @@ impl core::error::Error for DogsConfigError {
 }
 ```
 
-Match the crate's existing import style: if `crates/shep-core/src/config/daemon.rs` writes `use std::collections::BTreeMap;` rather than `alloc::`, do the same here. Grep it and follow, do not introduce a second convention.
+`std::collections::BTreeMap` matches `crates/shep-core/src/config/daemon.rs:8`, which is the neighbouring module. Checked, not guessed.
 
 `#[non_exhaustive]` on the error carries a reason comment per IR-20: add `// One variant today. `#[non_exhaustive]` so a second reading failure (a permissions error, once this type learns to open the file itself) is additive rather than breaking.` directly above the attribute.
 
 - [ ] **Step 4: Export it**
 
-In `crates/shep-core/src/config/mod.rs`, add `pub mod dogs;` in alphabetical position (between `pub mod daemon;` and `pub mod flockfile;`), and add `pub use dogs::{DogsConfig, DogsConfigError};` alongside the other re-exports if and only if the neighbouring modules are re-exported that way. Check `pub use daemon::...` first and match it.
+In `crates/shep-core/src/config/mod.rs`, add `pub mod dogs;` between `pub mod daemon;` (line 7) and `pub mod flockfile;` (line 8), and `pub use dogs::{DogsConfig, DogsConfigError};` immediately after `pub use daemon::{...}` on line 19. Every neighbouring module is re-exported that way; checked.
 
 - [ ] **Step 5: Add the path**
 
@@ -293,6 +293,10 @@ fn taking_from_a_file_with_no_dog_sections_changes_nothing() {
     let taken = ShepToml::edit(&path, ShepToml::take_dog_sections).expect("edit");
 
     assert!(taken.is_empty());
+    // Content identity, not proof that nothing was written: `edit` always
+    // stages and renames, so the file has a new inode either way. Not
+    // writing at all is the migration's job, and its own early return is
+    // where that is tested.
     assert_eq!(std::fs::read_to_string(&path).expect("read"), before);
 }
 ```
@@ -491,8 +495,12 @@ pub fn migrate_dog_sections(paths: &ShepPaths) -> Result<Vec<String>, DogMigrati
         Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
         Err(err) => return Err(DogMigrationError::Read(err)),
     };
-    // Cheap check first: parsing tells us whether there is anything to do
-    // without taking a lock or opening the other file.
+    // Cheap check first, and load-bearing rather than an optimisation.
+    // `ShepToml::edit` and `try_edit` both stage a temp file and rename it
+    // over the original whenever `save` runs, so opening the document at
+    // all would give an untouched `shep.toml` a fresh inode, force
+    // `CONFIG_FILE_MODE` on it, and replace a symlinked path with a plain
+    // file. A boot with nothing to do must not open it.
     if !existing_source.contains("[dog.") && !existing_source.contains("[dog]") {
         return Ok(Vec::new());
     }
@@ -503,39 +511,37 @@ pub fn migrate_dog_sections(paths: &ShepPaths) -> Result<Vec<String>, DogMigrati
         Err(err) => return Err(DogMigrationError::Read(err)),
     };
 
-    // Read-only pass so a refusal strikes nothing. `take_dog_sections`
-    // mutates, so the collision has to be found before the edit that would
-    // remove the evidence.
-    let incoming = ShepToml::edit(&paths.daemon_config, |doc| {
-        let taken = doc.take_dog_sections();
-        // Not saved: `edit` writes only what the closure leaves behind, and
-        // this pass exists to look rather than to change.
-        taken
+    // `try_edit`, never `edit`. `edit` calls `save` unconditionally
+    // (shep_toml.rs:169), so refusing from inside it would strike the
+    // sections from `shep.toml` and only then fail, leaving them in
+    // neither file. `try_edit`'s own `Err` skips `save` entirely and
+    // leaves `path` exactly as it was found.
+    ShepToml::try_edit(&paths.daemon_config, |doc| {
+        let incoming = doc.take_dog_sections();
+        if let Some(name) = incoming.keys().find(|name| already.dog.contains_key(*name)) {
+            return Err(DogMigrationError::WouldOverwrite { name: name.clone() });
+        }
+        let mut moved: Vec<String> = incoming.keys().cloned().collect();
+        moved.sort();
+
+        let mut merged = already.dog.clone();
+        merged.extend(incoming);
+        let rendered = toml::to_string(&merged).map_err(DogMigrationError::Render)?;
+        // Written before this closure returns, so `save` strikes the old
+        // sections only once the new file already holds them. A crash
+        // between the two leaves them readable from `shep.toml`, which is
+        // the direction that loses nothing.
+        std::fs::write(&paths.dogs_config, rendered).map_err(DogMigrationError::Write)?;
+        Ok(moved)
     })
-    .map_err(DogMigrationError::Edit)?;
-
-    if let Some(name) = incoming.keys().find(|name| already.dog.contains_key(*name)) {
-        return Err(DogMigrationError::WouldOverwrite { name: name.clone() });
-    }
-
-    let mut merged = already.dog;
-    let mut moved: Vec<String> = incoming.keys().cloned().collect();
-    merged.extend(incoming);
-    moved.sort();
-
-    let rendered = toml::to_string(&merged).map_err(DogMigrationError::Render)?;
-    std::fs::write(&paths.dogs_config, rendered).map_err(DogMigrationError::Write)?;
-
-    ShepToml::edit(&paths.daemon_config, |doc| {
-        doc.take_dog_sections();
-    })
-    .map_err(DogMigrationError::Edit)?;
-
-    Ok(moved)
 }
 ```
 
-**Two things to verify against the real `ShepToml` before writing this, because the sketch above is a guess about its contract, not a reading of it.** First, whether `edit` writes unconditionally or only when the closure produces something to save: `shep_toml.rs`'s module doc claims the latter, and the read-only pass above depends on it. If `edit` writes unconditionally, use a separate read-only path (parse the source with `toml_edit::DocumentMut` directly and inspect it) rather than an `edit` that quietly rewrites the file. Second, whether `edit`'s closure return type is what `try_edit` needs instead, given this function can refuse. Grep both signatures and follow them; the error type here should compose the way the other command modules compose `ShepTomlError`.
+`try_edit` is generic as `E: From<ShepTomlError>`, so `DogMigrationError` needs a
+`From<ShepTomlError>` impl rather than an `Edit` variant the caller maps into.
+Give it a `Toml(ShepTomlError)` variant and that `From`.
+
+**`ShepToml::edit` versus `try_edit` was checked before this plan shipped, and the answer is why the code above looks the way it does.** `edit` runs `doc.save()` unconditionally (shep_toml.rs:169); the module doc's "only when the closure actually produced a value to save" describes `try_edit`, whose `f` can return `Err`. An earlier draft of this task used `edit` for a read-only collision pass and would have struck the sections before refusing. Do not reintroduce it.
 
 Write `DogMigrationError` as an enum with the variants the doc names, a `Display`, a `core::error::Error` with `source`, and `#[non_exhaustive]` carrying a reason comment (IR-20). Derived `Debug` is correct here and needs saying in a comment: the variants carry a dog name and an I/O error, never a section's contents, so there is nothing to redact.
 

--- a/docs/writing-plans/plans/2026-09-03-dog-config-store-move.md
+++ b/docs/writing-plans/plans/2026-09-03-dog-config-store-move.md
@@ -362,7 +362,7 @@ git commit -m "feat(cli): ShepToml can take the dog sections out"
 - Modify: `crates/shep-cli/src/commands/mod.rs` (or wherever sibling command modules are declared, grep `mod shep_toml;` and follow)
 - Modify: `crates/shep-cli/src/commands/daemon.rs:298-306` (`run_daemon`)
 - Modify: `crates/shep-daemon/src/dogs.rs:337-354` (`dog_section`)
-- Modify: `crates/shep-daemon/src/rpc.rs:69-74` and `:484`
+- Modify: `crates/shep-daemon/src/rpc.rs:69-74` and `:507`
 - Modify: `crates/shep-daemon/src/boot.rs:1379`
 
 **Interfaces:**
@@ -574,7 +574,7 @@ Add a `DogMigration(DogMigrationError)` variant to `DaemonRunError` with its `Di
 
 In `crates/shep-daemon/src/dogs.rs`, `dog_section` currently loads `DaemonConfig` and reads `config.dog.get(name)`. Change it to `DogsConfig::load` and `config.dog.get(name)`, keeping the `NotFound` arm answering `Ok(String::new())` and keeping `toml::to_string(table)` as the return, so the bytes on the wire do not move. Update its doc comment, which names `shep.toml`.
 
-In `crates/shep-daemon/src/rpc.rs`, rename the context field `daemon_config` to `dogs_config` (its doc comment at line 69 says "Where `DogConfig` reads a dog's `[dog.<name>]` section from", which needs rewriting for the new file and the new key shape), and update the call at line 484. Update the test at line 2455 that writes `[dog.bark]` into that path: it now writes `[bark]` into `dogs.toml`.
+In `crates/shep-daemon/src/rpc.rs`, rename the context field `daemon_config` to `dogs_config` (its doc comment at line 69 says "Where `DogConfig` reads a dog's `[dog.<name>]` section from", which needs rewriting for the new file and the new key shape), and update the call at line 507. Update the test at line 2603 that writes `[dog.bark]` into that path: it now writes `[bark]` into `dogs.toml`.
 
 In `crates/shep-daemon/src/boot.rs:1379`, change `daemon_config: paths.daemon_config.clone()` to `dogs_config: paths.dogs_config.clone()`.
 

--- a/docs/writing-plans/plans/2026-09-03-dog-config-store-move.md
+++ b/docs/writing-plans/plans/2026-09-03-dog-config-store-move.md
@@ -325,21 +325,36 @@ Add to `impl ShepToml`, next to the other dog mutators:
         let Some(item) = self.doc.remove("dog") else {
             return BTreeMap::new();
         };
-        let Some(table) = item.as_table() else {
+
+        // A `Table`'s own `to_string()` renders only its direct key/value
+        // pairs -- a nested sub-table, an array of tables, or an inline
+        // table underneath it does not survive that round trip once the
+        // table is detached from the document root. Re-attaching `item`
+        // under a fresh document and rendering THAT is what keeps every
+        // header and array-of-tables marker: the fresh document is exactly
+        // as capable of printing `[dog.bark.sinks]` and `[[dog.bark.rules]]`
+        // as the original one was. Parsing the result with `toml` (not
+        // `toml_edit`) rather than walking `item` by hand is what also
+        // catches the inline-table shape, since `toml`'s deserializer does
+        // not care how a table was spelled.
+        let mut wrapper = DocumentMut::new();
+        wrapper.insert("dog", item);
+        let Ok(mut parsed) = wrapper.to_string().parse::<toml::Table>() else {
             return BTreeMap::new();
         };
-        table
-            .iter()
-            .filter_map(|(name, value)| {
-                let section = value.as_table()?;
-                let parsed = section.to_string().parse::<toml::Table>().ok()?;
-                Some((name.to_string(), parsed))
+        let Some(toml::Value::Table(dog)) = parsed.remove("dog") else {
+            return BTreeMap::new();
+        };
+        dog.into_iter()
+            .filter_map(|(name, value)| match value {
+                toml::Value::Table(section) => Some((name, section)),
+                _ => None,
             })
             .collect()
     }
 ```
 
-If `self.doc` is not the field name on `ShepToml`, grep the struct and use whatever it is. `disable_dog` reads `self.doc.get_mut("daemon")`, so `doc` is the expected name.
+**The body above is the one that shipped, and it is not the one this plan first carried.** The original used `section.to_string().parse::<toml::Table>()` per section, which renders only a table's own direct key/value pairs: the documented `[dog.bark.sinks]` plus `[[dog.bark.rules]]` shape came back as an empty table while `remove("dog")` had already struck the original, and an inline table under `[dog]` was dropped whole by `as_table()`. Re-attaching the removed item under a fresh `DocumentMut` and parsing that render once is what keeps every header and array marker, and parsing with `toml` rather than `toml_edit` is what makes the inline-table spelling stop mattering. Do not reintroduce the per-section round trip.
 
 - [ ] **Step 4: Run the tests**
 

--- a/docs/writing-plans/plans/2026-09-03-dog-config-store-move.md
+++ b/docs/writing-plans/plans/2026-09-03-dog-config-store-move.md
@@ -1,0 +1,704 @@
+# Dog config store move Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move a dog's `[dog.<name>]` settings out of `shep.toml` into a hand-editable `$SHEP_HOME/dogs.toml`, migrating any existing sections on first boot, without the dog-facing wire changing at all.
+
+**Architecture:** A new `DogsConfig` in shep-core parses the new file and is the only place its shape is decided, mirroring what `DaemonConfig` does for `shep.toml`. `ShepToml` grows one mutator that removes and returns the `[dog.*]` sections. The daemon's own entry point runs the migration once per boot before the supervisor starts, and `dog_section` reads the new file while still answering with byte-identical TOML.
+
+**Tech Stack:** Rust 2024, MSRV 1.88. `toml` for parsing, `toml_edit` for the format-preserving rewrite, `serde` for the derive. No new dependencies.
+
+**Spec:** `docs/brainstorming/specs/2026-09-03-dog-config-design.md` (decisions 1, 2 and 3 only; decisions 4 through 9 are releases 2 and 3 and are out of scope for this plan)
+
+## Global Constraints
+
+- **Clean-room rule, non-negotiable:** never open, read, or port source from the pm2 checkout. Work from this plan and the spec.
+- **Invoke the `shep-idiomatic-rust` skill before writing or reviewing any Rust.** Cite rules as `IR-<n>` in review.
+- **No em dashes or en dashes anywhere**, including code comments, doc comments, commit messages and PR bodies. Use a comma, colon, period or parentheses.
+- **Never write the maintainer's real name, personal email, or any absolute home-directory path** into a committed file or a commit message. Repo-relative paths only.
+- **Every new public item needs a doc comment and a deliberate `Debug` decision (IR-41).** Anything carrying dog config values is redacted, with an exact-string test, because `[dog.bark.sinks]` holds webhook credentials.
+- **`#![forbid(unsafe_code)]` is live in shep-core and shep-cli.** Nothing here needs unsafe.
+- **Every test's `await` needs a forcing mechanism, not a sleep (IR-46).**
+- **Prove every new test non-vacuous:** mutate what it protects, watch that specific test go red, restore. Say in the report which mutation you used.
+- **ONE cargo shape for every task in this plan:** `cargo test --workspace --lib --bins --all-features -- --skip ::slow::`. This change crosses three crates, so `-p` would need three invocations and each switch invalidates the others' features. Do not "also run the targeted crate tests to catch failures early": that is the churn this rule exists to prevent.
+- **Task gate, once, when the whole plan is done:** `cargo fmt --all --check`, then `cargo clippy --workspace --all-targets --all-features -- -D warnings`, then `cargo test --workspace --all-features`, then `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features`. Each from its own command with `$?` captured directly, never through a pipe: in zsh a pipeline's `$?` belongs to the last command.
+- **Worktree:** `.claude/worktrees/dog-config`, branch `feat/dog-config`. Run everything from there.
+
+---
+
+## File Structure
+
+| File | Responsibility |
+| --- | --- |
+| `crates/shep-core/src/config/dogs.rs` (new) | `DogsConfig`, `DogsConfigError`. The only place `dogs.toml`'s shape is decided. Redacted `Debug`. |
+| `crates/shep-core/src/config/mod.rs` | Export the new module. |
+| `crates/shep-core/src/paths.rs` | `ShepPaths::dogs_config`, `home.join("dogs.toml")`. |
+| `crates/shep-cli/src/commands/shep_toml.rs` | `ShepToml::take_dog_sections`, which removes `[dog.*]` and hands the tables back. |
+| `crates/shep-cli/src/commands/dog_migration.rs` (new) | The boot migration, and only that. Its own file because it is the piece most likely to need reading later, and `daemon.rs` is a command runner rather than a home for one-time upgrades. |
+| `crates/shep-cli/src/commands/daemon.rs` | Call the migration from `run_daemon` before the supervisor boots. |
+| `crates/shep-daemon/src/dogs.rs` | `dog_section` reads `DogsConfig` instead of `DaemonConfig`. |
+| `crates/shep-daemon/src/rpc.rs` | The context field it reads from. |
+| `crates/shep-daemon/src/boot.rs` | Populate that field from `paths.dogs_config`. |
+| `docs/dogs.md`, `web/`, `CLAUDE.md` | The operator-facing account. |
+
+`DaemonConfig::dog` and `RawDaemonConfig::dog` are deliberately **not** removed. Deleting either would stop every existing `shep.toml` with a `[dog.bark]` section from parsing, and `deny_unknown_fields` would turn that into a refused boot with the flock left unsupervised. Removing them is a separate breaking change with its own deprecation window, named in the spec's Out of scope.
+
+---
+
+### Task 1: `DogsConfig` and the path
+
+**Files:**
+- Create: `crates/shep-core/src/config/dogs.rs`
+- Modify: `crates/shep-core/src/config/mod.rs`
+- Modify: `crates/shep-core/src/paths.rs`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `shep_core::config::dogs::{DogsConfig, DogsConfigError}`. `DogsConfig` has one public field, `pub dog: BTreeMap<String, toml::Table>`, keyed by dog name with no prefix. `DogsConfig::load(source: Option<&str>) -> Result<Self, DogsConfigError>`. `ShepPaths::dogs_config: PathBuf`.
+
+This task is inert: nothing reads either yet. That is deliberate, so the type and the path can be reviewed on their own.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to a `#[cfg(test)] mod tests` at the bottom of `crates/shep-core/src/config/dogs.rs`:
+
+```rust
+#[test]
+fn a_missing_file_loads_as_an_empty_map() {
+    let config = DogsConfig::load(None).expect("None is not an error");
+    assert!(config.dog.is_empty());
+}
+
+#[test]
+fn sections_are_keyed_by_name_with_no_prefix() {
+    let source = "[metrics]\nbind = \"127.0.0.1:9615\"\n\n[bark.sinks]\noncall = { kind = \"discord\" }\n";
+    let config = DogsConfig::load(Some(source)).expect("valid TOML");
+    assert_eq!(config.dog.keys().collect::<Vec<_>>(), vec!["bark", "metrics"]);
+    assert_eq!(
+        config.dog["metrics"]["bind"].as_str(),
+        Some("127.0.0.1:9615")
+    );
+}
+
+#[test]
+fn invalid_toml_is_a_named_error() {
+    let err = DogsConfig::load(Some("[metrics")).expect_err("unterminated table header");
+    assert!(matches!(err, DogsConfigError::Toml(_)));
+}
+
+// IR-41: this map routinely holds webhook URLs with a bearer token in the
+// path. `Debug` is the one thing between such a token and any future
+// `tracing::debug!("{config:?}")`, so the exact string is pinned rather
+// than the shape.
+#[test]
+fn debug_redacts_every_dog_section() {
+    let source = "[bark.sinks]\noncall = { url = \"https://discord.com/api/webhooks/SECRET\" }\n";
+    let config = DogsConfig::load(Some(source)).expect("valid TOML");
+    assert_eq!(format!("{config:?}"), "DogsConfig { dog: <1 tables> }");
+}
+```
+
+- [ ] **Step 2: Run them to verify they fail**
+
+Run: `cargo test --workspace --lib --bins --all-features -- --skip ::slow::`
+Expected: FAIL, `unresolved module or unlinked crate 'dogs'` or `cannot find type DogsConfig`.
+
+- [ ] **Step 3: Write the module**
+
+`crates/shep-core/src/config/dogs.rs`:
+
+```rust
+//! `$SHEP_HOME/dogs.toml`, a dog's own settings.
+//!
+//! One table per dog, keyed by the name the dog was registered under, with
+//! no prefix: `[metrics]` here is what `[dog.metrics]` was in `shep.toml`
+//! before the move. The daemon serves a section verbatim over the socket as
+//! `Response::DogSection` and never interprets it, so this type parses
+//! exactly far enough to find the right table and no further.
+//!
+//! Hand-editable on purpose, and deliberately not a locked shep-owned store
+//! like `overrides.json`. A dog's config is authored intent rather than
+//! derived state, and an operator on a box with only a shell has to be able
+//! to set one without a dashboard.
+
+use alloc::collections::BTreeMap;
+use core::fmt;
+
+/// Every `[<dog>]` table in `dogs.toml`
+///
+/// `Debug` is redacted (IR-41): a dog section routinely carries a webhook
+/// URL with a bearer token in it, and this type exists to be logged near
+/// the boot path.
+#[derive(Clone, Default, PartialEq)]
+pub struct DogsConfig {
+    /// Raw `[<name>]` tables keyed by dog name
+    pub dog: BTreeMap<String, toml::Table>,
+}
+
+impl fmt::Debug for DogsConfig {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("DogsConfig")
+            .field("dog", &format_args!("<{} tables>", self.dog.len()))
+            .finish()
+    }
+}
+
+impl DogsConfig {
+    /// Parses `dogs.toml`, or answers empty when there is no file
+    ///
+    /// # Errors
+    ///
+    /// - [`DogsConfigError::Toml`] when `source` is not valid TOML.
+    pub fn load(source: Option<&str>) -> Result<Self, DogsConfigError> {
+        let Some(source) = source else {
+            return Ok(Self::default());
+        };
+        let dog = toml::from_str(source).map_err(DogsConfigError::Toml)?;
+        Ok(Self { dog })
+    }
+}
+
+/// Why `dogs.toml` could not be read
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum DogsConfigError {
+    /// The file is not valid TOML
+    Toml(toml::de::Error),
+}
+
+impl fmt::Display for DogsConfigError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Toml(err) => write!(f, "invalid TOML in dogs.toml: {err}"),
+        }
+    }
+}
+
+impl core::error::Error for DogsConfigError {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
+        match self {
+            Self::Toml(err) => Some(err),
+        }
+    }
+}
+```
+
+Match the crate's existing import style: if `crates/shep-core/src/config/daemon.rs` writes `use std::collections::BTreeMap;` rather than `alloc::`, do the same here. Grep it and follow, do not introduce a second convention.
+
+`#[non_exhaustive]` on the error carries a reason comment per IR-20: add `// One variant today. `#[non_exhaustive]` so a second reading failure (a permissions error, once this type learns to open the file itself) is additive rather than breaking.` directly above the attribute.
+
+- [ ] **Step 4: Export it**
+
+In `crates/shep-core/src/config/mod.rs`, add `pub mod dogs;` in alphabetical position (between `pub mod daemon;` and `pub mod flockfile;`), and add `pub use dogs::{DogsConfig, DogsConfigError};` alongside the other re-exports if and only if the neighbouring modules are re-exported that way. Check `pub use daemon::...` first and match it.
+
+- [ ] **Step 5: Add the path**
+
+In `crates/shep-core/src/paths.rs`, add the field to `ShepPaths` next to `daemon_config`:
+
+```rust
+    /// A dog's own settings: `dogs.toml`
+    ///
+    /// Separate from [`Self::daemon_config`] rather than a section inside
+    /// it, so lookout can write a dog's config without writing into the
+    /// daemon's own hand-authored file.
+    pub dogs_config: PathBuf,
+```
+
+and in the constructor, beside `daemon_config: home.join("shep.toml"),`:
+
+```rust
+            dogs_config: home.join("dogs.toml"),
+```
+
+Then extend the existing path assertion test in that file (the one asserting `p.daemon_config`) with the matching `dogs_config` line, following whatever home root that test already uses.
+
+- [ ] **Step 6: Run the tests**
+
+Run: `cargo test --workspace --lib --bins --all-features -- --skip ::slow::`
+Expected: PASS, including the four new tests and the extended path test.
+
+- [ ] **Step 7: Prove they are not vacuous**
+
+Change `<{} tables>` to `{:?}` in the `Debug` impl and confirm `debug_redacts_every_dog_section` fails with the webhook URL in the output. Restore. Report the mutation.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add crates/shep-core/src/config/dogs.rs crates/shep-core/src/config/mod.rs crates/shep-core/src/paths.rs
+git commit -m "feat(core): dogs.toml gets a type and a path"
+```
+
+---
+
+### Task 2: `ShepToml::take_dog_sections`
+
+**Files:**
+- Modify: `crates/shep-cli/src/commands/shep_toml.rs`
+
+**Interfaces:**
+- Consumes: nothing from Task 1.
+- Produces: `ShepToml::take_dog_sections(&mut self) -> BTreeMap<String, toml::Table>`. Removes the whole `[dog]` table from the document and returns what was under it, keyed by dog name. Returns an empty map when there was no `[dog]` table, and in that case leaves the document byte-identical.
+
+Still inert: nothing calls it until Task 3. Keeping it its own task means a reviewer can reject the rewrite semantics without rejecting the migration around them.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to the existing `#[cfg(test)] mod tests` in `crates/shep-cli/src/commands/shep_toml.rs`, following the fixture style already used there for `enable_dog` and `adopt_dog`:
+
+```rust
+#[test]
+fn taking_dog_sections_returns_them_keyed_by_name() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("shep.toml");
+    std::fs::write(
+        &path,
+        "[daemon]\nenabled_dogs = [\"metrics\"]\n\n[dog.metrics]\nbind = \"127.0.0.1:9615\"\n\n[dog.bark.sinks]\noncall = { kind = \"discord\" }\n",
+    )
+    .expect("write");
+
+    let taken = ShepToml::edit(&path, ShepToml::take_dog_sections).expect("edit");
+
+    assert_eq!(taken.keys().collect::<Vec<_>>(), vec!["bark", "metrics"]);
+    assert_eq!(taken["metrics"]["bind"].as_str(), Some("127.0.0.1:9615"));
+}
+
+#[test]
+fn taking_dog_sections_leaves_every_other_section_alone() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("shep.toml");
+    std::fs::write(
+        &path,
+        "# keep me\n[daemon]\nenabled_dogs = [\"metrics\"]\n\n[dog.metrics]\nbind = \"127.0.0.1:9615\"\n\n[style]\nlevel = \"full\"\n",
+    )
+    .expect("write");
+
+    ShepToml::edit(&path, ShepToml::take_dog_sections).expect("edit");
+
+    // Exact string: the whole reason this goes through `toml_edit` rather
+    // than a `toml::Table` round-trip is that a comment or a reordered key
+    // would be a reason not to run the upgrade.
+    assert_eq!(
+        std::fs::read_to_string(&path).expect("read"),
+        "# keep me\n[daemon]\nenabled_dogs = [\"metrics\"]\n\n[style]\nlevel = \"full\"\n"
+    );
+}
+
+#[test]
+fn taking_from_a_file_with_no_dog_sections_changes_nothing() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("shep.toml");
+    let before = "[daemon]\nlog_level = \"info\"\n";
+    std::fs::write(&path, before).expect("write");
+
+    let taken = ShepToml::edit(&path, ShepToml::take_dog_sections).expect("edit");
+
+    assert!(taken.is_empty());
+    assert_eq!(std::fs::read_to_string(&path).expect("read"), before);
+}
+```
+
+- [ ] **Step 2: Run them to verify they fail**
+
+Run: `cargo test --workspace --lib --bins --all-features -- --skip ::slow::`
+Expected: FAIL, `no function or associated item named 'take_dog_sections'`.
+
+- [ ] **Step 3: Write the method**
+
+Add to `impl ShepToml`, next to the other dog mutators:
+
+```rust
+    /// Removes the whole `[dog]` table and hands back what was under it
+    ///
+    /// Keyed by dog name with the `dog.` prefix dropped, which is the shape
+    /// `dogs.toml` wants. A document with no `[dog]` table yields an empty
+    /// map and is left byte-identical, so a second call after a migration
+    /// writes nothing.
+    ///
+    /// The one caller is the boot migration. This is not a general editing
+    /// primitive: it takes everything, because a partial move would leave
+    /// the same key readable from two files.
+    pub fn take_dog_sections(&mut self) -> BTreeMap<String, toml::Table> {
+        let Some(item) = self.doc.remove("dog") else {
+            return BTreeMap::new();
+        };
+        let Some(table) = item.as_table() else {
+            return BTreeMap::new();
+        };
+        table
+            .iter()
+            .filter_map(|(name, value)| {
+                let section = value.as_table()?;
+                let parsed = section.to_string().parse::<toml::Table>().ok()?;
+                Some((name.to_string(), parsed))
+            })
+            .collect()
+    }
+```
+
+If `self.doc` is not the field name on `ShepToml`, grep the struct and use whatever it is. `disable_dog` reads `self.doc.get_mut("daemon")`, so `doc` is the expected name.
+
+- [ ] **Step 4: Run the tests**
+
+Run: `cargo test --workspace --lib --bins --all-features -- --skip ::slow::`
+Expected: PASS.
+
+- [ ] **Step 5: Prove they are not vacuous**
+
+Change `self.doc.remove("dog")` to `self.doc.get("dog").cloned()` so the section is read but never struck, and confirm `taking_dog_sections_leaves_every_other_section_alone` fails on the exact string with `[dog.metrics]` still present. Restore. Report the mutation.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/shep-cli/src/commands/shep_toml.rs
+git commit -m "feat(cli): ShepToml can take the dog sections out"
+```
+
+---
+
+### Task 3: The migration, and the read that follows it
+
+**Files:**
+- Create: `crates/shep-cli/src/commands/dog_migration.rs`
+- Modify: `crates/shep-cli/src/commands/mod.rs` (or wherever sibling command modules are declared, grep `mod shep_toml;` and follow)
+- Modify: `crates/shep-cli/src/commands/daemon.rs:298-306` (`run_daemon`)
+- Modify: `crates/shep-daemon/src/dogs.rs:337-354` (`dog_section`)
+- Modify: `crates/shep-daemon/src/rpc.rs:69-74` and `:484`
+- Modify: `crates/shep-daemon/src/boot.rs:1379`
+
+**Interfaces:**
+- Consumes: `DogsConfig` and `ShepPaths::dogs_config` from Task 1, `ShepToml::take_dog_sections` from Task 2.
+- Produces: `migrate_dog_sections(paths: &ShepPaths) -> Result<Vec<String>, DogMigrationError>`, returning the names moved, empty when there was nothing to move.
+
+**These two changes share one commit, deliberately.** They are the exception in the one-commit-per-item rule: a commit that migrates sections without switching the read leaves every dog reading an empty section, and a commit that switches the read without migrating does the same. Neither is a state anyone should be able to bisect onto.
+
+- [ ] **Step 1: Write the failing tests**
+
+In `crates/shep-cli/src/commands/dog_migration.rs`:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn home_with(shep_toml: &str) -> (tempfile::TempDir, ShepPaths) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let paths = ShepPaths::for_home(dir.path());
+        std::fs::write(&paths.daemon_config, shep_toml).expect("write");
+        (dir, paths)
+    }
+
+    #[test]
+    fn sections_move_and_the_original_loses_them() {
+        let (_dir, paths) = home_with(
+            "# mine\n[daemon]\nenabled_dogs = [\"metrics\"]\n\n[dog.metrics]\nbind = \"127.0.0.1:9615\"\n",
+        );
+
+        let moved = migrate_dog_sections(&paths).expect("migrate");
+
+        assert_eq!(moved, vec!["metrics".to_string()]);
+        assert_eq!(
+            std::fs::read_to_string(&paths.daemon_config).expect("read"),
+            "# mine\n[daemon]\nenabled_dogs = [\"metrics\"]\n"
+        );
+        let written = std::fs::read_to_string(&paths.dogs_config).expect("read");
+        let parsed = DogsConfig::load(Some(&written)).expect("valid");
+        assert_eq!(parsed.dog["metrics"]["bind"].as_str(), Some("127.0.0.1:9615"));
+    }
+
+    #[test]
+    fn a_file_with_no_dog_sections_is_not_rewritten() {
+        let before = "[daemon]\nlog_level = \"info\"\n";
+        let (_dir, paths) = home_with(before);
+
+        let moved = migrate_dog_sections(&paths).expect("migrate");
+
+        assert!(moved.is_empty());
+        assert_eq!(std::fs::read_to_string(&paths.daemon_config).expect("read"), before);
+        assert!(!paths.dogs_config.exists(), "no sections means no file");
+    }
+
+    #[test]
+    fn a_second_boot_writes_nothing() {
+        let (_dir, paths) = home_with("[dog.metrics]\nbind = \"127.0.0.1:9615\"\n");
+        migrate_dog_sections(&paths).expect("first");
+        let after_first = std::fs::read_to_string(&paths.dogs_config).expect("read");
+
+        let moved = migrate_dog_sections(&paths).expect("second");
+
+        assert!(moved.is_empty());
+        assert_eq!(std::fs::read_to_string(&paths.dogs_config).expect("read"), after_first);
+    }
+
+    // The one case that must never silently merge: an operator who already
+    // hand-wrote dogs.toml and still has a stale section in shep.toml. Two
+    // values for one key, and picking either would be shep guessing.
+    #[test]
+    fn an_existing_dogs_file_makes_the_migration_refuse() {
+        let (_dir, paths) = home_with("[dog.metrics]\nbind = \"127.0.0.1:9615\"\n");
+        std::fs::write(&paths.dogs_config, "[metrics]\nbind = \"0.0.0.0:9615\"\n").expect("write");
+
+        let err = migrate_dog_sections(&paths).expect_err("both files hold metrics");
+
+        assert!(matches!(err, DogMigrationError::WouldOverwrite { .. }));
+        assert!(
+            std::fs::read_to_string(&paths.daemon_config)
+                .expect("read")
+                .contains("[dog.metrics]"),
+            "a refused migration strikes nothing"
+        );
+    }
+}
+```
+
+If `ShepPaths` has no `for_home` constructor, grep `paths.rs` for how its tests build one against a temp directory and use that instead. Do not add a constructor for the test's convenience.
+
+- [ ] **Step 2: Run them to verify they fail**
+
+Run: `cargo test --workspace --lib --bins --all-features -- --skip ::slow::`
+Expected: FAIL, `cannot find function 'migrate_dog_sections'`.
+
+- [ ] **Step 3: Write the migration**
+
+`crates/shep-cli/src/commands/dog_migration.rs`:
+
+```rust
+//! Moving `[dog.<name>]` out of `shep.toml` and into `dogs.toml`, once.
+//!
+//! Runs at the top of every daemon boot and does nothing on all but the
+//! first. `RawDaemonConfig` keeps its `dog` field so an un-migrated file
+//! still parses: deleting it would turn `deny_unknown_fields` into a
+//! refused boot for every operator carrying a dog section, with the flock
+//! left unsupervised at exactly the moment nobody is watching.
+
+/// Moves every `[dog.<name>]` section into `dogs.toml`, returning the names
+/// moved
+///
+/// Empty when there was nothing to move, which is every boot after the
+/// first. Writes `dogs.toml` before striking `shep.toml`, so a crash
+/// between the two leaves the sections readable from the old file rather
+/// than from neither.
+///
+/// # Errors
+///
+/// - [`DogMigrationError::WouldOverwrite`] when a name is present in both
+///   files. Two values for one key is a question shep cannot answer, so it
+///   refuses and changes nothing.
+/// - [`DogMigrationError::Read`], [`DogMigrationError::Write`] and
+///   [`DogMigrationError::Edit`] for the underlying I/O.
+pub fn migrate_dog_sections(paths: &ShepPaths) -> Result<Vec<String>, DogMigrationError> {
+    let existing_source = match std::fs::read_to_string(&paths.daemon_config) {
+        Ok(source) => source,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(err) => return Err(DogMigrationError::Read(err)),
+    };
+    // Cheap check first: parsing tells us whether there is anything to do
+    // without taking a lock or opening the other file.
+    if !existing_source.contains("[dog.") && !existing_source.contains("[dog]") {
+        return Ok(Vec::new());
+    }
+
+    let already = match std::fs::read_to_string(&paths.dogs_config) {
+        Ok(source) => DogsConfig::load(Some(&source)).map_err(DogMigrationError::Parse)?,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => DogsConfig::default(),
+        Err(err) => return Err(DogMigrationError::Read(err)),
+    };
+
+    // Read-only pass so a refusal strikes nothing. `take_dog_sections`
+    // mutates, so the collision has to be found before the edit that would
+    // remove the evidence.
+    let incoming = ShepToml::edit(&paths.daemon_config, |doc| {
+        let taken = doc.take_dog_sections();
+        // Not saved: `edit` writes only what the closure leaves behind, and
+        // this pass exists to look rather than to change.
+        taken
+    })
+    .map_err(DogMigrationError::Edit)?;
+
+    if let Some(name) = incoming.keys().find(|name| already.dog.contains_key(*name)) {
+        return Err(DogMigrationError::WouldOverwrite { name: name.clone() });
+    }
+
+    let mut merged = already.dog;
+    let mut moved: Vec<String> = incoming.keys().cloned().collect();
+    merged.extend(incoming);
+    moved.sort();
+
+    let rendered = toml::to_string(&merged).map_err(DogMigrationError::Render)?;
+    std::fs::write(&paths.dogs_config, rendered).map_err(DogMigrationError::Write)?;
+
+    ShepToml::edit(&paths.daemon_config, |doc| {
+        doc.take_dog_sections();
+    })
+    .map_err(DogMigrationError::Edit)?;
+
+    Ok(moved)
+}
+```
+
+**Two things to verify against the real `ShepToml` before writing this, because the sketch above is a guess about its contract, not a reading of it.** First, whether `edit` writes unconditionally or only when the closure produces something to save: `shep_toml.rs`'s module doc claims the latter, and the read-only pass above depends on it. If `edit` writes unconditionally, use a separate read-only path (parse the source with `toml_edit::DocumentMut` directly and inspect it) rather than an `edit` that quietly rewrites the file. Second, whether `edit`'s closure return type is what `try_edit` needs instead, given this function can refuse. Grep both signatures and follow them; the error type here should compose the way the other command modules compose `ShepTomlError`.
+
+Write `DogMigrationError` as an enum with the variants the doc names, a `Display`, a `core::error::Error` with `source`, and `#[non_exhaustive]` carrying a reason comment (IR-20). Derived `Debug` is correct here and needs saying in a comment: the variants carry a dog name and an I/O error, never a section's contents, so there is nothing to redact.
+
+- [ ] **Step 4: Wire it into the boot**
+
+In `crates/shep-cli/src/commands/daemon.rs`, at the top of `run_daemon`, before `boot_supervisor`:
+
+```rust
+pub async fn run_daemon(paths: ShepPaths, args: &DaemonArgs) -> Result<(), DaemonRunError> {
+    // Before the supervisor, because `dog_section` reads the new file from
+    // the first request onward and a dog can connect as soon as the socket
+    // is up. A boot after the first finds nothing and returns immediately.
+    let moved = crate::commands::dog_migration::migrate_dog_sections(&paths)
+        .map_err(DaemonRunError::DogMigration)?;
+    if !moved.is_empty() {
+        // Named individually: an operator who did not know this was coming
+        // needs to be able to find where their config went.
+        tracing::info!(
+            dogs = %moved.join(", "),
+            "moved dog config out of shep.toml and into dogs.toml"
+        );
+    }
+    // A production daemon always keeps its final roll -- `shep muster` after
+    // a reboot is the entire reason it exists.
+    boot_supervisor(paths, args, false)
+        .await?
+        .run()
+        .await
+        .map_err(DaemonRunError::Run)
+}
+```
+
+Add a `DogMigration(DogMigrationError)` variant to `DaemonRunError` with its `Display` arm and its `source`, and give it an exit code in `daemon_exit_code` matching whatever that function does for the other pre-boot failures. Match the file's existing `tracing` call style: if it uses `tracing::info!` with a message-first argument order, follow that.
+
+- [ ] **Step 5: Switch the read**
+
+In `crates/shep-daemon/src/dogs.rs`, `dog_section` currently loads `DaemonConfig` and reads `config.dog.get(name)`. Change it to `DogsConfig::load` and `config.dog.get(name)`, keeping the `NotFound` arm answering `Ok(String::new())` and keeping `toml::to_string(table)` as the return, so the bytes on the wire do not move. Update its doc comment, which names `shep.toml`.
+
+In `crates/shep-daemon/src/rpc.rs`, rename the context field `daemon_config` to `dogs_config` (its doc comment at line 69 says "Where `DogConfig` reads a dog's `[dog.<name>]` section from", which needs rewriting for the new file and the new key shape), and update the call at line 484. Update the test at line 2455 that writes `[dog.bark]` into that path: it now writes `[bark]` into `dogs.toml`.
+
+In `crates/shep-daemon/src/boot.rs:1379`, change `daemon_config: paths.daemon_config.clone()` to `dogs_config: paths.dogs_config.clone()`.
+
+- [ ] **Step 6: Add the wire-unchanged test**
+
+This is the assertion that decision 3 actually held. Put it beside the existing `dog_section` tests in `crates/shep-daemon/src/dogs.rs`:
+
+```rust
+#[test]
+fn a_section_reaches_the_wire_exactly_as_it_did_from_shep_toml() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("dogs.toml");
+    std::fs::write(&path, "[bark]\ndebounce = \"30s\"\n").expect("write");
+
+    // Byte-for-byte what the old `[dog.bark]` read produced. The dog-facing
+    // contract not moving is the whole of decision 3, so it is pinned as a
+    // string rather than as a parse.
+    assert_eq!(
+        dog_section(&path, "bark").expect("section"),
+        "debounce = \"30s\"\n"
+    );
+}
+
+#[test]
+fn a_dog_with_no_section_still_gets_an_empty_string() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("dogs.toml");
+    std::fs::write(&path, "[bark]\ndebounce = \"30s\"\n").expect("write");
+
+    assert_eq!(dog_section(&path, "metrics").expect("section"), "");
+}
+```
+
+If the existing `dog_section` tests assert a different exact string for the same input, use theirs: the point is that the value does not change, so the old expectation is the correct one.
+
+- [ ] **Step 7: Run the tests**
+
+Run: `cargo test --workspace --lib --bins --all-features -- --skip ::slow::`
+Expected: PASS.
+
+- [ ] **Step 8: Prove they are not vacuous**
+
+Two mutations, because this task has two halves. Make `migrate_dog_sections` return `Ok(Vec::new())` before doing anything and confirm `sections_move_and_the_original_loses_them` fails. Then make `dog_section` return `Ok(String::new())` unconditionally and confirm `a_section_reaches_the_wire_exactly_as_it_did_from_shep_toml` fails. Restore both. Report both.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add crates/shep-cli/src/commands/dog_migration.rs crates/shep-cli/src/commands/mod.rs crates/shep-cli/src/commands/daemon.rs crates/shep-daemon/src/dogs.rs crates/shep-daemon/src/rpc.rs crates/shep-daemon/src/boot.rs
+git commit -m "feat: dog config moves to dogs.toml, migrated on boot"
+```
+
+---
+
+### Task 4: The operator-facing account
+
+**Files:**
+- Modify: `docs/dogs.md` (the `## Configuration` section, around line 91)
+- Modify: `web/src/pages/docs/*.astro` (grep for `[dog.` first)
+- Modify: `CLAUDE.md`
+
+**Interfaces:**
+- Consumes: everything from Tasks 1 through 3.
+- Produces: nothing code-facing.
+
+`web/` is published and part of the public surface, so this is not optional upkeep.
+
+- [ ] **Step 1: Find every mention**
+
+```bash
+grep -rn '\[dog\.' docs/ web/src/ CLAUDE.md README.md
+```
+
+Grep the word, not the phrase: a claim about dog config is rarely in only one place, and a wrapped line will not match a phrase search.
+
+- [ ] **Step 2: Rewrite `docs/dogs.md`'s Configuration section**
+
+Its current text says settings live under `[dog.<name>]` in `shep.toml`, and that editing one does not reach a running dog so `shep disable <name> && shep enable <name>` is what re-reads it. Both halves change: the file is now `$SHEP_HOME/dogs.toml` with the section keyed as `[<name>]`, and the disable-and-enable sentence stays true for this release but should say the file it is talking about.
+
+Keep the paragraph explaining why the section rides the socket instead of the environment. It is still correct and it is the best thing on that page.
+
+Add a short paragraph on the migration: that it happens once, on the first boot of a version carrying it, that shep says which dogs moved, and that a name present in both files makes it refuse rather than guess.
+
+- [ ] **Step 3: Rewrite the web pages the grep found**
+
+Same substance, matching each page's existing voice rather than pasting the markdown across.
+
+- [ ] **Step 4: Update `CLAUDE.md`**
+
+One paragraph recording that dog config no longer lives in `shep.toml`, that `RawDaemonConfig` keeps its `dog` field on purpose and why, and that the migration is in `crates/shep-cli/src/commands/dog_migration.rs`.
+
+- [ ] **Step 5: Build the site**
+
+```bash
+cargo build --release
+```
+```bash
+./web/scripts/generate-cli-reference.sh
+```
+```bash
+cd web && npx astro build
+```
+```bash
+cd web && npx astro check
+```
+
+Each from its own command with `$?` captured directly. `astro check` is the one that catches a wrong prop: a page passing a component a prop it does not have builds clean and renders wrong, which shipped once already on `/docs/output`.
+
+`git diff` on `web/src/data/cli-reference.generated.txt` should be empty for this release, since no verb, flag or alias changed. If it is not empty, something drifted before this branch and the diff is worth reading rather than committing blind.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add docs/dogs.md web/ CLAUDE.md
+git commit -m "docs: dog config lives in dogs.toml now"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage.** Decision 1 is Tasks 1 and 3. Decision 2 is Task 3, with `RawDaemonConfig::dog` deliberately retained and that argued in the File Structure table. Decision 3 is Task 3 step 6, pinned as an exact string rather than assumed. The spec's Testing section lists eight cases: the migration exact-string, the no-sections no-rewrite, the second-boot no-op, and the byte-identical `dog_section` are Tasks 2 and 3. The remaining four (`probe` answering both flags, the three bad-`--schema` shapes, the secret marker round-trip, and the bus topic publishing once) all belong to decisions 4 through 9 and are releases 2 and 3, correctly absent here. The spec's Docs section is Task 4.
+
+**Additions the spec did not name.** The both-files collision refusal (`WouldOverwrite`) is not in the spec. It came out of writing Task 3: decision 1 makes `dogs.toml` hand-editable, so an operator can create one before upgrading, and a migration that merged silently would pick a winner between two values for the same key. Refusing is the only answer that does not guess. Worth folding back into the spec's decision 2 when this lands.
+
+**Placeholder scan.** No TBDs. Two steps deliberately say "grep and follow" rather than naming an exact line: the `config/mod.rs` re-export style in Task 1 step 4, and `ShepToml::edit`'s write-on-empty-closure semantics in Task 3 step 3. Both are questions about existing code that a plan should not answer from memory, and both say what to do with either answer.
+
+**Type consistency.** `DogsConfig::load(Option<&str>)` in Task 1 is what Task 3 calls. `take_dog_sections(&mut self) -> BTreeMap<String, toml::Table>` in Task 2 is what Task 3 consumes twice. `ShepPaths::dogs_config` from Task 1 is what Tasks 3 reads in three files. `dog_section(&Path, &str) -> Result<String, DogError>` keeps its existing signature throughout, which is what makes decision 3 true.

--- a/web/src/data/cli-reference.generated.txt
+++ b/web/src/data/cli-reference.generated.txt
@@ -871,7 +871,7 @@ Usage: shep enable [OPTIONS] <NAME>
 
 Arguments:
   <NAME>
-          The dog's name — the `[dog.<name>]` config key
+          The dog's name, the `[<name>]` config key in `dogs.toml`
 
 Options:
       --format <FORMAT>
@@ -918,14 +918,14 @@ Options:
 Turn off a registered dog: removes it from `[daemon] enabled_dogs`, and stops it now if a shepherd
 is running.
 
-Leaves `[dog.<name>]` in place — the dog's own configuration survives a disable/enable cycle. `shep
-rehome` is the verb that forgets a dog entirely.
+Leaves `[<name>]` in `dogs.toml` in place: the dog's own configuration survives a disable/enable
+cycle. `shep rehome` is the verb that forgets a dog entirely.
 
 Usage: shep disable [OPTIONS] <NAME>
 
 Arguments:
   <NAME>
-          The dog's name — the `[dog.<name>]` config key
+          The dog's name, the `[<name>]` config key in `dogs.toml`
 
 Options:
       --format <FORMAT>
@@ -999,8 +999,8 @@ Options:
           [default: table]
 
       --name <NAME>
-          The dog's name — the `[dog.<name>]` config key. Defaults to the binary's file stem with a
-          leading `shep-` stripped
+          The dog's name, the `[<name>]` config key in `dogs.toml`. Defaults to the binary's file
+          stem with a leading `shep-` stripped
 
   -q, --quiet
           Suppress non-essential output
@@ -1035,7 +1035,7 @@ Options:
           Print version
 @@VERB:rehome@@
 Forget an adopted dog entirely: stops it if a shepherd is running, and removes it from `[daemon]
-enabled_dogs`, `[daemon] adopted_dogs`, and its own `[dog.<name>]` table.
+enabled_dogs`, `[daemon] adopted_dogs`, and its own `[<name>]` table in `dogs.toml`.
 
 `shep disable` stops a dog without forgetting its configuration; `rehome` is the verb that forgets
 it.
@@ -1044,7 +1044,7 @@ Usage: shep rehome [OPTIONS] <NAME>
 
 Arguments:
   <NAME>
-          The dog's name — the `[dog.<name>]` config key
+          The dog's name, the `[<name>]` config key in `dogs.toml`
 
 Options:
       --format <FORMAT>

--- a/web/src/data/dogs.ts
+++ b/web/src/data/dogs.ts
@@ -102,9 +102,9 @@ export interface Dog {
   /**
    * The name this dog expects to be adopted under. A dog is given no argv
    * and cannot be told its own adopted name, so `shep adopt <name> <path>`
-   * with the wrong `<name>` silently discards its whole `[dog.<name>]`
-   * configuration. This field exists so the page's adopt line is correct by
-   * construction instead of a guess.
+   * with the wrong `<name>` silently discards its whole `[<name>]`
+   * configuration in `dogs.toml`. This field exists so the page's adopt
+   * line is correct by construction instead of a guess.
    */
   adopt_as: string;
   /** One line describing what the dog does. */

--- a/web/src/data/lexiconTable.md
+++ b/web/src/data/lexiconTable.md
@@ -32,7 +32,7 @@ The whole vocabulary, and whether it exists yet.
 | the shepherd channel | a private pipe on fd 3 between daemon and app | `channel = true`, `shep trigger` | yes |
 | a lamb | a child process of a sheep | tree-kill, `describe`'s tree view | yes |
 | a dog | a plugin process the shepherd supervises | `shep enable metrics`, `shep dogs` | yes |
-| a bark | a webhook alert | `[dog.bark.sinks]` config, `shep barks` | yes |
+| a bark | a webhook alert | `[bark.sinks]` config in `dogs.toml`, `shep barks` | yes |
 | a smit | a short mark a dog paints on a sheep | the SMIT column in `shep flock` and the lookout | yes |
 | the whistle | the MCP interface agents talk to | `shep whistle` | yes |
 | the lookout | the terminal dashboard | `shep lookout` (alias `dash`) | partly |

--- a/web/src/pages/docs/dogs.astro
+++ b/web/src/pages/docs/dogs.astro
@@ -174,8 +174,12 @@ $ shep disable metrics`}</CodeBlock>
     <Callout variant="careful">
       A section that used to live in <code>shep.toml</code> migrates to{" "}
       <code>dogs.toml</code> once, on the first boot of a shep carrying this
-      move, and it prints which dogs moved. If a name exists in both files,
-      the daemon refuses to boot until one of the two sections is deleted; a
+      move, and it prints which dogs moved. Any boot does it, including{" "}
+      <code>shep runtime</code> and <code>shep dev</code>. If a name carries
+      values in both files, the daemon refuses to boot until one of the two
+      sections is deleted, and <code>shep daemon reload</code> refuses before
+      it signals the shepherd it was going to replace. An empty{" "}
+      <code>[dog.&lt;name&gt;]</code> is not a value and refuses nothing. A
       dog present in only one file migrates or starts normally.
     </Callout>
 

--- a/web/src/pages/docs/dogs.astro
+++ b/web/src/pages/docs/dogs.astro
@@ -333,8 +333,12 @@ sinks = ["oncall"]`}</CodeBlock>
     <VerbSignature verb="rehome" usage="shep rehome <name>">
       <p>
         <code>disable</code>'s counterpart for a third-party dog: stops it
-        if running and forgets the registration entirely, rather than
-        leaving it disabled-but-known.
+        if running and forgets it entirely, rather than leaving it
+        disabled-but-known. That is both files, the registration in{" "}
+        <code>shep.toml</code> and the dog's own <code>[&lt;name&gt;]</code>
+        section in <code>dogs.toml</code>, webhook URLs and all.{" "}
+        <code>disable</code> keeps that section on purpose;{" "}
+        <code>rehome</code> is the verb that does not.
       </p>
     </VerbSignature>
     <CodeBlock>{`$ shep adopt ./bin/my-watchdog --name watchdog

--- a/web/src/pages/docs/dogs.astro
+++ b/web/src/pages/docs/dogs.astro
@@ -250,7 +250,7 @@ restarts = 5
 within = "2m"
 sinks = ["oncall"]`}</CodeBlock>
     <p>
-      Leave <code>[bark.rules]</code> out and bark doesn't go quiet:
+      Leave <code>[[bark.rules]]</code> out and bark doesn't go quiet:
       one rule is built in by default, firing on every configured sink
       whenever a sheep reaches <code>Errored</code>. That's the alert that
       must not be missed, so it needs no opt-in. <code>restart_rate</code>{" "}

--- a/web/src/pages/docs/dogs.astro
+++ b/web/src/pages/docs/dogs.astro
@@ -145,7 +145,8 @@ $ shep disable metrics`}</CodeBlock>
 
     <h2>Configuration lives on the socket, not the environment</h2>
     <p>
-      A dog's settings live under <code>[dog.&lt;name&gt;]</code> in{" "}
+      A dog's settings live under <code>[&lt;name&gt;]</code> in{" "}
+      <code>$SHEP_HOME/dogs.toml</code>, hand-editable and separate from{" "}
       <code>shep.toml</code>, and they never travel through the dog's
       environment. Instead the dog connects to the socket and asks for its
       own section over the wire. The daemon reads the file fresh for every
@@ -154,17 +155,24 @@ $ shep disable metrics`}</CodeBlock>
     <p>
       An environment variable is readable from the process table, inherited
       by every child the dog spawns, and captured into a crash dump.{" "}
-      <code>[dog.bark.sinks]</code> routinely holds a webhook URL, and a
+      <code>[bark.sinks]</code> routinely holds a webhook URL, and a
       webhook URL is a bearer credential. Keeping the whole section off the
       environment means nobody has to remember which dog's config is
       sensitive.
     </p>
     <Callout variant="careful">
-      Editing <code>[dog.&lt;name&gt;]</code> does not reach a dog that's
-      already running. It asked for its section once, at startup, and
-      nothing pushes it a new one. <code>shep disable &lt;name&gt; &amp;&amp;
-      shep enable &lt;name&gt;</code> is what re-reads it: a fresh process
-      asking a fresh question.
+      Editing <code>[&lt;name&gt;]</code> in <code>dogs.toml</code> does not
+      reach a dog that's already running. It asked for its section once, at
+      startup, and nothing pushes it a new one. <code>shep disable
+      &lt;name&gt; &amp;&amp; shep enable &lt;name&gt;</code> is what
+      re-reads it: a fresh process asking a fresh question.
+    </Callout>
+    <Callout variant="careful">
+      A section that used to live in <code>shep.toml</code> migrates to{" "}
+      <code>dogs.toml</code> once, on the first boot of a shep carrying this
+      move, and it prints which dogs moved. If a name exists in both files,
+      the daemon refuses to boot until one of the two sections is deleted; a
+      dog present in only one file migrates or starts normally.
     </Callout>
 
     <h2>The metrics dog</h2>
@@ -172,7 +180,7 @@ $ shep disable metrics`}</CodeBlock>
       <code>shep enable metrics</code> serves Prometheus exposition text over
       plain HTTP, bound to <code>127.0.0.1:9615</code> by default:
     </p>
-    <CodeBlock label="shep.toml">{`[dog.metrics]
+    <CodeBlock label="dogs.toml">{`[metrics]
 bind = "127.0.0.1:9615"`}</CodeBlock>
     <p>
       Nothing accumulates between scrapes. Every request rebuilds the
@@ -220,21 +228,21 @@ shep_host_memory_total_bytes 51539607552`}</CodeBlock>
       <code>shep enable bark</code> subscribes to the shepherd's event bus
       and delivers to named webhook sinks:
     </p>
-    <CodeBlock label="shep.toml">{`[dog.bark.sinks]
+    <CodeBlock label="dogs.toml">{`[bark.sinks]
 oncall = { kind = "discord", url = "https://discord.com/api/webhooks/..." }
 audit = { kind = "json", url = "https://example.internal/hook" }
 
-[[dog.bark.rules]]
+[[bark.rules]]
 on = "gave_up"
 sinks = ["oncall", "audit"]
 
-[[dog.bark.rules]]
+[[bark.rules]]
 on = "restart_rate"
 restarts = 5
 within = "2m"
 sinks = ["oncall"]`}</CodeBlock>
     <p>
-      Leave <code>[dog.bark.rules]</code> out and bark doesn't go quiet:
+      Leave <code>[bark.rules]</code> out and bark doesn't go quiet:
       one rule is built in by default, firing on every configured sink
       whenever a sheep reaches <code>Errored</code>. That's the alert that
       must not be missed, so it needs no opt-in. <code>restart_rate</code>{" "}
@@ -245,7 +253,7 @@ sinks = ["oncall"]`}</CodeBlock>
     </p>
     <Callout variant="careful">
       Verified directly: enable <code>bark</code> with{" "}
-      <code>[dog.bark.sinks]</code> absent entirely and it does not run
+      <code>[bark.sinks]</code> absent entirely and it does not run
       quietly with nowhere to send alerts: the default rule still exists
       with zero sinks to route to, bark logs{" "}
       <code>rule 0 routes to no sink at all</code> on every restart attempt,
@@ -363,7 +371,7 @@ watchdog  adopted  true      stopped`}</CodeBlock>
       section as opaque text. Shep sets two variables of its own on a dog:{" "}
       <code>$SHEP_HOME</code>, which is how it finds that socket in the first
       place, and <code>$SHEP_DOG_NAME</code>, which is the name to put in
-      that request. No <code>[dog.&lt;name&gt;]</code> value rides along
+      that request. No <code>[&lt;name&gt;]</code> value rides along
       beside them.
     </p>
     <p>
@@ -417,7 +425,7 @@ watchdog  adopted  true      stopped`}</CodeBlock>
       <code>HOME</code>, <code>USER</code>, <code>LANG</code> and{" "}
       <code>TZ</code> the shepherd itself has, plus{" "}
       <code>SHEP_INSTANCE</code>. Nothing from{" "}
-      <code>[dog.&lt;name&gt;]</code> is in there.
+      <code>[&lt;name&gt;]</code> is in there.
     </p>
     <Callout variant="careful">
       Read <code>$SHEP_DOG_NAME</code> rather than hardcoding a name. It

--- a/web/src/pages/docs/dogs.astro
+++ b/web/src/pages/docs/dogs.astro
@@ -140,7 +140,11 @@ $ shep disable metrics`}</CodeBlock>
       Running <code>enable</code> and <code>adopt</code> at once from a
       provisioning script is safe: each takes an exclusive lock on{" "}
       <code>shep.toml</code> for its whole read-edit-write, so the second
-      waits its turn.
+      waits its turn. <code>dogs.toml</code> has its own lock on the same
+      terms, held by both of its writers (<code>rehome</code>, and the
+      migration a boot runs once), so two backgrounded rehomes both land
+      and neither fights a boot. A boot holding both takes{" "}
+      <code>shep.toml</code>'s first.
     </p>
 
     <h2>Configuration lives on the socket, not the environment</h2>

--- a/web/src/pages/docs/kv.astro
+++ b/web/src/pages/docs/kv.astro
@@ -50,18 +50,19 @@ KEY  VALUE`;
     <h1>The KV store</h1>
     <ReferencePills slug="kv" />
     <p class="lede">
-      Two files already configure everything shep runs: a Flockfile
-      configures a sheep, <code>shep.toml</code> configures the shepherd and
-      its dogs. Neither has a field for "the port the last on-call engineer
-      picked" or a feature flag a provisioning script wants to leave a note
-      about. The KV store is what's left over: a flat, file-locked junk
-      drawer, explicitly not the primary config path.
+      Three files already configure everything shep runs: a Flockfile
+      configures a sheep, <code>shep.toml</code> configures the shepherd,
+      and <code>dogs.toml</code> configures its dogs. None has a field for
+      "the port the last on-call engineer picked" or a feature flag a
+      provisioning script wants to leave a note about. The KV store is
+      what's left over: a flat, file-locked junk drawer, explicitly not the
+      primary config path.
     </p>
 
     <Callout variant="note">
       Reaching for this to configure a <em>sheep</em>? Put it in the
       Flockfile. Configuring a <em>dog</em>? Put it under
-      <code>[dog.&lt;name&gt;]</code> in <code>shep.toml</code>. This store is
+      <code>[&lt;name&gt;]</code> in <code>dogs.toml</code>. This store is
       only for what's left after those two.
     </Callout>
 
@@ -144,8 +145,8 @@ KEY  VALUE`;
       <a href="/docs/dogs" class="next-card">
         <div class="next-title">Dogs →</div>
         <div class="next-body">
-          Per-dog settings live under <code>[dog.&lt;name&gt;]</code> in
-          <code>shep.toml</code>, not here. This page explains where the
+          Per-dog settings live under <code>[&lt;name&gt;]</code> in
+          <code>dogs.toml</code>, not here. This page explains where the
           line falls.
         </div>
       </a>


### PR DESCRIPTION
A dog's settings move out of `[dog.<name>]` in `$SHEP_HOME/shep.toml` and into `[<name>]` in a new `$SHEP_HOME/dogs.toml`, migrated once at boot. Release 1 of 3 from `docs/brainstorming/specs/2026-09-03-dog-config-design.md` (decisions 1, 2 and 3). The schema contract and the lookout pane are later slices. Plan: `docs/writing-plans/plans/2026-09-03-dog-config-store-move.md`.

- `DogsConfig` in shep-core is the only place the new file's shape is decided, with a redacted `Debug` and an exact-string test, because a dog section routinely holds a webhook URL with a bearer token in it
- `RawDaemonConfig` keeps its `dog` field on purpose. Deleting it would stop every existing `shep.toml` with a `[dog.bark]` section from parsing, and `deny_unknown_fields` turns that into a refused boot with the flock unsupervised
- the migration writes `dogs.toml` before it strikes `shep.toml`, so a crash between the two leaves the sections readable from the old file
- `dogs.toml` is hand-editable, created at `0600` through a staged temp plus `fsync` plus rename, and guarded by the same `ConfigLock` `shep.toml` uses. Both writers hold it. Lock order is `shep.toml` outer, `dogs.toml` inner, and only the migration holds both
- both writers go through `toml_edit`, so comments, inline-table spelling and key order survive an edit, in the file and in the sections carried over from `shep.toml`
- `shep enable` no longer scaffolds a section, and `shep rehome` forgets a dog in both files
- the dog-facing wire is unchanged. `Response::DogSection` carries the same TOML text it always did, so no existing dog breaks. `PROTOCOL_VERSION` stays 2 and `SCHEMA_VERSION` stays 1
- `web/`, `docs/dogs.md`, `docs/kv.md`, `docs/decisions.md`, five clap help strings and the regenerated CLI reference

The migration refuses, and the daemon does not start, when a dog name carries a value in both files. That is deliberate: two values for one key is a question shep cannot answer, and guessing would silently discard whichever it did not pick. It is narrower than it first reads. A dog present only in `shep.toml` migrates normally, an empty `[dog.<name>]` scaffolded by an older binary is skipped rather than refused, and the refusal now runs in the `shep daemon reload` pre-flight before any signal reaches the predecessor.

That last part was the worst thing in this branch and a final reviewer found it. `shep daemon reload` is the documented upgrade command, the successor runs the migration after `execve` has replaced the predecessor's image, and a refusal there left the flock alive with nothing supervising it, a muster roll reporting it stopped, and a duplicate process on recovery. Reproduced, fixed, and reproduced again inverted. The same reviewer found that `shep runtime` never migrated at all, because it calls `boot_supervisor` rather than `run_daemon`, so a container would have served compiled defaults forever and bark's sinks would have vanished with no warning. The migration now runs in both places and is idempotent across them.

Two other things worth knowing before merge. Downgrading is not as easy as the spec's rollout section claims: a pre-branch binary boots a migrated home and serves every dog its compiled defaults, silently, and reverting means hand-copying sections back. And roughly 55 `[dog.<name>]` rustdoc comments in the dog subsystem are still stale. They carry no behaviour and fixing them here would have buried a boot fix in comment churn, so they are their own follow-up.

Every new test proven non-vacuous by mutating what it protects and watching that one test go red: reverting the section round trip to `section.to_string()`, returning early from the migration, answering an empty string from `dog_section`, dropping the `permissions` argument and then reverting the whole write to `std::fs::write`, restoring the `dog_table_mut` scaffold, dropping the lock from each `dogs.toml` writer separately, and removing the `forget_dog_section` call from `rehome`. One mutation silently failed to apply because `cargo fmt` had rewrapped the line the patch matched, and three green runs briefly read as evidence the test could not fail, so every later mutation was grep-confirmed as applied before its run.

Gate, each command's `$?` captured directly rather than through a pipe: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`, `cargo test --workspace --all-features` (2409 passed, 0 failed), `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features`, all EXIT=0. `astro build` and `astro check` EXIT=0, 0 errors and 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dog configuration now uses `$SHEP_HOME/dogs.toml` with `[<name>]` sections.
  * Existing configurations migrate automatically during startup or reload.
  * Migration preserves formatting, supports concurrent updates, and refuses conflicting definitions.
  * `rehome` removes both registration and configuration; `disable` preserves configuration.
  * Bark restart-rate rules now require a `within` window.
* **Bug Fixes**
  * Improved handling of malformed, unreadable, and conflicting configuration files.
* **Documentation**
  * Updated CLI help, web documentation, and configuration examples for the new layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->