### PR TITLE
chore: release v0.1.32

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2058,7 +2058,7 @@ dependencies = [
 
 [[package]]
 name = "shep"
-version = "0.1.31"
+version = "0.1.32"
 dependencies = [
  "anstyle",
  "assert_cmd",
@@ -2096,11 +2096,11 @@ dependencies = [
 
 [[package]]
 name = "shep-cli"
-version = "0.1.31"
+version = "0.1.32"
 
 [[package]]
 name = "shep-client"
-version = "0.1.31"
+version = "0.1.32"
 dependencies = [
  "futures-util",
  "nix 0.29.0",
@@ -2113,7 +2113,7 @@ dependencies = [
 
 [[package]]
 name = "shep-core"
-version = "0.1.31"
+version = "0.1.32"
 dependencies = [
  "annotate-snippets",
  "anstyle",
@@ -2143,7 +2143,7 @@ dependencies = [
 
 [[package]]
 name = "shep-daemon"
-version = "0.1.31"
+version = "0.1.32"
 dependencies = [
  "bytes",
  "chrono",
@@ -2172,7 +2172,7 @@ dependencies = [
 
 [[package]]
 name = "shep-examples"
-version = "0.1.31"
+version = "0.1.32"
 dependencies = [
  "nix 0.29.0",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.31"
+version = "0.1.32"
 edition = "2024"
 # 1.88 forced by serde-saphyr (let-chains, stabilized 1.88) — a current dep,
 # not a future one. Also the floor for ratatui/sysinfo/rmcp in later phases.
@@ -31,9 +31,9 @@ license = "MIT OR Apache-2.0"
 # the `[package]` table — so this literal is not sourced from
 # `workspace.package.version` above and a release bump has to touch both
 # places by hand. If that drifts, `cargo-release` is the mechanical fix.
-shep-core = { path = "crates/shep-core", version = "0.1.31" }
-shep-daemon = { path = "crates/shep-daemon", version = "0.1.31" }
-shep-client = { path = "crates/shep-client", version = "0.1.31" }
+shep-core = { path = "crates/shep-core", version = "0.1.32" }
+shep-daemon = { path = "crates/shep-daemon", version = "0.1.32" }
+shep-client = { path = "crates/shep-client", version = "0.1.32" }
 serde = { version = "1", default-features = false, features = ["derive"] }
 serde_json = { version = "1", default-features = false, features = ["std"] }
 toml = { version = "0.8", default-features = false, features = ["parse", "display"] }

--- a/crates/shep-cli/CHANGELOG.md
+++ b/crates/shep-cli/CHANGELOG.md
@@ -13,6 +13,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.32] - 2026-09-04
+
+### Added
+
+- Dogs.toml gets a type and a path
+- ShepToml can take the dog sections out
+- Dog config moves to dogs.toml, migrated on boot
+
+### Fixed
+
+- Take_dog_sections keeps nested tables, arrays and inline tables
+- Dogs.toml is written at 0600 through the same staged rename shep.toml uses
+- The migration refuses on a dog entry that would be dropped, by name
+- Dog help text stops naming shep.toml for a key that moved
+- Shep enable stops scaffolding a section the next boot refuses
+- Shep rehome forgets a dog in dogs.toml too, not just shep.toml
+- Dogs.toml gets the lock shep.toml has, across both its writers
+- The dog migration runs before a reload signals the predecessor
+- Shep runtime migrates dog config, like every other boot
+- DogsConfigError's Debug no longer prints dogs.toml
+- Both writers of dogs.toml keep an operator's comments
+- An empty [dog.<name>] is not a second value to refuse
+- The last string sending an operator to [dog.bark.sinks]
+- A header spelled with spaces stranded its dog section forever
+- A bare header in dogs.toml refused a section carrying values
+- The moved section was not appended, though the comment said it was
+
+
 ## [0.1.31] - 2026-09-03
 
 ### Added

--- a/crates/shep-client/CHANGELOG.md
+++ b/crates/shep-client/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.32] - 2026-09-04
+
+
 ## [0.1.31] - 2026-09-03
 
 

--- a/crates/shep-core/CHANGELOG.md
+++ b/crates/shep-core/CHANGELOG.md
@@ -10,6 +10,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.32] - 2026-09-04
+
+### Added
+
+- Dogs.toml gets a type and a path
+
+### Fixed
+
+- DogsConfigError's Debug no longer prints dogs.toml
+
+
 ## [0.1.31] - 2026-09-03
 
 ### Added

--- a/crates/shep-daemon/CHANGELOG.md
+++ b/crates/shep-daemon/CHANGELOG.md
@@ -10,6 +10,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.32] - 2026-09-04
+
+### Added
+
+- Dogs.toml gets a type and a path
+- Dog config moves to dogs.toml, migrated on boot
+
+
 ## [0.1.31] - 2026-09-03
 
 ### Added


### PR DESCRIPTION



## 🤖 New release

* `shep-core`: 0.1.31 -> 0.1.32 (✓ API compatible changes)
* `shep-daemon`: 0.1.31 -> 0.1.32 (✓ API compatible changes)
* `shep-client`: 0.1.31 -> 0.1.32
* `shep`: 0.1.31 -> 0.1.32 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `shep-core`

<blockquote>

## [0.1.32] - 2026-09-04

### Added

- Dogs.toml gets a type and a path

### Fixed

- DogsConfigError's Debug no longer prints dogs.toml
</blockquote>

## `shep-daemon`

<blockquote>

## [0.1.32] - 2026-09-04

### Added

- Dogs.toml gets a type and a path
- Dog config moves to dogs.toml, migrated on boot
</blockquote>


## `shep`

<blockquote>

## [0.1.32] - 2026-09-04

### Added

- Dogs.toml gets a type and a path
- ShepToml can take the dog sections out
- Dog config moves to dogs.toml, migrated on boot

### Fixed

- Take_dog_sections keeps nested tables, arrays and inline tables
- Dogs.toml is written at 0600 through the same staged rename shep.toml uses
- The migration refuses on a dog entry that would be dropped, by name
- Dog help text stops naming shep.toml for a key that moved
- Shep enable stops scaffolding a section the next boot refuses
- Shep rehome forgets a dog in dogs.toml too, not just shep.toml
- Dogs.toml gets the lock shep.toml has, across both its writers
- The dog migration runs before a reload signals the predecessor
- Shep runtime migrates dog config, like every other boot
- DogsConfigError's Debug no longer prints dogs.toml
- Both writers of dogs.toml keep an operator's comments
- An empty [dog.<name>] is not a second value to refuse
- The last string sending an operator to [dog.bark.sinks]
- A header spelled with spaces stranded its dog section forever
- A bare header in dogs.toml refused a section carrying values
- The moved section was not appended, though the comment said it was
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).