### PR TITLE
refactor: one staging-file helper for every $SHEP_HOME store

### DIFF
--- a/crates/shep-cli/src/commands/dog_migration.rs
+++ b/crates/shep-cli/src/commands/dog_migration.rs
@@ -81,7 +81,7 @@ pub(crate) fn migrate_dog_sections(paths: &ShepPaths) -> Result<Vec<String>, Dog
     // rather than an optimisation. `ShepToml::edit` and `try_edit` both
     // stage a temp file and rename it over the original whenever `save`
     // runs, so opening the document at all would give an untouched
-    // `shep.toml` a fresh inode, force `CONFIG_FILE_MODE` on it, and
+    // `shep.toml` a fresh inode, force `OWNER_ONLY_FILE_MODE` on it, and
     // replace a symlinked path with a plain file. Every boot after the
     // first reaches this line, so that cost would land on everyone.
     //
@@ -445,7 +445,7 @@ fn renumber_tables(item: &mut Item, next: &mut usize) {
 }
 
 /// Writes `rendered` to `path`: staged in a sibling temp file at
-/// `CONFIG_FILE_MODE`, `fsync`ed, then `rename`d over `path`.
+/// `OWNER_ONLY_FILE_MODE`, `fsync`ed, then `rename`d over `path`.
 ///
 /// The same three steps, through the same helper, that
 /// [`ShepToml::save`] writes `shep.toml` with, and for the same two
@@ -1153,7 +1153,7 @@ mod tests {
     /// identical either way. `ShepToml::edit` and `try_edit` stage a temp
     /// file and rename it over the original whenever `save` runs, so
     /// opening the document on an idle boot would hand an untouched
-    /// `shep.toml` a fresh inode, force `CONFIG_FILE_MODE` onto it, and
+    /// `shep.toml` a fresh inode, force `OWNER_ONLY_FILE_MODE` onto it, and
     /// turn a symlinked path into a plain file. Every boot after the first
     /// takes this path, so the cost lands on every operator.
     #[cfg(unix)]

--- a/crates/shep-cli/src/commands/shep_toml.rs
+++ b/crates/shep-cli/src/commands/shep_toml.rs
@@ -44,26 +44,12 @@
 use std::collections::BTreeMap;
 use std::io::Write as _;
 #[cfg(unix)]
-use std::os::unix::fs::{DirBuilderExt as _, OpenOptionsExt as _, PermissionsExt as _};
+use std::os::unix::fs::{DirBuilderExt as _, OpenOptionsExt as _};
 use std::path::{Path, PathBuf};
 
 use toml_edit::{Array, DocumentMut, Item, Table, Value};
 
 use crate::style::StyleLevel;
-
-/// Mode `shep.toml` (and the sibling lock file and staging file it is
-/// written through, and `dogs.toml`, which
-/// `commands::dog_migration` stages through the same helper) is created
-/// with: owner read/write, nobody else.
-///
-/// Unlike `barks.jsonl`'s own `0600`, this is not belt-and-braces. This
-/// file is where `docs/dogs.md` tells an operator to paste a Discord or
-/// Slack webhook URL, and both carry a bearer token in the path, so the
-/// mode here is the guard rather than a second one behind `$SHEP_HOME`'s.
-/// It is also what a `tar`, a `cp -p` or a backup of `$SHEP_HOME` carries
-/// out with the file, somewhere no directory mode follows it.
-#[cfg_attr(windows, allow(dead_code))]
-const CONFIG_FILE_MODE: u32 = 0o600;
 
 /// Extensions [`ShepToml::write_starter_interpreters`] maps, in the order
 /// they land in `shep.toml`.
@@ -184,7 +170,8 @@ impl ShepToml {
     /// a table, say) must be able to say so without the read-modify-
     /// write underneath it staging and renaming a byte-identical copy of
     /// the file back over itself anyway — that rename still lands a fresh
-    /// inode and forces [`CONFIG_FILE_MODE`] on a file that a refused edit
+    /// inode and forces [`shep_core::atomic_file::OWNER_ONLY_FILE_MODE`]
+    /// on a file that a refused edit
     /// never actually touched, and for a symlinked `path` it is what
     /// replaces the link with a plain file. [`Self::edit`]'s `f` cannot
     /// refuse at all, so that failure mode did not exist before this
@@ -547,7 +534,8 @@ impl ShepToml {
     }
 
     /// Writes the document back: staged in a sibling temp file at
-    /// [`CONFIG_FILE_MODE`], `fsync`ed, then `rename`d over `path`.
+    /// [`shep_core::atomic_file::OWNER_ONLY_FILE_MODE`], `fsync`ed, then
+    /// `rename`d over `path`.
     ///
     /// Private, and reached only from [`Self::edit`] with the lock held.
     ///
@@ -629,28 +617,14 @@ fn create_home_dir(dir: &Path) -> std::io::Result<()> {
 /// Creates the staging file a config is written through, in `parent` so
 /// the later `rename` stays within one filesystem.
 ///
-/// Mode-at-creation rather than a separate `chmod` pass (`tempfile` passes
-/// these permissions to the `open` call itself): there is no window in
-/// which the file holding a webhook token sits at whatever the process
-/// umask leaves it. Same shape, and same reasoning, as
-/// `barks::create_ring_file`.
-///
-/// `pub(super)` rather than private, and deliberately shared rather than
-/// copied: `commands::dog_migration` writes `dogs.toml`, which holds the
-/// webhook URLs that used to live in this file and needs the same
-/// [`CONFIG_FILE_MODE`] at the same `open`. A second implementation of
-/// create-at-mode plus `fsync` plus `rename` is how the two would drift,
-/// and the one that drifted would be the one nobody was reading.
+/// The create-at-mode reasoning lives with
+/// [`shep_core::atomic_file::create_staging_file`], which four stores now
+/// share. What is left here is the pair of names, and this wrapper is
+/// where they stay: `commands::dog_migration` writes `dogs.toml` through
+/// the same staging name as `shep.toml`, and two call sites spelling that
+/// pair out separately is how the two would drift.
 pub(super) fn create_config_file(parent: &Path) -> std::io::Result<tempfile::NamedTempFile> {
-    let mut builder = tempfile::Builder::new();
-    builder.prefix("shep").suffix(".toml.tmp");
-    // `shep.toml` can hold a webhook token, so on unix it is created `0600`
-    // at the `open` itself rather than chmod'ed after. On Windows it
-    // inherits `$SHEP_HOME`'s ACL — the same gap `create_home_dir` above
-    // names, and the reason the operator docs say so out loud.
-    #[cfg(unix)]
-    builder.permissions(std::fs::Permissions::from_mode(CONFIG_FILE_MODE));
-    builder.tempfile_in(parent)
+    shep_core::atomic_file::create_staging_file(parent, "shep", ".toml.tmp")
 }
 
 /// An exclusive advisory lock over one config file, held for as long as
@@ -730,7 +704,7 @@ impl ConfigLock {
             .write(true)
             .create(true)
             .truncate(false)
-            .mode(CONFIG_FILE_MODE)
+            .mode(shep_core::atomic_file::OWNER_ONLY_FILE_MODE)
             .open(lock_path(path))?;
 
         // `LockExclusive` blocks; the non-blocking variant would need a
@@ -865,6 +839,8 @@ impl core::error::Error for ShepTomlError {
 // this module's unix coverage is unchanged.
 #[cfg(all(test, unix))]
 mod tests {
+    use std::os::unix::fs::PermissionsExt as _;
+
     use shep_core::config::DaemonConfig;
 
     use super::*;
@@ -1196,7 +1172,8 @@ mod tests {
     /// the closure runs regardless of what the closure returned, would
     /// still stage a fresh file and rename it over the original on a
     /// refusal: identical bytes, but a new inode, and the mode forced to
-    /// [`CONFIG_FILE_MODE`] even though the original here is `0644`.
+    /// [`shep_core::atomic_file::OWNER_ONLY_FILE_MODE`] even though the
+    /// original here is `0644`.
     /// Content equality alone hides that, which is why this checks the
     /// file's metadata rather than only what is in it.
     /// [`ShepToml::try_edit`] is what actually prevents it: it never

--- a/crates/shep-cli/src/lib.rs
+++ b/crates/shep-cli/src/lib.rs
@@ -1195,7 +1195,7 @@ async fn run(cli: Cli, style: style::Presentation) -> ExitCode {
                 // that refusal must never reach `ShepToml::save` -- `edit`
                 // always saves after its closure runs regardless of what
                 // the closure returned, which would rewrite (new inode,
-                // mode forced to `CONFIG_FILE_MODE`) a file this call is
+                // mode forced to `OWNER_ONLY_FILE_MODE`) a file this call is
                 // reporting as untouched.
                 // `result_large_err` on the closure, for the same reason and
                 // on the same platform as the module-wide allow in

--- a/crates/shep-cli/tests/cli_e2e.rs
+++ b/crates/shep-cli/tests/cli_e2e.rs
@@ -5097,7 +5097,7 @@ fn barks_reads_the_history_with_no_shepherd_running() {
 /// makes for `shep barks`.
 ///
 /// Folds in the file-mode claim `shep_core::kv`'s own module doc makes
-/// (`KV_FILE_MODE`, `0600`) rather than giving it a separate case: the file
+/// (`OWNER_ONLY_FILE_MODE`, `0600`) rather than giving it a separate case: the file
 /// this test's own first `set` creates is the one to check, and creating a
 /// second store just to stat it would prove nothing this one doesn't.
 ///

--- a/crates/shep-core/src/atomic_file.rs
+++ b/crates/shep-core/src/atomic_file.rs
@@ -82,9 +82,10 @@ pub fn create_staging_file(
 // DIRECTORY, which sits in the page cache until that directory is flushed
 // too. Lose power in between and the data survives with nothing pointing
 // at it. A crash is not that case: a completed `rename(2)` is visible to
-// every later process whether or not anything was flushed, so only a power
-// cut or a kernel panic can lose a landed rename. The muster roll needs
-// the difference most, its whole job being read back after a reboot.
+// every later process whether or not anything was flushed, so it takes an
+// unclean shutdown (power cut, kernel panic, hypervisor reset) to undo one,
+// and the old file is what comes back. The muster roll needs the
+// difference most, its whole job being read back after a reboot.
 //
 // Why the two arms differ, which is not a caller's question (IR-31).
 //

--- a/crates/shep-core/src/atomic_file.rs
+++ b/crates/shep-core/src/atomic_file.rs
@@ -1,11 +1,11 @@
 //! The atomic file replace, its first step and its last
 //!
-//! Every file this workspace rewrites in place goes the same way: stage a
-//! fresh file beside the real one, write it, `fsync` it, `rename` it over
-//! the target, then `fsync` the directory the rename landed in. A reader
-//! sees the whole old file or the whole new one, never a fragment.
-//!
-//! [`create_staging_file`] is the first step and [`sync_dir`] is the last.
+//! Stage a fresh file beside the real one, write it, `fsync` it, `rename`
+//! it over the target, then `fsync` the directory the rename landed in. A
+//! reader sees the whole old file or the whole new one, never a fragment.
+//! [`create_staging_file`] is the first step, [`sync_dir`] the last, and
+//! the middle stays with each store, which maps its failures onto its own
+//! error type.
 //!
 //! [`sync_dir`] makes the *rename* durable, which the temp file's own
 //! `fsync` does not. On unix. It is a no-op on Windows, so every
@@ -27,82 +27,45 @@
 //! kernel panic can lose a landed rename, and the writer that most needs
 //! the difference is the muster roll, whose whole reason to exist is being
 //! read back after the machine comes up again.
-//!
-//! The middle is not here. The write, the staging file's own `sync_all`
-//! and the `persist` stay with each store, because each maps a failure of
-//! them onto its own error type.
-
-// Where the create step came from, which is a maintainer's question rather
-// than a caller's (IR-31). `kv.json`, `barks.jsonl`, `overrides.json` and
-// `shep.toml` (with `dogs.toml` riding on the last one) each carried their
-// own copy of it, six lines apiece and identical but for a prefix, a
-// suffix and a mode constant that held `0o600` in all four. A fifth copy
-// was one `pub(super)` away when this became one function instead.
 
 use std::path::Path;
 
-// Why `0600` and not something a caller could widen (IR-31). Four files
-// reached it by different arguments, and the strictest is the one that
-// governs a shared value. `$SHEP_HOME` is itself `0700`, so for `kv.json`,
-// `barks.jsonl` and `overrides.json` this is a second lock on the same
-// door. For `shep.toml` and `dogs.toml` it is the only lock that counts:
-// `docs/dogs.md` tells an operator to paste a Discord or Slack webhook URL
-// there, and both of those carry a bearer token in the path. It is also
-// the mode a `tar`, a `cp -p` or a backup of `$SHEP_HOME` carries out with
-// the file, somewhere no directory mode follows it.
+// `$SHEP_HOME` is already `0700`, but `shep.toml` and `dogs.toml` hold
+// webhook URLs with a bearer token in the path, and a `tar` or `cp -p` of
+// them carries this mode somewhere no directory mode follows.
 /// Mode a file under `$SHEP_HOME` is created with: owner read/write,
 /// nobody else.
 ///
 /// # Platforms
 ///
-/// Unix only. Windows has no equivalent bit, so nothing there applies this
-/// and a file inherits the ACL of the directory it lands in. That is the
-/// same gap `shep.toml`'s own home-directory creation names in the
-/// operator docs.
+/// Unix only. On Windows a file inherits the ACL of the directory it lands
+/// in.
 pub const OWNER_ONLY_FILE_MODE: u32 = 0o600;
 
-// The three choices a caller might otherwise ask about (IR-31).
+// No mode parameter, because a caller that wanted a looser one would be
+// wrong: every file here holds a credential or an `env` value.
 //
-// NO MODE PARAMETER. Every caller writes a file under `$SHEP_HOME` that
-// holds a credential, an `env` value, or a record of what the shepherd
-// told an outside service, so none of them wants anything but
-// `OWNER_ONLY_FILE_MODE`. A parameter would buy nothing today and would be
-// the door a later caller walks a `0644` through.
+// The unique middle is not tidiness. Two writers sharing a fixed
+// `<path>.tmp` had one `rename` consume the other's staging file.
 //
-// A UNIQUE MIDDLE, not a fixed `<path>.tmp`. Two writers sharing one had
-// a process's `rename` consume the other's staging file, and the loser
-// died with `ENOENT` renaming a path that no longer existed.
-//
-// NO SEPARATOR IN EITHER PART. `tempfile`'s own docs call one legal and
-// inadvisable, and `tempfile_in` joins the result onto `parent`, so a `..`
-// in front of a separator stages the file outside the directory this
-// function's whole contract is that it stays inside. Nothing in the tree
-// passes anything but a literal; the check is what keeps that true now
-// four private helpers have become one public one.
-//
-// `tempfile`'s OWN TYPE back, rather than a newtype. The caller does the
-// writing, the `sync_all` and the `persist`, so a wrapper's whole body
-// would forward those three calls. The cost is a dependency's type in this
-// crate's public API, taken deliberately.
+// `tempfile_in` joins a separator onto `parent`, so `../evil` escapes the
+// one directory this is contracted to stay inside.
 /// Creates the staging file a store is rewritten through, in `parent` so
 /// the later `rename` stays within one filesystem.
 ///
 /// `prefix` and `suffix` bracket a unique middle `tempfile` picks, and
 /// neither may contain a path separator. The file is created
-/// [`OWNER_ONLY_FILE_MODE`] on unix, at the `open` itself rather than by a
-/// later `chmod`, so there is no window in which it sits at whatever the
-/// process umask leaves it. It carries no mode on Windows.
+/// [`OWNER_ONLY_FILE_MODE`] on unix at the `open` itself, never by a later
+/// `chmod`, so it is never briefly wider. It carries no mode on Windows.
 ///
 /// The caller writes it, `sync_all`s it, and `persist`s it over the real
 /// file.
 ///
 /// # Errors
 /// - [`std::io::ErrorKind::InvalidInput`] when `prefix` or `suffix`
-///   contains `/` or `\`. Both are refused on both platforms, so the same
-///   argument is accepted or refused wherever it runs.
-/// - Otherwise, the staging file could not be created in `parent`: the
-///   directory is missing or unwritable, or `tempfile` ran out of attempts
-///   at a unique name.
+///   contains `/` or `\`, both refused on both platforms.
+/// - Otherwise `parent` is missing or unwritable, or `tempfile` ran out of
+///   attempts at a unique name.
 pub fn create_staging_file(
     parent: &Path,
     prefix: &str,
@@ -190,10 +153,8 @@ pub fn sync_dir(dir: &Path) -> std::io::Result<()> {
 mod tests {
     use super::*;
 
-    /// fails if the staging file lands anywhere but the directory the
-    /// caller named. A `rename` is only atomic within one filesystem, so
-    /// staging next to the real file is the whole reason this takes a
-    /// `parent` rather than using the system temp directory.
+    /// fails if the file lands outside `parent`, where the later `rename`
+    /// would cross a filesystem and stop being atomic.
     #[test]
     fn the_staging_file_lands_in_the_parent_it_was_given() {
         let dir = tempfile::tempdir().unwrap();
@@ -201,9 +162,7 @@ mod tests {
         assert_eq!(tmp.path().parent(), Some(dir.path()));
     }
 
-    /// fails if a caller's prefix or suffix is dropped on the way to
-    /// `tempfile`. Each store passes its own pair, and swapping them would
-    /// leave every store staging under one name.
+    /// fails if either part is dropped or swapped on the way to `tempfile`.
     #[test]
     fn the_name_carries_the_prefix_and_the_suffix() {
         let dir = tempfile::tempdir().unwrap();
@@ -215,10 +174,9 @@ mod tests {
         assert!(name.len() > "barks.tmp".len(), "no unique middle: {name}");
     }
 
-    /// fails if a separator in either argument reaches `tempfile`, which
-    /// allows one and joins the result onto `parent`. Both spellings are
-    /// refused on both platforms so an argument cannot be legal on one and
-    /// an escape on the other.
+    /// fails if a separator reaches `tempfile`. Both spellings, both
+    /// platforms, so an argument cannot be legal on one and an escape on
+    /// the other.
     #[test]
     fn a_path_separator_is_refused_in_either_argument() {
         let dir = tempfile::tempdir().unwrap();
@@ -237,22 +195,6 @@ mod tests {
                 "{prefix:?} {suffix:?}: {err:?}"
             );
         }
-    }
-
-    /// fails if the staging file is created readable by anyone but its
-    /// owner. `persist` is a `rename`, which installs this inode and its
-    /// mode over the real file, so this mode is the one the store ends up
-    /// wearing on disk.
-    #[cfg(unix)]
-    #[test]
-    fn the_staging_file_is_owner_only() {
-        use std::os::unix::fs::PermissionsExt as _;
-
-        let dir = tempfile::tempdir().unwrap();
-        let tmp = create_staging_file(dir.path(), "overrides", ".tmp").unwrap();
-
-        let mode = tmp.as_file().metadata().unwrap().permissions().mode() & 0o777;
-        assert_eq!(mode, 0o600, "mode was {mode:o}");
     }
 
     #[test]

--- a/crates/shep-core/src/atomic_file.rs
+++ b/crates/shep-core/src/atomic_file.rs
@@ -11,22 +11,6 @@
 //! `fsync` does not. On unix, and there only where the filesystem
 //! implements the flush: it is a no-op on Windows, and it answers `Ok` to
 //! the `EINVAL` some FUSE and network mounts return instead of flushing.
-//!
-//! Those two flushes answer different questions, and it is easy to buy one
-//! and believe you bought both. `File::sync_all` on the staging file
-//! flushes that file's CONTENTS. The directory entry the rename then
-//! creates is a change to the parent DIRECTORY, and it sits in the page
-//! cache until that directory is itself flushed. Lose power in between and
-//! the data survives with nothing pointing at it: the old file is still
-//! there, and the write is silently undone.
-//!
-//! An ordinary crash is not the case [`sync_dir`] covers. A completed
-//! `rename(2)` is visible to every later process whether or not anything
-//! was flushed, so a panic, a `SIGKILL` or an `ENOSPC` already leaves
-//! either the whole old file or the whole new one. Only a power cut or a
-//! kernel panic can lose a landed rename, and the writer that most needs
-//! the difference is the muster roll, whose whole reason to exist is being
-//! read back after the machine comes up again.
 
 use std::path::Path;
 
@@ -92,6 +76,16 @@ pub fn create_staging_file(
     builder.tempfile_in(parent)
 }
 
+// The two flushes answer different questions and it is easy to buy one
+// believing you bought both. `sync_all` on the staging file flushes its
+// CONTENTS; the entry the rename creates is a change to the parent
+// DIRECTORY, which sits in the page cache until that directory is flushed
+// too. Lose power in between and the data survives with nothing pointing
+// at it. A crash is not that case: a completed `rename(2)` is visible to
+// every later process whether or not anything was flushed, so only a power
+// cut or a kernel panic can lose a landed rename. The muster roll needs
+// the difference most, its whole job being read back after a reboot.
+//
 // Why the two arms differ, which is not a caller's question (IR-31).
 //
 // UNIX. `fsync` on a directory descriptor is the portable way to flush the

--- a/crates/shep-core/src/atomic_file.rs
+++ b/crates/shep-core/src/atomic_file.rs
@@ -8,9 +8,9 @@
 //! error type.
 //!
 //! [`sync_dir`] makes the *rename* durable, which the temp file's own
-//! `fsync` does not. On unix. It is a no-op on Windows, so every
-//! durability claim below, and in the six writers that call it, is a unix
-//! one.
+//! `fsync` does not. On unix, and there only where the filesystem
+//! implements the flush: it is a no-op on Windows, and it answers `Ok` to
+//! the `EINVAL` some FUSE and network mounts return instead of flushing.
 //!
 //! Those two flushes answer different questions, and it is easy to buy one
 //! and believe you bought both. `File::sync_all` on the staging file

--- a/crates/shep-core/src/atomic_file.rs
+++ b/crates/shep-core/src/atomic_file.rs
@@ -64,6 +64,12 @@ pub const OWNER_ONLY_FILE_MODE: u32 = 0o600;
 /// had one process's `rename` consume the other's staging file, and the
 /// loser died with `ENOENT` renaming a path that no longer existed.
 ///
+/// Neither may contain a path separator. `tempfile` allows one and joins
+/// the result onto `parent`, so a `..` in front of a separator would stage
+/// the file outside the directory this function's whole contract is that
+/// it stays inside. No caller passes anything but a literal, and this is
+/// what keeps that true now the helper is public.
+///
 /// On unix the mode goes to the `open` itself rather than a later `chmod`
 /// pass, so there is no window in which a file holding a webhook token
 /// sits at whatever the process umask leaves it.
@@ -81,14 +87,26 @@ pub const OWNER_ONLY_FILE_MODE: u32 = 0o600;
 /// body forwards those three calls.
 ///
 /// # Errors
-/// The staging file could not be created in `parent`: the directory is
-/// missing or unwritable, or `tempfile` ran out of attempts at a unique
-/// name.
+/// - [`std::io::ErrorKind::InvalidInput`] when `prefix` or `suffix`
+///   contains `/` or `\`. Both are refused on both platforms, so the same
+///   argument is accepted or refused wherever it runs.
+/// - Otherwise, the staging file could not be created in `parent`: the
+///   directory is missing or unwritable, or `tempfile` ran out of attempts
+///   at a unique name.
 pub fn create_staging_file(
     parent: &Path,
     prefix: &str,
     suffix: &str,
 ) -> std::io::Result<tempfile::NamedTempFile> {
+    for (label, part) in [("prefix", prefix), ("suffix", suffix)] {
+        if part.contains(['/', '\\']) {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                format!("staging file {label} must not contain a path separator: {part:?}"),
+            ));
+        }
+    }
+
     let mut builder = tempfile::Builder::new();
     builder.prefix(prefix).suffix(suffix);
 
@@ -185,6 +203,30 @@ mod tests {
         assert!(name.starts_with("barks"), "{name}");
         assert!(name.ends_with(".tmp"), "{name}");
         assert!(name.len() > "barks.tmp".len(), "no unique middle: {name}");
+    }
+
+    /// fails if a separator in either argument reaches `tempfile`, which
+    /// allows one and joins the result onto `parent`. Both spellings are
+    /// refused on both platforms so an argument cannot be legal on one and
+    /// an escape on the other.
+    #[test]
+    fn a_path_separator_is_refused_in_either_argument() {
+        let dir = tempfile::tempdir().unwrap();
+
+        for (prefix, suffix) in [
+            ("../escape", ".tmp"),
+            ("kv", "/etc/passwd"),
+            ("..\\escape", ".tmp"),
+            ("kv", "\\tmp"),
+        ] {
+            let err = create_staging_file(dir.path(), prefix, suffix)
+                .expect_err("a separator must not reach tempfile");
+            assert_eq!(
+                err.kind(),
+                std::io::ErrorKind::InvalidInput,
+                "{prefix:?} {suffix:?}: {err:?}"
+            );
+        }
     }
 
     /// fails if the staging file is created readable by anyone but its

--- a/crates/shep-core/src/atomic_file.rs
+++ b/crates/shep-core/src/atomic_file.rs
@@ -84,8 +84,9 @@ pub fn create_staging_file(
 // at it. A crash is not that case: a completed `rename(2)` is visible to
 // every later process whether or not anything was flushed, so it takes an
 // unclean shutdown (power cut, kernel panic, hypervisor reset) to undo one,
-// and the old file is what comes back. The muster roll needs the
-// difference most, its whole job being read back after a reboot.
+// and what comes back is then the old file or the new one, never a
+// fragment. The muster roll needs the difference most, its whole job being
+// read back after a reboot.
 //
 // Why the two arms differ, which is not a caller's question (IR-31).
 //

--- a/crates/shep-core/src/atomic_file.rs
+++ b/crates/shep-core/src/atomic_file.rs
@@ -1,0 +1,125 @@
+//! The staging file every `$SHEP_HOME` store is rewritten through.
+//!
+//! Four stores replace themselves the same way: stage a fresh file beside
+//! the real one, `fsync` it, then `rename` it over the top, so a reader
+//! sees either the whole old file or the whole new one and never a
+//! half-written fragment. `kv.json`, `barks.jsonl`, `overrides.json` and
+//! `shep.toml` (with `dogs.toml` riding on the last one) each carried
+//! their own copy of the create step, six lines apiece and identical but
+//! for a name. This module is the one copy they share.
+//!
+//! Only the create step lives here. The write, the `sync_all` and the
+//! `persist` stay with each store, because each maps a failure of them
+//! onto its own error type.
+
+use std::path::Path;
+
+/// Mode a file under `$SHEP_HOME` is created with: owner read/write,
+/// nobody else.
+///
+/// `$SHEP_HOME` is itself `0700`, so for `kv.json`, `barks.jsonl` and
+/// `overrides.json` this is a second lock on the same door. For
+/// `shep.toml` and `dogs.toml` it is the only lock that counts:
+/// `docs/dogs.md` tells an operator to paste a Discord or Slack webhook
+/// URL there, and both of those carry a bearer token in the path. Four
+/// files reached `0600` by different arguments and the strictest of them
+/// is the one that governs the shared value.
+///
+/// It is also the mode a `tar`, a `cp -p` or a backup of `$SHEP_HOME`
+/// carries out with the file, somewhere no directory mode follows it.
+///
+/// Windows has no equivalent bit, so nothing there applies it and a file
+/// inherits the ACL of the directory it lands in. That is the same gap
+/// `shep.toml`'s own home-directory creation names in the operator docs.
+pub const OWNER_ONLY_FILE_MODE: u32 = 0o600;
+
+/// Creates the staging file a store is rewritten through, in `parent` so
+/// the later `rename` stays within one filesystem.
+///
+/// `prefix` and `suffix` bracket a unique middle `tempfile` picks. The
+/// uniqueness is not tidiness: two writers sharing a fixed `<path>.tmp`
+/// had one process's `rename` consume the other's staging file, and the
+/// loser died with `ENOENT` renaming a path that no longer existed.
+///
+/// On unix the mode goes to the `open` itself rather than a later `chmod`
+/// pass, so there is no window in which a file holding a webhook token
+/// sits at whatever the process umask leaves it.
+///
+/// There is no mode parameter, and that is the function rather than an
+/// omission. Every caller writes a file under `$SHEP_HOME` that holds a
+/// credential, an `env` value, or a record of what the shepherd told an
+/// outside service, so none of them wants anything but
+/// [`OWNER_ONLY_FILE_MODE`]. A parameter would buy nothing today and
+/// would be the door a later caller walks a `0644` through.
+///
+/// Returns `tempfile`'s own type, because the caller does the writing, the
+/// `sync_all` and the `persist`. That puts a dependency's type in this
+/// crate's public API on purpose: the alternative is a newtype whose whole
+/// body forwards those three calls.
+///
+/// # Errors
+/// The staging file could not be created in `parent`: the directory is
+/// missing or unwritable, or `tempfile` ran out of attempts at a unique
+/// name.
+pub fn create_staging_file(
+    parent: &Path,
+    prefix: &str,
+    suffix: &str,
+) -> std::io::Result<tempfile::NamedTempFile> {
+    let mut builder = tempfile::Builder::new();
+    builder.prefix(prefix).suffix(suffix);
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt as _;
+        builder.permissions(std::fs::Permissions::from_mode(OWNER_ONLY_FILE_MODE));
+    }
+
+    builder.tempfile_in(parent)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// fails if the staging file lands anywhere but the directory the
+    /// caller named. A `rename` is only atomic within one filesystem, so
+    /// staging next to the real file is the whole reason this takes a
+    /// `parent` rather than using the system temp directory.
+    #[test]
+    fn the_staging_file_lands_in_the_parent_it_was_given() {
+        let dir = tempfile::tempdir().unwrap();
+        let tmp = create_staging_file(dir.path(), "kv", ".tmp").unwrap();
+        assert_eq!(tmp.path().parent(), Some(dir.path()));
+    }
+
+    /// fails if a caller's prefix or suffix is dropped on the way to
+    /// `tempfile`. Each store passes its own pair, and swapping them would
+    /// leave every store staging under one name.
+    #[test]
+    fn the_name_carries_the_prefix_and_the_suffix() {
+        let dir = tempfile::tempdir().unwrap();
+        let tmp = create_staging_file(dir.path(), "barks", ".tmp").unwrap();
+
+        let name = tmp.path().file_name().unwrap().to_str().unwrap();
+        assert!(name.starts_with("barks"), "{name}");
+        assert!(name.ends_with(".tmp"), "{name}");
+        assert!(name.len() > "barks.tmp".len(), "no unique middle: {name}");
+    }
+
+    /// fails if the staging file is created readable by anyone but its
+    /// owner. `persist` is a `rename`, which installs this inode and its
+    /// mode over the real file, so this mode is the one the store ends up
+    /// wearing on disk.
+    #[cfg(unix)]
+    #[test]
+    fn the_staging_file_is_owner_only() {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let dir = tempfile::tempdir().unwrap();
+        let tmp = create_staging_file(dir.path(), "overrides", ".tmp").unwrap();
+
+        let mode = tmp.as_file().metadata().unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600, "mode was {mode:o}");
+    }
+}

--- a/crates/shep-core/src/atomic_file.rs
+++ b/crates/shep-core/src/atomic_file.rs
@@ -5,15 +5,12 @@
 //! the target, then `fsync` the directory the rename landed in. A reader
 //! sees the whole old file or the whole new one, never a fragment.
 //!
-//! [`create_staging_file`] is the first step. `kv.json`, `barks.jsonl`,
-//! `overrides.json` and `shep.toml` (with `dogs.toml` riding on the last
-//! one) each carried their own copy of it, six lines apiece and identical
-//! but for a name. This module is the one copy they share.
+//! [`create_staging_file`] is the first step and [`sync_dir`] is the last.
 //!
-//! [`sync_dir`] is the last step: it makes the *rename* durable, which the
-//! temp file's own `fsync` does not. On unix. It is a no-op on Windows, so
-//! every durability claim below, and in the six writers that call it, is a
-//! unix one.
+//! [`sync_dir`] makes the *rename* durable, which the temp file's own
+//! `fsync` does not. On unix. It is a no-op on Windows, so every
+//! durability claim below, and in the six writers that call it, is a unix
+//! one.
 //!
 //! Those two flushes answer different questions, and it is easy to buy one
 //! and believe you bought both. `File::sync_all` on the staging file
@@ -35,56 +32,69 @@
 //! and the `persist` stay with each store, because each maps a failure of
 //! them onto its own error type.
 
+// Where the create step came from, which is a maintainer's question rather
+// than a caller's (IR-31). `kv.json`, `barks.jsonl`, `overrides.json` and
+// `shep.toml` (with `dogs.toml` riding on the last one) each carried their
+// own copy of it, six lines apiece and identical but for a prefix, a
+// suffix and a mode constant that held `0o600` in all four. A fifth copy
+// was one `pub(super)` away when this became one function instead.
+
 use std::path::Path;
 
+// Why `0600` and not something a caller could widen (IR-31). Four files
+// reached it by different arguments, and the strictest is the one that
+// governs a shared value. `$SHEP_HOME` is itself `0700`, so for `kv.json`,
+// `barks.jsonl` and `overrides.json` this is a second lock on the same
+// door. For `shep.toml` and `dogs.toml` it is the only lock that counts:
+// `docs/dogs.md` tells an operator to paste a Discord or Slack webhook URL
+// there, and both of those carry a bearer token in the path. It is also
+// the mode a `tar`, a `cp -p` or a backup of `$SHEP_HOME` carries out with
+// the file, somewhere no directory mode follows it.
 /// Mode a file under `$SHEP_HOME` is created with: owner read/write,
 /// nobody else.
 ///
-/// `$SHEP_HOME` is itself `0700`, so for `kv.json`, `barks.jsonl` and
-/// `overrides.json` this is a second lock on the same door. For
-/// `shep.toml` and `dogs.toml` it is the only lock that counts:
-/// `docs/dogs.md` tells an operator to paste a Discord or Slack webhook
-/// URL there, and both of those carry a bearer token in the path. Four
-/// files reached `0600` by different arguments and the strictest of them
-/// is the one that governs the shared value.
+/// # Platforms
 ///
-/// It is also the mode a `tar`, a `cp -p` or a backup of `$SHEP_HOME`
-/// carries out with the file, somewhere no directory mode follows it.
-///
-/// Windows has no equivalent bit, so nothing there applies it and a file
-/// inherits the ACL of the directory it lands in. That is the same gap
-/// `shep.toml`'s own home-directory creation names in the operator docs.
+/// Unix only. Windows has no equivalent bit, so nothing there applies this
+/// and a file inherits the ACL of the directory it lands in. That is the
+/// same gap `shep.toml`'s own home-directory creation names in the
+/// operator docs.
 pub const OWNER_ONLY_FILE_MODE: u32 = 0o600;
 
+// The three choices a caller might otherwise ask about (IR-31).
+//
+// NO MODE PARAMETER. Every caller writes a file under `$SHEP_HOME` that
+// holds a credential, an `env` value, or a record of what the shepherd
+// told an outside service, so none of them wants anything but
+// `OWNER_ONLY_FILE_MODE`. A parameter would buy nothing today and would be
+// the door a later caller walks a `0644` through.
+//
+// A UNIQUE MIDDLE, not a fixed `<path>.tmp`. Two writers sharing one had
+// a process's `rename` consume the other's staging file, and the loser
+// died with `ENOENT` renaming a path that no longer existed.
+//
+// NO SEPARATOR IN EITHER PART. `tempfile`'s own docs call one legal and
+// inadvisable, and `tempfile_in` joins the result onto `parent`, so a `..`
+// in front of a separator stages the file outside the directory this
+// function's whole contract is that it stays inside. Nothing in the tree
+// passes anything but a literal; the check is what keeps that true now
+// four private helpers have become one public one.
+//
+// `tempfile`'s OWN TYPE back, rather than a newtype. The caller does the
+// writing, the `sync_all` and the `persist`, so a wrapper's whole body
+// would forward those three calls. The cost is a dependency's type in this
+// crate's public API, taken deliberately.
 /// Creates the staging file a store is rewritten through, in `parent` so
 /// the later `rename` stays within one filesystem.
 ///
-/// `prefix` and `suffix` bracket a unique middle `tempfile` picks. The
-/// uniqueness is not tidiness: two writers sharing a fixed `<path>.tmp`
-/// had one process's `rename` consume the other's staging file, and the
-/// loser died with `ENOENT` renaming a path that no longer existed.
+/// `prefix` and `suffix` bracket a unique middle `tempfile` picks, and
+/// neither may contain a path separator. The file is created
+/// [`OWNER_ONLY_FILE_MODE`] on unix, at the `open` itself rather than by a
+/// later `chmod`, so there is no window in which it sits at whatever the
+/// process umask leaves it. It carries no mode on Windows.
 ///
-/// Neither may contain a path separator. `tempfile` allows one and joins
-/// the result onto `parent`, so a `..` in front of a separator would stage
-/// the file outside the directory this function's whole contract is that
-/// it stays inside. No caller passes anything but a literal, and this is
-/// what keeps that true now the helper is public.
-///
-/// On unix the mode goes to the `open` itself rather than a later `chmod`
-/// pass, so there is no window in which a file holding a webhook token
-/// sits at whatever the process umask leaves it.
-///
-/// There is no mode parameter, and that is the function rather than an
-/// omission. Every caller writes a file under `$SHEP_HOME` that holds a
-/// credential, an `env` value, or a record of what the shepherd told an
-/// outside service, so none of them wants anything but
-/// [`OWNER_ONLY_FILE_MODE`]. A parameter would buy nothing today and
-/// would be the door a later caller walks a `0644` through.
-///
-/// Returns `tempfile`'s own type, because the caller does the writing, the
-/// `sync_all` and the `persist`. That puts a dependency's type in this
-/// crate's public API on purpose: the alternative is a newtype whose whole
-/// body forwards those three calls.
+/// The caller writes it, `sync_all`s it, and `persist`s it over the real
+/// file.
 ///
 /// # Errors
 /// - [`std::io::ErrorKind::InvalidInput`] when `prefix` or `suffix`

--- a/crates/shep-core/src/barks.rs
+++ b/crates/shep-core/src/barks.rs
@@ -38,25 +38,6 @@ use std::path::Path;
 
 use serde::{Deserialize, Serialize};
 
-/// Mode `barks.jsonl` (and the temp file it is rewritten through) is
-/// created with: owner read/write, nobody else.
-///
-/// `$SHEP_HOME` itself is already `0700` (`boot::DIR_MODE` in
-/// `shep-daemon`), so this is belt-and-braces, not the only guard between
-/// this file and another local user — and it is belt-and-braces for a
-/// different reason than `snapshot::write_atomic`'s own `0600`. That file
-/// holds `AppConfig::env` verbatim, a real secret. This one does not: a
-/// [`Bark`] carries a rule name, a subject and a message, and
-/// [`SinkOutcome`] names a sink by its `[dog.bark.sinks]` config key,
-/// never by the webhook URL or token behind it. The mode stays tight
-/// anyway, matching the rest of `$SHEP_HOME`'s posture (spec §10: no
-/// other user, at all) and because this is still a record of what the
-/// shepherd told an outside service — and so that a future field that DID
-/// carry a URL would arrive into a file that was already narrow, not one
-/// that has to widen for it.
-#[cfg(unix)]
-const BARK_FILE_MODE: u32 = 0o600;
-
 /// Cap the ring keeps itself under when nobody configured one.
 pub const DEFAULT_MAX_BYTES: u64 = 1024 * 1024;
 
@@ -259,7 +240,7 @@ fn ring_bytes(lines: &[String]) -> u64 {
 /// reaches `write_ring` by another route.
 fn write_ring(path: &Path, lines: &[String]) -> Result<(), BarkError> {
     let parent = path.parent().unwrap_or_else(|| Path::new("."));
-    let mut tmp = create_ring_file(parent)?;
+    let mut tmp = crate::atomic_file::create_staging_file(parent, "barks", ".tmp")?;
 
     for line in lines {
         tmp.write_all(line.as_bytes())?;
@@ -272,32 +253,6 @@ fn write_ring(path: &Path, lines: &[String]) -> Result<(), BarkError> {
     // failed replace does not leave one behind.
     tmp.persist(path).map_err(|err| BarkError::Io(err.error))?;
     Ok(())
-}
-
-/// Creates the staging file the ring is rewritten through, in `parent` so
-/// the later `rename` stays within one filesystem.
-///
-/// Mode-at-creation rather than a separate `chmod` pass ([`tempfile`]
-/// passes these permissions to the `open` call itself): there is no window
-/// where the file sits at whatever the process umask leaves it, the same
-/// TOCTOU `boot::create_dir_at_dir_mode`'s own doc explains for
-/// directories. On Windows the permissions are left alone — there is no
-/// unix permission-bit equivalent (the same split
-/// `snapshot::write_atomic`'s own `write_atomic_is_owner_only_on_unix`
-/// test uses) — and `tempfile`'s own default is already owner-only on
-/// unix, so this call only makes that choice explicit rather than
-/// inherited.
-fn create_ring_file(parent: &Path) -> std::io::Result<tempfile::NamedTempFile> {
-    let mut builder = tempfile::Builder::new();
-    builder.prefix("barks").suffix(".tmp");
-
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt as _;
-        builder.permissions(std::fs::Permissions::from_mode(BARK_FILE_MODE));
-    }
-
-    builder.tempfile_in(parent)
 }
 
 /// An exclusive advisory lock over one bark ring, held for as long as the
@@ -343,7 +298,7 @@ impl RingLock {
             .write(true)
             .create(true)
             .truncate(false)
-            .mode(BARK_FILE_MODE)
+            .mode(crate::atomic_file::OWNER_ONLY_FILE_MODE)
             .open(lock_path(path))?;
 
         // `LockExclusive` blocks; the non-blocking variant would need a
@@ -641,11 +596,14 @@ mod tests {
         );
     }
 
-    /// fails if the ring lands wider than owner-only. `Bark` carries no
-    /// credential today (see [`BARK_FILE_MODE`]'s own doc), but this file
-    /// is still a record of what the shepherd told an outside service, and
-    /// the mode is the one guarantee a reader of this test can check
-    /// without a live process.
+    /// fails if the ring lands wider than owner-only. A `Bark` carries no
+    /// credential today: it holds a rule name, a subject and a message,
+    /// and a [`SinkOutcome`] names a sink by its config key rather than by
+    /// the webhook URL behind it. The mode stays tight anyway, because
+    /// this file is still a record of what the shepherd told an outside
+    /// service, and because a future field that did carry a URL should
+    /// arrive into a file that is already narrow. See
+    /// [`crate::atomic_file::OWNER_ONLY_FILE_MODE`] for the shared value.
     #[cfg(unix)]
     #[test]
     fn append_creates_the_ring_owner_only_on_unix() {

--- a/crates/shep-core/src/kv.rs
+++ b/crates/shep-core/src/kv.rs
@@ -75,16 +75,6 @@ pub const MAX_KEY_BYTES: usize = 128;
 /// writable thing in `$SHEP_HOME` with no schema.
 pub const MAX_VALUE_BYTES: usize = 4096;
 
-/// Mode `kv.json` (and the temp file it is rewritten through) is created
-/// with: owner read/write, nobody else.
-///
-/// `$SHEP_HOME` itself is already `0700`, so this is belt-and-braces — and
-/// it is the mode a `tar`, a `cp -p` or a backup carries out of that
-/// directory with the file, where no directory mode follows it. Same
-/// argument `barks::BARK_FILE_MODE` records.
-#[cfg(unix)]
-const KV_FILE_MODE: u32 = 0o600;
-
 /// The file's shape: a version and a flat map.
 ///
 /// `BTreeMap`, not `HashMap`, so the file is written in key order and two
@@ -251,7 +241,7 @@ impl KvLock {
             .write(true)
             .create(true)
             .truncate(false)
-            .mode(KV_FILE_MODE)
+            .mode(crate::atomic_file::OWNER_ONLY_FILE_MODE)
             .open(lock_path(path))?;
 
         Flock::lock(file, FlockArg::LockExclusive)
@@ -315,26 +305,6 @@ impl KvLock {
     }
 }
 
-/// Creates the staging file the store is rewritten through, in `parent` so
-/// the later `rename` stays within one filesystem.
-///
-/// Mode-at-creation rather than a separate `chmod` pass: there is no window
-/// where the file sits at whatever the process umask leaves it. The unique
-/// name (not a fixed `.tmp`) is what keeps two writers' renames from
-/// consuming each other's staging file — see this module's own doc.
-fn create_kv_file(parent: &Path) -> std::io::Result<tempfile::NamedTempFile> {
-    let mut builder = tempfile::Builder::new();
-    builder.prefix("kv").suffix(".tmp");
-
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt as _;
-        builder.permissions(std::fs::Permissions::from_mode(KV_FILE_MODE));
-    }
-
-    builder.tempfile_in(parent)
-}
-
 /// Reads `path` under the lock the caller already holds.
 ///
 /// A missing file reads as an empty, current-version store — `shep get`
@@ -357,7 +327,7 @@ fn read_file(path: &Path) -> Result<KvFile, KvError> {
 /// own doc for the staged-temp-file-then-rename shape.
 fn write_file(path: &Path, file: &KvFile) -> Result<(), KvError> {
     let parent = path.parent().unwrap_or_else(|| Path::new("."));
-    let mut tmp = create_kv_file(parent)?;
+    let mut tmp = crate::atomic_file::create_staging_file(parent, "kv", ".tmp")?;
 
     let json = serde_json::to_string_pretty(file)?;
     tmp.write_all(json.as_bytes())?;

--- a/crates/shep-core/src/lib.rs
+++ b/crates/shep-core/src/lib.rs
@@ -20,6 +20,9 @@
 #![doc(test(attr(deny(warnings))))]
 #![forbid(unsafe_code)]
 
+// One create-at-`0600` staging file for every store under `$SHEP_HOME`,
+// declared before the four modules that were each carrying their own copy.
+pub mod atomic_file;
 pub mod barks;
 pub mod config;
 pub mod kv;

--- a/crates/shep-core/src/overrides.rs
+++ b/crates/shep-core/src/overrides.rs
@@ -42,16 +42,6 @@ use serde::{Deserialize, Serialize};
 /// downgrade that overwrites it. `kv.rs`'s `KV_VERSION` is the precedent.
 pub const OVERRIDES_VERSION: u32 = 1;
 
-/// Mode `overrides.json` (and the temp file it is rewritten through) is
-/// created with: owner read/write, nobody else.
-///
-/// `$SHEP_HOME` itself is already `0700`, so this is belt-and-braces, and
-/// it is the mode a `tar`, a `cp -p` or a backup carries out of that
-/// directory with the file, where no directory mode follows it. Same
-/// argument `kv::KV_FILE_MODE` records; this store holds `env` values too.
-#[cfg(unix)]
-const OVERRIDES_FILE_MODE: u32 = 0o600;
-
 /// One sheep's overrides: the fields an operator has set that its current
 /// Flockfile does not declare.
 ///
@@ -216,7 +206,7 @@ impl OverridesLock {
             .write(true)
             .create(true)
             .truncate(false)
-            .mode(OVERRIDES_FILE_MODE)
+            .mode(crate::atomic_file::OWNER_ONLY_FILE_MODE)
             .open(lock_path(path))?;
 
         Flock::lock(file, FlockArg::LockExclusive)
@@ -269,26 +259,6 @@ impl OverridesLock {
     }
 }
 
-/// Creates the staging file the store is rewritten through, in `parent` so
-/// the later `rename` stays within one filesystem.
-///
-/// Mode-at-creation rather than a separate `chmod` pass: there is no window
-/// where the file sits at whatever the process umask leaves it. The unique
-/// name (not a fixed `.tmp`) is what keeps two writers' renames from
-/// consuming each other's staging file: see this module's own doc.
-fn create_overrides_file(parent: &Path) -> std::io::Result<tempfile::NamedTempFile> {
-    let mut builder = tempfile::Builder::new();
-    builder.prefix("overrides").suffix(".tmp");
-
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt as _;
-        builder.permissions(std::fs::Permissions::from_mode(OVERRIDES_FILE_MODE));
-    }
-
-    builder.tempfile_in(parent)
-}
-
 /// Reads `path` under the lock the caller already holds.
 ///
 /// A missing file reads as an empty, current-version store: a fresh
@@ -313,7 +283,7 @@ fn read_file(path: &Path) -> Result<OverridesFile, OverridesError> {
 /// own doc for the staged-temp-file-then-rename shape.
 fn write_file(path: &Path, file: &OverridesFile) -> Result<(), OverridesError> {
     let parent = path.parent().unwrap_or_else(|| Path::new("."));
-    let mut tmp = create_overrides_file(parent)?;
+    let mut tmp = crate::atomic_file::create_staging_file(parent, "overrides", ".tmp")?;
 
     let json = serde_json::to_string_pretty(file)?;
     tmp.write_all(json.as_bytes())?;


### PR DESCRIPTION
Four modules had the same six-line helper: make a `tempfile` at `0600` for a later `sync_all` and `persist`. Only a prefix, a suffix and a mode constant differed, and the constant was `0o600` in all four.

- `shep_core::atomic_file::create_staging_file(parent, prefix, suffix)` replaces `create_config_file`, `create_kv_file`, `create_ring_file` and `create_overrides_file`
- No mode parameter. Every caller writes a `$SHEP_HOME` file holding a webhook URL, an `env` value or a bearer token, so a parameter buys nothing and is the door a later caller walks a `0644` through
- The four constants collapse into one `OWNER_ONLY_FILE_MODE`, same value at every site. After the helper landed each one only governed its module's unix lock file, so `KV_FILE_MODE` would have been documenting a file it no longer set the mode of
- `create_config_file` stays as a three-line wrapper: `shep.toml` and `dogs.toml` stage through the same name
- Only the create step moves. The write, `sync_all` and `persist` stay per store, each mapping failures onto its own error type
- A `/` or `\` in either name part is refused with `InvalidInput` (review point from CodeRabbit). No caller passes anything but a literal, but the helper is public now, and `tempfile` joins a separator straight onto `parent`

Pure deduplication, no behaviour change. The four exact-mode tests still assert the mode of the file on disk, unchanged.

Net -15 lines against `main`: code +15 (production -18, tests +33), comments -28.

Merged `main` in. #116 added a file at the same path for `sync_dir`, so the two are unioned into one module: `create_staging_file` is the first step of an atomic replace and `sync_dir` is the last.

Three new tests, each mutated to check it can fail: widening the mode to `0o644` reddens all four stores' existing tests, swapping prefix and suffix reddens only the name test, staging outside `parent` reddens only the parent test, dropping the separator refusal reddens only its own.

A fourth test asserting the staging file's own mode was dropped as redundant. The four stores already pin the mode of the file on disk, and neither they nor it can tell the explicit `permissions()` call from `tempfile`'s unix default of `0600`.

Gate green: fmt, clippy, `cargo test --workspace --all-features` (2418 passed), rustdoc. Windows cross-check clean, and still sets no mode.

Left alone: `snapshot::write_atomic` stages through `NamedTempFile::new_in` with no explicit mode, relying on tempfile's default. Different shape, so it keeps its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Standardized configuration, lock, override, and ring file creation with owner-only permissions.

* **Reliability**
  * Unified atomic file staging and replacement handling for consistent updates when multiple writes occur.
  * Improved safeguards for staging-file placement and naming.

* **Tests**
  * Added coverage for staging-file placement, naming, separator validation, and file permissions.

* **Documentation**
  * Clarified atomic file staging, durability, crash behavior, and platform-specific permission handling. 

<!-- end of auto-generated comment: release notes by coderabbit.ai -->