### PR TITLE
fix: atomic file writers fsync the directory the rename lands in

### DIFF
--- a/crates/shep-cli/src/commands/dog_migration.rs
+++ b/crates/shep-cli/src/commands/dog_migration.rs
@@ -38,7 +38,9 @@ use super::shep_toml::{ConfigLock, ShepToml, ShepTomlError, create_config_file};
 /// Empty when there was nothing to move, which is every boot after the
 /// first. Writes `dogs.toml` before striking `shep.toml`, so a crash
 /// between the two leaves the sections readable from the old file rather
-/// than from neither.
+/// than from neither. Both writes flush the directory holding them, which
+/// is what makes that an order at all rather than two renames a power cut
+/// can lose independently.
 ///
 /// # Errors
 ///
@@ -220,6 +222,21 @@ pub(crate) fn migrate_dog_sections(paths: &ShepPaths) -> Result<Vec<String>, Dog
         // sections only once the new file already holds them. A crash
         // between the two leaves them readable from `shep.toml`, which is
         // the direction that loses nothing.
+        //
+        // "Before" is a claim about durability, not about statement order,
+        // and it holds only because `write_dogs_config` flushes the
+        // directory it renamed into. Without that the two renames are
+        // independent under a power cut, and the interleaving that loses
+        // this one while landing the strike leaves the sections in NEITHER
+        // file: an operator's webhook URLs gone, from a path whose whole
+        // argument was that it could not happen.
+        //
+        // What the surviving interleaving costs is a refusal, not data.
+        // Landing here and losing the strike leaves values under both
+        // `[dog.<name>]` and `[<name>]`, which is what `collides` above
+        // answers `WouldOverwrite` to, so the next boot stops and says so
+        // rather than guessing between two values. Recoverable by hand and
+        // loud, which is the trade this order is choosing.
         write_dogs_config(&paths.dogs_config, &merged.to_string())
             .map_err(DogMigrationError::Write)?;
         Ok(moved)
@@ -241,6 +258,12 @@ pub(crate) fn migrate_dog_sections(paths: &ShepPaths) -> Result<Vec<String>, Dog
 /// the name is out of `enabled_dogs` and `adopted_dogs` by then. The other
 /// order loses an operator's webhook URLs while the dog is still enabled
 /// and still running, and says nothing about it.
+///
+/// Which of the two lands is only decided by the order once each rename is
+/// durable by itself. Both writers flush the directory they renamed into
+/// for that reason: a power cut between them can otherwise lose the
+/// `shep.toml` rewrite while keeping this removal, which is the bad order
+/// reached by accident.
 ///
 /// # Errors
 ///
@@ -459,6 +482,11 @@ fn renumber_tables(item: &mut Item, next: &mut usize) {
 /// mode follows. **Atomicity**: `std::fs::write` opens `O_TRUNC`, so a
 /// crash between the truncate and the write leaves a half-written
 /// `dogs.toml` behind; the rename installs the whole file or none of it.
+/// **Durability**: the rename is then published by flushing the directory
+/// that holds it, without which a power cut can lose the rename while
+/// keeping the bytes it pointed at. Both callers order this write against
+/// a `shep.toml` write and argue from that order, and an order between two
+/// renames means nothing until each one is durable on its own.
 fn write_dogs_config(path: &Path, rendered: &str) -> std::io::Result<()> {
     let parent = path.parent().unwrap_or_else(|| Path::new("."));
     let mut tmp = create_config_file(parent)?;
@@ -468,6 +496,10 @@ fn write_dogs_config(path: &Path, rendered: &str) -> std::io::Result<()> {
     // inside the error and its `Drop` removes the staging file, so a failed
     // replace leaves nothing behind in `$SHEP_HOME`.
     tmp.persist(path).map_err(|err| err.error)?;
+
+    // The `sync_all` above made the CONTENTS durable; this makes the rename
+    // that published them durable. See `shep_core::atomic_file`.
+    shep_core::atomic_file::sync_dir(parent)?;
     Ok(())
 }
 

--- a/crates/shep-cli/src/commands/dog_migration.rs
+++ b/crates/shep-cli/src/commands/dog_migration.rs
@@ -38,9 +38,10 @@ use super::shep_toml::{ConfigLock, ShepToml, ShepTomlError, create_config_file};
 /// Empty when there was nothing to move, which is every boot after the
 /// first. Writes `dogs.toml` before striking `shep.toml`, so a crash
 /// between the two leaves the sections readable from the old file rather
-/// than from neither. Both writes flush the directory holding them, which
-/// is what makes that an order at all rather than two renames a power cut
-/// can lose independently.
+/// than from neither. On unix both writes flush the directory holding
+/// them, which is what makes that an order at all rather than two renames
+/// a power cut can lose independently; on Windows `sync_dir` does nothing
+/// and the order holds only against an ordinary crash.
 ///
 /// # Errors
 ///
@@ -224,7 +225,7 @@ pub(crate) fn migrate_dog_sections(paths: &ShepPaths) -> Result<Vec<String>, Dog
         // the direction that loses nothing.
         //
         // "Before" is a claim about durability, not about statement order,
-        // and it holds only because `write_dogs_config` flushes the
+        // and on unix it holds only because `write_dogs_config` flushes the
         // directory it renamed into. Without that the two renames are
         // independent under a power cut, and the interleaving that loses
         // this one while landing the strike leaves the sections in NEITHER
@@ -260,10 +261,11 @@ pub(crate) fn migrate_dog_sections(paths: &ShepPaths) -> Result<Vec<String>, Dog
 /// and still running, and says nothing about it.
 ///
 /// Which of the two lands is only decided by the order once each rename is
-/// durable by itself. Both writers flush the directory they renamed into
-/// for that reason: a power cut between them can otherwise lose the
-/// `shep.toml` rewrite while keeping this removal, which is the bad order
-/// reached by accident.
+/// durable by itself. On unix both writers flush the directory they
+/// renamed into for that reason: a power cut between them can otherwise
+/// lose the `shep.toml` rewrite while keeping this removal, which is the
+/// bad order reached by accident. `sync_dir` does nothing on Windows, so
+/// there the order survives a crash but not a power cut.
 ///
 /// # Errors
 ///
@@ -482,11 +484,13 @@ fn renumber_tables(item: &mut Item, next: &mut usize) {
 /// mode follows. **Atomicity**: `std::fs::write` opens `O_TRUNC`, so a
 /// crash between the truncate and the write leaves a half-written
 /// `dogs.toml` behind; the rename installs the whole file or none of it.
-/// **Durability**: the rename is then published by flushing the directory
-/// that holds it, without which a power cut can lose the rename while
-/// keeping the bytes it pointed at. Both callers order this write against
-/// a `shep.toml` write and argue from that order, and an order between two
-/// renames means nothing until each one is durable on its own.
+/// **Durability**: on unix the rename is then published by flushing the
+/// directory that holds it, without which a power cut can lose the rename
+/// while keeping the bytes it pointed at. Both callers order this write
+/// against a `shep.toml` write and argue from that order, and an order
+/// between two renames means nothing until each one is durable on its own.
+/// That flush is a no-op on Windows, which is why those two arguments name
+/// the platform rather than claiming the order outright.
 fn write_dogs_config(path: &Path, rendered: &str) -> std::io::Result<()> {
     let parent = path.parent().unwrap_or_else(|| Path::new("."));
     let mut tmp = create_config_file(parent)?;

--- a/crates/shep-cli/src/commands/shep_toml.rs
+++ b/crates/shep-cli/src/commands/shep_toml.rs
@@ -547,7 +547,9 @@ impl ShepToml {
     }
 
     /// Writes the document back: staged in a sibling temp file at
-    /// [`CONFIG_FILE_MODE`], `fsync`ed, then `rename`d over `path`.
+    /// [`CONFIG_FILE_MODE`], `fsync`ed, `rename`d over `path`, and the
+    /// directory `fsync`ed in turn so the rename itself survives a power
+    /// cut (see `shep_core::atomic_file`).
     ///
     /// Private, and reached only from [`Self::edit`] with the lock held.
     ///
@@ -563,7 +565,8 @@ impl ShepToml {
     ///
     /// # Errors
     /// - [`ShepTomlError::Io`] — the staging file could not be created or
-    ///   written, or the rename over `path` failed.
+    ///   written, the rename over `path` failed, or the directory holding
+    ///   it could not be flushed.
     fn save(&self) -> Result<(), ShepTomlError> {
         let parent = self.path.parent().unwrap_or_else(|| Path::new("."));
         let mut tmp = create_config_file(parent).map_err(|source| self.io_error(source))?;
@@ -577,6 +580,10 @@ impl ShepToml {
         // so a failed replace leaves nothing behind in `$SHEP_HOME`.
         tmp.persist(&self.path)
             .map_err(|err| self.io_error(err.error))?;
+
+        // The `sync_all` above made the CONTENTS durable; this makes the
+        // rename that published them durable. See `shep_core::atomic_file`.
+        shep_core::atomic_file::sync_dir(parent).map_err(|source| self.io_error(source))?;
         Ok(())
     }
 

--- a/crates/shep-core/src/atomic_file.rs
+++ b/crates/shep-core/src/atomic_file.rs
@@ -5,6 +5,8 @@
 //! file, `fsync`ed, then `rename`d over the target, so a reader never
 //! observes a fragment. [`sync_dir`] is the last step of that shape: it
 //! makes the *rename* durable, which the temp file's own `fsync` does not.
+//! On unix. It is a no-op on Windows, so every durability claim below, and
+//! in the six writers that call it, is a unix one.
 //!
 //! The two halves answer different questions, and it is easy to buy one
 //! and believe you bought both. `File::sync_all` on the staging file
@@ -24,6 +26,28 @@
 
 use std::path::Path;
 
+// Why the two arms differ, which is not a caller's question (IR-31).
+//
+// UNIX. `fsync` on a directory descriptor is the portable way to flush the
+// entry a rename created, and `EINVAL` is tolerated because POSIX lets
+// `fsync` answer it when the implementation has no synchronized I/O to
+// perform for the file it was handed. Some FUSE and network mounts answer
+// exactly that for a directory, and reporting it as a failed write would
+// break writes that do land, on hosts where they land today. Every other
+// error propagates: a helper that swallowed `EIO` could never tell a
+// caller that the durability it asked for did not happen.
+//
+// WINDOWS. There is no call to make. `File::open` on a directory fails
+// outright unless the handle carries `FILE_FLAG_BACKUP_SEMANTICS`, which
+// `std` does not pass, so the unix arm would not even compile into
+// something runnable. NTFS journals metadata operations, which keeps the
+// filesystem CONSISTENT across a crash, and that is a weaker promise than
+// the unix arm makes: `MoveFileEx` without `MOVEFILE_WRITE_THROUGH` does
+// not force the rename out, so a power cut can still lose it. Closing that
+// would mean reaching past `std` for a directory handle, or a
+// write-through rename in place of `NamedTempFile::persist`. Neither is
+// free and neither is done here, so the honest position is that the
+// guarantee below is a unix one.
 /// Flushes `dir`'s own metadata, making renames into it durable.
 ///
 /// Call it after the `rename` that installs a staged file, not before: it
@@ -34,26 +58,16 @@ use std::path::Path;
 ///
 /// # Platforms
 ///
-/// A no-op on Windows, which has no equivalent of this call and does not
-/// need one for the same reasons. `File::open` on a directory fails there
-/// outright unless the handle is opened with `FILE_FLAG_BACKUP_SEMANTICS`,
-/// which `std` does not do; and NTFS journals metadata operations, so the
-/// rename `NamedTempFile::persist` performs is already recorded rather
-/// than left sitting in a cache for a directory flush to chase.
+/// Unix only. On Windows this is a no-op that answers `Ok` without
+/// touching `dir`, so a rename there is as durable as NTFS makes it and no
+/// more. Callers get the same API on both and a weaker guarantee on one.
 ///
 /// # Errors
 ///
 /// - [`std::io::Error`] when `dir` could not be opened, or when flushing
-///   it failed for a reason the filesystem could act on.
-///
-/// `EINVAL` is deliberately not one of them. POSIX lets `fsync` answer it
-/// when the implementation has no synchronized I/O to perform for the file
-/// it was handed, which is how some FUSE and network mounts answer for a
-/// directory. Reporting that as a failed write would break writes that do
-/// land, on hosts where they land today, so it reads as "this filesystem
-/// has no such step" and the write stands. Every other error is real and
-/// propagates: a helper that swallowed `EIO` could never tell a caller
-/// that the durability it asked for did not happen.
+///   it failed for a reason the filesystem could act on. `EINVAL` is not
+///   one of them: it reads as "this filesystem has no such step" and the
+///   write stands. Never returns an error on Windows.
 pub fn sync_dir(dir: &Path) -> std::io::Result<()> {
     #[cfg(unix)]
     {

--- a/crates/shep-core/src/atomic_file.rs
+++ b/crates/shep-core/src/atomic_file.rs
@@ -1,0 +1,97 @@
+//! Finishing an atomic file replace so it survives the machine, not just
+//! the process
+//!
+//! Every file this workspace rewrites in place is staged in a sibling temp
+//! file, `fsync`ed, then `rename`d over the target, so a reader never
+//! observes a fragment. [`sync_dir`] is the last step of that shape: it
+//! makes the *rename* durable, which the temp file's own `fsync` does not.
+//!
+//! The two halves answer different questions, and it is easy to buy one
+//! and believe you bought both. `File::sync_all` on the staging file
+//! flushes that file's CONTENTS. The directory entry the rename then
+//! creates is a change to the parent DIRECTORY, and it sits in the page
+//! cache until that directory is itself flushed. Lose power in between and
+//! the data survives with nothing pointing at it: the old file is still
+//! there, and the write is silently undone.
+//!
+//! An ordinary crash is not the case this covers. A completed `rename(2)`
+//! is visible to every later process whether or not anything was flushed,
+//! so a panic, a `SIGKILL` or an `ENOSPC` already leaves either the whole
+//! old file or the whole new one. Only a power cut or a kernel panic can
+//! lose a landed rename, and the writer that most needs the difference is
+//! the muster roll, whose whole reason to exist is being read back after
+//! the machine comes up again.
+
+use std::path::Path;
+
+/// Flushes `dir`'s own metadata, making renames into it durable.
+///
+/// Call it after the `rename` that installs a staged file, not before: it
+/// is the directory entry created by that rename that needs to reach the
+/// disk. Callers that skip it keep the atomicity guarantee (a reader sees
+/// the old file or the new one, never a fragment) and lose only the
+/// durability one, and only to a power cut.
+///
+/// # Platforms
+///
+/// A no-op on Windows, which has no equivalent of this call and does not
+/// need one for the same reasons. `File::open` on a directory fails there
+/// outright unless the handle is opened with `FILE_FLAG_BACKUP_SEMANTICS`,
+/// which `std` does not do; and NTFS journals metadata operations, so the
+/// rename `NamedTempFile::persist` performs is already recorded rather
+/// than left sitting in a cache for a directory flush to chase.
+///
+/// # Errors
+///
+/// - [`std::io::Error`] when `dir` could not be opened, or when flushing
+///   it failed for a reason the filesystem could act on.
+///
+/// `EINVAL` is deliberately not one of them. POSIX lets `fsync` answer it
+/// when the implementation has no synchronized I/O to perform for the file
+/// it was handed, which is how some FUSE and network mounts answer for a
+/// directory. Reporting that as a failed write would break writes that do
+/// land, on hosts where they land today, so it reads as "this filesystem
+/// has no such step" and the write stands. Every other error is real and
+/// propagates: a helper that swallowed `EIO` could never tell a caller
+/// that the durability it asked for did not happen.
+pub fn sync_dir(dir: &Path) -> std::io::Result<()> {
+    #[cfg(unix)]
+    {
+        match std::fs::File::open(dir)?.sync_all() {
+            Err(err) if err.kind() == std::io::ErrorKind::InvalidInput => Ok(()),
+            other => other,
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = dir;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sync_dir_accepts_a_real_directory() {
+        let dir = tempfile::tempdir().unwrap();
+        // The Windows arm returns `Ok` without looking at the path, so this
+        // only has teeth on unix -- which is the only place it has a job.
+        sync_dir(dir.path()).unwrap();
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn sync_dir_reports_a_directory_that_is_not_there() {
+        let dir = tempfile::tempdir().unwrap();
+        let missing = dir.path().join("never-created");
+
+        // Guards the `EINVAL` arm above from widening into "ignore every
+        // error": a `sync_dir` that answered `Ok` to everything would pass
+        // the test above and leave a caller unable to learn that the flush
+        // it asked for never happened.
+        let err = sync_dir(&missing).unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::NotFound, "{err:?}");
+    }
+}

--- a/crates/shep-core/src/barks.rs
+++ b/crates/shep-core/src/barks.rs
@@ -271,6 +271,10 @@ fn write_ring(path: &Path, lines: &[String]) -> Result<(), BarkError> {
     // inside the error and its `Drop` removes the staging file, so a
     // failed replace does not leave one behind.
     tmp.persist(path).map_err(|err| BarkError::Io(err.error))?;
+
+    // The `sync_all` above made the CONTENTS durable; this makes the rename
+    // that published them durable. See `shep_core::atomic_file`.
+    crate::atomic_file::sync_dir(parent)?;
     Ok(())
 }
 

--- a/crates/shep-core/src/kv.rs
+++ b/crates/shep-core/src/kv.rs
@@ -368,6 +368,10 @@ fn write_file(path: &Path, file: &KvFile) -> Result<(), KvError> {
     // inside the error and its `Drop` removes the staging file, so a failed
     // replace does not leave one behind.
     tmp.persist(path).map_err(|err| KvError::Io(err.error))?;
+
+    // The `sync_all` above made the CONTENTS durable; this makes the rename
+    // that published them durable. See `shep_core::atomic_file`.
+    crate::atomic_file::sync_dir(parent)?;
     Ok(())
 }
 

--- a/crates/shep-core/src/lib.rs
+++ b/crates/shep-core/src/lib.rs
@@ -20,6 +20,11 @@
 #![doc(test(attr(deny(warnings))))]
 #![forbid(unsafe_code)]
 
+// Declared above `barks`, `kv` and `overrides` because all three end a
+// write through it, as do `shep.toml`, `dogs.toml` and the muster roll in
+// the crates above this one: one definition of what finishes an atomic
+// replace, rather than six writers each deciding how far to flush.
+pub mod atomic_file;
 pub mod barks;
 pub mod config;
 pub mod kv;

--- a/crates/shep-core/src/overrides.rs
+++ b/crates/shep-core/src/overrides.rs
@@ -325,6 +325,10 @@ fn write_file(path: &Path, file: &OverridesFile) -> Result<(), OverridesError> {
     // replace does not leave one behind.
     tmp.persist(path)
         .map_err(|err| OverridesError::Io(err.error))?;
+
+    // The `sync_all` above made the CONTENTS durable; this makes the rename
+    // that published them durable. See `shep_core::atomic_file`.
+    crate::atomic_file::sync_dir(parent)?;
     Ok(())
 }
 

--- a/crates/shep-daemon/src/snapshot.rs
+++ b/crates/shep-daemon/src/snapshot.rs
@@ -255,8 +255,17 @@ impl From<std::io::Error> for SnapshotError {
 }
 
 /// Writes `snapshot` to `path` atomically: a temp file in the same
-/// directory (so `rename(2)` is guaranteed atomic — it only is within one
-/// filesystem), `fsync`ed, then renamed over `path`.
+/// directory (so `rename(2)` is guaranteed atomic, which it only is within
+/// one filesystem), `fsync`ed, renamed over `path`, and the directory
+/// `fsync`ed in turn so the rename itself survives a power cut.
+///
+/// That last step matters more here than anywhere else this workspace
+/// writes. The roll exists to be read back by the restore that runs
+/// unattended after a reboot, and the graceful write at the end of `boot`
+/// is exactly the one a power cut skips, so what a restore finds is
+/// whatever the debounced `SnapshotWriter` last renamed into place. Making
+/// the contents durable without the rename that publishes them would leave
+/// the flock unrecoverable by the event the file exists to survive.
 ///
 /// The temp file is created owner-only (unix mode 0600) and `persist` keeps
 /// that mode across the rename. That mode is not cosmetic: the roll stores
@@ -280,6 +289,10 @@ pub(crate) fn write_atomic(path: &Path, snapshot: &FlockSnapshot) -> Result<(), 
     tmp.as_file().sync_all()?;
     tmp.persist(path)
         .map_err(|err| SnapshotError::Io(err.error))?;
+
+    // The `sync_all` above made the CONTENTS durable; this makes the rename
+    // that published them durable. See `shep_core::atomic_file`.
+    shep_core::atomic_file::sync_dir(parent)?;
     Ok(())
 }
 

--- a/crates/shep-daemon/src/snapshot.rs
+++ b/crates/shep-daemon/src/snapshot.rs
@@ -256,8 +256,10 @@ impl From<std::io::Error> for SnapshotError {
 
 /// Writes `snapshot` to `path` atomically: a temp file in the same
 /// directory (so `rename(2)` is guaranteed atomic, which it only is within
-/// one filesystem), `fsync`ed, renamed over `path`, and the directory
-/// `fsync`ed in turn so the rename itself survives a power cut.
+/// one filesystem), `fsync`ed, renamed over `path`, and on unix the
+/// directory `fsync`ed in turn so the rename itself survives a power cut.
+/// `shep_core::atomic_file::sync_dir` is a no-op on Windows, where that
+/// last guarantee is only as strong as NTFS makes it.
 ///
 /// That last step matters more here than anywhere else this workspace
 /// writes. The roll exists to be read back by the restore that runs


### PR DESCRIPTION
`sync_all()` on the staged temp file makes its contents durable. The rename that publishes them is a change to the parent directory, and it sits in the page cache until that directory is flushed too. A power cut in between keeps the data and loses the pointer to it.

Not a crash bug. A completed rename is visible to the next process either way, so a panic, a SIGKILL or an ENOSPC was always safe. Only power loss or a kernel panic can lose a landed rename.

Worth fixing mostly for one file. The muster roll exists for "the restore that runs unattended after a reboot", and the graceful final write at the end of `boot` is exactly the one a power cut skips, so a restore reads whatever the debounced `SnapshotWriter` last renamed. Its design case was the event it could not survive. The other five range from an operator's daemon config down to a bounded observability ring.

New `shep_core::atomic_file::sync_dir`, called by all six writers:

- `snapshot.rs` `write_atomic` (flock.json)
- `shep_toml.rs` `ShepToml::save` (shep.toml)
- `dog_migration.rs` `write_dogs_config` (dogs.toml)
- `overrides.rs` `write_file` (overrides.json)
- `kv.rs` `write_file` (kv.json)
- `barks.rs` `write_ring` (barks.jsonl)

`boot.rs`'s `write_pidfile` is the seventh `persist` site and is left alone: it is `#[cfg(test)]` and seeds a fixture, so it has no durability to want.

Two comments in `dog_migration.rs` argued an ordering the code did not deliver, so they change with it. Both said "a crash", which was right for a crash. Under power loss the two renames were independent, so `migrate_dog_sections` could lose `dogs.toml` while landing the `shep.toml` strike and leave the sections in neither file, which is the webhook URLs gone.

The interleaving that survives is now documented instead of glossed: landing `dogs.toml` and losing the strike puts values in both files, which `collides` answers `WouldOverwrite` to, so the next boot refuses rather than guessing between two values. Pre-existing, loud, and recoverable by hand.

`EINVAL` is tolerated, everything else propagates. POSIX lets `fsync` return it when there is no synchronized I/O to do for the file it was handed, which is how some FUSE and network mounts answer for a directory. Propagating it would break writes that do land. Swallowing everything would hide a real `EIO`.

No-op on Windows, with the reason in the `cfg` rather than left to guess. `File::open` on a directory fails there without `FILE_FLAG_BACKUP_SEMANTICS`, which std does not pass, and NTFS journals metadata operations so the rename is already recorded.

Modes untouched. All six still stage through their existing `create_*_file` helper at 0600, and every exact-mode test still passes.

Verified by inspection, not by test. A directory fsync cannot be observed from a surviving process, which is the same limitation the six existing `sync_all` calls have and none of those is tested either. The two tests added cover what is observable: `sync_dir` accepts a real directory, and still reports a missing one. The second guards the `EINVAL` arm from widening into "ignore every error". Both proven non-vacuous by mutation, with the mutated source read back to confirm the patch applied.

Not folded in: the `create_*_file` consolidation has not landed, four helpers are still there. Better after this than with it, since this is a correctness fix and that is a refactor. Once it lands the natural shape is one `persist_durably(tmp, path)` doing sync_all, persist and sync_dir together, so no writer can do half of it.

Gate green: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`, `cargo test --workspace --all-features` (2415 passed, 0 failed), `cargo doc`. Both platform cross-checks pass and neither warns on the new code. No `web/` change: no verb, flag, key, exit code, JSON shape or default moved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Reliability**
  * Improved durability of configuration, migration, rehome, override, snapshot, bark, and metadata updates after atomic file replacement.
  * Reduced the risk of losing successfully saved changes during power loss or system crashes.
  * Strengthened persistence across supported platforms while preserving platform-specific behavior.

* **Documentation**
  * Clarified file durability guarantees, operation ordering, crash outcomes, and platform-specific behavior.

* **Testing**
  * Added coverage for directory synchronization, including valid and missing directory scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->