### PR TITLE
chore: release v0.1.33

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2058,7 +2058,7 @@ dependencies = [
 
 [[package]]
 name = "shep"
-version = "0.1.32"
+version = "0.1.33"
 dependencies = [
  "anstyle",
  "assert_cmd",
@@ -2096,11 +2096,11 @@ dependencies = [
 
 [[package]]
 name = "shep-cli"
-version = "0.1.32"
+version = "0.1.33"
 
 [[package]]
 name = "shep-client"
-version = "0.1.32"
+version = "0.1.33"
 dependencies = [
  "futures-util",
  "nix 0.29.0",
@@ -2113,7 +2113,7 @@ dependencies = [
 
 [[package]]
 name = "shep-core"
-version = "0.1.32"
+version = "0.1.33"
 dependencies = [
  "annotate-snippets",
  "anstyle",
@@ -2143,7 +2143,7 @@ dependencies = [
 
 [[package]]
 name = "shep-daemon"
-version = "0.1.32"
+version = "0.1.33"
 dependencies = [
  "bytes",
  "chrono",
@@ -2172,7 +2172,7 @@ dependencies = [
 
 [[package]]
 name = "shep-examples"
-version = "0.1.32"
+version = "0.1.33"
 dependencies = [
  "nix 0.29.0",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.32"
+version = "0.1.33"
 edition = "2024"
 # 1.88 forced by serde-saphyr (let-chains, stabilized 1.88) — a current dep,
 # not a future one. Also the floor for ratatui/sysinfo/rmcp in later phases.
@@ -31,9 +31,9 @@ license = "MIT OR Apache-2.0"
 # the `[package]` table — so this literal is not sourced from
 # `workspace.package.version` above and a release bump has to touch both
 # places by hand. If that drifts, `cargo-release` is the mechanical fix.
-shep-core = { path = "crates/shep-core", version = "0.1.32" }
-shep-daemon = { path = "crates/shep-daemon", version = "0.1.32" }
-shep-client = { path = "crates/shep-client", version = "0.1.32" }
+shep-core = { path = "crates/shep-core", version = "0.1.33" }
+shep-daemon = { path = "crates/shep-daemon", version = "0.1.33" }
+shep-client = { path = "crates/shep-client", version = "0.1.33" }
 serde = { version = "1", default-features = false, features = ["derive"] }
 serde_json = { version = "1", default-features = false, features = ["std"] }
 toml = { version = "0.8", default-features = false, features = ["parse", "display"] }

--- a/crates/shep-cli/CHANGELOG.md
+++ b/crates/shep-cli/CHANGELOG.md
@@ -13,6 +13,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.33] - 2026-09-04
+
+### Fixed
+
+- Atomic file writers fsync the directory the rename lands in
+- Atomic file writers fsync the directory the rename lands in ([#116](https://github.com/shep-pm/shep/pull/116))
+
+
 ## [0.1.32] - 2026-09-04
 
 ### Added

--- a/crates/shep-client/CHANGELOG.md
+++ b/crates/shep-client/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.33] - 2026-09-04
+
+
 ## [0.1.32] - 2026-09-04
 
 

--- a/crates/shep-core/CHANGELOG.md
+++ b/crates/shep-core/CHANGELOG.md
@@ -10,6 +10,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.33] - 2026-09-04
+
+### Fixed
+
+- Atomic file writers fsync the directory the rename lands in
+- Atomic file writers fsync the directory the rename lands in ([#116](https://github.com/shep-pm/shep/pull/116))
+
+
 ## [0.1.32] - 2026-09-04
 
 ### Added

--- a/crates/shep-daemon/CHANGELOG.md
+++ b/crates/shep-daemon/CHANGELOG.md
@@ -10,6 +10,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.33] - 2026-09-04
+
+### Fixed
+
+- Atomic file writers fsync the directory the rename lands in
+- Atomic file writers fsync the directory the rename lands in ([#116](https://github.com/shep-pm/shep/pull/116))
+
+
 ## [0.1.32] - 2026-09-04
 
 ### Added


### PR DESCRIPTION



## 🤖 New release

* `shep-core`: 0.1.32 -> 0.1.33 (✓ API compatible changes)
* `shep-daemon`: 0.1.32 -> 0.1.33 (✓ API compatible changes)
* `shep-client`: 0.1.32 -> 0.1.33
* `shep`: 0.1.32 -> 0.1.33 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `shep-core`

<blockquote>

## [0.1.33] - 2026-09-04

### Fixed

- Atomic file writers fsync the directory the rename lands in
- Atomic file writers fsync the directory the rename lands in ([#116](https://github.com/shep-pm/shep/pull/116))
</blockquote>

## `shep-daemon`

<blockquote>

## [0.1.33] - 2026-09-04

### Fixed

- Atomic file writers fsync the directory the rename lands in
- Atomic file writers fsync the directory the rename lands in ([#116](https://github.com/shep-pm/shep/pull/116))
</blockquote>


## `shep`

<blockquote>

## [0.1.33] - 2026-09-04

### Fixed

- Atomic file writers fsync the directory the rename lands in
- Atomic file writers fsync the directory the rename lands in ([#116](https://github.com/shep-pm/shep/pull/116))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).