### PR TITLE
chore: release v0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2058,7 +2058,7 @@ dependencies = [
 
 [[package]]
 name = "shep"
-version = "0.1.34"
+version = "0.2.0"
 dependencies = [
  "anstyle",
  "assert_cmd",
@@ -2096,11 +2096,11 @@ dependencies = [
 
 [[package]]
 name = "shep-cli"
-version = "0.1.34"
+version = "0.2.0"
 
 [[package]]
 name = "shep-client"
-version = "0.1.34"
+version = "0.2.0"
 dependencies = [
  "futures-util",
  "nix 0.29.0",
@@ -2113,7 +2113,7 @@ dependencies = [
 
 [[package]]
 name = "shep-core"
-version = "0.1.34"
+version = "0.2.0"
 dependencies = [
  "annotate-snippets",
  "anstyle",
@@ -2143,7 +2143,7 @@ dependencies = [
 
 [[package]]
 name = "shep-daemon"
-version = "0.1.34"
+version = "0.2.0"
 dependencies = [
  "bytes",
  "chrono",
@@ -2172,7 +2172,7 @@ dependencies = [
 
 [[package]]
 name = "shep-examples"
-version = "0.1.34"
+version = "0.2.0"
 dependencies = [
  "nix 0.29.0",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.34"
+version = "0.2.0"
 edition = "2024"
 # 1.88 forced by serde-saphyr (let-chains, stabilized 1.88) — a current dep,
 # not a future one. Also the floor for ratatui/sysinfo/rmcp in later phases.
@@ -31,9 +31,9 @@ license = "MIT OR Apache-2.0"
 # the `[package]` table — so this literal is not sourced from
 # `workspace.package.version` above and a release bump has to touch both
 # places by hand. If that drifts, `cargo-release` is the mechanical fix.
-shep-core = { path = "crates/shep-core", version = "0.1.34" }
-shep-daemon = { path = "crates/shep-daemon", version = "0.1.34" }
-shep-client = { path = "crates/shep-client", version = "0.1.34" }
+shep-core = { path = "crates/shep-core", version = "0.2.0" }
+shep-daemon = { path = "crates/shep-daemon", version = "0.2.0" }
+shep-client = { path = "crates/shep-client", version = "0.2.0" }
 serde = { version = "1", default-features = false, features = ["derive"] }
 serde_json = { version = "1", default-features = false, features = ["std"] }
 toml = { version = "0.8", default-features = false, features = ["parse", "display"] }

--- a/crates/shep-cli/CHANGELOG.md
+++ b/crates/shep-cli/CHANGELOG.md
@@ -13,6 +13,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-09-04
+
+### Added
+
+- Replace --reset/--reset-all with --reset=<mode>
+
+### Changed
+
+- ResetDepth gains File and Env, Settings becomes Policy **(BREAKING)**
+
+### Fixed
+
+- Drive --reset through value_enum instead of a bespoke parser
+- A reset refusal echoes the mode the operator typed
+
+
 ## [0.1.34] - 2026-09-04
 
 ### Changed

--- a/crates/shep-client/CHANGELOG.md
+++ b/crates/shep-client/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-09-04
+
+
 ## [0.1.34] - 2026-09-04
 
 

--- a/crates/shep-core/CHANGELOG.md
+++ b/crates/shep-core/CHANGELOG.md
@@ -10,6 +10,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-09-04
+
+### Changed
+
+- ResetDepth gains File and Env, Settings becomes Policy **(BREAKING)**
+
+### Fixed
+
+- Drop three em dashes from the PROTOCOL_VERSION bump prose
+- --reset=env touches env and no setting at all
+- ResetDepth's own rustdoc still described the wrong two discards
+- Two test docs asserted PROTOCOL_VERSION is 2, which it is not
+
+
 ## [0.1.34] - 2026-09-04
 
 ### Changed

--- a/crates/shep-daemon/CHANGELOG.md
+++ b/crates/shep-daemon/CHANGELOG.md
@@ -10,6 +10,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-09-04
+
+### Added
+
+- The four reset modes get their own arms
+
+### Changed
+
+- ResetDepth gains File and Env, Settings becomes Policy **(BREAKING)**
+
+### Fixed
+
+- --reset=env touches env and no setting at all
+- The instances refusal advises a mode, not a bare flag
+- Env never reaches handle_scale either, so name it
+- The instances refusal named a purpose, not a scope
+
+
 ## [0.1.34] - 2026-09-04
 
 


### PR DESCRIPTION



## 🤖 New release

* `shep-core`: 0.1.34 -> 0.2.0 (✓ API compatible changes)
* `shep-daemon`: 0.1.34 -> 0.2.0 (✓ API compatible changes)
* `shep-client`: 0.1.34 -> 0.2.0
* `shep`: 0.1.34 -> 0.2.0 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `shep-core`

<blockquote>

## [0.2.0] - 2026-09-04

### Changed

- ResetDepth gains File and Env, Settings becomes Policy **(BREAKING)**

### Fixed

- Drop three em dashes from the PROTOCOL_VERSION bump prose
- --reset=env touches env and no setting at all
- ResetDepth's own rustdoc still described the wrong two discards
- Two test docs asserted PROTOCOL_VERSION is 2, which it is not
</blockquote>

## `shep-daemon`

<blockquote>

## [0.2.0] - 2026-09-04

### Added

- The four reset modes get their own arms

### Changed

- ResetDepth gains File and Env, Settings becomes Policy **(BREAKING)**

### Fixed

- --reset=env touches env and no setting at all
- The instances refusal advises a mode, not a bare flag
- Env never reaches handle_scale either, so name it
- The instances refusal named a purpose, not a scope
</blockquote>


## `shep`

<blockquote>

## [0.2.0] - 2026-09-04

### Added

- Replace --reset/--reset-all with --reset=<mode>

### Changed

- ResetDepth gains File and Env, Settings becomes Policy **(BREAKING)**

### Fixed

- Drive --reset through value_enum instead of a bespoke parser
- A reset refusal echoes the mode the operator typed
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).