### PR TITLE
feat(dogs)!: dogs publish a config schema, and BusEvent::topic returns Cow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -362,6 +362,16 @@ jobs:
         if: ${{ needs.changes.outputs.rust == 'true' || needs.changes.result != 'success' || github.event_name == 'workflow_dispatch' }}
       - run: 'cargo test -p shep-daemon --locked --no-default-features -- --skip ::slow:: --skip two_concurrent_boots --skip signal_ignored_then_kill_tree_reaps --skip a_reload_costs_a'
         if: ${{ needs.changes.outputs.rust == 'true' || needs.changes.result != 'success' || github.event_name == 'workflow_dispatch' }}
+      # shep-client's `schema` feature is ON by default and a dog is
+      # allowed to turn it off, so the opt-out needs a leg of its own: the
+      # shep-daemon line above says nothing about it. Without one, the
+      # crate's `#[cfg(test)] mod tests` named `schemars` in a build that
+      # has no schemars and nothing noticed, because the task gate is
+      # `--all-features`. `cargo test` rather than `cargo check`, both to
+      # match the line above and because the doctest was broken the same
+      # way and only a doctest run reads it.
+      - run: cargo test -p shep-client --locked --no-default-features
+        if: ${{ needs.changes.outputs.rust == 'true' || needs.changes.result != 'success' || github.event_name == 'workflow_dispatch' }}
       - run: 'cargo test --workspace --locked --all-features -- --skip ::slow:: --skip two_concurrent_boots --skip signal_ignored_then_kill_tree_reaps --skip a_reload_costs_a'
         if: ${{ needs.changes.outputs.rust == 'true' || needs.changes.result != 'success' || github.event_name == 'workflow_dispatch' }}
   # Tests that need a quiet machine, run serially in a job of their own.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2182,7 +2182,7 @@ dependencies = [
 
 [[package]]
 name = "shep-macros"
-version = "0.1.34"
+version = "0.2.0"
 dependencies = [
  "proc-macro2",
  "quote 1.0.47",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2186,6 +2186,9 @@ version = "0.1.34"
 dependencies = [
  "proc-macro2",
  "quote 1.0.47",
+ "schemars",
+ "serde",
+ "shep-client",
  "syn 2.0.119",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2178,6 +2178,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "shep-macros"
+version = "0.1.34"
+dependencies = [
+ "proc-macro2",
+ "quote 1.0.47",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2104,7 +2104,10 @@ version = "0.2.0"
 dependencies = [
  "futures-util",
  "nix 0.29.0",
+ "schemars",
+ "serde_json",
  "shep-core",
+ "shep-macros",
  "tempfile",
  "tokio",
  "tokio-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "crates/shep-core",
     "crates/shep-daemon",
     "crates/shep-client",
+    "crates/shep-macros",
     "crates/shep-cli",
     "crates/shep-cli-redirect",
     # Small runnable demos of shep's supervision behaviours (probes, restart
@@ -25,15 +26,16 @@ license = "MIT OR Apache-2.0"
 
 [workspace.dependencies]
 # `cargo publish` strips `path` from a dependency and needs a version to put
-# in its place, so these three need one even though every consumer in this
+# in its place, so these four need one even though every consumer in this
 # workspace resolves them by path. There is no `version.workspace = true`
-# form inside a dependency entry — Cargo only supports that shorthand for
-# the `[package]` table — so this literal is not sourced from
+# form inside a dependency entry, since Cargo only supports that shorthand for
+# the `[package]` table. This literal is not sourced from
 # `workspace.package.version` above and a release bump has to touch both
 # places by hand. If that drifts, `cargo-release` is the mechanical fix.
 shep-core = { path = "crates/shep-core", version = "0.2.0" }
 shep-daemon = { path = "crates/shep-daemon", version = "0.2.0" }
 shep-client = { path = "crates/shep-client", version = "0.2.0" }
+shep-macros = { path = "crates/shep-macros", version = "0.2.0" }
 serde = { version = "1", default-features = false, features = ["derive"] }
 serde_json = { version = "1", default-features = false, features = ["std"] }
 toml = { version = "0.8", default-features = false, features = ["parse", "display"] }
@@ -60,8 +62,20 @@ annotate-snippets = { version = "0.12.3", default-features = false }
 anstyle = { version = "1.0.5", default-features = false }
 encoding_rs_io = { version = "0.1.2", default-features = false }
 pest = { version = "2.0.2", default-features = false }
-quote = { version = "0.3.15", default-features = false }
-syn = { version = "1.0.1", default-features = false }
+# Renamed keys, not the plain names: `shep-macros` needs the CURRENT syn and
+# quote to build a real proc macro, and a workspace dependency key can only be
+# spelled once. These two entries are floors for someone else's under-declared
+# transitive dependency and are never compiled, so they are the pair that gives
+# the names up.
+quote-floor = { package = "quote", version = "0.3.15", default-features = false }
+syn-floor = { package = "syn", version = "1.0.1", default-features = false }
+# The current lines of the same two crates, plus proc-macro2, for
+# `shep-macros`. `proc-macro` is what lets a `proc_macro2::TokenStream` become
+# the `proc_macro::TokenStream` a derive has to return, so it is not optional
+# here even though it is not a default.
+proc-macro2 = { version = "1.0", default-features = false, features = ["proc-macro"] }
+quote = { version = "1.0", default-features = false, features = ["proc-macro"] }
+syn = { version = "2.0", default-features = false }
 json5 = { version = "0.4", default-features = false }
 # regex 1.8.0's compiled-size accounting lets `selector_spec_oversized_regex_is_rejected`'s
 # huge pattern slip under the 1 MiB `size_limit`; 1.9+ rejects it. Floor to 1.9 so the

--- a/crates/shep-cli/src/commands/daemon.rs
+++ b/crates/shep-cli/src/commands/daemon.rs
@@ -333,9 +333,23 @@ pub async fn boot_supervisor(
     let notify_socket: Option<std::ffi::OsString> = None;
     let mut options = boot_options(&config, args, notify_socket.as_deref());
     options.delete_flock_on_shutdown = delete_flock_on_shutdown;
-    boot(TokioRunner::new(), paths, options)
+    let daemon = boot(TokioRunner::new(), paths, options)
         .await
-        .map_err(DaemonRunError::Boot)
+        .map_err(DaemonRunError::Boot)?;
+    // The one publisher of `config.dog.<name>` in the workspace, and it is
+    // here because this is where the bus is: the migration above ran before
+    // `boot`, in a process that had none yet, so the announcement waits for
+    // the daemon it will travel through. A dog that attaches after this
+    // frame has gone out has not missed anything -- it asks for its section
+    // at startup, and the section it gets is the moved one.
+    //
+    // The other two writers of `dogs.toml` deliberately say nothing, each
+    // for its own reason, and both carry that reason at their own call site:
+    // `reload_with_wait`'s pre-flight below, and `forget_dog_section` in
+    // `commands::dogs`. Neither is fixable by routing a CLI write through a
+    // request variant, and neither wants to be.
+    daemon.context().announce_dog_config(&moved);
+    Ok(daemon)
 }
 
 /// Runs the supervisor in this process until a signal or `KillDaemon`.
@@ -715,6 +729,17 @@ async fn reload_with_wait(
     // This is the CLI process, and nothing below has signalled the
     // predecessor yet, so a refusal here ends the verb with the running
     // shepherd untouched -- which is the whole point.
+    //
+    // NO `config.dog.<name>` frame goes out from here, unlike the same
+    // call in `boot_supervisor` above, and that is the deliberate half.
+    // This is an operator's own short-lived process: it has no bus, and
+    // the daemon's bus is not something a client may publish onto. Adding
+    // a request variant so a CLI write could reach it would put an
+    // announcement anything holding the socket can forge next to one the
+    // daemon makes about work it did itself. Nothing is lost by the
+    // silence: this pre-flight is followed immediately by the handover it
+    // is clearing the way for, and every dog re-asks for its section when
+    // it comes back up against the successor.
     match dog_migration::migrate_dog_sections(paths) {
         Ok(moved) if moved.is_empty() => {}
         Ok(moved) => {

--- a/crates/shep-cli/src/commands/daemon.rs
+++ b/crates/shep-cli/src/commands/daemon.rs
@@ -738,8 +738,13 @@ async fn reload_with_wait(
     // announcement anything holding the socket can forge next to one the
     // daemon makes about work it did itself. Nothing is lost by the
     // silence: this pre-flight is followed immediately by the handover it
-    // is clearing the way for, and every dog re-asks for its section when
-    // it comes back up against the successor.
+    // is clearing the way for, and the migration relocates values without
+    // changing any of them. A dog that re-reads its section against the
+    // successor finds the same settings in the new file, and a dog that
+    // never re-reads is already holding them. Both exist: bark's event
+    // source ends on a handover, so it exits and comes back up reading
+    // `dogs.toml`, while metrics redials underneath a `ReconnectingClient`,
+    // keeps its pid and its `restarts 0`, and reads no config again.
     match dog_migration::migrate_dog_sections(paths) {
         Ok(moved) if moved.is_empty() => {}
         Ok(moved) => {

--- a/crates/shep-cli/src/commands/dogs.rs
+++ b/crates/shep-cli/src/commands/dogs.rs
@@ -1012,6 +1012,24 @@ pub(crate) const VERSION_BUDGET: Duration = Duration::from_secs(1);
 /// than inventing a second one.
 const VERSION_POLL_INTERVAL: Duration = Duration::from_millis(2);
 
+/// The most a probe will read from a candidate, per spawn.
+///
+/// One mebibyte, against a version answer of two lines and a JSON Schema
+/// that runs to single-digit kilobytes for a config with a lot of fields.
+/// Three orders of magnitude of headroom, and still a bound: without one,
+/// the read is limited only by the budget and by how fast the candidate can
+/// write, which measured at roughly 290MB of resident memory for a second
+/// of spew and is a stranger's binary deciding how much of this machine's
+/// memory to take. `adopt` runs that binary twice, so it is asked twice.
+///
+/// Truncation is not a new outcome and never a refusal. A cut-off version
+/// answer is output shep cannot read, which is the unknown protocol it
+/// already was; a cut-off schema is not valid JSON, so it is
+/// [`DogSchema::Unreadable`] and earns the warning decision 4 already
+/// defines. Both need a dog to print a megabyte before answering, which no
+/// dog following the contract does.
+const PROBE_OUTPUT_LIMIT: u64 = 1024 * 1024;
+
 /// Drains `stdout` to end on a thread, handing the text back through the
 /// returned channel.
 ///
@@ -1023,14 +1041,23 @@ const VERSION_POLL_INTERVAL: Duration = Duration::from_millis(2);
 /// could do forever. On the timeout path the thread is left to end on its
 /// own when the pipe closes: it holds nothing but a `String` and a sender,
 /// and `adopt` is a one-shot command.
-fn read_in_background(mut stdout: std::process::ChildStdout) -> Receiver<String> {
+fn read_in_background(stdout: std::process::ChildStdout) -> Receiver<String> {
     let (tx, rx) = std::sync::mpsc::channel();
     std::thread::spawn(move || {
         use std::io::Read as _;
         let mut text = String::new();
+        // Bounded by [`PROBE_OUTPUT_LIMIT`], and the drop that follows is
+        // half of what the bound buys: the read end closes, so a candidate
+        // still writing takes an EPIPE instead of being left blocked on a
+        // full pipe until the budget kills it.
+        //
         // A candidate answering in bytes that are not UTF-8 is answering
-        // nothing shep can read, which is the same unknown as silence.
-        let _ = stdout.read_to_string(&mut text);
+        // nothing shep can read, which is the same unknown as silence. That
+        // now includes a multi-byte character the cap cut in half, since
+        // `read_to_string` leaves `text` empty when it fails: a candidate
+        // that reached the cap mid-character was already answering
+        // something no reader here was going to use.
+        let _ = stdout.take(PROBE_OUTPUT_LIMIT).read_to_string(&mut text);
         let _ = tx.send(text);
     });
     rx
@@ -2660,6 +2687,45 @@ mod tests {
         assert!(
             elapsed < Duration::from_secs(10),
             "the vet is bounded by its own budget, not by the candidate: {elapsed:?}"
+        );
+    }
+
+    /// fails if a candidate decides how much of this machine's memory a
+    /// probe takes. The read is on a thread with no bound but the budget
+    /// and the writer's speed, so a binary that spews reached roughly 290MB
+    /// resident for a second of it, and `adopt` spawns that binary twice.
+    ///
+    /// Twice the cap is written, so a read that stopped anywhere else shows
+    /// up in the length rather than only in the memory it took. `trap ''
+    /// PIPE` is what lets the script reach its own `exit 0` after shep
+    /// closes the pipe underneath it, since a candidate killed by SIGPIPE
+    /// would answer `None` for its exit status and say nothing about where
+    /// the read stopped.
+    ///
+    /// Mutation check: dropping the `take` reddens this on the length.
+    #[test]
+    fn a_candidate_that_will_not_stop_talking_is_read_no_further_than_the_cap() {
+        let dir = tempfile::tempdir().unwrap();
+        let chunk = "a".repeat(1024);
+        let chunks = PROBE_OUTPUT_LIMIT / 1024 * 2;
+        let bin = probe_script(
+            dir.path(),
+            "shep-otel",
+            &format!(
+                "trap '' PIPE\ni=0\nwhile [ $i -lt {chunks} ]; do \
+                 printf '%s' '{chunk}'; i=$((i+1)); done\nexit 0"
+            ),
+            "exit 0",
+        );
+
+        let answer = ask(&bin, VERSION_FLAG, dir.path(), "otel", TEST_BUDGET)
+            .expect("what a candidate prints is never a refusal")
+            .expect("it exited 0, so it answered");
+
+        assert_eq!(
+            answer.len() as u64,
+            PROBE_OUTPUT_LIMIT,
+            "the read stops at the cap, whatever the candidate does after it"
         );
     }
 

--- a/crates/shep-cli/src/commands/dogs.rs
+++ b/crates/shep-cli/src/commands/dogs.rs
@@ -39,7 +39,7 @@ use std::time::{Duration, Instant};
 
 use shep_client::{Client, ConnectError, PROTOCOL_VERSION};
 use shep_core::barks;
-use shep_core::dogs::{DogVersion, VERSION_FLAG, parse_version_answer};
+use shep_core::dogs::{DogVersion, SCHEMA_FLAG, VERSION_FLAG, parse_version_answer};
 use shep_core::paths::ShepPaths;
 use shep_core::protocol::{DogSource, Request, Response, SelectorSpec};
 
@@ -549,17 +549,21 @@ impl core::error::Error for AdoptRefusal {}
 /// is an [`ExitCode::Internal`].
 /// Proves this kernel can exec `path`, and asks it what protocol it speaks.
 ///
-/// The candidate is spawned twice over: once bare, to prove the exec works
-/// at all rather than discovering it at supervision time, and once with
-/// `--version` to read the contract in `docs/dogs.md`. A group-writable
-/// binary is reported rather than refused, since an operator naming a path
-/// has already made that call.
+/// The candidate is spawned once per probe flag, and no more: `--version`
+/// first, which proves the exec works at all rather than leaving it to be
+/// discovered at supervision time and reads the contract in
+/// `docs/dogs.md`, then `--schema`, which asks the dog to describe its own
+/// config. The second runs only once the first has decided nothing is being
+/// refused. A group-writable binary is reported rather than refused, since
+/// an operator naming a path has already made that call.
 ///
 /// # Errors
 /// [`AdoptRefusal`] when the path does not resolve, is not a file this
 /// kernel will exec, or answers a protocol this shep cannot talk to. A
 /// candidate that does not answer `--version` is NOT an error: its protocol
 /// is recorded as unknown, which `docs/dogs.md` promises is never a refusal.
+/// Nothing a candidate does with `--schema` is an error either, down to
+/// failing to run at all; see [`DogSchema`].
 pub fn vet_binary(path: &Path, home: &Path, name: &str) -> Result<VettedBinary, AdoptRefusal> {
     vet_binary_within(path, home, name, VERSION_BUDGET)
 }
@@ -588,11 +592,11 @@ pub fn vet_binary(path: &Path, home: &Path, name: &str) -> Result<VettedBinary, 
 ///
 /// # What `budget` actually bounds
 ///
-/// One wait, not the call. [`version_answer`] bounds two things separately
-/// and gives each the full `budget`: the wait for the child to exit, and
-/// the wait for its output to arrive. So the call is bounded by roughly
-/// twice `budget`, plus up to 50ms on macOS for
-/// `macos_deferred_exec_failure`'s own poll.
+/// One wait, not the call. [`answer_text`] bounds two things separately and
+/// gives each the full `budget`: the wait for the child to exit, and the
+/// wait for its output to arrive. So one probe is bounded by roughly twice
+/// `budget`, plus up to 50ms on macOS for `macos_deferred_exec_failure`'s
+/// own poll, and a vet runs two of them, `--version` and then `--schema`.
 ///
 /// Deliberate, and the alternative is worse. One absolute deadline shared
 /// between the two waits reads tidier and would make this doc a single
@@ -653,32 +657,18 @@ pub fn vet_binary_within(
             shep: PROTOCOL_VERSION,
         });
     }
+    // Asked AFTER the protocol refusal above, so a candidate shep is about
+    // to refuse is not run a third time to answer a question the refusal
+    // makes moot.
+    let schema = ask_schema(&canonical, home, name, budget);
     Ok(VettedBinary {
         path: canonical,
         group_writable,
         answer,
+        schema,
     })
 }
 
-/// Runs `path` with [`VERSION_FLAG`] and reads what it answers, within
-/// [`VERSION_BUDGET`].
-///
-/// `Ok(None)` is an UNKNOWN protocol and is never a fault: silence, output
-/// shep cannot read, a run that failed, and a run still going when the
-/// budget ran out all arrive here the same way. Answering is optional and stays
-/// optional, so every dog written before the contract existed reads as
-/// unknown rather than as broken.
-///
-/// Two callers ask the same binary the same question for different reasons.
-/// [`vet_binary`] asks a candidate nobody has adopted yet;
-/// [`warn_of_a_dog_a_restart_would_break`] asks a dog that has been adopted
-/// for months, because the answer lives in the binary and the binary
-/// changes on disk with nothing watching (G12 row 5). Neither writes the
-/// answer down.
-///
-/// # Errors
-/// [`AdoptRefusal::WillNotExec`], and only that: nothing here judges the
-/// answer it read, so [`AdoptRefusal::ProtocolMismatch`] stays
 /// The environment the probe runs a candidate with: what the daemon would
 /// give the dog, and nothing else.
 ///
@@ -725,15 +715,38 @@ fn probe_env() -> Vec<(String, String)> {
     env
 }
 
+/// Runs `path` with `flag`, one of [`VERSION_FLAG`] or [`SCHEMA_FLAG`], and
+/// hands back what it printed on stdout, within `budget`.
+///
+/// One spawn shape for both probes rather than two, because the argument
+/// each of them changes is the flag and everything else about running a
+/// stranger's binary is the same: the cleared environment, the two
+/// variables a dog is promised, the null stdin and stderr, the bounded
+/// wait, and the kill afterwards. A second, looser path would be a second
+/// place for one of those to be missing.
+///
+/// `Ok(None)` is NO ANSWER, and is never a fault: silence, a run that
+/// failed, and a run still going when the budget ran out all arrive here
+/// the same way. Answering either flag is optional and stays optional, so
+/// every dog written before the contract existed reads as unanswered rather
+/// than as broken. `Ok(Some(text))` is only ever the output of a run that
+/// exited 0, which is what `docs/dogs.md` asks a dog for; nothing here
+/// reads `text`, so what counts as a usable answer is each caller's own
+/// question.
+///
+/// # Errors
+/// [`AdoptRefusal::WillNotExec`], and only that: nothing here judges the
+/// answer it read, so [`AdoptRefusal::ProtocolMismatch`] stays
 /// [`vet_binary`]'s to raise. A caller that only wants an answer treats the
 /// error as one more way of not getting one.
-fn ask_version(
+fn ask(
     path: &Path,
+    flag: &str,
     home: &Path,
     name: &str,
     budget: Duration,
-) -> Result<Option<DogVersion>, AdoptRefusal> {
-    // Spawned with ONE argument, `--version`, and torn down
+) -> Result<Option<String>, AdoptRefusal> {
+    // Spawned with ONE argument, the flag being asked, and torn down
     // unconditionally: `kill` is ignored (a process that already exited is
     // not a failure to vet), but `wait` always runs, on every path out of
     // this match, so no zombie survives a refusal or a success.
@@ -745,12 +758,13 @@ fn ask_version(
     // right, because they are different runs. A supervised dog must work
     // for a stranger who never read this repo, so shep asks it for nothing.
     // This process is a throwaway that exists only to be observed and
-    // killed, so the cost of a candidate disagreeing about `--version` is
-    // an unknown protocol -- and `docs/dogs.md` promises that an unknown
-    // protocol is never a refusal. The vet asks; the supervisor does not.
+    // killed, so the cost of a candidate disagreeing about a probe flag is
+    // an unknown protocol or an unread schema -- and `docs/dogs.md`
+    // promises that neither is a refusal. The vet asks; the supervisor does
+    // not.
     //
     // A candidate is somebody else's binary and is not assumed to be well
-    // behaved about any of it: [`version_answer`] bounds the wait by
+    // behaved about any of it: [`answer_text`] bounds the wait by
     // `budget`, so one that never exits costs that and is then killed,
     // rather than hanging the command that asked.
     //
@@ -810,12 +824,12 @@ fn ask_version(
     // than to the terminal. A candidate that writes on its way up would
     // otherwise scribble over the operator's terminal mid-vet, and a hostile
     // one could imitate shep's own output at the exact moment somebody is
-    // deciding whether to trust it. The pipe is read by [`version_answer`]
-    // and never rendered.
+    // deciding whether to trust it. The pipe is read by [`answer_text`] and
+    // never rendered.
     // `env_clear` and then the allowlist, never the operator's environment.
     // Argued at the top of this function; `probe_env` builds the list.
     match Command::new(path)
-        .arg(VERSION_FLAG)
+        .arg(flag)
         .env_clear()
         .envs(probe_env())
         .env("SHEP_HOME", home)
@@ -838,11 +852,67 @@ fn ask_version(
                 let _ = child.wait();
                 return Err(AdoptRefusal::WillNotExec { reason });
             }
-            let answer = version_answer(&mut child, reading, budget);
+            let answer = answer_text(&mut child, reading, budget);
             let _ = child.kill();
             let _ = child.wait();
             Ok(answer)
         }
+    }
+}
+
+/// Asks `path` for its version with [`VERSION_FLAG`] and parses the answer.
+///
+/// `Ok(None)` is an UNKNOWN protocol and is never a fault: everything
+/// [`ask`] answers `None` for, plus output with no line 1 to read a version
+/// from.
+///
+/// Two callers ask the same binary the same question for different reasons.
+/// [`vet_binary`] asks a candidate nobody has adopted yet;
+/// [`warn_of_a_dog_a_restart_would_break`] asks a dog that has been adopted
+/// for months, because the answer lives in the binary and the binary
+/// changes on disk with nothing watching (G12 row 5). Neither writes the
+/// answer down.
+///
+/// # Errors
+/// [`AdoptRefusal::WillNotExec`], and only that, for the reason [`ask`]
+/// gives.
+fn ask_version(
+    path: &Path,
+    home: &Path,
+    name: &str,
+    budget: Duration,
+) -> Result<Option<DogVersion>, AdoptRefusal> {
+    Ok(ask(path, VERSION_FLAG, home, name, budget)?
+        .as_deref()
+        .and_then(parse_version_answer))
+}
+
+/// Asks `path` for its config schema with [`SCHEMA_FLAG`], and reads the
+/// answer as JSON.
+///
+/// No `Result`, because nothing a candidate does to this probe can refuse
+/// an adopt (decision 4): a dog whose schema flag is broken may still do
+/// its job perfectly, and the version probe has already answered the only
+/// question that can. So a failure to spawn arrives as
+/// [`DogSchema::Silent`], the same as a dog that has never heard of the
+/// flag.
+///
+/// The answer is not written anywhere, here or by any caller (decision 7).
+/// `cargo install` replaces a dog's binary with nothing watching, so a
+/// stored schema would be wrong at the moment it mattered, and a stale
+/// schema is worse than a stale version number because it mislabels which
+/// field is a credential.
+fn ask_schema(path: &Path, home: &Path, name: &str, budget: Duration) -> DogSchema {
+    // A run that exited 0 and printed nothing is a dog with no schema, not
+    // a dog whose schema failed to parse: empty input IS invalid JSON, so
+    // without this the ordinary case would earn the warning meant for a
+    // broken one.
+    match ask(path, SCHEMA_FLAG, home, name, budget) {
+        Ok(Some(text)) if !text.trim().is_empty() => match serde_json::from_str(&text) {
+            Ok(schema) => DogSchema::Published(schema),
+            Err(_) => DogSchema::Unreadable,
+        },
+        Ok(_) | Err(_) => DogSchema::Silent,
     }
 }
 
@@ -862,10 +932,60 @@ pub struct VettedBinary {
     /// with no first line. `adopt` reports it and does not record it; see
     /// [`DogVersion`].
     pub answer: Option<DogVersion>,
+    /// What it answered when asked for its config schema. Read by the
+    /// caller and written down by nobody, for the reason [`ask_schema`]
+    /// gives.
+    pub schema: DogSchema,
 }
 
-/// How long [`ask_version`] gives a binary to answer, and separately how
-/// long it then waits for that answer to reach the reader thread.
+/// What a candidate answered when asked for its config schema, and the
+/// three answers are not one `Option`: only one of the two ways of having
+/// no schema is worth telling an operator about.
+///
+/// Nothing here is a refusal. A dog with a broken schema flag may still do
+/// its job perfectly, and refusing one would be shep judging a binary on a
+/// question the binary never promised to answer.
+#[derive(PartialEq, Eq)]
+pub enum DogSchema {
+    /// The dog printed JSON, and this is it, exactly as it wrote it. It is
+    /// not validated as JSON Schema past being JSON: the dog is the
+    /// authority on its own config, and a shep that disagreed about the
+    /// document's shape would be wrong in the direction that hides a
+    /// working dog's settings.
+    Published(serde_json::Value),
+    /// The dog answered nothing shep can use: it printed nothing, its run
+    /// failed, it never exited, or it could not be spawned at all. Every
+    /// dog written before this contract existed lands here, so it earns no
+    /// warning.
+    Silent,
+    /// The dog printed something that is not JSON. It meant to answer and
+    /// its answer cannot be read, which is a bug in that dog and the one
+    /// shape `adopt` warns about.
+    Unreadable,
+}
+
+/// Reports THAT there is a schema, never what is in it.
+///
+/// Manual, and a derive here would be a regression (IR-41). A schema
+/// carries the dog's own defaults, which is the same field the secret
+/// marker exists to keep off a screen, and a `{vetted:?}` in a test
+/// assertion or a future log line is all it would take to put a credential
+/// somewhere it is read later. `debug_reports_that_there_is_a_schema_and_never_what_is_in_it`
+/// pins the exact strings.
+impl core::fmt::Debug for DogSchema {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::Published(_) => f.write_str("Published(..)"),
+            Self::Silent => f.write_str("Silent"),
+            Self::Unreadable => f.write_str("Unreadable"),
+        }
+    }
+}
+
+/// How long [`ask`] gives a binary to answer one probe flag, and separately
+/// how long it then waits for that answer to reach the reader thread. Each
+/// flag is asked in its own spawn and gets the whole budget; the name
+/// predates the second flag and the number is the same for both.
 ///
 /// One second, against the milliseconds a `println!` and an exit take. The
 /// generosity is for a cold, dynamically linked binary on a loaded machine,
@@ -887,7 +1007,7 @@ pub struct VettedBinary {
 /// it, never block it.
 pub(crate) const VERSION_BUDGET: Duration = Duration::from_secs(1);
 
-/// How often [`version_answer`] polls within [`VERSION_BUDGET`], following
+/// How often [`answer_text`] polls within [`VERSION_BUDGET`], following
 /// [`macos_deferred_exec_failure`]'s own polled-with-a-budget shape rather
 /// than inventing a second one.
 const VERSION_POLL_INTERVAL: Duration = Duration::from_millis(2);
@@ -916,7 +1036,8 @@ fn read_in_background(mut stdout: std::process::ChildStdout) -> Receiver<String>
     rx
 }
 
-/// Waits, bounded by [`VERSION_BUDGET`], for `child` to answer.
+/// Waits, bounded by `budget`, for `child` to answer, and returns what it
+/// printed.
 ///
 /// Twice that is the worst case rather than once, because the wait for the
 /// exit and the wait for the text the reader thread collected are bounded
@@ -925,20 +1046,22 @@ fn read_in_background(mut stdout: std::process::ChildStdout) -> Receiver<String>
 /// closed; that bound is there for a grandchild still holding the inherited
 /// pipe open, not for anything the dog itself is doing.
 ///
-/// `None` -- an unknown protocol, never a refusal -- for every way of not
-/// answering: no pipe to read, a run that did not exit inside the budget, a
-/// run that exited non-zero, or output with no line 1.
+/// `None` -- no answer, never a refusal -- for every way of not answering:
+/// no pipe to read, a run that did not exit inside the budget, or a run
+/// that exited non-zero. `Some` may still be empty: a run that exited 0 and
+/// printed nothing answered, and it is each caller's own business what that
+/// means for the question it asked.
 ///
 /// The non-zero exit is not a technicality. `docs/dogs.md` says a dog
 /// answers on stdout AND exits 0, so lines printed by a run that then
 /// failed are not an answer -- and believing them would let a candidate
 /// refuse its own adopt with a protocol number from a code path that did
 /// not work.
-fn version_answer(
+fn answer_text(
     child: &mut Child,
     reading: Option<Receiver<String>>,
     budget: Duration,
-) -> Option<DogVersion> {
+) -> Option<String> {
     let reading = reading?;
     let started = Instant::now();
     loop {
@@ -949,7 +1072,7 @@ fn version_answer(
             Ok(None) => std::thread::sleep(VERSION_POLL_INTERVAL),
         }
     }
-    parse_version_answer(&reading.recv_timeout(budget).ok()?)
+    reading.recv_timeout(budget).ok()
 }
 
 /// Who besides the owner can write `canonical` and the directory holding
@@ -1145,6 +1268,32 @@ fn report_dog_version(streams: &mut Streams<'_>, name: &str, answer: &DogVersion
     streams.aside(DOG_VERSION_NOTICE, &message);
 }
 
+/// [`emit_notice`] code for the unreadable-schema warning -- caller-defined
+/// like the two above, and like them not a failure: `adopt` succeeded.
+const DOG_SCHEMA_UNREADABLE_NOTICE: &str = "dog_schema_unreadable";
+
+/// Warns that `name` answered the schema flag with something that is not
+/// JSON, and lets the adopt proceed.
+///
+/// The one schema answer worth a line, and the reason is the difference
+/// between a dog that said nothing and a dog that tried. Silence is the
+/// ordinary case, since every dog written before this contract is silent,
+/// and a notice for each of them is how an operator learns to skip the one
+/// that matters. Unreadable output is a bug in that dog which its author
+/// can fix, and shep is the only thing positioned to notice it.
+///
+/// What it costs the operator is named rather than left to be discovered:
+/// the dog works, and the settings it would have described are edited by
+/// hand instead.
+fn warn_unreadable_schema(streams: &mut Streams<'_>, name: &str) {
+    let message = format!(
+        "{name} answered `{SCHEMA_FLAG}` with something that is not JSON, so shep has \
+         no description of its settings and they stay a hand-edited section. The dog \
+         is adopted and runs normally; this is a bug to report to whoever wrote it"
+    );
+    streams.aside(DOG_SCHEMA_UNREADABLE_NOTICE, &message);
+}
+
 /// [`emit_notice`](crate::output::emit_notice) code for the warning
 /// `restart` prints before it restarts a dog whose binary on disk cannot
 /// speak to this shepherd -- caller-defined, like the two above, and like
@@ -1306,6 +1455,12 @@ pub async fn adopt(streams: &mut Streams<'_>, paths: &ShepPaths, args: &AdoptArg
     }
     if let Some(answer) = &vetted.answer {
         report_dog_version(streams, &name, answer);
+    }
+    // The schema itself is reported by nothing and stored by nothing: it is
+    // asked fresh wherever it is needed (decision 7), so the only thing
+    // `adopt` has to say about it is the one way of answering that is a bug.
+    if vetted.schema == DogSchema::Unreadable {
+        warn_unreadable_schema(streams, &name);
     }
     if let Err(err) = ShepToml::edit(&paths.daemon_config, |cfg| {
         cfg.adopt_dog(&name, &path);
@@ -2562,6 +2717,174 @@ mod tests {
             }),
             "a protocol that is not a decimal is unknown, not a refusal"
         );
+    }
+
+    /// Writes a dog that answers the two flags differently, which is the
+    /// shape every real dog has: one binary, one dispatch on `$1`. The
+    /// version half always names this shep's own protocol, so a schema test
+    /// never fails for a reason that has nothing to do with the schema.
+    fn two_flag_dog(dir: &Path, schema_body: &str) -> PathBuf {
+        dog_script(
+            dir,
+            "shep-otel",
+            &format!(
+                "case \"$1\" in\n\
+                 --version) echo 'shep-otel 0.1.3'; echo 'shep-protocol: {PROTOCOL_VERSION}' ;;\n\
+                 --schema) {schema_body} ;;\n\
+                 esac"
+            ),
+        )
+    }
+
+    /// fails if a dog that answers the schema flag with real JSON Schema is
+    /// not asked, or is asked and not read. This is the whole point of the
+    /// second probe: everything below is a way of getting nothing, and this
+    /// is the way of getting something.
+    ///
+    /// Mutation check: never spawning the schema flag, or dropping the
+    /// parse, leaves `schema` anything but `Published` and reddens this.
+    #[test]
+    fn a_dog_that_answers_a_schema_has_it_recorded() {
+        let dir = tempfile::tempdir().unwrap();
+        let bin = two_flag_dog(
+            dir.path(),
+            "echo '{\"title\":\"otel\",\"properties\":{\"endpoint\":{\"type\":\"string\"}}}'",
+        );
+
+        let vetted = vet_binary_within(&bin, dir.path(), "otel", TEST_BUDGET).unwrap();
+
+        let DogSchema::Published(schema) = &vetted.schema else {
+            panic!("a dog that printed valid JSON Schema has one: {vetted:?}");
+        };
+        assert_eq!(
+            schema["properties"]["endpoint"]["type"], "string",
+            "the schema is kept as the dog wrote it, not summarised"
+        );
+    }
+
+    /// fails if a run that printed a schema and then failed is believed, or
+    /// is treated as a fault. `docs/dogs.md` asks for stdout AND an exit 0,
+    /// so a non-zero exit means the run that printed those bytes did not
+    /// work -- and a dog with a broken schema flag may still scrape
+    /// perfectly, so it is adopted with no schema and no warning.
+    ///
+    /// Mutation check: dropping the exit-status test records that `{}` as a
+    /// published schema and reddens the first assertion.
+    #[tokio::test]
+    async fn a_dog_whose_schema_run_exits_non_zero_has_no_schema_and_no_warning() {
+        let dir = tempfile::tempdir().unwrap();
+        let paths = ShepPaths::resolve(&|_| None, dir.path());
+        let bin = two_flag_dog(dir.path(), "echo '{}'; exit 3");
+
+        let vetted = vet_binary_within(&bin, dir.path(), "otel", TEST_BUDGET).unwrap();
+        assert_eq!(
+            vetted.schema,
+            DogSchema::Silent,
+            "a failed run printed no answer, whatever reached stdout"
+        );
+
+        let mut out = Vec::new();
+        let mut err = Vec::new();
+        let args = AdoptArgs {
+            name: Some("otel".to_string()),
+            path: bin,
+        };
+        let code = adopt(&mut streams(&mut out, &mut err), &paths, &args).await;
+
+        assert_eq!(code, ExitCode::Success, "no schema is not a refusal");
+        let text = String::from_utf8(err).unwrap();
+        assert!(
+            !text.contains(DOG_SCHEMA_UNREADABLE_NOTICE),
+            "only unreadable output earns the warning, not a failed run: {text}"
+        );
+    }
+
+    /// fails if silence on the schema flag is anything but a dog with no
+    /// schema. Every dog written before this contract is in that group: it
+    /// exits without printing, or prints its usage on stderr, and a warning
+    /// for each of them is a line about the ordinary case.
+    ///
+    /// Mutation check: treating empty output as unparseable JSON reddens
+    /// both assertions here at once.
+    #[tokio::test]
+    async fn a_dog_that_prints_no_schema_has_no_schema_and_no_warning() {
+        let dir = tempfile::tempdir().unwrap();
+        let paths = ShepPaths::resolve(&|_| None, dir.path());
+        let bin = two_flag_dog(dir.path(), "exit 0");
+
+        let vetted = vet_binary_within(&bin, dir.path(), "otel", TEST_BUDGET).unwrap();
+        assert_eq!(vetted.schema, DogSchema::Silent, "silence is no schema");
+
+        let mut out = Vec::new();
+        let mut err = Vec::new();
+        let args = AdoptArgs {
+            name: Some("otel".to_string()),
+            path: bin,
+        };
+        let code = adopt(&mut streams(&mut out, &mut err), &paths, &args).await;
+
+        assert_eq!(code, ExitCode::Success, "silence is not a refusal");
+        let text = String::from_utf8(err).unwrap();
+        assert!(
+            !text.contains(DOG_SCHEMA_UNREADABLE_NOTICE),
+            "a dog that answered nothing is the ordinary case, not a warning: {text}"
+        );
+    }
+
+    /// fails if a dog that answers the schema flag with something that is
+    /// not JSON is refused, or is passed over in silence. It is the one
+    /// shape that earns a warning: the dog meant to answer and its answer
+    /// cannot be read, which is a bug in that dog its author can fix.
+    /// Exactly one warning, because the count is what an operator reads.
+    ///
+    /// Mutation check: dropping the `Unreadable` arm silences the warning
+    /// and reddens the count.
+    #[tokio::test]
+    async fn a_dog_that_prints_invalid_json_is_adopted_with_one_warning() {
+        let dir = tempfile::tempdir().unwrap();
+        let paths = ShepPaths::resolve(&|_| None, dir.path());
+        let bin = two_flag_dog(dir.path(), "echo 'error: unrecognized option --schema'");
+
+        let vetted = vet_binary_within(&bin, dir.path(), "otel", TEST_BUDGET).unwrap();
+        assert_eq!(
+            vetted.schema,
+            DogSchema::Unreadable,
+            "output that is not JSON is unreadable, not absent"
+        );
+
+        let mut out = Vec::new();
+        let mut err = Vec::new();
+        let args = AdoptArgs {
+            name: Some("otel".to_string()),
+            path: bin,
+        };
+        let code = adopt(&mut streams(&mut out, &mut err), &paths, &args).await;
+
+        assert_eq!(code, ExitCode::Success, "a broken schema is not a refusal");
+        let text = String::from_utf8(err).unwrap();
+        assert_eq!(
+            text.matches(&format!("notice[{DOG_SCHEMA_UNREADABLE_NOTICE}]"))
+                .count(),
+            1,
+            "one warning, and only one: {text}"
+        );
+        assert!(
+            paths.daemon_config.exists(),
+            "the dog is adopted despite the warning"
+        );
+    }
+
+    /// fails if a schema's own text can reach a log through `Debug`. A dog
+    /// author's `Default` is what a `default` in the schema carries, and it
+    /// is the same field the secret marker exists to keep off a screen, so
+    /// the shape goes out and the content does not (IR-41). Exact string,
+    /// because the failure mode is somebody replacing this with a derive.
+    #[test]
+    fn debug_reports_that_there_is_a_schema_and_never_what_is_in_it() {
+        let schema = DogSchema::Published(serde_json::json!({"token": "hunter2"}));
+        assert_eq!(format!("{schema:?}"), "Published(..)");
+        assert_eq!(format!("{:?}", DogSchema::Silent), "Silent");
+        assert_eq!(format!("{:?}", DogSchema::Unreadable), "Unreadable");
     }
 
     /// fails if a group-writable deployment directory is refused rather

--- a/crates/shep-cli/src/commands/dogs.rs
+++ b/crates/shep-cli/src/commands/dogs.rs
@@ -39,6 +39,7 @@ use std::time::{Duration, Instant};
 
 use shep_client::{Client, ConnectError, PROTOCOL_VERSION};
 use shep_core::barks;
+use shep_core::dogs::{DogVersion, VERSION_FLAG, parse_version_answer};
 use shep_core::paths::ShepPaths;
 use shep_core::protocol::{DogSource, Request, Response, SelectorSpec};
 
@@ -863,16 +864,6 @@ pub struct VettedBinary {
     pub answer: Option<DogVersion>,
 }
 
-/// The flag [`vet_binary`] asks a candidate with, and the one
-/// `docs/dogs.md` publishes as the contract.
-const VERSION_FLAG: &str = "--version";
-
-/// The one key [`parse_version_answer`] reads. Every other `shep-` key is
-/// reserved for a number this shep has not heard of, and is ignored rather
-/// than refused, so a dog written against a later contract stays adoptable
-/// by this one.
-const SHEP_PROTOCOL_KEY: &str = "shep-protocol";
-
 /// How long [`ask_version`] gives a binary to answer, and separately how
 /// long it then waits for that answer to reach the reader thread.
 ///
@@ -900,54 +891,6 @@ pub(crate) const VERSION_BUDGET: Duration = Duration::from_secs(1);
 /// [`macos_deferred_exec_failure`]'s own polled-with-a-budget shape rather
 /// than inventing a second one.
 const VERSION_POLL_INTERVAL: Duration = Duration::from_millis(2);
-
-/// What a candidate answered to `--version`, parsed by
-/// [`parse_version_answer`] from the format `docs/dogs.md` publishes.
-///
-/// The two fields answer different questions and only one of them can
-/// refuse an adopt: see [`AdoptRefusal::ProtocolMismatch`].
-#[derive(Debug, PartialEq, Eq)]
-/// What a dog answered `--version` with.
-///
-/// Two numbers rather than one, because they answer different questions:
-/// `protocol` decides whether the dog can handshake at all, and `version`
-/// only says which build it is. A dog may give the second and not the
-/// first, which is why `protocol` is optional and an absent one is unknown
-/// rather than incompatible.
-pub struct DogVersion {
-    /// The last whitespace-separated field of line 1 -- the version. The
-    /// name before it is ignored, so a crate whose name differs from the
-    /// dog's registered name answers correctly without knowing it.
-    pub version: String,
-    /// The `shep-protocol` line's value, and `None` when the answer carried
-    /// no such line or carried one that is not a decimal number. Answering
-    /// is optional, so `None` is an unknown protocol rather than a fault.
-    pub protocol: Option<u32>,
-}
-
-/// Parses the format `docs/dogs.md` publishes: `<name> <version>` on line
-/// 1, then `<key>: <value>` lines.
-///
-/// `None` when there is no line 1 to read a version from. Everything past
-/// that is tolerated rather than refused -- unknown keys, blank lines, key
-/// order, and a `shep-protocol` that is not a number -- because a shep that
-/// refuses a dog over the shape of text the dog never promised to print is
-/// refusing on its own guess. The strictness is all in the other direction:
-/// only an exact [`SHEP_PROTOCOL_KEY`] carrying a decimal is believed, and
-/// only a believed protocol can refuse.
-fn parse_version_answer(text: &str) -> Option<DogVersion> {
-    let mut lines = text.lines();
-    let version = lines.next()?.split_whitespace().next_back()?.to_string();
-    let mut protocol = None;
-    for line in lines {
-        if let Some((key, value)) = line.split_once(':')
-            && key.trim() == SHEP_PROTOCOL_KEY
-        {
-            protocol = value.trim().parse().ok();
-        }
-    }
-    Some(DogVersion { version, protocol })
-}
 
 /// Drains `stdout` to end on a thread, handing the text back through the
 /// returned channel.

--- a/crates/shep-cli/src/commands/dogs.rs
+++ b/crates/shep-cli/src/commands/dogs.rs
@@ -2370,15 +2370,37 @@ mod tests {
         chmod(dir.path(), 0o700);
     }
 
-    /// Writes an executable `/bin/sh` script at `dir/name` whose body is
-    /// `body`, for the `--version` cases below: a dog's answer is text on
-    /// stdout and an exit status, and a shell script is the shortest thing
-    /// that can produce any pair of those on demand.
-    fn dog_script(dir: &Path, name: &str, body: &str) -> PathBuf {
+    /// Writes an executable `/bin/sh` script at `dir/name` that dispatches
+    /// on `$1` the way a real dog does: `version_body` for the version
+    /// flag, `schema_body` for the schema flag, and nothing at all for any
+    /// other argument. A dog's answer is text on stdout and an exit status,
+    /// and a shell script is the shortest thing that can produce any pair of
+    /// those on demand.
+    ///
+    /// The dispatch is not decoration. A fixture that answers every flag the
+    /// same way answers the schema flag with its version text, which is
+    /// unreadable JSON and earns a warning, so nine tests about something
+    /// else would each carry a notice nobody asserts on and a real
+    /// regression in that warning could hide among them.
+    fn probe_script(dir: &Path, name: &str, version_body: &str, schema_body: &str) -> PathBuf {
         let path = dir.join(name);
-        std::fs::write(&path, format!("#!/bin/sh\n{body}\n")).unwrap();
+        let body = format!(
+            "#!/bin/sh\ncase \"$1\" in\n--version)\n{version_body}\n;;\n\
+             --schema)\n{schema_body}\n;;\nesac\n"
+        );
+        std::fs::write(&path, body).unwrap();
         chmod(&path, 0o755);
         path
+    }
+
+    /// A dog that answers the version flag with `body`, and the schema flag
+    /// the way every dog written before this contract does: with nothing.
+    /// A binary built on clap exits non-zero on a flag it has never heard
+    /// of, and one that ignores its arguments prints its version; both are
+    /// [`DogSchema::Silent`], and silence is the shorter of the two to
+    /// write.
+    fn dog_script(dir: &Path, name: &str, body: &str) -> PathBuf {
+        probe_script(dir, name, body, "exit 0")
     }
 
     /// fails if a dog built against a protocol this shep cannot speak is
@@ -2719,20 +2741,15 @@ mod tests {
         );
     }
 
-    /// Writes a dog that answers the two flags differently, which is the
-    /// shape every real dog has: one binary, one dispatch on `$1`. The
-    /// version half always names this shep's own protocol, so a schema test
-    /// never fails for a reason that has nothing to do with the schema.
+    /// A dog whose schema half is what the test is about. The version half
+    /// always names this shep's own protocol, so a schema test never fails
+    /// for a reason that has nothing to do with the schema.
     fn two_flag_dog(dir: &Path, schema_body: &str) -> PathBuf {
-        dog_script(
+        probe_script(
             dir,
             "shep-otel",
-            &format!(
-                "case \"$1\" in\n\
-                 --version) echo 'shep-otel 0.1.3'; echo 'shep-protocol: {PROTOCOL_VERSION}' ;;\n\
-                 --schema) {schema_body} ;;\n\
-                 esac"
-            ),
+            &format!("echo 'shep-otel 0.1.3'\necho 'shep-protocol: {PROTOCOL_VERSION}'"),
+            schema_body,
         )
     }
 

--- a/crates/shep-cli/src/commands/dogs.rs
+++ b/crates/shep-cli/src/commands/dogs.rs
@@ -1771,6 +1771,15 @@ pub async fn rehome(streams: &mut Streams<'_>, paths: &ShepPaths, name: &str) ->
     // `shep.toml` by now, so the daemon half below would stop it and the
     // operator would be told it was forgotten while its configuration, and
     // the webhook URLs in it, were still on disk.
+    //
+    // The third writer of `dogs.toml`, and the one that needs no
+    // `config.dog.<name>` frame at all. The other two are in
+    // `commands::daemon`, where `boot_supervisor` publishes and the reload
+    // pre-flight explains why it cannot. This one removes the dog: the
+    // daemon half below stops it, so by the time anything could be told
+    // its section changed there is no subscriber left to tell. A frame
+    // here would reach a process on its way out and ask it to re-read a
+    // section that is gone.
     if let Err(err) = dog_migration::forget_dog_section(&paths.dogs_config, name) {
         return fail_dogs_config(streams, &err);
     }

--- a/crates/shep-cli/src/commands/dogs.rs
+++ b/crates/shep-cli/src/commands/dogs.rs
@@ -2957,6 +2957,76 @@ mod tests {
         );
     }
 
+    /// Every file under `dir`, recursively, as text. A file shep wrote that
+    /// is not UTF-8 is skipped rather than failing the walk; none of them
+    /// are today, and a binary one could not carry the marker anyway.
+    fn every_file_under(dir: &Path) -> Vec<(PathBuf, String)> {
+        let mut found = Vec::new();
+        let Ok(entries) = std::fs::read_dir(dir) else {
+            return found;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                found.extend(every_file_under(&path));
+            } else if let Ok(text) = std::fs::read_to_string(&path) {
+                found.push((path, text));
+            }
+        }
+        found
+    }
+
+    /// fails if a schema reaches anything shep writes. Decision 7: asked
+    /// fresh, stored nowhere, because `cargo install` replaces a dog's
+    /// binary with nothing watching and a stale schema is worse than a
+    /// stale version number, since it mislabels which field is a
+    /// credential.
+    ///
+    /// Nothing stores it today, and it is guaranteed structurally: the
+    /// function that records an adopted dog has no schema to take. A
+    /// structural guarantee is exactly the kind a later signature change
+    /// removes with nothing going red, so this asserts on the files rather
+    /// than on the shape of a call. The whole home is walked, not just
+    /// `shep.toml`, so a schema parked in `dogs.toml` or a cache beside it
+    /// would be caught too. The dog's binary lives in its own directory
+    /// because the fixture script contains the schema text it prints.
+    ///
+    /// Mutation check: appending the schema to `shep.toml` after the edit
+    /// reddens this.
+    #[tokio::test]
+    async fn a_published_schema_reaches_no_file_shep_writes() {
+        let home = tempfile::tempdir().unwrap();
+        let binaries = tempfile::tempdir().unwrap();
+        let paths = ShepPaths::resolve(&|_| None, home.path());
+        let marker = "only-ever-in-the-schema";
+        let bin = two_flag_dog(
+            binaries.path(),
+            &format!("echo '{{\"title\":\"{marker}\",\"properties\":{{}}}}'"),
+        );
+
+        let mut out = Vec::new();
+        let mut err = Vec::new();
+        let args = AdoptArgs {
+            name: Some("otel".to_string()),
+            path: bin,
+        };
+        let code = adopt(&mut streams(&mut out, &mut err), &paths, &args).await;
+        assert_eq!(code, ExitCode::Success);
+
+        let written = every_file_under(home.path());
+        assert!(
+            written.iter().any(|(_, text)| text.contains("otel")),
+            "the adopt has to have written the dog somewhere for this to mean anything: {written:?}"
+        );
+        for (path, text) in &written {
+            assert!(
+                !text.contains(marker),
+                "the schema was stored in {}: {text}",
+                path.display()
+            );
+        }
+    }
+
     /// fails if a schema's own text can reach a log through `Debug`. A dog
     /// author's `Default` is what a `default` in the schema carries, and it
     /// is the same field the secret marker exists to keep off a screen, so

--- a/crates/shep-cli/src/commands/dogs.rs
+++ b/crates/shep-cli/src/commands/dogs.rs
@@ -824,8 +824,17 @@ fn ask(
     // than to the terminal. A candidate that writes on its way up would
     // otherwise scribble over the operator's terminal mid-vet, and a hostile
     // one could imitate shep's own output at the exact moment somebody is
-    // deciding whether to trust it. The pipe is read by [`answer_text`] and
-    // never rendered.
+    // deciding whether to trust it.
+    //
+    // The pipe is read by [`answer_text`], and part of what comes back IS
+    // rendered: [`report_dog_version`] puts the parsed version string in a
+    // notice. What makes that safe is `emit_notice`, which runs every message
+    // through `terminal_safe::sanitise` before it reaches the stream, not the
+    // pipe. An earlier revision of this comment said the answer was "never
+    // rendered", which was false and pointed at the wrong protection, so
+    // anyone removing that `sanitise` call would have read this and believed
+    // there was nothing downstream to break.
+    //
     // `env_clear` and then the allowlist, never the operator's environment.
     // Argued at the top of this function; `probe_env` builds the list.
     match Command::new(path)

--- a/crates/shep-cli/src/dog/bark/mod.rs
+++ b/crates/shep-cli/src/dog/bark/mod.rs
@@ -568,6 +568,12 @@ mod tests {
     /// belongs to a type one level down. See [`BarkConfig::sinks`]. The key
     /// is spelled out rather than read from `shep_core::dogs::SECRET_KEY`
     /// for the reason `sinks.rs`'s own marker test gives.
+    ///
+    /// `Rule` is checked where it lives, under `$defs`, and not only as the
+    /// `rules` array at the top level. The array was never going to be
+    /// marked and pinning it said nothing: `Rule::sinks` shares a name with
+    /// the credential above it, so the definition is the one place a marker
+    /// could land on a list of sink names.
     #[test]
     fn the_bark_schema_marks_the_sinks_map_and_leaves_the_rules_plain() {
         let schema = shep_client::dogs::config_schema::<BarkConfig>()
@@ -583,6 +589,16 @@ mod tests {
             schema.pointer("/properties/rules/x-shep-secret"),
             None,
             "a rule names sinks and holds no credential of its own"
+        );
+        assert!(
+            schema.pointer("/$defs/Rule/properties/sinks").is_some(),
+            "the pointer below is only a check while `Rule` still has this \
+             shape, so a rename that moved it must fail here first"
+        );
+        assert_eq!(
+            schema.pointer("/$defs/Rule/properties/sinks/x-shep-secret"),
+            None,
+            "a rule's sinks are names, and a name is not a credential"
         );
     }
 

--- a/crates/shep-cli/src/dog/bark/mod.rs
+++ b/crates/shep-cli/src/dog/bark/mod.rs
@@ -663,42 +663,6 @@ mod tests {
         addr
     }
 
-    /// Awaits `fut` against `timeout`, under a genuinely real clock rather
-    /// than the paused one `#[tokio::test(start_paused = true)]` installs.
-    ///
-    /// Bridges through [`tokio::task::spawn_blocking`] — the technique
-    /// `tokio::time::pause`'s own doc names under "Preventing auto-advance"
-    /// — because a plain `tokio::time::timeout(..).await` races real
-    /// socket I/O against the paused clock's auto-advance and reliably
-    /// LOSES: with nothing else runnable, tokio jumps straight from "now"
-    /// to the next pending timer's deadline in one step (confirmed against
-    /// `tokio` 1.53's own `time::park_thread_timeout`, which does exactly
-    /// one non-blocking, zero-duration I/O poll before deciding to jump —
-    /// not a bounded real wait), and a loopback TCP round trip does not
-    /// finish inside that single zero-duration poll. `spawn_blocking`
-    /// inhibits auto-advance for as long as it runs (tokio tracks this
-    /// with a plain counter — see `Clock::inhibit_auto_advance`), so the
-    /// nested `Handle::block_on` below waits out `timeout` on the ACTUAL
-    /// wall clock while this test's spawned server and this dog's own
-    /// delivery task keep running normally on the runtime's own worker
-    /// thread, freed by the calling test task moving off it.
-    ///
-    /// A bare `tokio::time::timeout` loses this race 100% of the time under
-    /// a paused clock, never intermittently: a minimal reproduction (two
-    /// tasks, a real `TcpListener`, nothing else) confirmed it. The
-    /// property each test asserts — a real delivery over a real socket
-    /// happened — is unchanged; only the mechanism used to wait for it
-    /// without fighting the paused clock is different.
-    async fn await_real_io<T: Send + 'static>(
-        timeout: Duration,
-        fut: impl Future<Output = T> + Send + 'static,
-    ) -> Result<T, tokio::time::error::Elapsed> {
-        let handle = tokio::runtime::Handle::current();
-        tokio::task::spawn_blocking(move || handle.block_on(tokio::time::timeout(timeout, fut)))
-            .await
-            .expect("the spawn_blocking bridge task must not itself panic")
-    }
-
     fn base_info(name: &str, status: ProcStatus, restarts: u32) -> ProcessInfo {
         ProcessInfo::builder(1, name, status)
             .pid(Some(4242))
@@ -796,9 +760,19 @@ mod tests {
     /// THE test this dog exists for. fails if the poll is only ever driven
     /// by its interval: `web`'s `errored` frame is genuinely dropped by a
     /// real broadcast channel, so a loop that reconciles on a timer alone
-    /// stays silent for the whole poll interval — and under a paused clock,
-    /// forever.
-    #[tokio::test(start_paused = true)]
+    /// stays silent for the whole poll interval, which this fixture sets to
+    /// 60s.
+    ///
+    /// A real clock, and the 60s is what replaces the paused one. This test
+    /// used to pause the clock and wait through a `spawn_blocking` bridge,
+    /// a combination in which the deadline could never elapse: the bridge
+    /// inhibits auto-advance, so nothing moved the virtual clock to the
+    /// timeout and a regression hung the suite instead of failing it.
+    /// Measured, by making `spawn_firings` a no-op: over a minute, then
+    /// killed by hand. Nothing here needs the clock stopped. No interval can
+    /// fire inside a test that finishes in milliseconds, so the poll below
+    /// is still attributable to the lag and to nothing else.
+    #[tokio::test]
     async fn a_dropped_frame_makes_bark_poll_and_catch_up() {
         let (tx, mut rx) = tokio::sync::broadcast::channel(4);
         for i in 0..64 {
@@ -835,7 +809,7 @@ mod tests {
             ScriptedConfig::answering(String::new()),
         ));
 
-        let req = await_real_io(Duration::from_secs(5), captured)
+        let req = tokio::time::timeout(Duration::from_secs(5), captured)
             .await
             .expect("a dropped frame must produce a delivered bark")
             .unwrap();
@@ -847,16 +821,13 @@ mod tests {
         // building the outcome, appending to `barks.jsonl`). A short,
         // bounded poll — not a sleep the test just hopes is long enough —
         // covers that ordinary scheduling gap.
-        let recorded = await_real_io(Duration::from_secs(5), {
-            let barks_path = barks_path.clone();
-            async move {
-                loop {
-                    let records = shep_core::barks::read(&barks_path).unwrap();
-                    if !records.is_empty() {
-                        break records;
-                    }
-                    tokio::task::yield_now().await;
+        let recorded = tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                let records = shep_core::barks::read(&barks_path).unwrap();
+                if !records.is_empty() {
+                    break records;
                 }
+                tokio::task::yield_now().await;
             }
         })
         .await
@@ -868,8 +839,8 @@ mod tests {
         assert_eq!(
             flock.calls(),
             1,
-            "the poll ran because of the lag, not because an interval elapsed \
-             — the clock is paused, so no interval has"
+            "the poll ran because of the lag, not because an interval elapsed: \
+             the interval is 60s and this test is milliseconds old"
         );
 
         loop_handle.abort();
@@ -943,9 +914,19 @@ mod tests {
     /// before the loop is given a chance to run either delivery to
     /// completion. If firings were awaited inline rather than spawned, the
     /// fast sink could only be reached after the slow one's own
-    /// `sink_timeout` (10s of virtual time) elapsed; this asserts it is
-    /// reached in well under that, with no timer needing to fire at all.
-    #[tokio::test(start_paused = true)]
+    /// `sink_timeout` elapsed; this asserts it is reached in well under
+    /// that.
+    ///
+    /// A real clock, for the reason
+    /// `a_dropped_frame_makes_bark_poll_and_catch_up` gives above: the
+    /// paused one it used to run under could not elapse the deadline it was
+    /// given, so an inline-awaiting loop would have hung here rather than
+    /// failed. The budget is 2s against a 10s `sink_timeout`. It was 50ms of
+    /// nominal virtual time, which no clock ever enforced; a real 50ms is a
+    /// claim about how fast a contended runner schedules two tasks, and this
+    /// project has lost CI runs to exactly that. Five times under the
+    /// timeout is still the whole of what this test means.
+    #[tokio::test]
     async fn a_slow_sink_never_stalls_the_loop() {
         let slow_addr = slow_sink().await;
         let (fast_addr, fast_captured) = one_shot_sink(200, "").await;
@@ -1008,7 +989,7 @@ mod tests {
             ScriptedConfig::answering(String::new()),
         ));
 
-        let req = await_real_io(Duration::from_millis(50), fast_captured)
+        let req = tokio::time::timeout(Duration::from_secs(2), fast_captured)
             .await
             .expect(
                 "the fast sink must be reached promptly; a slow sink in flight \
@@ -1100,16 +1081,14 @@ sinks = ["oncall"]
     /// a bark that restarted itself instead would add a restart to the
     /// column an operator reads as instability.
     ///
-    /// The one test in this module that does NOT pause the clock, and it
-    /// is about how this fails rather than how it passes. Under
-    /// `start_paused` the deadline inside [`await_real_io`] cannot elapse:
-    /// `spawn_blocking` inhibits auto-advance for as long as it runs, so
-    /// nothing moves the virtual clock to the timeout and a broken swap
-    /// hangs the suite instead of failing it. Measured, by mutating the
-    /// swap into a no-op. On a real clock the same wait is bounded, and
-    /// nothing here needs a paused one: the only timer in the loop is a
-    /// 60s poll interval that must not fire either way, and there is no
-    /// sleep anywhere below.
+    /// A real clock, and it is about how this fails rather than how it
+    /// passes. This test found the trap the other two in this module then
+    /// had to be taken out of: under `start_paused`, a deadline awaited
+    /// through a `spawn_blocking` bridge cannot elapse, because the bridge
+    /// inhibits auto-advance and nothing else moves the virtual clock to
+    /// it. A broken swap hung the suite rather than failing it. Measured,
+    /// by mutating the swap into a no-op. On a real clock the same wait is
+    /// bounded and the same mutation fails in 5.01s.
     #[tokio::test]
     async fn a_config_change_swaps_barks_sinks_in_place() {
         let (old_addr, mut old_captured) = one_shot_sink(200, "").await;

--- a/crates/shep-cli/src/dog/bark/mod.rs
+++ b/crates/shep-cli/src/dog/bark/mod.rs
@@ -137,6 +137,49 @@ pub trait FlockSource: Send + Sync {
     fn flock(&self) -> impl Future<Output = Result<Vec<ProcessInfo>, RequestError>> + Send;
 }
 
+/// What bark re-asks its own `[bark]` section through, so a config change
+/// is drivable without a socket.
+///
+/// The shepherd publishes `config.dog.bark` and says nothing about what
+/// changed (`BusEvent::DogConfigChanged`), so the frame is a prompt and
+/// this trait is the answer to it: one `Request::DogConfig` for bark's own
+/// section, which is the only section that request ever answers with.
+///
+/// `Sync` for the same reason [`FlockSource`] is: [`run_loop`]'s own future
+/// holds a `&C` across the `.await` in [`reloaded_config`].
+pub trait ConfigSource: Send + Sync {
+    /// This dog's `[bark]` section as it stands now, empty when the file
+    /// has no such section.
+    ///
+    /// # Errors
+    /// Whatever the underlying source could not answer with -- for the
+    /// production implementation, whatever `Request::DogConfig` failed
+    /// with.
+    fn section(&self) -> impl Future<Output = Result<String, RequestError>> + Send;
+}
+
+/// The rule set a `[bark]` section means: its own rules, or
+/// [`rules::Rules::default_rules`] when it configured none.
+///
+/// One function rather than two copies, because it is asked twice now: at
+/// startup by `dog::run_bark`, and again on every `config.dog.bark` frame
+/// by [`run_loop`]. A change that gave a reloading bark different defaults
+/// from a starting one would be invisible until the alert it silently
+/// stopped sending.
+///
+/// # Errors
+/// - [`rules::RulesError`] -- as [`rules::Rules::new`]: a rule routing to a
+///   sink the section does not define, an unknown event kind, or an
+///   insecure webhook scheme.
+pub fn rules_for(config: &BarkConfig) -> Result<Rules, rules::RulesError> {
+    let rule_list = if config.rules.is_empty() {
+        Rules::default_rules(&config.sinks)
+    } else {
+        config.rules.clone()
+    };
+    Rules::new(rule_list, &config.sinks)
+}
+
 /// Bark's loop: subscribe for speed, poll for correctness.
 ///
 /// **A dropped frame polls immediately** rather than waiting for the next
@@ -180,16 +223,17 @@ pub trait FlockSource: Send + Sync {
 /// the caller's `config`/`barks_path` outlive. Callers still `.await` or
 /// `tokio::spawn` the result exactly as they would an `async fn` — the
 /// sugar difference is invisible at every call site in this module.
-pub fn run_loop<E: EventSource, F: FlockSource>(
+pub fn run_loop<E: EventSource, F: FlockSource, C: ConfigSource>(
     events: E,
     flock: F,
     rules: Rules,
     config: &BarkConfig,
     barks_path: &Path,
-) -> impl Future<Output = ExitCode> + Send + use<E, F> {
-    let sinks = Arc::new(config.sinks.clone());
-    let sink_timeout = config.sink_timeout.as_duration();
-    let max_bytes = config.history_bytes;
+    config_source: C,
+) -> impl Future<Output = ExitCode> + Send + use<E, F, C> {
+    let mut sinks = Arc::new(config.sinks.clone());
+    let mut sink_timeout = config.sink_timeout.as_duration();
+    let mut max_bytes = config.history_bytes;
     // `interval_at`, not `interval`: a plain `tokio::time::interval` fires
     // its first tick immediately, which would make every dog poll once at
     // startup for no reason attributable to either a drop or the interval
@@ -197,7 +241,7 @@ pub fn run_loop<E: EventSource, F: FlockSource>(
     // by one of those two, never by the timer's own startup quirk —
     // `a_dropped_frame_makes_bark_poll_and_catch_up` is built entirely on
     // being able to say "the poll ran because of the lag."
-    let poll_period = config.poll.as_duration();
+    let mut poll_period = config.poll.as_duration();
     let barks_path = Arc::new(barks_path.to_path_buf());
 
     async move {
@@ -246,6 +290,47 @@ pub fn run_loop<E: EventSource, F: FlockSource>(
                         // carries it, under "The bark dog still restarts
                         // once per reload".
                         None => break,
+                        // Ahead of the ordinary event arm, and matched on
+                        // the variant rather than on the dog's name: the
+                        // subscription is what narrows this to bark's own
+                        // topic (`config.dog.bark`), so a name check here
+                        // would be a second place for the name to be
+                        // wrong rather than a second line of defence.
+                        Some(Ok(BusEvent::DogConfigChanged { .. })) => {
+                            if let Some((next, next_rules)) = reloaded_config(&config_source).await {
+                                // In place, never a restart. Sinks and
+                                // rules are pure data with no OS resource
+                                // attached, so nothing here has to be
+                                // rebound or reopened -- the metrics dog's
+                                // `bind` is the case that would. A bark
+                                // that answered a config change by exiting
+                                // would add a restart to the column an
+                                // operator reads as instability, and would
+                                // have to say so in this log to be told
+                                // apart from a crash loop.
+                                sinks = Arc::new(next.sinks.clone());
+                                sink_timeout = next.sink_timeout.as_duration();
+                                max_bytes = next.history_bytes;
+                                // Rebuilt, which resets each rule's
+                                // per-subject debounce: a subject already
+                                // alerted on can alert once more straight
+                                // after a change. The alternative is
+                                // carrying state across a rule set the
+                                // operator may have renumbered, where
+                                // index 0 no longer means the rule it did
+                                // when the debounce was recorded.
+                                rules = next_rules;
+                                if next.poll.as_duration() != poll_period {
+                                    poll_period = next.poll.as_duration();
+                                    poll_interval = tokio::time::interval_at(
+                                        tokio::time::Instant::now() + poll_period,
+                                        poll_period,
+                                    );
+                                    poll_interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
+                                }
+                                eprintln!("shep dog bark: reloaded [bark] from dogs.toml");
+                            }
+                        }
                         Some(Ok(event)) => {
                             let firings = rules.on_event(&event, now_ms());
                             spawn_firings(firings, &sinks, &append_lock, &barks_path, sink_timeout, max_bytes);
@@ -265,6 +350,46 @@ pub fn run_loop<E: EventSource, F: FlockSource>(
         }
 
         ExitCode::Success
+    }
+}
+
+/// Re-asks `source` for `[bark]` and rebuilds what a config change can
+/// swap, or `None` when the answer cannot be used.
+///
+/// Every failure is reported and dropped rather than propagated: a dog
+/// that exited on a bad edit would stop alerting at exactly the moment an
+/// operator is editing config, and the section it was already running on
+/// is still a working one. What reaches stderr is the FACT and the
+/// parser's own position, never the section: `[bark]` carries webhook URLs
+/// that are themselves bearer credentials.
+async fn reloaded_config<C: ConfigSource>(source: &C) -> Option<(BarkConfig, Rules)> {
+    let section = match source.section().await {
+        Ok(section) => section,
+        Err(err) => {
+            eprintln!("shep dog bark: could not re-read [bark] from the shepherd: {err}");
+            return None;
+        }
+    };
+    // Empty means the section is gone, which is a legitimate edit and not
+    // a failure -- the same reading `DogRuntime::config` gives it at
+    // startup. bark keeps running with no sinks and no rules.
+    let config = if section.is_empty() {
+        BarkConfig::default()
+    } else {
+        match toml::from_str::<BarkConfig>(&section) {
+            Ok(config) => config,
+            Err(_err) => {
+                eprintln!("shep dog bark: [bark] in dogs.toml does not parse; see `shep dogs`");
+                return None;
+            }
+        }
+    };
+    match rules_for(&config) {
+        Ok(rules) => Some((config, rules)),
+        Err(err) => {
+            eprintln!("shep dog bark: keeping the running rules; the new ones are refused: {err}");
+            None
+        }
     }
 }
 
@@ -466,6 +591,37 @@ mod tests {
         async fn flock(&self) -> Result<Vec<ProcessInfo>, RequestError> {
             self.calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
             Ok((*self.answer).clone())
+        }
+    }
+
+    /// A [`ConfigSource`] answering one fixed `[bark]` section, counting
+    /// how many times it was asked. The count is what proves the loop
+    /// RE-ASKS on a `config.dog.bark` frame rather than acting on the frame
+    /// itself: shep publishes that a section changed and nothing about what
+    /// changed, so a loop that did not ask learned nothing.
+    #[derive(Clone)]
+    struct ScriptedConfig {
+        section: Arc<String>,
+        calls: Arc<std::sync::atomic::AtomicU32>,
+    }
+
+    impl ScriptedConfig {
+        fn answering(section: String) -> Self {
+            Self {
+                section: Arc::new(section),
+                calls: Arc::new(std::sync::atomic::AtomicU32::new(0)),
+            }
+        }
+
+        fn calls(&self) -> u32 {
+            self.calls.load(std::sync::atomic::Ordering::SeqCst)
+        }
+    }
+
+    impl ConfigSource for ScriptedConfig {
+        async fn section(&self) -> Result<String, RequestError> {
+            self.calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            Ok((*self.section).clone())
         }
     }
 
@@ -673,6 +829,10 @@ mod tests {
             gave_up_rules(),
             &config_with_sink(addr, &barks_path),
             &barks_path,
+            // Never asked: no `config.dog.bark` frame is sent here, and
+            // `calls()` in the config test is what proves the loop only
+            // asks when one is.
+            ScriptedConfig::answering(String::new()),
         ));
 
         let req = await_real_io(Duration::from_secs(5), captured)
@@ -839,7 +999,14 @@ mod tests {
             .unwrap();
 
         let flock = ScriptedFlock::answering(Vec::new());
-        let loop_handle = tokio::spawn(run_loop(rx, flock, rules, &config, &barks_path));
+        let loop_handle = tokio::spawn(run_loop(
+            rx,
+            flock,
+            rules,
+            &config,
+            &barks_path,
+            ScriptedConfig::answering(String::new()),
+        ));
 
         let req = await_real_io(Duration::from_millis(50), fast_captured)
             .await
@@ -921,4 +1088,69 @@ sinks = ["oncall"]
         // is necessary but not sufficient for the dog to actually start.
         Rules::new(config.rules, &config.sinks).expect("both documented rules route to real sinks");
     }
+
+    /// fails if a `config.dog.bark` frame does not reach bark's sinks. The
+    /// swap is observable at the only place it matters: the next firing is
+    /// delivered to the sink the NEW section names, over a real socket,
+    /// while the old sink's server is still up and receives nothing.
+    ///
+    /// The loop is the same loop throughout, which is the other half of
+    /// what this pins. bark answers a config change in place because its
+    /// config is sinks and rules, pure data with no OS resource attached;
+    /// a bark that restarted itself instead would add a restart to the
+    /// column an operator reads as instability.
+    #[tokio::test(start_paused = true)]
+    async fn a_config_change_swaps_barks_sinks_in_place() {
+        let (old_addr, mut old_captured) = one_shot_sink(200, "").await;
+        let (new_addr, new_captured) = one_shot_sink(200, "").await;
+        let dir = tempfile::tempdir().unwrap();
+        let barks_path = dir.path().join("barks.jsonl");
+        let source = ScriptedConfig::answering(format!(
+            "[sinks.ops]\nkind = \"json\"\nurl = \"http://{new_addr}/hook\"\n"
+        ));
+
+        let (tx, rx) = broadcast::channel(16);
+        let loop_handle = tokio::spawn(run_loop(
+            rx,
+            ScriptedFlock::answering(Vec::new()),
+            gave_up_rules(),
+            &config_with_sink(old_addr, &barks_path),
+            &barks_path,
+            source.clone(),
+        ));
+
+        // One receiver, one queue: the loop reads these in the order they
+        // were sent and awaits the re-ask before it takes the second, so
+        // the delivery below is attributable to the new section and never
+        // to a race this test would have to sleep through.
+        tx.send(BusEvent::DogConfigChanged {
+            dog: "bark".to_owned(),
+        })
+        .unwrap();
+        tx.send(errored_event("web")).unwrap();
+
+        let req = await_real_io(Duration::from_secs(5), new_captured)
+            .await
+            .expect("the bark must reach the sink the new section names")
+            .unwrap();
+        assert!(String::from_utf8_lossy(&req.body).contains("web"));
+
+        assert_eq!(source.calls(), 1, "one frame, one re-ask");
+        assert!(
+            !loop_handle.is_finished(),
+            "bark swaps its config in place; it does not exit to pick one up"
+        );
+        // `try_recv`, never an await: the old sink's server is still
+        // parked in `accept`, so it holds its own sender alive and an
+        // await here would wait for a connection that must never come.
+        // The delivery above has already happened, so a bark that went to
+        // the old address would be sitting in this channel now.
+        assert!(
+            old_captured.try_recv().is_err(),
+            "the sink the old section named must be left alone"
+        );
+
+        loop_handle.abort();
+    }
+
 }

--- a/crates/shep-cli/src/dog/bark/mod.rs
+++ b/crates/shep-cli/src/dog/bark/mod.rs
@@ -705,14 +705,26 @@ mod tests {
 
     /// Accepts exactly one connection and then never answers it — up, but
     /// stalled forever, exactly the shape `sink_timeout` exists for.
-    async fn slow_sink() -> SocketAddr {
+    /// A sink that accepts a connection and then never answers, plus a
+    /// signal that fires the moment it has accepted one.
+    ///
+    /// The signal is what lets a caller assert an ORDER rather than a
+    /// duration. Without it the only way to say "the fast sink was not stuck
+    /// behind the slow one" is to bound the fast sink's arrival by a wall
+    /// clock, which is a claim about how quickly a runner schedules two
+    /// tasks rather than about the loop.
+    async fn slow_sink() -> (SocketAddr, tokio::sync::oneshot::Receiver<()>) {
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
+        let (connected, rx) = tokio::sync::oneshot::channel();
         tokio::spawn(async move {
             let (_stream, _peer) = listener.accept().await.unwrap();
+            // Ignored: the receiver is dropped by any caller that does not
+            // care, and this task's job afterwards is to never answer.
+            let _ = connected.send(());
             core::future::pending::<()>().await;
         });
-        addr
+        (addr, rx)
     }
 
     fn base_info(name: &str, status: ProcStatus, restarts: u32) -> ProcessInfo {
@@ -973,14 +985,27 @@ mod tests {
     /// `a_dropped_frame_makes_bark_poll_and_catch_up` gives above: the
     /// paused one it used to run under could not elapse the deadline it was
     /// given, so an inline-awaiting loop would have hung here rather than
-    /// failed. The budget is 2s against a 10s `sink_timeout`. It was 50ms of
-    /// nominal virtual time, which no clock ever enforced; a real 50ms is a
-    /// claim about how fast a contended runner schedules two tasks, and this
-    /// project has lost CI runs to exactly that. Five times under the
-    /// timeout is still the whole of what this test means.
+    /// failed.
+    ///
+    /// No duration carries the meaning, though, which is the part worth
+    /// reading. The proof is an ORDER: the slow sink signals that it has
+    /// accepted and parked, and the fast sink is reached AFTER that. An
+    /// inline-awaiting loop could not do it, because it would still be
+    /// parked on the slow delivery. `sink_timeout` is ten minutes here for
+    /// the same reason the poll above is 60s, to make the elapsed-time path
+    /// to success unreachable inside a test that finishes in milliseconds,
+    /// so a timeout firing is the only thing that can end this test early
+    /// and it can only end it in failure.
+    ///
+    /// An earlier revision bounded the fast sink at 2s against a 10s
+    /// `sink_timeout` and called five times under the timeout the whole
+    /// meaning. It was defensible and it was still a claim about how fast a
+    /// contended runner schedules two tasks, which is what this project has
+    /// lost CI runs to. The timeouts below are failure guards now and
+    /// nothing else, so their exact values do not change what passes.
     #[tokio::test]
     async fn a_slow_sink_never_stalls_the_loop() {
-        let slow_addr = slow_sink().await;
+        let (slow_addr, slow_connected) = slow_sink().await;
         let (fast_addr, fast_captured) = one_shot_sink(200, "").await;
         let dir = tempfile::tempdir().unwrap();
         let barks_path = dir.path().join("barks.jsonl");
@@ -1023,7 +1048,7 @@ mod tests {
             rules: Vec::new(),
             poll: UpDuration::from_millis(60_000),
             history_bytes: barks::DEFAULT_MAX_BYTES,
-            sink_timeout: UpDuration::from_millis(10_000),
+            sink_timeout: UpDuration::from_millis(600_000),
         };
 
         let (tx, rx) = tokio::sync::broadcast::channel(8);
@@ -1041,11 +1066,24 @@ mod tests {
             ScriptedConfig::answering(String::new()),
         ));
 
-        let req = tokio::time::timeout(Duration::from_secs(2), fast_captured)
+        // The order is the assertion. First the slow sink confirms it has a
+        // connection and is parked on it, so the loop is provably mid-delivery
+        // to a sink that will never answer.
+        tokio::time::timeout(Duration::from_secs(30), slow_connected)
+            .await
+            .expect("the slow sink must be reached at all, or this test proves nothing")
+            .unwrap();
+
+        // Then the fast sink is reached anyway. A loop awaiting firings inline
+        // could not get here: it would still be parked on the delivery above,
+        // for the ten minutes `sink_timeout` allows it. Both timeouts are
+        // failure guards, so their values change how long a broken loop takes
+        // to report, never what passes.
+        let req = tokio::time::timeout(Duration::from_secs(30), fast_captured)
             .await
             .expect(
-                "the fast sink must be reached promptly; a slow sink in flight \
-                 must not stall the loop",
+                "the fast sink must be reached while a slow sink is still in \
+                 flight; a slow sink must not stall the loop",
             )
             .unwrap();
         assert_eq!(req.method, "POST");

--- a/crates/shep-cli/src/dog/bark/mod.rs
+++ b/crates/shep-cli/src/dog/bark/mod.rs
@@ -303,7 +303,7 @@ pub fn run_loop<E: EventSource, F: FlockSource, C: ConfigSource>(
                         // Ahead of the ordinary event arm, and matched on
                         // the variant rather than on the dog's name: the
                         // subscription is what narrows this to bark's own
-                        // topic (`config.dog.bark`), so a name check here
+                        // topic (`config.dog.<name>`), so a name check here
                         // would be a second place for the name to be
                         // wrong rather than a second line of defence.
                         Some(Ok(BusEvent::DogConfigChanged { .. })) => {

--- a/crates/shep-cli/src/dog/bark/mod.rs
+++ b/crates/shep-cli/src/dog/bark/mod.rs
@@ -1099,7 +1099,18 @@ sinks = ["oncall"]
     /// config is sinks and rules, pure data with no OS resource attached;
     /// a bark that restarted itself instead would add a restart to the
     /// column an operator reads as instability.
-    #[tokio::test(start_paused = true)]
+    ///
+    /// The one test in this module that does NOT pause the clock, and it
+    /// is about how this fails rather than how it passes. Under
+    /// `start_paused` the deadline inside [`await_real_io`] cannot elapse:
+    /// `spawn_blocking` inhibits auto-advance for as long as it runs, so
+    /// nothing moves the virtual clock to the timeout and a broken swap
+    /// hangs the suite instead of failing it. Measured, by mutating the
+    /// swap into a no-op. On a real clock the same wait is bounded, and
+    /// nothing here needs a paused one: the only timer in the loop is a
+    /// 60s poll interval that must not fire either way, and there is no
+    /// sleep anywhere below.
+    #[tokio::test]
     async fn a_config_change_swaps_barks_sinks_in_place() {
         let (old_addr, mut old_captured) = one_shot_sink(200, "").await;
         let (new_addr, new_captured) = one_shot_sink(200, "").await;
@@ -1129,7 +1140,7 @@ sinks = ["oncall"]
         .unwrap();
         tx.send(errored_event("web")).unwrap();
 
-        let req = await_real_io(Duration::from_secs(5), new_captured)
+        let req = tokio::time::timeout(Duration::from_secs(5), new_captured)
             .await
             .expect("the bark must reach the sink the new section names")
             .unwrap();
@@ -1152,5 +1163,4 @@ sinks = ["oncall"]
 
         loop_handle.abort();
     }
-
 }

--- a/crates/shep-cli/src/dog/bark/mod.rs
+++ b/crates/shep-cli/src/dog/bark/mod.rs
@@ -37,6 +37,7 @@ use std::time::Duration;
 
 use serde::Deserialize;
 use shep_client::RequestError;
+use shep_client::dogs::DogConfig;
 use shep_core::barks::{self, SinkOutcome};
 use shep_core::protocol::{BusEvent, ProcessInfo};
 use shep_core::values::UpDuration;
@@ -52,10 +53,19 @@ use crate::exit::ExitCode;
 /// `deny_unknown_fields`: a misspelled key must be a startup error naming
 /// it, the same reasoning [`super::metrics::MetricsConfig`] gives for its
 /// own section.
-#[derive(Debug, Clone, PartialEq, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Deserialize, schemars::JsonSchema, DogConfig)]
 #[serde(deny_unknown_fields, default)]
 pub struct BarkConfig {
     /// Named sinks, `[dog.bark.sinks]`.
+    ///
+    /// Marked whole, not per URL, and the difference is where the mark
+    /// lands. `#[shep(secret)]` names a field of THIS type, and the URL is
+    /// a field of [`Sink`] one level down, so a mark there is absent from
+    /// the schema shep generates for [`BarkConfig`]: every sink would go
+    /// out with its bearer token as an ordinary string. Marking the map
+    /// says less than marking each URL would, and it says it about the
+    /// type shep actually asks. Over-redacting is the safe direction.
+    #[shep(secret)]
     pub sinks: BTreeMap<String, Sink>,
     /// Named rules, `[[dog.bark.rules]]`. Empty means
     /// [`Rules::default_rules`].
@@ -549,6 +559,32 @@ mod tests {
 
     use super::*;
     use crate::http::{HttpRequest, read_request, write_response};
+
+    /// The sinks map carries the credential marker, and the rules beside
+    /// it do not.
+    ///
+    /// Marked at the map rather than at each `Sink`'s `url`, because
+    /// `#[shep(secret)]` names a field of the type being asked and the URL
+    /// belongs to a type one level down. See [`BarkConfig::sinks`]. The key
+    /// is spelled out rather than read from `shep_core::dogs::SECRET_KEY`
+    /// for the reason `sinks.rs`'s own marker test gives.
+    #[test]
+    fn the_bark_schema_marks_the_sinks_map_and_leaves_the_rules_plain() {
+        let schema = shep_client::dogs::config_schema::<BarkConfig>()
+            .expect("`sinks` is a property of this type");
+        let schema = schema.as_value();
+
+        assert_eq!(
+            schema.pointer("/properties/sinks/x-shep-secret"),
+            Some(&serde_json::Value::Bool(true)),
+            "every sink holds a webhook URL, which is a bearer credential"
+        );
+        assert_eq!(
+            schema.pointer("/properties/rules/x-shep-secret"),
+            None,
+            "a rule names sinks and holds no credential of its own"
+        );
+    }
 
     /// [`EventSource`] over the real thing bark's local subscription lags
     /// on: a `tokio::sync::broadcast::Receiver`. Only ever built by tests —

--- a/crates/shep-cli/src/dog/bark/rules.rs
+++ b/crates/shep-cli/src/dog/bark/rules.rs
@@ -58,7 +58,7 @@ fn default_debounce() -> UpDuration {
 // unknown from `Rule`'s point of view. Everything `sinks` and `debounce`
 // do not consume flows into `Trigger`'s deserialize instead, which catches
 // the typo one level down from where the attribute used to sit.
-#[derive(Debug, Clone, PartialEq, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Deserialize, schemars::JsonSchema)]
 pub struct Rule {
     /// What fires it.
     #[serde(flatten)]
@@ -79,7 +79,7 @@ pub struct Rule {
 /// `deny_unknown_fields` lives here rather than on [`Rule`] — see that
 /// type's own doc for why the combination with `#[serde(flatten)]` forced
 /// the move.
-#[derive(Debug, Clone, PartialEq, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Deserialize, schemars::JsonSchema)]
 #[serde(tag = "on", rename_all = "snake_case", deny_unknown_fields)]
 pub enum Trigger {
     /// Any of these bus event kinds, by their wire spelling

--- a/crates/shep-cli/src/dog/bark/sinks.rs
+++ b/crates/shep-cli/src/dog/bark/sinks.rs
@@ -54,6 +54,7 @@ use core::fmt;
 use std::time::Duration;
 
 use serde::Deserialize;
+use shep_client::dogs::DogConfig;
 use shep_core::barks::Bark;
 use tokio::io::{AsyncBufReadExt, AsyncRead, AsyncWrite, AsyncWriteExt, BufReader};
 use tokio::net::TcpStream;
@@ -67,22 +68,31 @@ use crate::fetch::{self, Target};
 /// Discord or Slack webhook URL is a bearer credential — anyone holding it
 /// can post to that channel. A sink printed into a log, a panic message or
 /// an error chain leaks it to whoever reads the log.
-#[derive(Clone, PartialEq, Eq, Deserialize)]
+///
+/// `#[shep(secret)]` says the same thing to a schema that the `Debug` says
+/// to a log. It reaches a pane only for a dog whose whole config IS a sink,
+/// since the marks a schema carries are the ones the type shep asked about
+/// declared; bark's own section is asked as [`super::BarkConfig`], which
+/// marks the map instead and says why.
+#[derive(Clone, PartialEq, Eq, Deserialize, schemars::JsonSchema, DogConfig)]
 #[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]
 pub enum Sink {
     /// A Discord webhook: `{"content": "..."}`.
     Discord {
         /// The webhook URL.
+        #[shep(secret)]
         url: String,
     },
     /// A Slack incoming webhook: `{"text": "..."}`.
     Slack {
         /// The webhook URL.
+        #[shep(secret)]
         url: String,
     },
     /// A JSON POST with a body the operator templates.
     Json {
         /// Where to POST.
+        #[shep(secret)]
         url: String,
         /// The body, with `{subject}`, `{rule}`, `{message}` and `{at_ms}`
         /// substituted. Defaults to an object carrying all four.
@@ -480,6 +490,41 @@ mod tests {
 
     use super::*;
     use crate::http::{HttpRequest, read_request, write_response};
+
+    /// Every variant's `url` carries the credential marker, and nothing
+    /// beside it does.
+    ///
+    /// The key is spelled out here rather than read from
+    /// `shep_core::dogs::SECRET_KEY`, because the constant and the schema
+    /// agreeing is the thing under test: a rename of one that leaves the
+    /// other behind is how a webhook token reaches a screen (IR-41).
+    ///
+    /// Both halves in one test on purpose. Marking every property would
+    /// pass a test that only looked at the marked one.
+    #[test]
+    fn every_sink_variant_marks_its_url_and_leaves_the_rest_plain() {
+        let schema = shep_client::dogs::config_schema::<Sink>()
+            .expect("`url` is a property of all three variants");
+        let variants = schema
+            .as_value()
+            .get("oneOf")
+            .and_then(|it| it.as_array())
+            .expect("an internally tagged enum is a oneOf");
+        assert_eq!(variants.len(), 3);
+
+        for variant in variants {
+            assert_eq!(
+                variant.pointer("/properties/url/x-shep-secret"),
+                Some(&serde_json::Value::Bool(true)),
+                "a webhook URL is a bearer credential in every variant"
+            );
+            assert_eq!(
+                variant.pointer("/properties/kind/x-shep-secret"),
+                None,
+                "the tag names the variant and is not a credential"
+            );
+        }
+    }
 
     /// A representative fired alert, tagged by `subject` and `message` — the
     /// two fields these tests vary. `at_ms`/`rule` are fixed since no test

--- a/crates/shep-cli/src/dog/metrics/mod.rs
+++ b/crates/shep-cli/src/dog/metrics/mod.rs
@@ -17,6 +17,7 @@ use std::time::Duration;
 
 use serde::Deserialize;
 use shep_client::ReconnectingClient;
+use shep_client::dogs::DogConfig;
 use shep_core::protocol::{ProcessInfo, Request, Response};
 use sysinfo::{MemoryRefreshKind, ProcessRefreshKind, RefreshKind, System};
 use tokio::net::{TcpListener, TcpStream};
@@ -36,7 +37,11 @@ const READ_TIMEOUT: Duration = Duration::from_secs(5);
 ///
 /// `deny_unknown_fields`: a misspelled key must be a startup error naming
 /// it, not a dog silently serving on a port the operator did not choose.
-#[derive(Debug, Clone, PartialEq, Deserialize)]
+///
+/// `DogConfig` carries no `#[shep(secret)]`, because an address is not a
+/// credential. The derive is still what lets `config_schema` publish this
+/// section, and a config type with nothing to mark still wants the impl.
+#[derive(Debug, Clone, PartialEq, Deserialize, schemars::JsonSchema, DogConfig)]
 #[serde(deny_unknown_fields, default)]
 pub struct MetricsConfig {
     /// Where to listen. Loopback by default; binding wider is explicit.
@@ -297,6 +302,39 @@ mod tests {
     use tokio::task::JoinHandle;
 
     use super::*;
+
+    /// What `deny_unknown_fields` and `default` do to the generated schema,
+    /// measured rather than assumed: the first becomes
+    /// `additionalProperties: false`, and the second drops `required`
+    /// altogether and puts the real default beside the key.
+    ///
+    /// That combination is what makes a settings pane honest about this
+    /// dog. Every key is optional, so a pane can offer `9615` as the port
+    /// this dog would actually bind rather than as an empty box, and a key
+    /// this dog does not have is refused by the schema before it reaches a
+    /// startup error.
+    #[test]
+    fn the_metrics_schema_offers_the_port_it_would_bind_and_refuses_unknown_keys() {
+        let schema = shep_client::dogs::config_schema::<MetricsConfig>()
+            .expect("this config marks no field, so no mark can be missing");
+        let schema = schema.as_value();
+
+        assert_eq!(
+            schema.get("additionalProperties"),
+            Some(&serde_json::Value::Bool(false)),
+            "`deny_unknown_fields` is what catches a misspelled key"
+        );
+        assert_eq!(
+            schema.get("required"),
+            None,
+            "`default` on the type makes every key optional"
+        );
+        assert_eq!(
+            schema.pointer("/properties/bind/default"),
+            Some(&serde_json::Value::String("127.0.0.1:9615".to_owned())),
+            "the default is loopback, and a pane shows the port rather than a blank"
+        );
+    }
 
     /// A minimal, online sheep fixture — enough for the exposition to name
     /// it in a `sheep="..."` label, nothing more precise than that.

--- a/crates/shep-cli/src/dog/mod.rs
+++ b/crates/shep-cli/src/dog/mod.rs
@@ -461,7 +461,10 @@ mod tests {
     use std::path::{Path, PathBuf};
     use std::time::Duration;
 
-    use shep_client::testing::{fake_reconnecting_client_on, sample_ack, serve_one_request};
+    use shep_client::testing::{
+        Handshake, fake_daemon_across_handovers, fake_reconnecting_client_on, sample_ack,
+        serve_one_request,
+    };
 
     use super::*;
 
@@ -730,5 +733,70 @@ mod tests {
             debug.contains(&format!("section: \"<{byte_len} bytes>\"")),
             "{debug}"
         );
+    }
+
+    /// fails if bark stops asking for its own config topic. Everything
+    /// else about a config change is covered one layer down, against
+    /// `run_loop` directly, and all of it is unreachable if this
+    /// subscription is not made: a dog that never asked for
+    /// `config.dog.bark` is never sent one, and goes on running on a
+    /// section an operator has already edited with nothing to say so.
+    ///
+    /// Deleting the topic from the vec below leaves the whole suite green
+    /// without this test, which is how it came to be written.
+    ///
+    /// A handover fixture rather than `serve_one_request`: that one closes
+    /// after its single reply, so the `Subscribe` that follows a dog's
+    /// `DogConfig` is never read off the wire. This one keeps the
+    /// connection open and records every envelope, which is the only place
+    /// the topics a dog asked for are visible.
+    #[tokio::test]
+    async fn bark_subscribes_to_its_own_config_topic() {
+        let dir = tempfile::tempdir().unwrap();
+        let socket = shep_client::testing::control_address(dir.path());
+        let daemon = fake_daemon_across_handovers(&socket, vec![Handshake::Accept(sample_ack())]);
+        // A section with a real sink, because bark refuses to run without
+        // one: the default rule set routes to every configured sink, and a
+        // rule routing nowhere is refused at `Rules::new`. Port 1 is never
+        // dialled -- no bark fires in this test.
+        daemon.reply_to_dog_config(
+            "[sinks.ops]\nkind = \"json\"\nurl = \"http://127.0.0.1:1/hook\"\n",
+        );
+        let paths = test_paths(dir.path(), socket);
+
+        let task = tokio::spawn(run_dog("bark", paths));
+
+        // Polled rather than slept on, and bounded: the fixture records
+        // envelopes as it reads them, so the test yields until the
+        // subscribe arrives and fails with its own message if it never
+        // does.
+        let topics =
+            tokio::time::timeout(Duration::from_secs(5), async {
+                loop {
+                    let subscribed = daemon.envelopes().into_iter().find_map(|(_, envelope)| {
+                        match envelope.body {
+                            Request::Subscribe { topics } => Some(topics),
+                            _ => None,
+                        }
+                    });
+                    if let Some(topics) = subscribed {
+                        break topics;
+                    }
+                    tokio::task::yield_now().await;
+                }
+            })
+            .await
+            .expect("bark must subscribe once its config parses");
+
+        assert!(
+            topics.iter().any(|topic| topic == "config.dog.bark"),
+            "bark must ask for its own config topic: {topics:?}"
+        );
+        assert!(
+            topics.iter().any(|topic| topic == "process.*"),
+            "the lifecycle topics every rule reads must survive: {topics:?}"
+        );
+
+        task.abort();
     }
 }

--- a/crates/shep-cli/src/dog/mod.rs
+++ b/crates/shep-cli/src/dog/mod.rs
@@ -337,14 +337,20 @@ async fn run_bark(runtime: DogRuntime) -> ExitCode {
             return ExitCode::InvalidConfig;
         }
     };
-    // `config.dog.bark` alongside the lifecycle topics: the shepherd
+    // `config.dog.<name>` alongside the lifecycle topics: the shepherd
     // publishes it when this dog's section changes and says nothing about
-    // what changed, so the frame is a prompt to re-ask. Bark's own name,
+    // what changed, so the frame is a prompt to re-ask. This dog's own name,
     // not `config.*` -- a glob would hand this dog every other dog's
     // prompts to filter for itself.
+    //
+    // Taken from the runtime rather than written out, because the same name
+    // has to reach `ClientShepherd`'s re-read request. Two literals would be
+    // free to drift, and drift here is silent: bark would keep answering a
+    // topic it still subscribes to by re-reading somebody else's section.
+    let dog = runtime.name.clone();
     let events = match runtime
         .client
-        .subscribe(vec!["process.*".to_owned(), "config.dog.bark".to_owned()])
+        .subscribe(vec!["process.*".to_owned(), format!("config.dog.{dog}")])
         .await
     {
         Ok(events) => events,
@@ -356,6 +362,7 @@ async fn run_bark(runtime: DogRuntime) -> ExitCode {
     let barks_path = runtime.paths.barks.clone();
     let shepherd = Arc::new(ClientShepherd {
         client: runtime.client,
+        dog,
     });
     bark::run_loop(
         events,
@@ -389,12 +396,17 @@ impl bark::EventSource for EventStream {
 /// Wraps [`ReconnectingClient`] as both of the things [`bark::run_loop`]
 /// asks the shepherd for: `Request::ListFlock` for the reconciliation poll
 /// ([`bark::FlockSource`]) and `Request::DogConfig` for a re-read after a
-/// `config.dog.bark` frame ([`bark::ConfigSource`]). One connection answers
+/// `config.dog.<name>` frame ([`bark::ConfigSource`]). One connection answers
 /// both, and [`ReconnectingClient`] is not `Clone`, so the two roles reach
 /// it through one [`Arc`] rather than through two clients that would
 /// reconnect independently.
 struct ClientShepherd {
     client: ReconnectingClient,
+    /// The dog whose section [`bark::ConfigSource`] re-asks for. Held rather
+    /// than spelled in the impl, so the name this dog subscribes on and the
+    /// name its re-read request carries come from one value and cannot
+    /// disagree.
+    dog: String,
 }
 
 impl bark::FlockSource for ClientShepherd {
@@ -421,7 +433,7 @@ impl bark::ConfigSource for ClientShepherd {
         let response = self
             .client
             .request(Request::DogConfig {
-                name: "bark".to_owned(),
+                name: self.dog.clone(),
             })
             .await?;
         match response {

--- a/crates/shep-cli/src/dog/mod.rs
+++ b/crates/shep-cli/src/dog/mod.rs
@@ -29,6 +29,7 @@ pub mod bark;
 pub mod metrics;
 
 use core::fmt;
+use std::sync::Arc;
 
 use shep_client::{ConnectError, EventStream, ReconnectingClient, RequestError};
 use shep_core::paths::ShepPaths;
@@ -329,19 +330,23 @@ async fn run_bark(runtime: DogRuntime) -> ExitCode {
             return ExitCode::InvalidConfig;
         }
     };
-    let rule_list = if config.rules.is_empty() {
-        bark::rules::Rules::default_rules(&config.sinks)
-    } else {
-        config.rules.clone()
-    };
-    let rules = match bark::rules::Rules::new(rule_list, &config.sinks) {
+    let rules = match bark::rules_for(&config) {
         Ok(rules) => rules,
         Err(err) => {
             eprintln!("shep dog bark: {err}");
             return ExitCode::InvalidConfig;
         }
     };
-    let events = match runtime.client.subscribe(vec!["process.*".to_owned()]).await {
+    // `config.dog.bark` alongside the lifecycle topics: the shepherd
+    // publishes it when this dog's section changes and says nothing about
+    // what changed, so the frame is a prompt to re-ask. Bark's own name,
+    // not `config.*` -- a glob would hand this dog every other dog's
+    // prompts to filter for itself.
+    let events = match runtime
+        .client
+        .subscribe(vec!["process.*".to_owned(), "config.dog.bark".to_owned()])
+        .await
+    {
         Ok(events) => events,
         Err(err) => {
             eprintln!("shep dog bark: could not subscribe to the shepherd's bus: {err}");
@@ -349,10 +354,18 @@ async fn run_bark(runtime: DogRuntime) -> ExitCode {
         }
     };
     let barks_path = runtime.paths.barks.clone();
-    let flock = ClientFlockSource {
+    let shepherd = Arc::new(ClientShepherd {
         client: runtime.client,
-    };
-    bark::run_loop(events, flock, rules, &config, &barks_path).await
+    });
+    bark::run_loop(
+        events,
+        Arc::clone(&shepherd),
+        rules,
+        &config,
+        &barks_path,
+        shepherd,
+    )
+    .await
 }
 
 /// Adapts [`EventStream`] to [`bark::EventSource`]: its own `next` already
@@ -373,14 +386,18 @@ impl bark::EventSource for EventStream {
     }
 }
 
-/// Wraps [`ReconnectingClient`] as [`bark::FlockSource`]: `Request::ListFlock`, mapped
-/// into the shape [`bark::run_loop`] can poll without a socket of its own —
-/// the same reason [`bark::EventSource`] exists for the subscription side.
-struct ClientFlockSource {
+/// Wraps [`ReconnectingClient`] as both of the things [`bark::run_loop`]
+/// asks the shepherd for: `Request::ListFlock` for the reconciliation poll
+/// ([`bark::FlockSource`]) and `Request::DogConfig` for a re-read after a
+/// `config.dog.bark` frame ([`bark::ConfigSource`]). One connection answers
+/// both, and [`ReconnectingClient`] is not `Clone`, so the two roles reach
+/// it through one [`Arc`] rather than through two clients that would
+/// reconnect independently.
+struct ClientShepherd {
     client: ReconnectingClient,
 }
 
-impl bark::FlockSource for ClientFlockSource {
+impl bark::FlockSource for ClientShepherd {
     async fn flock(&self) -> Result<Vec<ProcessInfo>, RequestError> {
         match self.client.request(Request::ListFlock).await? {
             Response::Flock(flock) => Ok(flock),
@@ -396,6 +413,46 @@ impl bark::FlockSource for ClientFlockSource {
                 daemon_version: None,
             })),
         }
+    }
+}
+
+impl bark::ConfigSource for ClientShepherd {
+    async fn section(&self) -> Result<String, RequestError> {
+        let response = self
+            .client
+            .request(Request::DogConfig {
+                name: "bark".to_owned(),
+            })
+            .await?;
+        match response {
+            Response::DogSection { toml } => Ok(toml.as_str().to_string()),
+            // Never returned by a daemon on the same protocol version, and
+            // reportable rather than `unreachable!()` for the reason
+            // `DogRunError::UnexpectedReply`'s own doc gives.
+            _ => Err(RequestError::Rpc(RpcError {
+                code: RpcErrorCode::Internal,
+                message: "the shepherd answered DogConfig with something other than \
+                          Response::DogSection"
+                    .to_owned(),
+                daemon_version: None,
+            })),
+        }
+    }
+}
+
+/// Both traits reach the client through one [`Arc`] -- see
+/// [`ClientShepherd`]'s own doc. The forwarding impls live here rather than
+/// beside the traits in `bark::mod`, so nothing in bark has to know that
+/// the production shepherd is shared.
+impl bark::FlockSource for Arc<ClientShepherd> {
+    async fn flock(&self) -> Result<Vec<ProcessInfo>, RequestError> {
+        bark::FlockSource::flock(&**self).await
+    }
+}
+
+impl bark::ConfigSource for Arc<ClientShepherd> {
+    async fn section(&self) -> Result<String, RequestError> {
+        bark::ConfigSource::section(&**self).await
     }
 }
 

--- a/crates/shep-client/Cargo.toml
+++ b/crates/shep-client/Cargo.toml
@@ -11,11 +11,26 @@ documentation = "https://docs.rs/shep-client"
 keywords = ["shep", "process-manager", "client", "ipc", "async"]
 categories = ["asynchronous", "network-programming", "api-bindings"]
 
-# No `[package.metadata.docs.rs]` here, deliberately: `test-support` is this
-# crate's only feature, and its own comment below says what it is — test
-# scaffolding for other crates' tests, not public API. There is nothing else
-# behind it worth unlocking for docs.rs, unlike shep-core's `schema`.
+# No `[package.metadata.docs.rs]` here, deliberately. There are two features
+# and neither wants unlocking on docs.rs: `schema` is on by default, so the
+# default build already documents `dogs::config_schema` and everything it
+# gates, and `test-support` is test scaffolding rather than public API (its
+# own comment below says so). Unlike shep-core, whose `schema` is OFF by
+# default and whose docs would otherwise render as though half the crate did
+# not exist.
 [features]
+default = ["schema"]
+
+# Option: build a dog's config schema, `dogs::config_schema` and the
+# `dogs::probe` arm that prints it. ON by default, so following the dog docs
+# works with no feature line; off is for a dog that would rather not compile
+# schemars for an answer it does not want to give. Not answering is legal
+# rather than broken (see `dogs`'s module docs), so this stays additive: with
+# it off, `probe` still answers the version flag and exits silently on the
+# schema flag. The name matches the feature shep-core already uses for the
+# same dependency.
+schema = ["dep:schemars", "dep:serde_json"]
+
 # Option: expose `testing` (the hand-rolled daemon fakes) to other crates'
 # tests. Off by default — it is test scaffolding, not public API. Mirrors
 # shep-daemon's `test-fakes` (`crates/shep-daemon/Cargo.toml:12`), which does
@@ -55,6 +70,17 @@ required-features = ["test-support"]
 
 [dependencies]
 shep-core.workspace = true
+# The `DogConfig` derive, re-exported from `dogs` next to the trait it
+# implements so a dog author takes one dependency and never names this crate.
+# Not optional: the derive is what stops `x-shep-secret` being a string a dog
+# author hand-types, and it needs no schemars of its own to emit a name list.
+shep-macros.workspace = true
+# Both behind `schema`. `dogs::config_schema` generates a dog's schema and
+# walks it as a `serde_json::Value` to mark the credential fields; `probe`
+# prints the result. schemars is workspace-pinned and already in the tree
+# through shep-core and whistle, so this adds an edge rather than a crate.
+schemars = { workspace = true, optional = true }
+serde_json = { workspace = true, optional = true }
 tokio = { workspace = true, features = ["net", "rt", "time", "sync", "macros"] }
 tokio-util.workspace = true
 tokio-stream.workspace = true   # wrappers::BroadcastStream, for the event-bus subscription stream

--- a/crates/shep-client/src/dogs.rs
+++ b/crates/shep-client/src/dogs.rs
@@ -8,7 +8,8 @@
 //! author:
 //!
 //! ```no_run
-//! # #[derive(schemars::JsonSchema, shep_client::dogs::DogConfig)]
+//! # #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+//! # #[derive(shep_client::dogs::DogConfig)]
 //! # struct MyDogConfig {}
 //! fn main() {
 //!     shep_client::dogs::probe::<MyDogConfig>(
@@ -342,156 +343,6 @@ fn schema_answer<T: DogConfig + schemars::JsonSchema>() -> Result<String, Secret
 mod tests {
     use super::*;
 
-    #[derive(schemars::JsonSchema, DogConfig)]
-    #[allow(dead_code, reason = "read by the generated schema, not by Rust")]
-    struct Webhook {
-        #[shep(secret)]
-        url: String,
-        channel: String,
-    }
-
-    #[derive(schemars::JsonSchema, DogConfig)]
-    #[serde(tag = "kind", rename_all = "snake_case")]
-    #[allow(dead_code, reason = "read by the generated schema, not by Rust")]
-    enum Sink {
-        Discord {
-            #[shep(secret)]
-            url: String,
-            quiet: bool,
-        },
-        Slack {
-            #[shep(secret)]
-            url: String,
-        },
-    }
-
-    #[derive(schemars::JsonSchema, DogConfig)]
-    #[allow(dead_code, reason = "read by the generated schema, not by Rust")]
-    struct Renamed {
-        #[shep(secret)]
-        #[serde(rename = "webhook_url")]
-        url: String,
-    }
-
-    /// A type the root only mentions, so `schemars` hoists it into `$defs`.
-    /// Its `token` is an ordinary string, and it is named to collide with
-    /// the credential the two roots below mark.
-    #[derive(schemars::JsonSchema)]
-    #[allow(dead_code, reason = "read by the generated schema, not by Rust")]
-    struct Inner {
-        token: String,
-    }
-
-    #[derive(schemars::JsonSchema, DogConfig)]
-    #[allow(dead_code, reason = "read by the generated schema, not by Rust")]
-    struct Outer {
-        #[shep(secret)]
-        token: String,
-        inner: Inner,
-    }
-
-    #[derive(schemars::JsonSchema, DogConfig)]
-    #[allow(dead_code, reason = "read by the generated schema, not by Rust")]
-    struct RenamedOuter {
-        #[shep(secret)]
-        #[serde(rename = "api_token")]
-        token: String,
-        inner: Inner,
-    }
-
-    /// Both halves in one test on purpose: an implementation that marked
-    /// every property would pass a test that only checked the marked one.
-    #[test]
-    fn a_secret_field_carries_the_marker_and_a_plain_one_does_not() {
-        let schema = config_schema::<Webhook>().expect("`url` is a real property");
-        let props = schema
-            .as_value()
-            .get("properties")
-            .expect("a derived struct schema has properties");
-
-        assert_eq!(
-            props.get("url").and_then(|url| url.get(SECRET_KEY)),
-            Some(&serde_json::Value::Bool(true)),
-            "the marked field carries the marker"
-        );
-        assert_eq!(
-            props.get("channel").and_then(|it| it.get(SECRET_KEY)),
-            None,
-            "the unmarked field carries nothing"
-        );
-    }
-
-    /// A tagged enum has no top-level `properties` at all: it is a `oneOf` of
-    /// one object per variant. Marking code that reads only the top level
-    /// finds nothing, marks nothing, and says nothing.
-    #[test]
-    fn a_marker_reaches_every_variant_of_a_tagged_enum_and_no_plain_field() {
-        let schema = config_schema::<Sink>().expect("`url` is a real property in both variants");
-        let variants = schema
-            .as_value()
-            .get("oneOf")
-            .and_then(|it| it.as_array())
-            .expect("a tagged enum is a oneOf");
-        assert_eq!(variants.len(), 2);
-
-        for variant in variants {
-            let props = variant
-                .get("properties")
-                .expect("each variant carries its own properties");
-            assert_eq!(
-                props.get("url").and_then(|url| url.get(SECRET_KEY)),
-                Some(&serde_json::Value::Bool(true)),
-                "every occurrence of the marked name is marked"
-            );
-            assert_eq!(
-                props.get("quiet").and_then(|it| it.get(SECRET_KEY)),
-                None,
-                "a plain field in the same variant carries nothing"
-            );
-        }
-    }
-
-    #[test]
-    fn a_renamed_secret_field_is_an_error_rather_than_a_silent_pass() {
-        assert_eq!(
-            config_schema::<Renamed>(),
-            Err(SecretFieldMissing { field: "url" })
-        );
-    }
-
-    /// A mark names a field of the type shep asked about, so a like-named
-    /// property of some other type the root merely mentions is not that
-    /// field and must come out plain. `Rule::sinks` is the live case: it
-    /// lists sink NAMES, one level under a `BarkConfig::sinks` that really
-    /// does hold credentials.
-    #[test]
-    fn a_like_named_property_of_a_nested_type_is_left_plain() {
-        let schema = config_schema::<Outer>().expect("`token` is a real property of the root");
-        let schema = schema.as_value();
-
-        assert_eq!(
-            schema.pointer("/properties/token/x-shep-secret"),
-            Some(&serde_json::Value::Bool(true)),
-            "the root's own marked field carries the marker"
-        );
-        assert_eq!(
-            schema.pointer("/$defs/Inner/properties/token/x-shep-secret"),
-            None,
-            "a stranger that shares the name is not the marked field"
-        );
-    }
-
-    /// The same reach, pointing the other way: a `$defs` entry that happens
-    /// to carry the pre-rename name would satisfy the missing-field check on
-    /// behalf of a credential that shipped unmarked.
-    #[test]
-    fn a_renamed_secret_field_is_an_error_even_when_a_nested_type_has_the_old_name() {
-        assert_eq!(
-            config_schema::<RenamedOuter>(),
-            Err(SecretFieldMissing { field: "token" })
-        );
-    }
-
     /// The two ends of the grammar: what a dog prints and what shep reads.
     /// Pinned as a round trip rather than as a string, because the format is
     /// only ever interesting to the parser.
@@ -503,5 +354,169 @@ mod tests {
 
         assert_eq!(parsed.version, "0.1.3");
         assert_eq!(parsed.protocol, Some(crate::PROTOCOL_VERSION));
+    }
+
+    /// Everything the `schema` feature gates, gated the same way.
+    ///
+    /// A dog that turns the feature off gets a library with no
+    /// `config_schema` in it, which is the supported opt-out rather than a
+    /// broken build. The tests have to say so too: gated on `test` alone
+    /// they name `schemars`, `serde_json` and `config_schema` in a build
+    /// that has none of them, so the crate's own test target was the one
+    /// place the feature stopped being additive.
+    #[cfg(feature = "schema")]
+    mod schema {
+        use super::*;
+
+        #[derive(schemars::JsonSchema, DogConfig)]
+        #[allow(dead_code, reason = "read by the generated schema, not by Rust")]
+        struct Webhook {
+            #[shep(secret)]
+            url: String,
+            channel: String,
+        }
+
+        #[derive(schemars::JsonSchema, DogConfig)]
+        #[serde(tag = "kind", rename_all = "snake_case")]
+        #[allow(dead_code, reason = "read by the generated schema, not by Rust")]
+        enum Sink {
+            Discord {
+                #[shep(secret)]
+                url: String,
+                quiet: bool,
+            },
+            Slack {
+                #[shep(secret)]
+                url: String,
+            },
+        }
+
+        #[derive(schemars::JsonSchema, DogConfig)]
+        #[allow(dead_code, reason = "read by the generated schema, not by Rust")]
+        struct Renamed {
+            #[shep(secret)]
+            #[serde(rename = "webhook_url")]
+            url: String,
+        }
+
+        /// A type the root only mentions, so `schemars` hoists it into `$defs`.
+        /// Its `token` is an ordinary string, and it is named to collide with
+        /// the credential the two roots below mark.
+        #[derive(schemars::JsonSchema)]
+        #[allow(dead_code, reason = "read by the generated schema, not by Rust")]
+        struct Inner {
+            token: String,
+        }
+
+        #[derive(schemars::JsonSchema, DogConfig)]
+        #[allow(dead_code, reason = "read by the generated schema, not by Rust")]
+        struct Outer {
+            #[shep(secret)]
+            token: String,
+            inner: Inner,
+        }
+
+        #[derive(schemars::JsonSchema, DogConfig)]
+        #[allow(dead_code, reason = "read by the generated schema, not by Rust")]
+        struct RenamedOuter {
+            #[shep(secret)]
+            #[serde(rename = "api_token")]
+            token: String,
+            inner: Inner,
+        }
+
+        /// Both halves in one test on purpose: an implementation that marked
+        /// every property would pass a test that only checked the marked one.
+        #[test]
+        fn a_secret_field_carries_the_marker_and_a_plain_one_does_not() {
+            let schema = config_schema::<Webhook>().expect("`url` is a real property");
+            let props = schema
+                .as_value()
+                .get("properties")
+                .expect("a derived struct schema has properties");
+
+            assert_eq!(
+                props.get("url").and_then(|url| url.get(SECRET_KEY)),
+                Some(&serde_json::Value::Bool(true)),
+                "the marked field carries the marker"
+            );
+            assert_eq!(
+                props.get("channel").and_then(|it| it.get(SECRET_KEY)),
+                None,
+                "the unmarked field carries nothing"
+            );
+        }
+
+        /// A tagged enum has no top-level `properties` at all: it is a `oneOf` of
+        /// one object per variant. Marking code that reads only the top level
+        /// finds nothing, marks nothing, and says nothing.
+        #[test]
+        fn a_marker_reaches_every_variant_of_a_tagged_enum_and_no_plain_field() {
+            let schema =
+                config_schema::<Sink>().expect("`url` is a real property in both variants");
+            let variants = schema
+                .as_value()
+                .get("oneOf")
+                .and_then(|it| it.as_array())
+                .expect("a tagged enum is a oneOf");
+            assert_eq!(variants.len(), 2);
+
+            for variant in variants {
+                let props = variant
+                    .get("properties")
+                    .expect("each variant carries its own properties");
+                assert_eq!(
+                    props.get("url").and_then(|url| url.get(SECRET_KEY)),
+                    Some(&serde_json::Value::Bool(true)),
+                    "every occurrence of the marked name is marked"
+                );
+                assert_eq!(
+                    props.get("quiet").and_then(|it| it.get(SECRET_KEY)),
+                    None,
+                    "a plain field in the same variant carries nothing"
+                );
+            }
+        }
+
+        #[test]
+        fn a_renamed_secret_field_is_an_error_rather_than_a_silent_pass() {
+            assert_eq!(
+                config_schema::<Renamed>(),
+                Err(SecretFieldMissing { field: "url" })
+            );
+        }
+
+        /// A mark names a field of the type shep asked about, so a like-named
+        /// property of some other type the root merely mentions is not that
+        /// field and must come out plain. `Rule::sinks` is the live case: it
+        /// lists sink NAMES, one level under a `BarkConfig::sinks` that really
+        /// does hold credentials.
+        #[test]
+        fn a_like_named_property_of_a_nested_type_is_left_plain() {
+            let schema = config_schema::<Outer>().expect("`token` is a real property of the root");
+            let schema = schema.as_value();
+
+            assert_eq!(
+                schema.pointer("/properties/token/x-shep-secret"),
+                Some(&serde_json::Value::Bool(true)),
+                "the root's own marked field carries the marker"
+            );
+            assert_eq!(
+                schema.pointer("/$defs/Inner/properties/token/x-shep-secret"),
+                None,
+                "a stranger that shares the name is not the marked field"
+            );
+        }
+
+        /// The same reach, pointing the other way: a `$defs` entry that happens
+        /// to carry the pre-rename name would satisfy the missing-field check on
+        /// behalf of a credential that shipped unmarked.
+        #[test]
+        fn a_renamed_secret_field_is_an_error_even_when_a_nested_type_has_the_old_name() {
+            assert_eq!(
+                config_schema::<RenamedOuter>(),
+                Err(SecretFieldMissing { field: "token" })
+            );
+        }
     }
 }

--- a/crates/shep-client/src/dogs.rs
+++ b/crates/shep-client/src/dogs.rs
@@ -1,0 +1,418 @@
+//! The dog side of the probe contract: one call a dog makes as its first
+//! line, which answers every question shep asks its binary.
+//!
+//! A dog is a plugin process the shepherd supervises. Before shep adopts one,
+//! and again whenever it needs the dog's config schema, it spawns the binary
+//! with a flag and reads what comes back. [`probe`] answers both flags, so
+//! neither the answer's format nor the flag names are ever typed by a dog
+//! author:
+//!
+//! ```no_run
+//! # #[derive(schemars::JsonSchema, shep_client::dogs::DogConfig)]
+//! # struct MyDogConfig {}
+//! fn main() {
+//!     shep_client::dogs::probe::<MyDogConfig>(
+//!         env!("CARGO_PKG_NAME"),
+//!         env!("CARGO_PKG_VERSION"),
+//!     );
+//!     // ...normal startup, reached only when this run is not a probe.
+//! }
+//! ```
+//!
+//! # Why the name and version are arguments
+//!
+//! They are the two facts only the dog knows. `env!` expands where it is
+//! written, so a `CARGO_PKG_VERSION` inside this crate would report
+//! `shep-client`'s version to every dog that called it. Everything else in
+//! the answer, the flag names, the key that carries the protocol number, and
+//! the protocol number itself, comes from shep and is not the dog's to get
+//! wrong.
+//!
+//! # Answering is optional, and that is what the `schema` feature turns off
+//!
+//! A dog that answers nothing is recorded as having no schema and is refused
+//! nothing. Turning `schema` off (it is on by default) therefore is not a
+//! broken state: [`probe`] still answers the version flag, and for the schema
+//! flag it exits without printing, which reads to shep as a dog with no
+//! schema.
+
+use std::io::Write as _;
+
+pub use shep_core::dogs::SECRET_KEY;
+use shep_core::dogs::{SCHEMA_FLAG, SHEP_PROTOCOL_KEY, VERSION_FLAG};
+/// The derive that implements [`DogConfig`], re-exported so a dog takes one
+/// dependency rather than two.
+///
+/// Its own documentation carries the rules: which shapes accept
+/// `#[shep(secret)]`, which refuse it, and what the expansion looks like.
+pub use shep_macros::DogConfig;
+
+/// What a dog's config type tells shep about itself: which of its fields are
+/// credentials, and the schema extension key that says so.
+///
+/// Do not write this impl by hand. Derive it, and mark each credential field
+/// with `#[shep(secret)]`. The derive exists precisely so that
+/// [`SECRET_KEY`]'s value is never typed by a dog author: a transposed letter
+/// in it compiles, validates, marks nothing, and paints a webhook credential
+/// on screen.
+pub trait DogConfig {
+    /// The schema extension key a marked field carries. Always
+    /// [`SECRET_KEY`]; it is an associated const so the derive can name it
+    /// through this crate rather than reaching into `shep_core`.
+    const SECRET_KEY: &'static str;
+
+    /// The Rust identifiers of the fields marked `#[shep(secret)]`, deduped.
+    /// A name repeated across the variants of an enum appears once, because
+    /// this is a list of names to look for rather than places to look.
+    const SECRET_FIELDS: &'static [&'static str];
+}
+
+/// A field marked `#[shep(secret)]` whose name appears nowhere in the
+/// generated schema, so the marker had nothing to land on.
+///
+/// `Debug` is derived: the field it names is an identifier from the dog's
+/// own source, never a credential's value (IR-41).
+#[cfg(feature = "schema")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SecretFieldMissing {
+    /// The Rust identifier that was marked and could not be found.
+    pub field: &'static str,
+}
+
+#[cfg(feature = "schema")]
+impl core::fmt::Display for SecretFieldMissing {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(
+            f,
+            "the field `{}` is marked `#[shep(secret)]` but the schema has no \
+             property of that name, so the credential would go out unmarked. \
+             A `#[serde(rename)]` on the field, or a `rename_all_fields` on \
+             the type, renames the property and leaves the mark with nothing \
+             to land on.",
+            self.field
+        )
+    }
+}
+
+#[cfg(feature = "schema")]
+impl core::error::Error for SecretFieldMissing {}
+
+/// The JSON Schema a dog answers the schema flag with: what `schemars`
+/// generates for `T`, with every field `T` marked `#[shep(secret)]` carrying
+/// [`SECRET_KEY`].
+///
+/// [`probe`] calls this. It is public because a dog that renders its own
+/// settings, or a test that wants to see the marks, should not have to spawn
+/// itself to get them.
+///
+/// # Errors
+///
+/// [`SecretFieldMissing`] when a marked name appears in no property anywhere
+/// in the schema. That is a credential which did not get marked, so it is an
+/// error rather than a silent pass.
+#[cfg(feature = "schema")]
+pub fn config_schema<T: DogConfig + schemars::JsonSchema>()
+-> Result<schemars::Schema, SecretFieldMissing> {
+    let mut schema = schemars::SchemaGenerator::default().into_root_schema_for::<T>();
+    let mut found: Vec<&'static str> = Vec::new();
+    // `None` only for a schema that is the bare `true` or `false`, which has
+    // no property to mark and so leaves every marked name unfound below.
+    if let Some(root) = schema.as_object_mut() {
+        mark_secrets_in_object(root, T::SECRET_FIELDS, T::SECRET_KEY, &mut found);
+    }
+    for field in T::SECRET_FIELDS {
+        if !found.contains(field) {
+            return Err(SecretFieldMissing { field });
+        }
+    }
+    Ok(schema)
+}
+
+/// Writes `key` into every property named in `secrets`, wherever in the
+/// schema that property occurs, and records which names were reached.
+///
+/// Every object node is visited rather than only the root's `properties`,
+/// which is what makes an enum work. A tagged enum's schema has NO top-level
+/// `properties` at all: it is a `oneOf` of one object per variant, each with
+/// its own. Reading only the top level would find nothing, mark nothing, and
+/// say nothing, which is the failure this whole contract exists to remove.
+/// Walking the tree covers `anyOf` and `allOf` (untagged and adjacently
+/// tagged enums) and `$defs` for free, rather than by listing keywords that a
+/// later serde representation could add to.
+///
+/// Two consequences, both deliberate. Marking is by NAME, so two variants
+/// sharing a field name are both marked even if only one carried the
+/// attribute; that over-redacts, which is the safe direction. And a property
+/// whose schema is not an object (a bare `true`, which is legal JSON Schema
+/// and which `schemars` does not emit for a typed field) is left alone and
+/// not recorded as found, so it surfaces as [`SecretFieldMissing`] rather
+/// than as a silent miss.
+#[cfg(feature = "schema")]
+fn mark_secrets_in_object(
+    map: &mut serde_json::Map<String, serde_json::Value>,
+    secrets: &[&'static str],
+    key: &str,
+    found: &mut Vec<&'static str>,
+) {
+    if let Some(serde_json::Value::Object(properties)) = map.get_mut("properties") {
+        for name in secrets {
+            if let Some(serde_json::Value::Object(property)) = properties.get_mut(*name) {
+                property.insert(key.to_owned(), serde_json::Value::Bool(true));
+                if !found.contains(name) {
+                    found.push(name);
+                }
+            }
+        }
+    }
+    for value in map.values_mut() {
+        mark_secrets(value, secrets, key, found);
+    }
+}
+
+/// [`mark_secrets_in_object`] for a node that may be any JSON value: an
+/// object is marked, an array is descended (a `oneOf` is one), and anything
+/// else is a leaf.
+#[cfg(feature = "schema")]
+fn mark_secrets(
+    node: &mut serde_json::Value,
+    secrets: &[&'static str],
+    key: &str,
+    found: &mut Vec<&'static str>,
+) {
+    match node {
+        serde_json::Value::Object(map) => mark_secrets_in_object(map, secrets, key, found),
+        serde_json::Value::Array(items) => {
+            for item in items {
+                mark_secrets(item, secrets, key, found);
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Answers shep's probes, and returns when this run is not a probe, so a dog
+/// calls it as the first line of `main` and carries on into normal startup.
+///
+/// `name` and `version` are the dog's own, ordinarily
+/// `env!("CARGO_PKG_NAME")` and `env!("CARGO_PKG_VERSION")`. Only the version
+/// is read by shep; the name is there because a human runs `--version` too.
+///
+/// # Exits
+///
+/// This function ends the process when it answered, with
+/// [`process::exit`](std::process::exit): the run was shep asking a question,
+/// and a dog that answered and then started up would leave a process behind
+/// for shep to kill. Nothing after the call runs in that case, and no
+/// destructor runs either, which is why it belongs on the first line of
+/// `main` before anything has been opened.
+///
+/// The exit status is 0 for an answer given, and 1 for a config type whose
+/// [`SecretFieldMissing`] makes its schema unpublishable. That failure prints
+/// to stderr, so a dog author who runs the flag by hand sees it, and shep
+/// sees an empty answer and records a dog with no schema.
+#[cfg(feature = "schema")]
+pub fn probe<T: DogConfig + schemars::JsonSchema>(name: &str, version: &str) {
+    match first_argument().as_deref() {
+        Some(VERSION_FLAG) => answer(&version_answer(name, version)),
+        Some(SCHEMA_FLAG) => match schema_answer::<T>() {
+            Ok(json) => answer(&json),
+            Err(err) => {
+                eprintln!("{err}");
+                std::process::exit(1);
+            }
+        },
+        _ => (),
+    }
+}
+
+/// Answers shep's probes, and returns when this run is not a probe, so a dog
+/// calls it as the first line of `main` and carries on into normal startup.
+///
+/// `name` and `version` are the dog's own, ordinarily
+/// `env!("CARGO_PKG_NAME")` and `env!("CARGO_PKG_VERSION")`. Only the version
+/// is read by shep; the name is there because a human runs `--version` too.
+///
+/// This is the build with the `schema` feature off, so there is no schema to
+/// answer with: the schema flag exits without printing, and shep records a
+/// dog with no schema, which it refuses nothing for. Exiting rather than
+/// falling through is the kinder half of that, since the alternative is a dog
+/// booting itself with an argument it does not understand while shep waits
+/// out a timeout for an answer that is never coming.
+///
+/// # Exits
+///
+/// This function ends the process when it answered, with
+/// [`process::exit`](std::process::exit), status 0. Nothing after the call
+/// runs in that case, and no destructor runs either, which is why it belongs
+/// on the first line of `main` before anything has been opened.
+#[cfg(not(feature = "schema"))]
+pub fn probe<T: DogConfig>(name: &str, version: &str) {
+    match first_argument().as_deref() {
+        Some(VERSION_FLAG) => answer(&version_answer(name, version)),
+        Some(SCHEMA_FLAG) => std::process::exit(0),
+        _ => (),
+    }
+}
+
+/// The argument shep spawns a probe with, which is the only one it passes.
+///
+/// The first argument and not a scan of all of them, because that is the
+/// contract `docs/dogs.md` publishes and a dog's own arguments are its
+/// business. A dog whose real command line happens to start with one of these
+/// flags was being probed as far as this contract is concerned.
+fn first_argument() -> Option<String> {
+    std::env::args().nth(1)
+}
+
+/// Prints an answer and ends the process, which is what makes a probe run
+/// end where a normal run would carry on.
+///
+/// The explicit flush is not decoration: [`std::process::exit`] runs no
+/// destructor, so nothing else would push a partial buffer out. Both answers
+/// end in a newline, which Rust's line-buffered stdout would flush anyway,
+/// and neither of those two facts is one to leave the contract resting on.
+fn answer(text: &str) -> ! {
+    let mut stdout = std::io::stdout();
+    // A write to a closed stdout is not something a dog can do anything
+    // about, and shep reads it as silence, which is a legal answer.
+    let _ = write!(stdout, "{text}");
+    let _ = stdout.flush();
+    std::process::exit(0);
+}
+
+/// The `--version` answer, whole, ending in a newline.
+///
+/// Split out from [`probe`] so the format can be tested against
+/// [`shep_core::dogs::parse_version_answer`], which is the code that reads
+/// it. The two used to be a docs snippet and a parser with nothing holding
+/// them together.
+fn version_answer(name: &str, version: &str) -> String {
+    format!(
+        "{name} {version}\n{SHEP_PROTOCOL_KEY}: {}\n",
+        crate::PROTOCOL_VERSION
+    )
+}
+
+/// The `--schema` answer, whole, ending in a newline.
+///
+/// # Errors
+///
+/// [`SecretFieldMissing`], straight from [`config_schema`].
+#[cfg(feature = "schema")]
+fn schema_answer<T: DogConfig + schemars::JsonSchema>() -> Result<String, SecretFieldMissing> {
+    let schema = config_schema::<T>()?;
+    // The same expectation shep-core's own schema printer holds: a schemars
+    // `Schema` is a `serde_json::Value` already, so serializing it cannot
+    // meet a type serde_json has no representation for.
+    let json = serde_json::to_string_pretty(&schema).expect("a schemars Schema always serializes");
+    Ok(format!("{json}\n"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(schemars::JsonSchema, DogConfig)]
+    #[allow(dead_code, reason = "read by the generated schema, not by Rust")]
+    struct Webhook {
+        #[shep(secret)]
+        url: String,
+        channel: String,
+    }
+
+    #[derive(schemars::JsonSchema, DogConfig)]
+    #[serde(tag = "kind", rename_all = "snake_case")]
+    #[allow(dead_code, reason = "read by the generated schema, not by Rust")]
+    enum Sink {
+        Discord {
+            #[shep(secret)]
+            url: String,
+            quiet: bool,
+        },
+        Slack {
+            #[shep(secret)]
+            url: String,
+        },
+    }
+
+    #[derive(schemars::JsonSchema, DogConfig)]
+    #[allow(dead_code, reason = "read by the generated schema, not by Rust")]
+    struct Renamed {
+        #[shep(secret)]
+        #[serde(rename = "webhook_url")]
+        url: String,
+    }
+
+    /// Both halves in one test on purpose: an implementation that marked
+    /// every property would pass a test that only checked the marked one.
+    #[test]
+    fn a_secret_field_carries_the_marker_and_a_plain_one_does_not() {
+        let schema = config_schema::<Webhook>().expect("`url` is a real property");
+        let props = schema
+            .as_value()
+            .get("properties")
+            .expect("a derived struct schema has properties");
+
+        assert_eq!(
+            props.get("url").and_then(|url| url.get(SECRET_KEY)),
+            Some(&serde_json::Value::Bool(true)),
+            "the marked field carries the marker"
+        );
+        assert_eq!(
+            props.get("channel").and_then(|it| it.get(SECRET_KEY)),
+            None,
+            "the unmarked field carries nothing"
+        );
+    }
+
+    /// A tagged enum has no top-level `properties` at all: it is a `oneOf` of
+    /// one object per variant. Marking code that reads only the top level
+    /// finds nothing, marks nothing, and says nothing.
+    #[test]
+    fn a_marker_reaches_every_variant_of_a_tagged_enum_and_no_plain_field() {
+        let schema = config_schema::<Sink>().expect("`url` is a real property in both variants");
+        let variants = schema
+            .as_value()
+            .get("oneOf")
+            .and_then(|it| it.as_array())
+            .expect("a tagged enum is a oneOf");
+        assert_eq!(variants.len(), 2);
+
+        for variant in variants {
+            let props = variant
+                .get("properties")
+                .expect("each variant carries its own properties");
+            assert_eq!(
+                props.get("url").and_then(|url| url.get(SECRET_KEY)),
+                Some(&serde_json::Value::Bool(true)),
+                "every occurrence of the marked name is marked"
+            );
+            assert_eq!(
+                props.get("quiet").and_then(|it| it.get(SECRET_KEY)),
+                None,
+                "a plain field in the same variant carries nothing"
+            );
+        }
+    }
+
+    #[test]
+    fn a_renamed_secret_field_is_an_error_rather_than_a_silent_pass() {
+        assert_eq!(
+            config_schema::<Renamed>(),
+            Err(SecretFieldMissing { field: "url" })
+        );
+    }
+
+    /// The two ends of the grammar: what a dog prints and what shep reads.
+    /// Pinned as a round trip rather than as a string, because the format is
+    /// only ever interesting to the parser.
+    #[test]
+    fn the_version_answer_parses_with_the_shepherds_own_parser() {
+        let answer = version_answer("shep-otel", "0.1.3");
+        let parsed = shep_core::dogs::parse_version_answer(&answer)
+            .expect("the answer shep's own parser cannot read is the bug this pins");
+
+        assert_eq!(parsed.version, "0.1.3");
+        assert_eq!(parsed.protocol, Some(crate::PROTOCOL_VERSION));
+    }
+}

--- a/crates/shep-client/src/dogs.rs
+++ b/crates/shep-client/src/dogs.rs
@@ -67,8 +67,12 @@ pub trait DogConfig {
     const SECRET_FIELDS: &'static [&'static str];
 }
 
-/// A field marked `#[shep(secret)]` whose name appears nowhere in the
-/// generated schema, so the marker had nothing to land on.
+/// A field marked `#[shep(secret)]` that names no property of the config
+/// type's own schema, so the marker had nothing to land on.
+///
+/// A like-named property of some other type under `$defs` does not count.
+/// That is a different field of a different type, and letting it answer for
+/// this one is how a renamed credential ships unmarked.
 ///
 /// `Debug` is derived: the field it names is an identifier from the dog's
 /// own source, never a credential's value (IR-41).
@@ -84,11 +88,11 @@ impl core::fmt::Display for SecretFieldMissing {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(
             f,
-            "the field `{}` is marked `#[shep(secret)]` but the schema has no \
-             property of that name, so the credential would go out unmarked. \
-             A `#[serde(rename)]` on the field, or a `rename_all_fields` on \
-             the type, renames the property and leaves the mark with nothing \
-             to land on.",
+            "the field `{}` is marked `#[shep(secret)]` but this type's own \
+             schema has no property of that name, so the credential would go \
+             out unmarked. A `#[serde(rename)]` on the field, or a \
+             `rename_all_fields` on the type, renames the property and leaves \
+             the mark with nothing to land on.",
             self.field
         )
     }
@@ -99,7 +103,9 @@ impl core::error::Error for SecretFieldMissing {}
 
 /// The JSON Schema a dog answers the schema flag with: what `schemars`
 /// generates for `T`, with every field `T` marked `#[shep(secret)]` carrying
-/// [`SECRET_KEY`].
+/// [`SECRET_KEY`]. The marks land on `T`'s own fields: the types `T` merely
+/// mentions answer for themselves, and are asked separately when one of them
+/// is what shep asked about.
 ///
 /// [`probe`] calls this. It is public because a dog that renders its own
 /// settings, or a test that wants to see the marks, should not have to spawn
@@ -107,9 +113,11 @@ impl core::error::Error for SecretFieldMissing {}
 ///
 /// # Errors
 ///
-/// [`SecretFieldMissing`] when a marked name appears in no property anywhere
-/// in the schema. That is a credential which did not get marked, so it is an
-/// error rather than a silent pass.
+/// [`SecretFieldMissing`] when a marked name matches no property of `T`'s own
+/// representation. That is a credential which did not get marked, so it is an
+/// error rather than a silent pass. A property of that name under `$defs`
+/// belongs to another type, so it neither carries the mark nor answers for
+/// it.
 #[cfg(feature = "schema")]
 pub fn config_schema<T: DogConfig + schemars::JsonSchema>()
 -> Result<schemars::Schema, SecretFieldMissing> {
@@ -128,25 +136,44 @@ pub fn config_schema<T: DogConfig + schemars::JsonSchema>()
     Ok(schema)
 }
 
-/// Writes `key` into every property named in `secrets`, wherever in the
-/// schema that property occurs, and records which names were reached.
+/// Where `schemars` puts the schema of every OTHER named type the root
+/// mentions, and the one keyword [`mark_secrets_in_object`] refuses to walk.
+#[cfg(feature = "schema")]
+const DEFS: &str = "$defs";
+
+/// Writes `key` into every property named in `secrets` that belongs to the
+/// root type's OWN representation, and records which names were reached.
 ///
-/// Every object node is visited rather than only the root's `properties`,
-/// which is what makes an enum work. A tagged enum's schema has NO top-level
-/// `properties` at all: it is a `oneOf` of one object per variant, each with
-/// its own. Reading only the top level would find nothing, mark nothing, and
-/// say nothing, which is the failure this whole contract exists to remove.
-/// Walking the tree covers `anyOf` and `allOf` (untagged and adjacently
-/// tagged enums) and `$defs` for free, rather than by listing keywords that a
-/// later serde representation could add to.
+/// The whole node is walked rather than only its `properties`, because a
+/// struct is the one shape that has a top-level `properties` to read. An
+/// internally tagged enum is a `oneOf` of one object per variant, an untagged
+/// one an `anyOf`, and an adjacently tagged one nests each variant's fields
+/// under the content property's own `properties`. Reading the top level alone
+/// would find nothing in all three, mark nothing, and say nothing, which is
+/// the failure this whole contract exists to remove.
 ///
-/// Two consequences, both deliberate. Marking is by NAME, so two variants
-/// sharing a field name are both marked even if only one carried the
-/// attribute; that over-redacts, which is the safe direction. And a property
-/// whose schema is not an object (a bare `true`, which is legal JSON Schema
-/// and which `schemars` does not emit for a typed field) is left alone and
-/// not recorded as found, so it surfaces as [`SecretFieldMissing`] rather
-/// than as a silent miss.
+/// [`DEFS`] is where the walk stops, and that is what keeps the mark on the
+/// type shep asked about. Entering it marks a property because some stranger
+/// one level down shares a name, and records that name as found, which then
+/// answers the missing-name check on behalf of a field that never got marked.
+/// Both halves were live at once: `BarkConfig::sinks` holds webhook
+/// credentials and is marked, `Rule::sinks` lists sink names and is not, and
+/// the second came out marked while a renamed credential could have come out
+/// plain.
+///
+/// Stopping there costs the root nothing. A root enum's variant objects are
+/// emitted inline, and a recursive root points at itself with `$ref: "#"`
+/// rather than through a definition, so no shape this contract accepts keeps
+/// its own fields in `$defs`. A `$ref` needs no skipping of its own: it is a
+/// string, and a string is a leaf.
+///
+/// Two consequences remain, both deliberate. Marking is by NAME within that
+/// representation, so two variants sharing a field name are both marked even
+/// if only one carried the attribute; that over-redacts, which is the safe
+/// direction. And a property whose schema is not an object (a bare `true`,
+/// which is legal JSON Schema and which `schemars` does not emit for a typed
+/// field) is left alone and not recorded as found, so it surfaces as
+/// [`SecretFieldMissing`] rather than as a silent miss.
 #[cfg(feature = "schema")]
 fn mark_secrets_in_object(
     map: &mut serde_json::Map<String, serde_json::Value>,
@@ -164,7 +191,10 @@ fn mark_secrets_in_object(
             }
         }
     }
-    for value in map.values_mut() {
+    for (keyword, value) in map.iter_mut() {
+        if keyword == DEFS {
+            continue;
+        }
         mark_secrets(value, secrets, key, found);
     }
 }
@@ -343,6 +373,32 @@ mod tests {
         url: String,
     }
 
+    /// A type the root only mentions, so `schemars` hoists it into `$defs`.
+    /// Its `token` is an ordinary string, and it is named to collide with
+    /// the credential the two roots below mark.
+    #[derive(schemars::JsonSchema)]
+    #[allow(dead_code, reason = "read by the generated schema, not by Rust")]
+    struct Inner {
+        token: String,
+    }
+
+    #[derive(schemars::JsonSchema, DogConfig)]
+    #[allow(dead_code, reason = "read by the generated schema, not by Rust")]
+    struct Outer {
+        #[shep(secret)]
+        token: String,
+        inner: Inner,
+    }
+
+    #[derive(schemars::JsonSchema, DogConfig)]
+    #[allow(dead_code, reason = "read by the generated schema, not by Rust")]
+    struct RenamedOuter {
+        #[shep(secret)]
+        #[serde(rename = "api_token")]
+        token: String,
+        inner: Inner,
+    }
+
     /// Both halves in one test on purpose: an implementation that marked
     /// every property would pass a test that only checked the marked one.
     #[test]
@@ -400,6 +456,39 @@ mod tests {
         assert_eq!(
             config_schema::<Renamed>(),
             Err(SecretFieldMissing { field: "url" })
+        );
+    }
+
+    /// A mark names a field of the type shep asked about, so a like-named
+    /// property of some other type the root merely mentions is not that
+    /// field and must come out plain. `Rule::sinks` is the live case: it
+    /// lists sink NAMES, one level under a `BarkConfig::sinks` that really
+    /// does hold credentials.
+    #[test]
+    fn a_like_named_property_of_a_nested_type_is_left_plain() {
+        let schema = config_schema::<Outer>().expect("`token` is a real property of the root");
+        let schema = schema.as_value();
+
+        assert_eq!(
+            schema.pointer("/properties/token/x-shep-secret"),
+            Some(&serde_json::Value::Bool(true)),
+            "the root's own marked field carries the marker"
+        );
+        assert_eq!(
+            schema.pointer("/$defs/Inner/properties/token/x-shep-secret"),
+            None,
+            "a stranger that shares the name is not the marked field"
+        );
+    }
+
+    /// The same reach, pointing the other way: a `$defs` entry that happens
+    /// to carry the pre-rename name would satisfy the missing-field check on
+    /// behalf of a credential that shipped unmarked.
+    #[test]
+    fn a_renamed_secret_field_is_an_error_even_when_a_nested_type_has_the_old_name() {
+        assert_eq!(
+            config_schema::<RenamedOuter>(),
+            Err(SecretFieldMissing { field: "token" })
         );
     }
 

--- a/crates/shep-client/src/lib.rs
+++ b/crates/shep-client/src/lib.rs
@@ -17,6 +17,12 @@
 #![doc(test(attr(deny(warnings))))]
 #![forbid(unsafe_code)]
 
+// The `DogConfig` derive expands to `impl ::shep_client::dogs::DogConfig`,
+// which is a path this crate does not otherwise have for itself. `dogs`'s own
+// tests derive it, so the name has to resolve from inside. Same reason serde
+// does this.
+extern crate self as shep_client;
+
 // Portable on both tiers: `connection` names `shep_core::transport::ClientStream`
 // rather than `tokio::net::UnixStream` directly, so the OS choice is made one
 // crate down and nothing here has a platform arm at all. `spawn`'s exit-code
@@ -25,6 +31,12 @@
 mod actor;
 mod client;
 mod connection;
+// The dog side of the probe contract: one call a dog makes as its first line.
+// Public because a dog is a third-party binary, so this module IS the API it
+// is written against, and it stays a module rather than a flattened re-export
+// for the same reason `spawn` does: `dogs::probe` reads as an agreement
+// between two processes, which `probe` alone would not.
+pub mod dogs;
 mod events;
 mod reconnect;
 // `spawn` stays a public module rather than a flattened re-export: the

--- a/crates/shep-client/src/testing.rs
+++ b/crates/shep-client/src/testing.rs
@@ -251,6 +251,7 @@ pub struct Handovers {
     hellos: Arc<Mutex<Vec<Hello>>>,
     envelopes: Arc<Mutex<Vec<(u32, Envelope)>>>,
     armed_list: Arc<Mutex<Vec<ProcessInfo>>>,
+    armed_dog_section: Arc<Mutex<String>>,
     task: JoinHandle<()>,
 }
 
@@ -305,6 +306,17 @@ impl Handovers {
     pub fn reply_to_list(&self, flock: Vec<ProcessInfo>) {
         *self.armed_list.lock().unwrap() = flock;
     }
+
+    /// Arms the `[<name>]` section every generation answers
+    /// `Request::DogConfig` with. Empty until a test says otherwise, which
+    /// is what a home with no dog configured really answers.
+    ///
+    /// Not consumed, for the same reason [`Self::reply_to_list`] is not: a
+    /// dog asks its own section again after a handover, and again whenever
+    /// a `config.dog.<name>` frame tells it to.
+    pub fn reply_to_dog_config(&self, section: &str) {
+        *self.armed_dog_section.lock().unwrap() = section.to_owned();
+    }
 }
 
 impl Drop for Handovers {
@@ -332,6 +344,7 @@ pub fn fake_daemon_across_handovers(path: &Path, handshakes: Vec<Handshake>) -> 
     let hellos: Arc<Mutex<Vec<Hello>>> = Arc::new(Mutex::new(Vec::new()));
     let envelopes: Arc<Mutex<Vec<(u32, Envelope)>>> = Arc::new(Mutex::new(Vec::new()));
     let armed_list: Arc<Mutex<Vec<ProcessInfo>>> = Arc::new(Mutex::new(Vec::new()));
+    let armed_dog_section: Arc<Mutex<String>> = Arc::new(Mutex::new(String::new()));
 
     let task = tokio::spawn({
         let cut_on_next_request = Arc::clone(&cut_on_next_request);
@@ -339,6 +352,7 @@ pub fn fake_daemon_across_handovers(path: &Path, handshakes: Vec<Handshake>) -> 
         let hellos = Arc::clone(&hellos);
         let envelopes = Arc::clone(&envelopes);
         let armed_list = Arc::clone(&armed_list);
+        let armed_dog_section = Arc::clone(&armed_dog_section);
         async move {
             let mut generation: u32 = 0;
             while let Ok(stream) = listener.accept().await {
@@ -387,6 +401,14 @@ pub fn fake_daemon_across_handovers(path: &Path, handshakes: Vec<Handshake>) -> 
                                     Response::Flock(armed_list.lock().unwrap().clone())
                                 }
                                 Request::Subscribe { .. } => Response::Subscribed,
+                                // A real answer rather than the `Pong`
+                                // below, because a dog refuses to run on a
+                                // reply it cannot parse: this is the first
+                                // request every dog makes, and a fixture
+                                // that fumbles it never sees the second.
+                                Request::DogConfig { .. } => Response::DogSection {
+                                    toml: armed_dog_section.lock().unwrap().clone().into(),
+                                },
                                 _ => Response::Pong,
                             };
                             write_reply(&mut frames, id, response).await;
@@ -405,6 +427,7 @@ pub fn fake_daemon_across_handovers(path: &Path, handshakes: Vec<Handshake>) -> 
         hellos,
         envelopes,
         armed_list,
+        armed_dog_section,
         task,
     }
 }

--- a/crates/shep-core/Cargo.toml
+++ b/crates/shep-core/Cargo.toml
@@ -94,8 +94,8 @@ annotate-snippets.workspace = true
 anstyle.workspace = true
 encoding_rs_io.workspace = true
 pest.workspace = true
-quote.workspace = true
-syn.workspace = true
+quote-floor.workspace = true
+syn-floor.workspace = true
 
 [lints]
 workspace = true

--- a/crates/shep-core/src/dogs.rs
+++ b/crates/shep-core/src/dogs.rs
@@ -1,0 +1,116 @@
+//! The probe contract between shep and a dog: the flag names, the
+//! `shep-protocol:` line's grammar, and the schema's secret marker key.
+//!
+//! # Why this lives here and not in the crate that asks or the crate that answers
+//!
+//! `shep-cli`'s `adopt` spawns a candidate binary with [`VERSION_FLAG`] and
+//! parses what it prints; `shep-client` (the dog side) will answer that same
+//! flag from `shep_client::dogs::probe`. Both sides read a string a dog
+//! author currently hand-types from a snippet in `docs/dogs.md`, so a typo
+//! reads as "protocol unknown" and nothing says so. One definition, owned by
+//! the crate both already depend on, is what lets the asker and the answerer
+//! agree by construction instead of by copying a doc snippet correctly.
+//!
+//! The asker itself (spawning the binary, applying the timeout, deciding
+//! whether an unknown protocol refuses an adopt) stays in `shep-cli`,
+//! beside the rest of the vetting `adopt` already does. Only the shape of
+//! the question and the answer moves here.
+//!
+//! [`DogVersion`] moved with the parser rather than staying behind: its two
+//! fields (`version`, `protocol`) are plain data with no CLI-specific type
+//! in them, and it IS the grammar `parse_version_answer` returns, so
+//! splitting the struct from the function that builds it would put one
+//! definition of the answer's shape in one crate and the reader of that
+//! shape in another.
+
+/// The flag a candidate is spawned with when shep asks for its version, and
+/// the one `docs/dogs.md` publishes as the contract. Read by
+/// `shep-cli`'s `adopt`; answered, from release 2, by
+/// `shep_client::dogs::probe`.
+pub const VERSION_FLAG: &str = "--version";
+
+/// The flag a candidate is spawned with when shep asks for its config
+/// schema. Unused today: `shep_client::dogs::probe` starts answering it in
+/// a later task, and the reader that acts on the answer arrives with it.
+pub const SCHEMA_FLAG: &str = "--schema";
+
+/// The one key [`parse_version_answer`] reads in a `--version` answer.
+/// Every other `shep-` key is reserved for a number this shep has not
+/// heard of, and is ignored rather than refused, so a dog written against a
+/// later contract stays adoptable by this one.
+pub const SHEP_PROTOCOL_KEY: &str = "shep-protocol";
+
+/// The schemars extension key that marks a config field as a credential.
+/// Unused today: the `DogConfig` derive that expands to it, and the reader
+/// in `shep lookout` that redacts a field carrying it, both arrive in a
+/// later task. Getting this string right matters more than the other three
+/// here, because a typo in it does not fail loudly: the schema still
+/// validates, the field is simply not marked, and a credential can end up
+/// rendered on screen.
+pub const SECRET_KEY: &str = "x-shep-secret";
+
+/// What a dog answered [`VERSION_FLAG`] with, parsed by
+/// [`parse_version_answer`] from the format `docs/dogs.md` publishes.
+///
+/// Two fields rather than one, because they answer different questions:
+/// `protocol` decides whether the dog can handshake at all, and `version`
+/// only says which build it is. A dog may give the second and not the
+/// first, which is why `protocol` is optional and an absent one reads as
+/// unknown rather than as a fault.
+#[derive(Debug, PartialEq, Eq)]
+pub struct DogVersion {
+    /// The last whitespace-separated field of line 1, the version. The
+    /// name before it is ignored, so a crate whose name differs from the
+    /// dog's registered name answers correctly without knowing it.
+    pub version: String,
+    /// The `shep-protocol` line's value, and `None` when the answer carried
+    /// no such line or carried one that is not a decimal number. Answering
+    /// is optional, so `None` is an unknown protocol rather than a fault.
+    pub protocol: Option<u32>,
+}
+
+/// Parses the format `docs/dogs.md` publishes: `<name> <version>` on line
+/// 1, then `<key>: <value>` lines.
+///
+/// `None` when there is no line 1 to read a version from. Everything past
+/// that is tolerated rather than refused: unknown keys, blank lines, key
+/// order, and a `shep-protocol` that is not a number, because a shep that
+/// refuses a dog over the shape of text the dog never promised to print is
+/// refusing on its own guess. The strictness is all in the other direction:
+/// only an exact [`SHEP_PROTOCOL_KEY`] carrying a decimal is believed, and
+/// only a believed protocol can refuse.
+#[must_use]
+pub fn parse_version_answer(text: &str) -> Option<DogVersion> {
+    let mut lines = text.lines();
+    let version = lines.next()?.split_whitespace().next_back()?.to_string();
+    let mut protocol = None;
+    for line in lines {
+        if let Some((key, value)) = line.split_once(':')
+            && key.trim() == SHEP_PROTOCOL_KEY
+        {
+            protocol = value.trim().parse().ok();
+        }
+    }
+    Some(DogVersion { version, protocol })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn no_output_is_no_answer() {
+        assert_eq!(parse_version_answer(""), None);
+    }
+
+    #[test]
+    fn a_bad_protocol_number_reads_as_unknown_not_a_fault() {
+        assert_eq!(
+            parse_version_answer("shep-otel 0.1.3\nshep-protocol: two\n"),
+            Some(DogVersion {
+                version: "0.1.3".to_string(),
+                protocol: None,
+            })
+        );
+    }
+}

--- a/crates/shep-core/src/dogs.rs
+++ b/crates/shep-core/src/dogs.rs
@@ -4,12 +4,13 @@
 //! # Why this lives here and not in the crate that asks or the crate that answers
 //!
 //! `shep-cli`'s `adopt` spawns a candidate binary with [`VERSION_FLAG`] and
-//! parses what it prints; `shep-client` (the dog side) will answer that same
-//! flag from `shep_client::dogs::probe`. Both sides read a string a dog
-//! author currently hand-types from a snippet in `docs/dogs.md`, so a typo
-//! reads as "protocol unknown" and nothing says so. One definition, owned by
-//! the crate both already depend on, is what lets the asker and the answerer
-//! agree by construction instead of by copying a doc snippet correctly.
+//! [`SCHEMA_FLAG`] and parses what it prints; `shep-client` (the dog side)
+//! answers both from `shep_client::dogs::probe`. Before that call existed,
+//! both sides read a string a dog author hand-typed from a snippet in
+//! `docs/dogs.md`, so a typo read as "protocol unknown" and nothing said so.
+//! One definition, owned by the crate both already depend on, is what lets
+//! the asker and the answerer agree by construction instead of by copying a
+//! doc snippet correctly.
 //!
 //! The asker itself (spawning the binary, applying the timeout, deciding
 //! whether an unknown protocol refuses an adopt) stays in `shep-cli`,
@@ -30,8 +31,9 @@
 pub const VERSION_FLAG: &str = "--version";
 
 /// The flag a candidate is spawned with when shep asks for its config
-/// schema. Unused today: `shep_client::dogs::probe` starts answering it in
-/// a later task, and the reader that acts on the answer arrives with it.
+/// schema. Asked by `shep-cli`'s `adopt`, beside the version and on the
+/// same terms: a dog that answers nothing is refused nothing. Answered by
+/// `shep_client::dogs::probe`.
 pub const SCHEMA_FLAG: &str = "--schema";
 
 /// The one key [`parse_version_answer`] reads in a `--version` answer.
@@ -41,12 +43,12 @@ pub const SCHEMA_FLAG: &str = "--schema";
 pub const SHEP_PROTOCOL_KEY: &str = "shep-protocol";
 
 /// The schemars extension key that marks a config field as a credential.
-/// Unused today: the `DogConfig` derive that expands to it, and the reader
-/// in `shep lookout` that redacts a field carrying it, both arrive in a
-/// later task. Getting this string right matters more than the other three
-/// here, because a typo in it does not fail loudly: the schema still
-/// validates, the field is simply not marked, and a credential can end up
-/// rendered on screen.
+/// Written by the `DogConfig` derive, which exists so that no dog author
+/// ever types it; the reader in `shep lookout` that redacts a field
+/// carrying it arrives in a later task. Getting this string right matters
+/// more than the other three here, because a typo in it does not fail
+/// loudly: the schema still validates, the field is simply not marked, and
+/// a credential can end up rendered on screen.
 pub const SECRET_KEY: &str = "x-shep-secret";
 
 /// What a dog answered [`VERSION_FLAG`] with, parsed by

--- a/crates/shep-core/src/lib.rs
+++ b/crates/shep-core/src/lib.rs
@@ -28,6 +28,9 @@
 pub mod atomic_file;
 pub mod barks;
 pub mod config;
+// The probe contract both sides of a dog's `--version`/`--schema` answer
+// parse: flag names, the answer grammar, the schema's secret marker key.
+pub mod dogs;
 pub mod kv;
 // One definition of the log-line timestamp for the writer and every reader:
 // the daemon stamps, and three different file readers in shep-cli strip.

--- a/crates/shep-core/src/protocol/events.rs
+++ b/crates/shep-core/src/protocol/events.rs
@@ -556,5 +556,4 @@ mod tests {
         );
         assert_eq!(serde_json::from_str::<BusEvent>(&json).unwrap(), event);
     }
-
 }

--- a/crates/shep-core/src/protocol/events.rs
+++ b/crates/shep-core/src/protocol/events.rs
@@ -1,5 +1,7 @@
 //! Bus events broadcast to subscribed clients
 
+use std::borrow::Cow;
+
 use serde::{Deserialize, Serialize};
 
 use crate::protocol::channel::ChildMessage;
@@ -144,13 +146,48 @@ pub enum BusEvent {
     },
     /// Daemon is shutting down
     DaemonShutdown,
+    /// A dog's section in `dogs.toml` changed. Published under
+    /// `config.dog.<name>`, so a dog subscribes to its own name and hears
+    /// nobody else's.
+    ///
+    /// Says THAT it changed and nothing about what it means. A dog that
+    /// wants the values re-asks with
+    /// [`Request::DogConfig`](crate::protocol::Request::DogConfig) and
+    /// decides for itself what to do with them: swap values in place,
+    /// rebind a listener, or ask for its own restart. Putting a live
+    /// versus needs-restart axis here would mean shep knowing what a
+    /// third-party dog's fields mean, which is the one thing this whole
+    /// contract refuses.
+    ///
+    /// # What it carries, and what it must never carry
+    ///
+    /// A NAME, and nothing else. The bus is a broadcast: a `config.*`
+    /// subscriber sees every dog's frames, and a `[bark]` section
+    /// routinely holds a webhook URL that is itself a bearer credential,
+    /// which is why [`DogSectionToml`] redacts its own `Debug`.
+    /// `Request::DogConfig` answers a dog for its OWN section, so
+    /// re-asking is the whole design rather than an extra round trip. A
+    /// derived `Debug` is safe here for the same reason: a dog's name is
+    /// what an operator typed into `enabled_dogs`.
+    ///
+    /// [`DogSectionToml`]: crate::protocol::DogSectionToml
+    DogConfigChanged {
+        /// The dog whose section changed.
+        dog: String,
+    },
 }
 
 impl BusEvent {
     /// The dotted subscription topic for this event (spec §6 grammar)
+    ///
+    /// A [`Cow`] rather than a `&'static str`, because one topic is not
+    /// fixed: [`Self::DogConfigChanged`] names its dog in the topic
+    /// itself, which is what lets a dog subscribe to its own config and
+    /// hear nobody else's. Every other variant is still a borrowed
+    /// literal and allocates nothing.
     #[must_use]
-    pub fn topic(&self) -> &'static str {
-        match self {
+    pub fn topic(&self) -> Cow<'static, str> {
+        let fixed = match self {
             Self::Process { event, .. } => match event {
                 ProcessEventKind::Start => "process.start",
                 ProcessEventKind::Online => "process.online",
@@ -177,7 +214,13 @@ impl BusEvent {
             },
             Self::Dropped { .. } => "daemon.dropped",
             Self::DaemonShutdown => "daemon.shutdown",
-        }
+            // The one topic built rather than named. `config.dog.` is the
+            // prefix a subscriber globs on; the dog's own name is the last
+            // segment, so `config.dog.bark` reaches one dog and `config.*`
+            // reaches all of them.
+            Self::DogConfigChanged { dog } => return Cow::Owned(format!("config.dog.{dog}")),
+        };
+        Cow::Borrowed(fixed)
     }
 }
 
@@ -313,6 +356,14 @@ mod tests {
                 },
             },
         ]);
+
+        // Last, so every row above keeps its index. The one topic that is
+        // not a fixed string, and the one frame a dog subscribes to on its
+        // own name: an operator's `dogs.toml` edit reaches a running dog
+        // through this shape or through nothing.
+        events.push(BusEvent::DogConfigChanged {
+            dog: "bark".to_string(),
+        });
 
         insta::assert_json_snapshot!("bus_event_wire_v3", events);
     }
@@ -472,4 +523,38 @@ mod tests {
         assert!(json.contains("freed 12MB"), "{json}");
         assert_eq!(serde_json::from_str::<BusEvent>(&json).unwrap(), event);
     }
+
+    /// fails if a dog's config topic stops naming the dog. The topic is the
+    /// whole of what a dog subscribes with, so a name that did not reach it
+    /// (or reached it under a different separator) leaves the dog attached
+    /// to a topic nothing ever publishes and silently running on config an
+    /// operator has already changed.
+    #[test]
+    fn a_dog_config_event_names_the_dog_in_its_topic() {
+        for dog in ["bark", "metrics", "otel-shipper"] {
+            let event = BusEvent::DogConfigChanged {
+                dog: dog.to_string(),
+            };
+            assert_eq!(event.topic(), format!("config.dog.{dog}"));
+        }
+    }
+
+    /// fails if the event grows a payload. shep says THAT a section changed
+    /// and nothing about what it means or what is in it: a dog re-asks with
+    /// `Request::DogConfig`, which is the one path that answers a dog for
+    /// its own section only. A value on this wire would put another dog's
+    /// webhook credential in front of every subscriber on `config.*`.
+    #[test]
+    fn a_dog_config_event_carries_the_name_and_nothing_else() {
+        let event = BusEvent::DogConfigChanged {
+            dog: "bark".to_string(),
+        };
+        let json = serde_json::to_string(&event).unwrap();
+        assert_eq!(
+            json,
+            r#"{"event":"dog_config_changed","data":{"dog":"bark"}}"#
+        );
+        assert_eq!(serde_json::from_str::<BusEvent>(&json).unwrap(), event);
+    }
+
 }

--- a/crates/shep-core/src/protocol/snapshots/shep_core__protocol__events__tests__bus_event_wire_v3.snap
+++ b/crates/shep-core/src/protocol/snapshots/shep_core__protocol__events__tests__bus_event_wire_v3.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/shep-core/src/protocol/events.rs
-assertion_line: 305
 expression: events
 ---
 [
@@ -292,6 +291,12 @@ expression: events
         "body": "freed 12MB",
         "id": 7
       }
+    }
+  },
+  {
+    "event": "dog_config_changed",
+    "data": {
+      "dog": "bark"
     }
   }
 ]

--- a/crates/shep-daemon/src/bus.rs
+++ b/crates/shep-daemon/src/bus.rs
@@ -141,6 +141,28 @@ impl Deref for Bus {
     }
 }
 
+/// Announces one `config.dog.<name>` per dog whose section changed.
+///
+/// Says THAT it changed and nothing more, per the dog-config design's
+/// decision 8: a dog re-asks with `Request::DogConfig` and decides for
+/// itself whether that means swapping values, rebinding a listener or
+/// asking for its own restart.
+///
+/// Exactly one event per name, and none at all for an empty list, which is
+/// what every boot after the first passes. A dog told twice re-asks twice,
+/// and for a dog that answers a change by restarting itself that is two
+/// restarts on the column an operator reads as instability.
+///
+/// Not published through [`Bus::publish_log`]'s gate: that gate counts
+/// subscribers wanting LOG topics, and a dog subscribed to its own config
+/// is not one of them. The send is a no-op when nothing is attached, which
+/// is the ordinary case here.
+pub fn publish_dog_config_changed(bus: &Bus, dogs: &[String]) {
+    for dog in dogs {
+        let _ = bus.send(BusEvent::DogConfigChanged { dog: dog.clone() }.into());
+    }
+}
+
 /// One subscriber's registered interest in log topics, released on drop.
 ///
 /// `None` for a filter that never wanted logs, so a caller holds the same
@@ -270,7 +292,7 @@ impl SharedEvent {
                     Err(err) => {
                         tracing::warn!(
                             %err,
-                            topic = self.0.event.topic(),
+                            topic = %self.0.event.topic(),
                             "dropping an unencodable bus event"
                         );
                         None
@@ -352,7 +374,7 @@ impl TopicFilter {
     /// True when `event`'s [`BusEvent::topic`] matches one of this filter's patterns.
     #[must_use]
     pub fn matches(&self, event: &BusEvent) -> bool {
-        self.set.is_match(event.topic())
+        self.set.is_match(&*event.topic())
     }
 
     /// True when this filter would match either log topic.
@@ -858,5 +880,52 @@ mod tests {
         );
         bus.publish_log(log_out("dropped again"));
         assert!(plain.try_recv().is_err());
+    }
+
+    /// fails if a dog's config topic drifts out from under the glob a
+    /// subscriber writes, or under a glob that was never meant to reach it.
+    /// `config.*` is what a dashboard watching every dog's config asks for,
+    /// and a `log.*` subscriber that started receiving these would be
+    /// getting frames it never asked for on the busiest filter shep has.
+    #[test]
+    fn a_dog_config_event_is_under_the_config_glob_and_no_other() {
+        let event = BusEvent::DogConfigChanged {
+            dog: "bark".to_string(),
+        };
+        assert!(filter(&["config.*"]).matches(&event));
+        assert!(filter(&["config.dog.bark"]).matches(&event));
+        assert!(!filter(&["log.*"]).matches(&event));
+        assert!(!filter(&["process.*"]).matches(&event));
+        // The dog next door does not hear it, which is the whole point of
+        // putting the name in the topic rather than in a payload every
+        // subscriber has to filter for itself.
+        assert!(!filter(&["config.dog.metrics"]).matches(&event));
+    }
+
+    /// fails if the announcement stops being one event per dog. A dog that
+    /// heard nothing runs on config that has moved out from under it; a dog
+    /// told twice re-asks twice, and for a dog that answers a change by
+    /// restarting itself that is two restarts on the column an operator
+    /// reads as instability.
+    #[tokio::test(start_paused = true)]
+    async fn every_moved_dog_is_announced_exactly_once() {
+        let (bus, mut events) = test_bus(16);
+        let moved = ["metrics".to_string(), "bark".to_string()];
+
+        publish_dog_config_changed(&bus, &moved);
+
+        for dog in &moved {
+            let event = events.try_recv().expect("one event per moved dog");
+            assert_eq!(event.topic(), format!("config.dog.{dog}"));
+        }
+        assert!(
+            events.try_recv().is_err(),
+            "a dog announced twice is a dog restarted twice"
+        );
+
+        // Nothing moved, nothing said: an ordinary boot reaches this call
+        // with an empty list and must leave the bus alone.
+        publish_dog_config_changed(&bus, &[]);
+        assert!(events.try_recv().is_err());
     }
 }

--- a/crates/shep-daemon/src/rpc.rs
+++ b/crates/shep-daemon/src/rpc.rs
@@ -127,6 +127,22 @@ impl RpcContext {
         let _ = self.shutdown.send(true);
     }
 
+    /// Announces that these dogs' `dogs.toml` sections changed.
+    ///
+    /// The daemon's own half of the dog-config contract, and the ONE place
+    /// a `config.dog.<name>` frame comes from. The publisher has to be
+    /// inside the daemon process, because that is where the bus is: the
+    /// CLI's other two writers of `dogs.toml` run in an operator's
+    /// short-lived process and say nothing (see their own call sites for
+    /// which and why).
+    ///
+    /// Public because the caller is `shep`'s own boot, which runs the
+    /// migration before this daemon exists and hands the names over once
+    /// it does.
+    pub fn announce_dog_config(&self, dogs: &[String]) {
+        crate::bus::publish_dog_config_changed(&self.events, dogs);
+    }
+
     /// Writes the muster roll now, reporting what it recorded.
     ///
     /// `None` means the supervisor engine has already stopped: there is

--- a/crates/shep-daemon/src/rpc.rs
+++ b/crates/shep-daemon/src/rpc.rs
@@ -519,9 +519,13 @@ async fn run(id: u64, conn: ConnId, request: Request, ctx: &RpcContext) -> Outco
                 },
             }
         }
-        // Re-read per request, never cached: `shep disable X && shep enable X`
-        // is the supported way to reload a dog's configuration, and a copy
-        // taken at boot would answer that with the section as it was.
+        // Re-read per request, never cached. `shep disable X && shep enable
+        // X` reloads a dog's configuration by bouncing it, and a copy taken
+        // at boot would answer that with the section as it was. It is no
+        // longer the only way: a dog subscribed to `config.dog.<name>` asks
+        // again without going down (`bus::publish_dog_config_changed`), and
+        // that path is this same arm answered a second time, which only a
+        // fresh read makes worth anything.
         Request::DogConfig { name } => match crate::dogs::dog_section(&ctx.dogs_config, &name) {
             Ok(toml) => reply(Ok(Response::DogSection { toml: toml.into() })),
             Err(err) => reply(Err(RpcError {

--- a/crates/shep-macros/CHANGELOG.md
+++ b/crates/shep-macros/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+All notable changes to `shep-macros` are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]

--- a/crates/shep-macros/Cargo.toml
+++ b/crates/shep-macros/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "shep-macros"
+description = "The DogConfig derive for shep plugins: marks a config field as a credential so shep renders it redacted"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+repository.workspace = true
+license.workspace = true
+readme = "README.md"
+documentation = "https://docs.rs/shep-macros"
+keywords = ["shep", "process-manager", "derive", "macro", "schema"]
+categories = ["development-tools", "config"]
+
+[lib]
+proc-macro = true
+
+[dependencies]
+syn = { workspace = true, features = ["derive", "parsing", "printing", "clone-impls", "proc-macro"] }
+quote.workspace = true
+proc-macro2.workspace = true
+
+[lints]
+workspace = true

--- a/crates/shep-macros/Cargo.toml
+++ b/crates/shep-macros/Cargo.toml
@@ -19,5 +19,17 @@ syn = { workspace = true, features = ["derive", "parsing", "printing", "clone-im
 quote.workspace = true
 proc-macro2.workspace = true
 
+# A dependency cycle on paper and none in the build graph: `shep-client`
+# depends on this crate normally, and dev-dependencies sit outside the library
+# build, so cargo allows it. What it buys is the doctest on the derive, which
+# has to name `shep_client::dogs::DogConfig` because that is what the
+# expansion names. The alternative was leaving the example `ignore`d, which
+# means publishing a snippet nothing compiles for the one crate whose whole
+# job is to turn a typo into a compile error.
+[dev-dependencies]
+shep-client.workspace = true
+schemars.workspace = true
+serde.workspace = true
+
 [lints]
 workspace = true

--- a/crates/shep-macros/LICENSE-APACHE
+++ b/crates/shep-macros/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../../LICENSE-APACHE

--- a/crates/shep-macros/LICENSE-MIT
+++ b/crates/shep-macros/LICENSE-MIT
@@ -1,0 +1,1 @@
+../../LICENSE-MIT

--- a/crates/shep-macros/README.md
+++ b/crates/shep-macros/README.md
@@ -1,0 +1,39 @@
+# shep-macros
+
+The `DogConfig` derive for [shep](https://github.com/shep-pm/shep), a process
+manager written in Rust. A dog (a plugin process shep supervises) publishes a
+JSON Schema for its own config, and this derive is how it marks which of those
+fields is a credential.
+
+```rust,ignore
+use shep_client::dogs::DogConfig;
+
+#[derive(serde::Deserialize, schemars::JsonSchema, DogConfig)]
+struct Sink {
+    kind: SinkKind,
+    #[shep(secret)]
+    url: String,
+}
+```
+
+A field marked `#[shep(secret)]` reaches shep carrying the `x-shep-secret`
+schema extension, and shep shows `<set>` in place of the value.
+
+Depend on `shep-client` rather than on this crate: it re-exports the derive
+next to the trait the derive implements, so a dog takes one dependency.
+
+## Why a derive and not a documented extension
+
+`schemars` can already say the same thing by hand, with
+`#[schemars(extend("x-shep-secret" = true))]`. The reason to ship a derive
+anyway is that `x-shep-secret` is a string shep parses and the author types.
+Transpose two of its letters and it still compiles, the schema still
+validates, the field is simply not marked, and a webhook credential ends up
+painted on screen. Nothing fails and nothing warns. It cannot be linted
+either, because `schemars` takes a string literal for the extension key, so no
+exported constant can go in that position. The derive is what turns that into
+a compile error.
+
+## License
+
+MIT OR Apache-2.0, at your option.

--- a/crates/shep-macros/README.md
+++ b/crates/shep-macros/README.md
@@ -9,15 +9,23 @@ fields is a credential.
 use shep_client::dogs::DogConfig;
 
 #[derive(serde::Deserialize, schemars::JsonSchema, DogConfig)]
-struct Sink {
-    kind: SinkKind,
-    #[shep(secret)]
-    url: String,
+#[serde(tag = "kind", rename_all = "snake_case")]
+enum Sink {
+    Discord {
+        #[shep(secret)]
+        url: String,
+    },
+    Slack {
+        #[shep(secret)]
+        url: String,
+    },
 }
 ```
 
 A field marked `#[shep(secret)]` reaches shep carrying the `x-shep-secret`
-schema extension, and shep shows `<set>` in place of the value.
+schema extension, and shep shows `<set>` in place of the value. A struct works
+the same way; the enum is here because a bark sink is one, tagged by kind,
+with a webhook URL in every variant.
 
 Depend on `shep-client` rather than on this crate: it re-exports the derive
 next to the trait the derive implements, so a dog takes one dependency.

--- a/crates/shep-macros/src/lib.rs
+++ b/crates/shep-macros/src/lib.rs
@@ -2,8 +2,8 @@
 //!
 //! A dog (a plugin process the shepherd supervises) publishes a JSON Schema
 //! for its own config so shep can render a settings pane for it. One kind of
-//! field needs marking: a credential, such as a webhook URL, which a pane
-//! shows as `<set>` rather than as its value.
+//! field needs marking: a credential, such as the webhook URL in a bark sink,
+//! which a pane shows as `<set>` rather than as its value.
 //!
 //! `schemars` can express that by hand, with
 //! `#[schemars(extend("x-shep-secret" = true))]`. This crate exists because
@@ -23,7 +23,7 @@
 use proc_macro::TokenStream;
 use proc_macro2::TokenStream as TokenStream2;
 use quote::quote;
-use syn::{Attribute, Data, DeriveInput, Field, Fields, Meta, Token, parse_macro_input};
+use syn::{Attribute, Data, DeriveInput, Field, Meta, Token, parse_macro_input};
 
 /// The attribute this derive claims. Only `#[shep(secret)]` is spelled with
 /// it today.
@@ -35,18 +35,25 @@ const SECRET: &str = "secret";
 /// Marks which of a dog's config fields are credentials, so shep can redact
 /// them without the dog author ever typing the extension key that says so.
 ///
-/// Derive it on the struct a dog deserializes its config into, alongside
+/// Derive it on the type a dog deserializes its config into, alongside
 /// `schemars::JsonSchema`, and mark each credential field with
-/// `#[shep(secret)]`:
+/// `#[shep(secret)]`. A struct and an enum both work, and the enum matters:
+/// a bark sink is one, tagged by kind, with a webhook URL in every variant.
 ///
 /// ```rust,ignore
 /// use shep_client::dogs::DogConfig;
 ///
 /// #[derive(serde::Deserialize, schemars::JsonSchema, DogConfig)]
-/// struct Sink {
-///     kind: String,
-///     #[shep(secret)]
-///     url: String,
+/// #[serde(tag = "kind", rename_all = "snake_case")]
+/// enum Sink {
+///     Discord {
+///         #[shep(secret)]
+///         url: String,
+///     },
+///     Slack {
+///         #[shep(secret)]
+///         url: String,
+///     },
 /// }
 /// ```
 ///
@@ -68,26 +75,38 @@ const SECRET: &str = "secret";
 /// }
 /// ```
 ///
-/// # Limitations
+/// One `"url"`, not two, for the two variants above: the list is names, and a
+/// name repeated across variants is one name. The schema `schemars` builds
+/// for a tagged enum is a `oneOf` of one object per variant, each with its own
+/// `properties`, so whatever marks a field has to reach every occurrence of
+/// the name rather than a single top-level property.
 ///
-/// A field is named by its Rust identifier. A `#[serde(rename)]` or
-/// `#[serde(rename_all)]` that changes what the field is called in the schema
-/// is not followed, and the marker would then miss it silently, which is the
-/// failure this derive exists to remove. Do not rename a field marked
-/// `#[shep(secret)]`.
+/// # Renames
+///
+/// A field is named here by its Rust identifier. A `#[serde(rename)]` on a
+/// marked field changes what the schema calls it, and the marker would then
+/// have no property to land on. That is caught where the marking happens, in
+/// `shep_client`, which refuses a name it cannot find rather than passing an
+/// unmarked credential on.
+///
+/// A `#[serde(rename_all)]` on a tagged enum renames the VARIANTS, not their
+/// fields, so a `url` inside one stays `url`. Measured against `schemars`
+/// 1.2.2 rather than assumed.
 ///
 /// # Compile errors
 ///
 /// Deliberate refusals, each with its own message:
 ///
-/// - an enum, a union, or a tuple struct, none of which has a named field for
-///   the schema to carry a property for;
-/// - `#[shep(...)]` on the struct itself, which marks nothing;
+/// - `#[shep(secret)]` on a field with no name, in a tuple struct or a tuple
+///   variant, where a schema has no named property for it to mark;
+/// - `#[shep(...)]` on the type or on a variant, neither of which is a field;
+/// - a union, which has no serde representation to build a schema from;
 /// - any option other than `secret`, which is the misspelling this crate is
 ///   here to catch.
 ///
-/// A struct with no fields, or with no field marked, is accepted: a dog whose
-/// config holds no credential still wants the impl.
+/// Everything else is accepted and simply carries no marks: a struct or a
+/// variant with no fields, an unmarked tuple, an enum of plain unit variants.
+/// A dog whose config holds no credential still wants the impl.
 #[proc_macro_derive(DogConfig, attributes(shep))]
 pub fn derive_dog_config(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
@@ -107,12 +126,25 @@ fn expand(input: &DeriveInput) -> syn::Result<TokenStream2> {
         ));
     }
 
-    let mut secrets = Vec::new();
+    let mut secrets: Vec<String> = Vec::new();
     for field in fields_of(input)? {
-        if is_secret(field)?
-            && let Some(ident) = &field.ident
-        {
-            secrets.push(ident.to_string());
+        if !is_secret(field)? {
+            continue;
+        }
+        let Some(ident) = &field.ident else {
+            return Err(syn::Error::new_spanned(
+                field,
+                "`#[shep(secret)]` cannot mark an unnamed field: a JSON Schema \
+                 property has a name and this field has none, so the mark would \
+                 have nothing to land on. Name the field.",
+            ));
+        };
+        let name = ident.to_string();
+        // Deduped rather than pushed blind: an internally tagged enum repeats
+        // a field name across its variants, the way a bark sink repeats
+        // `url`, and the list is names to look for rather than places to look.
+        if !secrets.contains(&name) {
+            secrets.push(name);
         }
     }
 
@@ -126,32 +158,36 @@ fn expand(input: &DeriveInput) -> syn::Result<TokenStream2> {
     })
 }
 
-/// The named fields of a struct, or the refusal that shape earns.
+/// Every field the type has, a struct's directly and an enum's gathered from
+/// its variants.
 ///
-/// A unit struct has no fields and gets an empty list rather than an error: a
-/// dog with nothing to configure is a real dog. A tuple struct is refused
-/// instead of being treated the same way, because it does have fields and an
-/// author marking one would reasonably expect the mark to land.
+/// Shapes that cannot hold a named field are not refused here, only left
+/// empty. A unit variant has nothing to mark, and an unmarked tuple is a
+/// config type someone wrote for other reasons. What is refused is a mark
+/// that cannot land, and [`expand`] does that once it knows which fields
+/// carry one, so the rule stays the same wherever the field came from.
 fn fields_of(input: &DeriveInput) -> syn::Result<Vec<&Field>> {
-    let refusal = |what: &str| {
-        Err(syn::Error::new_spanned(
-            &input.ident,
-            format!(
-                "`DogConfig` cannot be derived for {what}: a dog's config is a \
-                 struct with named fields, since `#[shep(secret)]` marks one of \
-                 them by the name it carries in the schema",
-            ),
-        ))
-    };
-
     match &input.data {
-        Data::Struct(data) => match &data.fields {
-            Fields::Named(named) => Ok(named.named.iter().collect()),
-            Fields::Unit => Ok(Vec::new()),
-            Fields::Unnamed(_) => refusal("a tuple struct"),
-        },
-        Data::Enum(_) => refusal("an enum"),
-        Data::Union(_) => refusal("a union"),
+        Data::Struct(data) => Ok(data.fields.iter().collect()),
+        Data::Enum(data) => {
+            let mut fields = Vec::new();
+            for variant in &data.variants {
+                if let Some(attr) = find_shep_attribute(&variant.attrs) {
+                    return Err(syn::Error::new_spanned(
+                        attr,
+                        "`#[shep(secret)]` marks a field, not a variant: move \
+                         it onto the field inside that holds the credential",
+                    ));
+                }
+                fields.extend(variant.fields.iter());
+            }
+            Ok(fields)
+        }
+        Data::Union(_) => Err(syn::Error::new_spanned(
+            &input.ident,
+            "`DogConfig` cannot be derived for a union: a union has no serde \
+             representation, so there is no schema for a mark to go into",
+        )),
     }
 }
 

--- a/crates/shep-macros/src/lib.rs
+++ b/crates/shep-macros/src/lib.rs
@@ -57,9 +57,13 @@ const SECRET: &str = "secret";
 /// }
 /// ```
 ///
-/// The example is `ignore`d rather than run because `shep-client` depends on
-/// this crate, so this crate cannot depend back on it to compile a doctest.
-/// The derive's behaviour is tested in `shep-client`, where it is used.
+/// The example is `ignore`d because `shep_client::dogs::DogConfig` does not
+/// exist yet, so there is nothing for a doctest to import. That is a fact
+/// about today rather than a property of the crate: a dev-dependency cycle is
+/// allowed, since dev-dependencies sit outside the library build graph, so
+/// once the trait lands this should become a running doctest with
+/// `shep-client` as a dev-dependency. The derive's behaviour is tested in
+/// `shep-client`, where it is used.
 ///
 /// # What it expands to
 ///

--- a/crates/shep-macros/src/lib.rs
+++ b/crates/shep-macros/src/lib.rs
@@ -40,7 +40,7 @@ const SECRET: &str = "secret";
 /// `#[shep(secret)]`. A struct and an enum both work, and the enum matters:
 /// a bark sink is one, tagged by kind, with a webhook URL in every variant.
 ///
-/// ```rust,ignore
+/// ```rust
 /// use shep_client::dogs::DogConfig;
 ///
 /// #[derive(serde::Deserialize, schemars::JsonSchema, DogConfig)]
@@ -55,15 +55,15 @@ const SECRET: &str = "secret";
 ///         url: String,
 ///     },
 /// }
+///
+/// // One name, not two: see below.
+/// assert_eq!(Sink::SECRET_FIELDS, ["url"]);
 /// ```
 ///
-/// The example is `ignore`d because `shep_client::dogs::DogConfig` does not
-/// exist yet, so there is nothing for a doctest to import. That is a fact
-/// about today rather than a property of the crate: a dev-dependency cycle is
-/// allowed, since dev-dependencies sit outside the library build graph, so
-/// once the trait lands this should become a running doctest with
-/// `shep-client` as a dev-dependency. The derive's behaviour is tested in
-/// `shep-client`, where it is used.
+/// That example runs, which needs `shep-client` as a dev-dependency of this
+/// crate: a cycle on paper, allowed because dev-dependencies sit outside the
+/// library build graph. The derive's behaviour is tested in `shep-client`,
+/// where the marking happens and where a real schema can be looked at.
 ///
 /// # What it expands to
 ///

--- a/crates/shep-macros/src/lib.rs
+++ b/crates/shep-macros/src/lib.rs
@@ -1,0 +1,199 @@
+//! The `DogConfig` derive, and nothing else.
+//!
+//! A dog (a plugin process the shepherd supervises) publishes a JSON Schema
+//! for its own config so shep can render a settings pane for it. One kind of
+//! field needs marking: a credential, such as a webhook URL, which a pane
+//! shows as `<set>` rather than as its value.
+//!
+//! `schemars` can express that by hand, with
+//! `#[schemars(extend("x-shep-secret" = true))]`. This crate exists because
+//! `x-shep-secret` is then a string the author types: transpose two of its
+//! letters and it compiles, the schema validates, the field is not marked,
+//! and the credential is painted on screen. Nothing fails and nothing warns.
+//! It cannot be linted either, because `schemars` takes a string literal for
+//! the extension key, so no exported constant can go in that position. The
+//! derive is what turns that into a compile error.
+//!
+//! Depend on `shep-client`, not on this crate directly. It re-exports the
+//! derive next to the `DogConfig` trait the derive implements, so a dog takes
+//! one dependency.
+
+#![forbid(unsafe_code)]
+
+use proc_macro::TokenStream;
+use proc_macro2::TokenStream as TokenStream2;
+use quote::quote;
+use syn::{Attribute, Data, DeriveInput, Field, Fields, Meta, Token, parse_macro_input};
+
+/// The attribute this derive claims. Only `#[shep(secret)]` is spelled with
+/// it today.
+const ATTR: &str = "shep";
+
+/// The one option `#[shep(...)]` accepts.
+const SECRET: &str = "secret";
+
+/// Marks which of a dog's config fields are credentials, so shep can redact
+/// them without the dog author ever typing the extension key that says so.
+///
+/// Derive it on the struct a dog deserializes its config into, alongside
+/// `schemars::JsonSchema`, and mark each credential field with
+/// `#[shep(secret)]`:
+///
+/// ```rust,ignore
+/// use shep_client::dogs::DogConfig;
+///
+/// #[derive(serde::Deserialize, schemars::JsonSchema, DogConfig)]
+/// struct Sink {
+///     kind: String,
+///     #[shep(secret)]
+///     url: String,
+/// }
+/// ```
+///
+/// The example is `ignore`d rather than run because `shep-client` depends on
+/// this crate, so this crate cannot depend back on it to compile a doctest.
+/// The derive's behaviour is tested in `shep-client`, where it is used.
+///
+/// # What it expands to
+///
+/// An `impl shep_client::dogs::DogConfig`, carrying the names of the marked
+/// fields and the extension key that marks them. The key comes from
+/// `shep_core::dogs::SECRET_KEY` by way of `shep_client`'s re-export, so it is
+/// never spelled out here or in the dog:
+///
+/// ```rust,ignore
+/// impl ::shep_client::dogs::DogConfig for Sink {
+///     const SECRET_KEY: &'static str = ::shep_client::dogs::SECRET_KEY;
+///     const SECRET_FIELDS: &'static [&'static str] = &["url"];
+/// }
+/// ```
+///
+/// # Limitations
+///
+/// A field is named by its Rust identifier. A `#[serde(rename)]` or
+/// `#[serde(rename_all)]` that changes what the field is called in the schema
+/// is not followed, and the marker would then miss it silently, which is the
+/// failure this derive exists to remove. Do not rename a field marked
+/// `#[shep(secret)]`.
+///
+/// # Compile errors
+///
+/// Deliberate refusals, each with its own message:
+///
+/// - an enum, a union, or a tuple struct, none of which has a named field for
+///   the schema to carry a property for;
+/// - `#[shep(...)]` on the struct itself, which marks nothing;
+/// - any option other than `secret`, which is the misspelling this crate is
+///   here to catch.
+///
+/// A struct with no fields, or with no field marked, is accepted: a dog whose
+/// config holds no credential still wants the impl.
+#[proc_macro_derive(DogConfig, attributes(shep))]
+pub fn derive_dog_config(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    expand(&input)
+        .unwrap_or_else(syn::Error::into_compile_error)
+        .into()
+}
+
+/// The derive's whole body, in a form that can return an error instead of
+/// a token stream.
+fn expand(input: &DeriveInput) -> syn::Result<TokenStream2> {
+    if let Some(attr) = find_shep_attribute(&input.attrs) {
+        return Err(syn::Error::new_spanned(
+            attr,
+            "`#[shep(secret)]` marks a field, not the type: move it onto the \
+             field that holds the credential",
+        ));
+    }
+
+    let mut secrets = Vec::new();
+    for field in fields_of(input)? {
+        if is_secret(field)?
+            && let Some(ident) = &field.ident
+        {
+            secrets.push(ident.to_string());
+        }
+    }
+
+    let name = &input.ident;
+    let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
+    Ok(quote! {
+        impl #impl_generics ::shep_client::dogs::DogConfig for #name #ty_generics #where_clause {
+            const SECRET_KEY: &'static str = ::shep_client::dogs::SECRET_KEY;
+            const SECRET_FIELDS: &'static [&'static str] = &[#(#secrets),*];
+        }
+    })
+}
+
+/// The named fields of a struct, or the refusal that shape earns.
+///
+/// A unit struct has no fields and gets an empty list rather than an error: a
+/// dog with nothing to configure is a real dog. A tuple struct is refused
+/// instead of being treated the same way, because it does have fields and an
+/// author marking one would reasonably expect the mark to land.
+fn fields_of(input: &DeriveInput) -> syn::Result<Vec<&Field>> {
+    let refusal = |what: &str| {
+        Err(syn::Error::new_spanned(
+            &input.ident,
+            format!(
+                "`DogConfig` cannot be derived for {what}: a dog's config is a \
+                 struct with named fields, since `#[shep(secret)]` marks one of \
+                 them by the name it carries in the schema",
+            ),
+        ))
+    };
+
+    match &input.data {
+        Data::Struct(data) => match &data.fields {
+            Fields::Named(named) => Ok(named.named.iter().collect()),
+            Fields::Unit => Ok(Vec::new()),
+            Fields::Unnamed(_) => refusal("a tuple struct"),
+        },
+        Data::Enum(_) => refusal("an enum"),
+        Data::Union(_) => refusal("a union"),
+    }
+}
+
+/// Whether a field carries `#[shep(secret)]`.
+///
+/// Repeating the attribute on one field is accepted and marks it once. It is
+/// redundant rather than wrong, and a second error message for it would be
+/// noise next to the one that matters, which is a misspelled option.
+fn is_secret(field: &Field) -> syn::Result<bool> {
+    let mut secret = false;
+    for attr in &field.attrs {
+        if !attr.path().is_ident(ATTR) {
+            continue;
+        }
+        if !matches!(attr.meta, Meta::List(_)) {
+            return Err(syn::Error::new_spanned(
+                attr,
+                "`#[shep]` needs an option in parentheses: the only one is \
+                 `secret`, as in `#[shep(secret)]`",
+            ));
+        }
+        attr.parse_nested_meta(|meta| {
+            if !meta.path.is_ident(SECRET) {
+                return Err(meta.error(
+                    "unknown `shep` option: the only one is `secret`, as in \
+                     `#[shep(secret)]`",
+                ));
+            }
+            if meta.input.peek(Token![=]) {
+                return Err(meta.error(
+                    "`secret` is a flag and takes no value: write \
+                     `#[shep(secret)]`",
+                ));
+            }
+            secret = true;
+            Ok(())
+        })?;
+    }
+    Ok(secret)
+}
+
+/// The first `#[shep(...)]` in a list, for the places one does not belong.
+fn find_shep_attribute(attrs: &[Attribute]) -> Option<&Attribute> {
+    attrs.iter().find(|attr| attr.path().is_ident(ATTR))
+}

--- a/docs/brainstorming/specs/2026-09-03-dog-config-design.md
+++ b/docs/brainstorming/specs/2026-09-03-dog-config-design.md
@@ -188,6 +188,26 @@ That is the same bug class decision 5 removes for `--version`, and the marker
 is the one field where getting it wrong has a security consequence rather than
 a cosmetic one.
 
+### 6b. Two calls decision 6 left open, settled 2026-09-04
+
+**The derive ships as `shep-macros`, re-exported by `shep-client`.** A proc
+macro cannot live in `shep-client`, so it needs a crate of its own. Keeping it
+minimal and re-exporting means a dog author still takes one dependency and
+writes `use shep_client::dogs::DogConfig`, which is how `shep_core` already
+reaches them. A larger `shep-dog` SDK crate was considered and refused: it
+would be a second published name and would split the dog contract across two
+crates rather than one.
+
+**`shep-client` gains schemars behind a `schema` feature, on by default.** The
+name matches the feature `shep-core` already uses for the same dependency.
+Enabled by default so following the docs works, and opt-out for a dog that does
+not want roughly fourteen crates of build it will never use.
+
+Turning it off is not a broken state, and that falls out of decision 4 rather
+than being a special case: a dog without the feature does not answer `--schema`,
+and a dog that answers nothing is recorded as having no schema and refused
+nothing. The design already had a hole this shape.
+
 ### 7. The schema is asked fresh, never stored
 
 `docs/dogs.md` already refuses to store a dog's protocol version, on the

--- a/docs/brainstorming/specs/2026-09-03-dog-config-design.md
+++ b/docs/brainstorming/specs/2026-09-03-dog-config-design.md
@@ -261,11 +261,25 @@ has not adopted the contract yet, bark included until it does.
 ## Wire
 
 `Request` and `Response` are unchanged. `Subscribe` and `DogConfig` already
-exist and `config.dog.<name>` is a topic, not a variant. `PROTOCOL_VERSION`
-stays at 2 and `SCHEMA_VERSION` stays at 1.
+exist, so nothing an operator or a dog SENDS is new.
 
-The new contract is entirely outside the socket: two flags on a binary and what
-they print.
+**`BusEvent` gains a variant, and an earlier draft of this section denied it.**
+It said `config.dog.<name>` is "a topic, not a variant", which is not how the
+bus works: a topic is derived from a variant, `BusEvent::LogOut` giving
+`"log.out"`, and the six that exist (`Process`, `LogOut`, `LogErr`, `Channel`,
+`Dropped`, `DaemonShutdown`) have nowhere to put a config change. Publishing on
+this topic needs a seventh.
+
+That is additive, on the same terms as the six precedents in shep-core's
+changelog: an older peer never subscribed to a topic it does not know, so it
+receives nothing new and breaks on nothing. `PROTOCOL_VERSION` does not move
+again for it. Note that it is already 3, moved by the reset-mode rename in
+`#119`; this section said 2 until that landed.
+
+`SCHEMA_VERSION` stays 1. The bus is not the output envelope.
+
+Everything else in the new contract really is outside the socket: two flags on
+a binary and what they print.
 
 ## Surfacing
 

--- a/docs/brainstorming/specs/2026-09-03-dog-config-design.md
+++ b/docs/brainstorming/specs/2026-09-03-dog-config-design.md
@@ -166,12 +166,32 @@ adopt's vetting across two crates.
 
 ```rust
 #[derive(Deserialize, DogConfig)]
-struct Sink {
-    kind: SinkKind,
-    #[shep(secret)]
-    url: String,
+#[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]
+enum Sink {
+    Discord {
+        #[shep(secret)]
+        url: String,
+    },
+    Slack {
+        #[shep(secret)]
+        url: String,
+    },
 }
 ```
+
+**An earlier draft of this example showed a struct-shaped `Sink` carrying a
+`kind: SinkKind` field, and no such type exists.** The real one
+(`crates/shep-cli/src/dog/bark/sinks.rs`) is an internally tagged enum whose
+variants each carry a `url`, and those URLs are the Discord and Slack webhooks
+this marker exists for. The type already holds a manual redacted `Debug` for the
+same reason.
+
+That mattered rather than being a typo: an implementer built the derive against
+the invented shape and refused enums outright, which made the motivating example
+unmarkable. schemars itself has no such limit, measured on bark's exact shape
+including `tag`, `rename_all` and `deny_unknown_fields`: a field-level extend
+inside a variant lands in that variant's subschema, once per variant. So the
+derive walks variants too.
 
 schemars can express this without shep shipping anything:
 `#[schemars(extend("x-shep-secret" = true))]` works at field level in 1.2. On

--- a/docs/dogs.md
+++ b/docs/dogs.md
@@ -269,8 +269,10 @@ exist, is not a file, has no execute bit for anyone, or is world-writable
 that already belongs to a built-in verb or alias, since a dog by that
 name could never be reached. It warns rather than refuses on a merely
 group-writable path. Passing all of that, it actually spawns the binary
-with no arguments and kills it immediately, because the only honest way
-to know whether this kernel can exec a file is to ask this kernel. What
+and kills it immediately, because the only honest way to know whether this
+kernel can exec a file is to ask this kernel. The `--version` probe below
+is that spawn, so the exec proof and the version answer cost one child
+rather than two. What
 gets recorded in `shep.toml` is the canonicalized, absolute path — never
 whatever relative path you typed — because the daemon may resolve it
 again after a reboot from a different working directory than the one

--- a/docs/dogs.md
+++ b/docs/dogs.md
@@ -447,10 +447,10 @@ the ordinary case, not a skew, and comparing the two would report every
 dog that exists.
 
 A candidate gets one second to exit and another to have its output read,
-so two seconds is the worst case rather than one. It is killed either way,
-so a dog
-that ignores `--version` and runs costs that second and is adopted with an
-unknown protocol. It cannot hang the `adopt` that is vetting it.
+and an adopt runs two probes, so roughly four seconds is the worst case. It
+is killed either way, so a dog that ignores both flags and runs costs that
+time and is adopted with an unknown protocol. It cannot hang the `adopt`
+that is vetting it.
 
 None of the answer is written down. `[daemon] adopted_dogs` records the
 path and nothing else, and a protocol stored at adopt time would be a copy

--- a/docs/dogs.md
+++ b/docs/dogs.md
@@ -111,6 +111,19 @@ is what re-reads it: that stop/start cycle is a fresh process asking a
 fresh question, and the daemon answers off the file as it stands at that
 moment.
 
+**A dog can subscribe instead of waiting to be bounced.** Shep publishes on
+`config.dog.<name>` when it changes a dog's section itself. A dog holding a
+subscription re-asks with `Request::DogConfig` and decides what the change
+means: swap the values, rebind a listener, or ask for its own restart. The
+frame says that the section changed and nothing about what is in it. Bark
+subscribes and swaps in place, since sinks and rules are pure data with no
+OS resource attached. One thing publishes today, the boot that moves a
+section out of `shep.toml`, so a hand edit still needs the stop/start above.
+
+**A dog that restarts itself on a config change has to say so in its own
+log.** Nothing else can tell that apart from a crash loop, and the restart
+count is the column an operator reads as instability.
+
 The reason the section rides the socket instead of the environment is the
 same reason it applies to every dog and not just the ones with obvious
 secrets: an environment variable is readable from the process table,
@@ -443,16 +456,27 @@ of a number that can change on disk with nothing watching. That is G12's
 row 5, the one case where the stored copy would be wrong exactly when it
 mattered, so the binary is asked again rather than remembered.
 
-Emitting it needs four lines and no dependency a dog does not already
-have:
+A dog written against `shep-client` answers this probe and the schema one
+below with a single call, as the first line of `main`:
 
 ```rust
-if std::env::args().nth(1).as_deref() == Some("--version") {
-    println!("{} {}", env!("CARGO_PKG_NAME"), env!("CARGO_PKG_VERSION"));
-    println!("shep-protocol: {}", shep_client::PROTOCOL_VERSION);
-    return;
+fn main() {
+    shep_client::dogs::probe::<MyDogConfig>(
+        env!("CARGO_PKG_NAME"),
+        env!("CARGO_PKG_VERSION"),
+    );
+    // ...normal startup, reached only when this run is not a probe.
 }
 ```
+
+It prints the answer and exits when shep asked a question, and returns when
+it did not, so nothing after it runs on a probe: put it before anything has
+been opened. The name and the version are arguments because `env!` expands
+where it is written, and they are the two facts only the dog knows. The flag
+names, the `shep-protocol` key and the number it carries all come from shep,
+which is the point of the call: they were hand-typed from this page until it
+existed, and a typo in any of them read as "protocol unknown" with nothing
+saying so.
 
 Lines rather than JSON, because a human runs `--version` far more often
 than shep does, and because a stranger writing a dog in a language shep
@@ -577,6 +601,73 @@ which daemon, and a version comparison standing in for one would report
 dogs that are fine. What catches it is the dog's own CI building against
 a current `shep-core`, which is where both published dogs' breakage was
 already visible and unread.
+
+## Answering `--schema`
+
+`shep adopt` asks a second question straight after the first: `--schema`,
+answered on stdout with a JSON Schema for the dog's own `[<name>]` section.
+Same shape as `--version` and the same budget: spawn, read, kill.
+
+Asked of the binary rather than over the socket, because the dog most in
+need of configuring is the one that is disabled or has never started, and it
+has no connection to answer on. Configure then enable is the order an
+operator wants.
+
+`probe` answers this flag too, from its type parameter. Derive `JsonSchema`
+and `DogConfig` on the type the dog deserializes its config into, and mark
+every field holding a credential:
+
+```rust
+use shep_client::dogs::DogConfig;
+
+#[derive(serde::Deserialize, schemars::JsonSchema, DogConfig)]
+#[serde(deny_unknown_fields, default)]
+struct MyDogConfig {
+    /// Where to POST. Doc comments become the schema's descriptions.
+    #[shep(secret)]
+    webhook: String,
+    /// What to watch.
+    path: String,
+}
+```
+
+`#[shep(secret)]` says the field is a bearer credential, and shep renders
+one as `<set>`: replaceable, never read back. The attribute exists rather
+than the schemars extension it expands to because that extension key is a
+string the author types, and a transposed letter in it compiles, validates,
+marks nothing, and paints the credential on screen. Marking a field the
+schema does not have, which is what a `#[serde(rename)]` on it produces, is
+a refusal rather than a silent pass.
+
+**A mark names a field of the type shep asked about.** A credential one type
+down, in a nested struct or in a map's values, is not covered by a mark down
+there: mark the field that holds them. Bark's own `sinks` map is marked
+whole for this reason, and every sink in it carries a webhook URL.
+
+**Answering is optional, exactly as `--version` is.** A dog that says
+nothing is adopted, recorded as having no schema, and refused nothing, which
+is every dog written before this contract. What it gives up is a description
+of itself: a settings pane needs a schema to render, so its section stays a
+file an operator hand-edits. Nothing else changes.
+
+A dog that answers something that is not JSON gets one line, and is adopted
+anyway:
+
+```
+notice[dog_schema_unreadable]: pydog answered `--schema` with something that
+is not JSON, so shep has no description of its settings and they stay a
+hand-edited section. The dog is adopted and runs normally; this is a bug to
+report to whoever wrote it
+```
+
+Silence earns no such line, for the reason an unstated protocol earns none:
+it is the ordinary case, and a notice for every dog is how an operator
+learns to skip the one that matters.
+
+**The answer is not written down**, on the same rule the protocol number
+follows. `cargo install` replaces a binary with nothing watching, and a
+stale schema is worse than a stale version number, because it mislabels
+which field is a credential. Shep asks the binary again when it needs one.
 
 ## What shep writes into a dog's own log
 

--- a/docs/dogs.md
+++ b/docs/dogs.md
@@ -620,7 +620,7 @@ every field holding a credential:
 ```rust
 use shep_client::dogs::DogConfig;
 
-#[derive(serde::Deserialize, schemars::JsonSchema, DogConfig)]
+#[derive(Default, serde::Deserialize, schemars::JsonSchema, DogConfig)]
 #[serde(deny_unknown_fields, default)]
 struct MyDogConfig {
     /// Where to POST. Doc comments become the schema's descriptions.

--- a/docs/writing-plans/plans/2026-09-04-dog-contract.md
+++ b/docs/writing-plans/plans/2026-09-04-dog-contract.md
@@ -1,0 +1,243 @@
+# Dog contract Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A dog can describe its own config to shep, and shep can tell a running dog its config changed. Release 2 of three.
+
+**Architecture:** Two flag names and one grammar move into `shep-core` so both sides of the probe read one definition. `shep-macros` is a new published crate holding only a derive. `shep-client` gains `dogs::probe`, which answers both flags. `shep-cli`'s adopt asks the second one beside where it already asks the first. Both built-in dogs get a schema, `BusEvent` gains a variant, and bark subscribes to it.
+
+**Tech Stack:** Rust 2024, MSRV 1.88. `schemars` 1.2.2 (already workspace-pinned), `syn` and `quote` for the derive.
+
+**Spec:** `docs/brainstorming/specs/2026-09-03-dog-config-design.md`, decisions 4 through 8 plus 6b. Read it first. Two sections were corrected on this branch before planning (`62c174a`, `debe38a`) and the corrections are load-bearing.
+
+## Global Constraints
+
+- **Clean-room rule, non-negotiable:** never open, read, or port source from any pm2 checkout on this machine.
+- **Invoke the `shep-idiomatic-rust` skill before writing or reviewing any Rust.** Cite rules as `IR-<n>`.
+- **No em dashes or en dashes anywhere**, including code comments and commit messages. Three rounds on the previous branch lost time to this.
+- **Never write a real person's name, a personal email, or any absolute home-directory path** into a committed file or a commit message. Repo-relative paths only.
+- **Every new public item needs a doc comment** with `# Errors` on anything fallible, and a deliberate `Debug` decision (IR-41).
+- **`#[non_exhaustive]` needs a reason comment** (IR-20), and the reason may not claim wire tolerance. It buys source compatibility only; serde gets nothing from it, measured on the previous branch.
+- **`#![forbid(unsafe_code)]` is live** in shep-core, shep-client and shep-cli. The new crate gets it too.
+- **Prove every new test non-vacuous** by mutation, and **grep the file after each mutation patch to confirm it applied** before believing a green run.
+- **A comment that stops being true is a defect.**
+- **ONE cargo shape:** `cargo test --workspace --lib --bins --all-features -- --skip ::slow::` while iterating.
+- **Task gate, once, at the end:** `cargo fmt --all --check`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`, `cargo test --workspace --all-features`, `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features`, then `cargo build --release`, `./web/scripts/generate-cli-reference.sh`, and from `web/`: `npx astro build` and `npx astro check`. Each from its own command with `$?` captured directly, never through a pipe.
+- **Worktree:** `.claude/worktrees/dog-contract`, branch `feat/dog-contract`, cut from `03bea9e`.
+
+---
+
+## What is verified and what is not
+
+Read at `debe38a`. Line numbers drift; grep.
+
+- `VERSION_FLAG = "--version"` is a private const at `crates/shep-cli/src/commands/dogs.rs:868`, and `SHEP_PROTOCOL_KEY = "shep-protocol"` at `:874`.
+- `DogVersion` at `:917` carries `version: String` and `protocol: Option<u32>`, with `None` meaning unknown rather than faulty.
+- The probe spawns with `env_clear()`, `probe_env()`, `SHEP_HOME`, `SHEP_DOG_NAME`, null stdin, piped stdout, null stderr (around `:817`).
+- `shep-core` already has `schemars` as an optional dep behind a `schema` feature; `shep-cli` turns it on, `shep-client` does not.
+- `shep-client` depends on `shep-core` and re-exports it.
+- `BusEvent` (`crates/shep-core/src/protocol/events.rs:86`) has six variants: `Process`, `LogOut`, `LogErr`, `Channel`, `Dropped`, `DaemonShutdown`. Its topic string is a match on the variant.
+- `MetricsConfig` (`crates/shep-cli/src/dog/metrics/mod.rs:41`) has one field, `bind: SocketAddr`. `BarkConfig` (`crates/shep-cli/src/dog/bark/mod.rs:57`) has `sinks`, `rules`, `poll`, `history_bytes`, `sink_timeout`. Both derive `Deserialize` with `deny_unknown_fields, default` and neither derives `JsonSchema` yet.
+- `migrate_dog_sections` is called at `crates/shep-cli/src/commands/daemon.rs:298` and `:718`.
+
+**Which of those two call sites can publish, and why it matters.** `:298` is inside `boot_supervisor`, in the daemon process, where the bus exists. `:718` is the reload pre-flight, which runs in the operator's short-lived CLI process with no bus. The only other writer of `dogs.toml` is `forget_dog_section`, called from `rehome` at `commands/dogs.rs:1649`, also CLI-side. That one needs no publish at all: rehome removes the dog, so there is no subscriber left to tell. Do not add a request variant to let a CLI write reach the bus.
+
+**Not verified, and the implementer must check:** whether `Bus` has a publish method other than `publish_log`, what `probe_env()` returns, and whether `shep-macros` needs anything in `release-plz.toml` to be released alongside the others.
+
+---
+
+## File Structure
+
+| File | Responsibility |
+| --- | --- |
+| `crates/shep-core/src/dogs.rs` (new) | both flag names, the `shep-protocol:` grammar and its parser, the secret marker key |
+| `crates/shep-macros/` (new crate) | the `DogConfig` derive and `#[shep(secret)]`, nothing else |
+| `crates/shep-client/src/dogs.rs` (new) | `probe`, and the re-export of the derive |
+| `crates/shep-cli/src/commands/dogs.rs` | a second probe beside the first, sharing its vetting |
+| `crates/shep-cli/src/dog/{metrics,bark}/mod.rs` | `JsonSchema` on both config types, and bark's subscription |
+| `crates/shep-core/src/protocol/events.rs` | the seventh `BusEvent` variant |
+| `crates/shep-daemon/src/` | publishing it |
+| `docs/dogs.md`, `web/` | the contract a dog author reads |
+
+---
+
+### Task 1: one home for the strings both sides parse
+
+**Files:**
+- Create: `crates/shep-core/src/dogs.rs`
+- Modify: `crates/shep-core/src/lib.rs`, `crates/shep-cli/src/commands/dogs.rs`
+
+**Interfaces:**
+- Produces: `shep_core::dogs::{VERSION_FLAG, SCHEMA_FLAG, SHEP_PROTOCOL_KEY, SECRET_KEY}` and a parser for the `--version` answer returning the same shape `DogVersion` holds today.
+
+Behaviour-neutral. `shep-cli` stops owning the private consts and reads shep-core's, and its existing tests must pass unchanged.
+
+- [ ] **Step 1: Move the strings, and the grammar with them**
+
+The point is not the constants, it is that the `shep-protocol:` line's PARSER moves too. Today shep-cli parses an answer that dog authors hand-type from a docs snippet, and a typo reads as "protocol unknown" with nothing saying so. One definition is what lets Task 3 emit exactly what Task 4 reads.
+
+Keep `DogVersion` where it is if it carries CLI-only concerns; move only the parse. Decide which and say why in the module doc.
+
+- [ ] **Step 2: Run the suite**
+
+Run: `cargo test --workspace --lib --bins --all-features -- --skip ::slow::`
+Expected: PASS with no test edited. If a test needs changing, the move was not neutral: stop and report which.
+
+- [ ] **Step 3: Commit**
+
+---
+
+### Task 2: `shep-macros`
+
+**Files:**
+- Create: `crates/shep-macros/{Cargo.toml,src/lib.rs}`
+- Modify: root `Cargo.toml` members, `release-plz.toml` if needed
+
+**Interfaces:**
+- Produces: `#[derive(DogConfig)]` and the `#[shep(secret)]` field attribute, expanding to the schemars extension keyed on `shep_core::dogs::SECRET_KEY`'s value.
+
+**Why a whole crate for one derive**, per decision 6: `x-shep-secret` is a string shep parses and a dog author would otherwise hand-type. Transpose two letters and it compiles, the schema validates, the field is not marked, and lookout paints a webhook credential on screen. schemars takes a string literal for the extension key, so no exported const can go there and no lint can catch it. The macro is the only thing that turns that into a compile error.
+
+- [ ] **Step 1: Write the failing test**
+
+Proc-macro crates cannot test their own expansion from inside. Put the test where the derive is used, in `shep-client` under Task 3, and note here that Task 2 ships with its compile-time behaviour unproven until then. Say so in the report rather than claiming coverage.
+
+What Task 3's test must pin: a struct with a `#[shep(secret)]` field produces a schema whose field carries the extension, and a struct without one does not.
+
+- [ ] **Step 2: Write the crate**
+
+`[lib] proc-macro = true`. Dependencies: `syn`, `quote`, `proc-macro2`. Add each to the workspace dependency table rather than pinning locally, matching how every other dependency here is declared.
+
+Publishing metadata matters and is permanent: `description`, `license` matching the workspace (`MIT OR Apache-2.0`), `repository`, and `categories`/`keywords` if the siblings carry them. Copy the shape from `crates/shep-client/Cargo.toml` rather than inventing one. Check `release-plz.toml` for whether a new member needs an entry to be released, and say what you found.
+
+- [ ] **Step 3: Confirm it builds and commit**
+
+---
+
+### Task 3: `shep_client::dogs::probe`
+
+**Files:**
+- Create: `crates/shep-client/src/dogs.rs`
+- Modify: `crates/shep-client/{Cargo.toml,src/lib.rs}`
+
+**Interfaces:**
+- Consumes: Task 1's constants, Task 2's derive.
+- Produces: `shep_client::dogs::probe::<T>()`, and `shep_client::dogs::DogConfig` re-exporting the derive.
+
+- [ ] **Step 1: Write the failing tests**
+
+```rust
+#[test]
+fn a_secret_field_carries_the_marker_and_a_plain_one_does_not() {
+    // The whole reason the derive exists. Both halves in one test: a schema
+    // where every field is marked would pass a test that only checked the
+    // secret one.
+}
+
+#[test]
+fn the_version_answer_parses_with_shep_cli_s_own_parser() {
+    // What `probe` prints for `--version` must be what Task 1's parser
+    // reads. These are the two ends of the grammar that was hand-typed
+    // from a docs snippet, so pin the round trip rather than the format.
+}
+```
+
+- [ ] **Step 2: Add the feature and the dependency**
+
+`schema` feature, on by default, per decision 6b. `schemars` optional, `shep-macros` a normal dependency. The feature name matches shep-core's own for the same crate.
+
+Work out what `probe` does when the feature is off. Decision 4 says a dog that answers nothing is recorded as having no schema and refused nothing, so not answering is legal, and the design has a hole this shape already. Whether that means a second entry point, a `cfg` inside one, or a different signature is yours to decide; argue it at the call site.
+
+- [ ] **Step 3: Write `probe`**
+
+It answers `--version` and `--schema` and returns for anything else, so a dog calls it as its first line and carries on. Print the `--version` answer using Task 1's constants rather than a literal.
+
+- [ ] **Step 4: Run, prove non-vacuous, commit**
+
+Mutation: remove the extension from the derive's expansion and confirm the marker test goes red.
+
+---
+
+### Task 4: adopt asks the second flag
+
+**Files:**
+- Modify: `crates/shep-cli/src/commands/dogs.rs`
+
+**Interfaces:**
+- Consumes: Task 1's constants.
+- Produces: a schema alongside `DogVersion` from the same vetting path.
+
+- [ ] **Step 1: Write the failing tests**
+
+One test per shape decision 4 names, because they are four different outcomes and a single "handles bad input" test would pass while three of them were wrong: a dog that answers valid JSON Schema, one that exits non-zero, one that prints nothing, and one that prints invalid JSON. The last three are all recorded as no schema, and only the invalid JSON earns a warning at adopt.
+
+- [ ] **Step 2: Add the probe**
+
+Reuse the spawn shape the `--version` probe already has, including `env_clear()`, `probe_env()`, the null stdin and the null stderr. This executes an untrusted third-party binary; it belongs next to the vetting that already governs that (execute bit, world-writable refusal, canonicalized path, spawn and kill) and must not grow a second, looser path.
+
+Per decision 7 the schema is never stored. If you find yourself adding a field to `shep.toml` or `dogs.toml` to cache it, stop: a stale schema mislabels which field is a credential, which is worse than a stale version number.
+
+- [ ] **Step 3: Run, prove non-vacuous, commit**
+
+---
+
+### Task 5: the topic, and bark listening on it
+
+**Files:**
+- Modify: `crates/shep-core/src/protocol/events.rs`, `crates/shep-daemon/src/`, `crates/shep-cli/src/dog/bark/mod.rs`
+
+**Interfaces:**
+- Produces: a seventh `BusEvent` variant whose topic is `config.dog.<name>`, published from the daemon-side migration only.
+
+**The spec denied this variant was needed and was wrong**, corrected in `debe38a`. A topic is derived from a variant and the six that exist have nowhere to carry a config change. The variant is additive, so `PROTOCOL_VERSION` does not move: an older peer never subscribed to a topic it does not know.
+
+- [ ] **Step 1: Write the failing tests**
+
+That the variant's topic renders as `config.dog.<name>` for a given name, that a `Topic` pattern of `config.*` matches it and `log.*` does not, and that the daemon-side migration publishes exactly once per dog it moved.
+
+- [ ] **Step 2: Add the variant and publish it**
+
+Publish from `daemon.rs:298` only. `:718` is the reload pre-flight in a CLI process with no bus, and `rehome`'s `forget_dog_section` removes the dog so there is no subscriber left to tell. Both are deliberate; say so in a comment at each, because the next reader will wonder why one of three writers publishes.
+
+- [ ] **Step 3: Make bark subscribe**
+
+bark re-asks with `Request::DogConfig` and swaps its sinks and rules in place, which decision 8 says it can do because they are pure data with no OS resource attached. metrics is NOT in scope here: its one key is a listening socket and rebinding is real work.
+
+If bark restarts itself for any reason, it must say so in its own log. The restart count cannot tell that apart from a crash loop, and that column is what an operator reads as instability.
+
+- [ ] **Step 4: Run, prove non-vacuous, commit**
+
+---
+
+### Task 6: schemas on both built-in dogs, and the contract an author reads
+
+**Files:**
+- Modify: `crates/shep-cli/src/dog/{metrics,bark}/mod.rs`, `docs/dogs.md`, `web/src/pages/docs/dogs.astro`
+
+- [ ] **Step 1: Derive `JsonSchema` on both config types**
+
+`MetricsConfig` has one field. `BarkConfig` has five, and `sinks` is a map of a type carrying a webhook URL, which is the field the whole secret marker exists for. Mark it.
+
+Both types derive `Deserialize` with `deny_unknown_fields, default`. Check what those do to a generated schema before assuming the result is right, and pin the marked field with an exact-string test.
+
+- [ ] **Step 2: Write the contract**
+
+`docs/dogs.md` is where a dog author learns this. It gains `--schema`, `probe`, the derive, the secret marker, and the bus topic. Keep the existing paragraph explaining why a dog's section travels over the socket rather than through the environment; it is still true and it is the best thing on that page.
+
+Say plainly that answering is optional and what a dog that stays silent loses, which is release 3's pane.
+
+- [ ] **Step 3: Run the full gate**
+
+Including `astro check`, which CI does not run and which catches a prop a build accepts.
+
+---
+
+## Self-Review
+
+**Spec coverage.** Decision 4 is Tasks 3 and 4. Decision 5 is Task 1 and Task 3. Decision 6 and 6b are Tasks 2 and 3. Decision 7 is Task 4 step 2's warning against caching. Decision 8 is Task 5. The built-in schemas and bark's subscription are Tasks 5 and 6.
+
+**Left open for the implementer, deliberately.** What `probe` does with the `schema` feature off (Task 3 step 2). Whether `DogVersion` moves or only its parser (Task 1 step 1). Whether `release-plz.toml` needs an entry for a new member (Task 2 step 2). Each is flagged at its step, because on the previous branch three defects came from a plan asserting things about existing code its author had not read.
+
+**Placeholder scan.** No TBDs. Test bodies in Tasks 3 to 5 are named and their purpose stated but not written out: the fixtures depend on signatures Task 1 and Task 2 produce, and a plan inventing them would send an implementer to reconcile the difference.
+
+**Type consistency.** `shep_core::dogs::{VERSION_FLAG, SCHEMA_FLAG, SHEP_PROTOCOL_KEY, SECRET_KEY}` is the spelling throughout. `shep_client::dogs::probe` and `shep_client::dogs::DogConfig` are what a dog author touches; `shep-macros` is never named in a dog's own source.

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -121,6 +121,10 @@ name = "shep-client"
 version_group = "shep"
 
 [[package]]
+name = "shep-macros"
+version_group = "shep"
+
+[[package]]
 name = "shep-daemon"
 version_group = "shep"
 

--- a/web/src/pages/docs/dogs.astro
+++ b/web/src/pages/docs/dogs.astro
@@ -15,6 +15,31 @@ const barksDemo = `$ shep barks
 WHEN                 RULE    SUBJECT  MESSAGE                                                                     SINKS
 2026-08-29 21:06:35  daemon  flaky    dog flaky exhausted its restart budget: 15 restarts against a budget of 16  -`;
 
+const probeSnippet = `fn main() {
+    shep_client::dogs::probe::<MyDogConfig>(
+        env!("CARGO_PKG_NAME"),
+        env!("CARGO_PKG_VERSION"),
+    );
+    // ...normal startup, reached only when this run is not a probe.
+}`;
+
+const configSnippet = `use shep_client::dogs::DogConfig;
+
+#[derive(Default, serde::Deserialize, schemars::JsonSchema, DogConfig)]
+#[serde(deny_unknown_fields, default)]
+struct MyDogConfig {
+    /// Where to POST. Doc comments become the schema's descriptions.
+    #[shep(secret)]
+    webhook: String,
+    /// What to watch.
+    path: String,
+}`;
+
+const schemaNotice = `notice[dog_schema_unreadable]: pydog answered \`--schema\` with something that
+is not JSON, so shep has no description of its settings and they stay a
+hand-edited section. The dog is adopted and runs normally; this is a bug to
+report to whoever wrote it`;
+
 const dogLogDemo = `2026-09-02T14:22:31.412+02:00 [shep] shep started this dog; its process is pid 5512
 2026-09-02T14:22:31.480+02:00 [shep] shep accepted this dog's handshake; it is registered with this shepherd as \`log-rotate\`, on protocol 3
 2026-09-02T14:22:31.492+02:00 rotating web-0-out.log (12.4 MiB)`;
@@ -170,6 +195,23 @@ $ shep disable metrics`}</CodeBlock>
       startup, and nothing pushes it a new one. <code>shep disable
       &lt;name&gt; &amp;&amp; shep enable &lt;name&gt;</code> is what
       re-reads it: a fresh process asking a fresh question.
+    </Callout>
+    <p>
+      A dog can subscribe instead of waiting to be bounced. Shep publishes
+      on <code>config.dog.&lt;name&gt;</code> when it changes a dog's
+      section itself, and a dog holding a subscription re-asks for its
+      section and decides what the change means: swap the values, rebind a
+      listener, or ask for its own restart. The frame says that the section
+      changed and nothing about what is in it. Bark subscribes and swaps in
+      place, since sinks and rules are pure data with no OS resource
+      attached. One thing publishes today, the boot that moves a section out
+      of <code>shep.toml</code>, so a hand edit still needs the stop and
+      start above.
+    </p>
+    <Callout variant="careful">
+      A dog that restarts itself on a config change has to say so in its own
+      log. Nothing else can tell that apart from a crash loop, and the
+      restart count is the column an operator reads as instability.
     </Callout>
     <Callout variant="careful">
       A section that used to live in <code>shep.toml</code> migrates to{" "}
@@ -516,12 +558,23 @@ shep-protocol: 3`}</CodeBlock>
       right on the first try. Hand written JSON is where the quoting and the
       trailing comma go wrong, and nothing here nests.
     </p>
-    <p>Emitting it needs no dependency a dog doesn't already have:</p>
-    <CodeBlock label="main.rs">{`if std::env::args().nth(1).as_deref() == Some("--version") {
-    println!("{} {}", env!("CARGO_PKG_NAME"), env!("CARGO_PKG_VERSION"));
-    println!("shep-protocol: {}", shep_client::PROTOCOL_VERSION);
-    return;
-}`}</CodeBlock>
+    <p>
+      A dog written against <code>shep-client</code> answers this probe and
+      the schema one below with a single call, as the first line of{" "}
+      <code>main</code>:
+    </p>
+    <CodeBlock label="main.rs">{probeSnippet}</CodeBlock>
+    <p>
+      It prints the answer and exits when shep asked a question, and returns
+      when it didn't, so nothing after it runs on a probe: put it before
+      anything has been opened. The name and the version are arguments
+      because <code>env!</code> expands where it's written, and they're the
+      two facts only the dog knows. The flag names, the{" "}
+      <code>shep-protocol</code> key and the number it carries all come from
+      shep. That's the point of the call: they were hand-typed from this
+      page until it existed, and a typo in any of them read as "protocol
+      unknown" with nothing saying so.
+    </p>
     <Callout variant="note">
       Answering is optional and stays optional. Dogs predating the
       convention are still adoptable, and a dog that doesn't answer is never
@@ -727,6 +780,68 @@ shep-dog 0.1.24`}</CodeBlock>
       fine. What catches it is the dog's own CI building against a current{" "}
       <code>shep-core</code>, which is where both published dogs' breakage
       was already visible and unread.
+    </p>
+
+    <h2>Answering <code>--schema</code></h2>
+    <p>
+      <code>shep adopt</code> asks a second question straight after the
+      first: <code>--schema</code>, answered on stdout with a JSON Schema
+      for the dog's own <code>[&lt;name&gt;]</code> section. Same shape as{" "}
+      <code>--version</code> and the same budget: spawn, read, kill.
+    </p>
+    <p>
+      Asked of the binary rather than over the socket, because the dog most
+      in need of configuring is the one that's disabled or has never
+      started, and it has no connection to answer on. Configure then enable
+      is the order an operator wants.
+    </p>
+    <p>
+      <code>probe</code> answers this flag too, from its type parameter.
+      Derive <code>JsonSchema</code> and <code>DogConfig</code> on the type
+      the dog deserializes its config into, and mark every field holding a
+      credential:
+    </p>
+    <CodeBlock label="config.rs">{configSnippet}</CodeBlock>
+    <p>
+      <code>#[shep(secret)]</code> says the field is a bearer credential,
+      and shep renders one as <code>&lt;set&gt;</code>: replaceable, never
+      read back. The attribute exists rather than the schemars extension it
+      expands to because that extension key is a string the author types,
+      and a transposed letter in it compiles, validates, marks nothing, and
+      paints the credential on screen. Marking a field the schema doesn't
+      have, which is what a <code>#[serde(rename)]</code> on it produces, is
+      a refusal rather than a silent pass.
+    </p>
+    <Callout variant="careful">
+      A mark names a field of the type shep asked about. A credential one
+      type down, in a nested struct or in a map's values, isn't covered by a
+      mark down there: mark the field that holds them. Bark's own{" "}
+      <code>sinks</code> map is marked whole for this reason, and every sink
+      in it carries a webhook URL.
+    </Callout>
+    <Callout variant="note">
+      Answering is optional, exactly as <code>--version</code> is. A dog
+      that says nothing is adopted, recorded as having no schema, and
+      refused nothing, which is every dog written before this contract. What
+      it gives up is a description of itself: a settings pane needs a schema
+      to render, so its section stays a file an operator hand-edits.
+    </Callout>
+    <p>
+      A dog that answers something that isn't JSON gets one line, and is
+      adopted anyway:
+    </p>
+    <CodeBlock>{schemaNotice}</CodeBlock>
+    <p>
+      Silence earns no such line, for the reason an unstated protocol earns
+      none: it's the ordinary case, and a notice for every dog is how an
+      operator learns to skip the one that matters.
+    </p>
+    <p>
+      The answer isn't written down, on the same rule the protocol number
+      follows. <code>cargo install</code> replaces a binary with nothing
+      watching, and a stale schema is worse than a stale version number,
+      because it mislabels which field is a credential. Shep asks the binary
+      again when it needs one.
     </p>
 
     <h2>What shep writes into a dog's own log</h2>

--- a/web/src/pages/docs/dogs.astro
+++ b/web/src/pages/docs/dogs.astro
@@ -613,11 +613,10 @@ current shep-core, or run a shep that speaks 2`}</CodeBlock>
     </p>
     <p>
       A candidate gets one second to exit and another to have its output
-      read, so two seconds is the worst case rather than one. It is killed
-      either way, so a
-      dog that ignores <code>--version</code> and runs costs that second and
-      is adopted with an unknown protocol. It can't hang the{" "}
-      <code>adopt</code> that's vetting it.
+      read, and an adopt runs two probes, so roughly four seconds is the
+      worst case. It is killed either way, so a dog that ignores both flags
+      and runs costs that time and is adopted with an unknown protocol. It
+      can't hang the <code>adopt</code> that's vetting it.
     </p>
     <p>
       None of the answer is written down. <code>[daemon] adopted_dogs</code>{" "}

--- a/web/src/pages/docs/dogs.astro
+++ b/web/src/pages/docs/dogs.astro
@@ -1,9 +1,9 @@
 ---
 /*
- * Dogs (docs/dogs.md, 309 lines, ported for a reader who is not a
- * contributor). Every command and table below was run against
- * target/release/shep during page-writing — see the commit message for the
- * transcript. Quality bar: getting-started.astro.
+ * Dogs (docs/dogs.md, ported for a reader who is not a contributor).
+ * Every command and table below was run against target/release/shep during
+ * page-writing: the commit message carries the transcript. Quality bar:
+ * getting-started.astro.
  */
 import DocsLayout from "../../layouts/DocsLayout.astro";
 import ReferencePills from "../../components/docs/ReferencePills.astro";

--- a/web/src/pages/docs/dogs.astro
+++ b/web/src/pages/docs/dogs.astro
@@ -375,9 +375,11 @@ sinks = ["oncall"]`}</CodeBlock>
         anything that exists, isn't a file, has no execute bit, or is
         world-writable, and refusing a name that already belongs to a
         built-in verb or alias, since such a dog could never be reached.
-        Passing all of that, it actually spawns the binary with no
-        arguments and kills it immediately, because the only honest way to
-        know whether this kernel can exec a file is to ask this kernel.
+        Passing all of that, it actually spawns the binary and kills it
+        immediately, because the only honest way to know whether this kernel
+        can exec a file is to ask this kernel. The <code>--version</code>
+        probe below is that spawn, so the exec proof and the version answer
+        cost one child rather than two.
       </p>
     </VerbSignature>
     <VerbSignature verb="rehome" usage="shep rehome <name>">


### PR DESCRIPTION
A dog now publishes a JSON Schema for its own config, and shep asks for it on adoption. Release 2 of `docs/brainstorming/specs/2026-09-03-dog-config-design.md`, decisions 4 through 8. Plan: `docs/writing-plans/plans/2026-09-04-dog-contract.md`. Release 1 was #112, the store move.

Before this, a dog's config was opaque to shep: a section in `dogs.toml` it copied around without knowing what was in it. Nothing could render a settings pane for something it cannot describe. Six pieces:

- `shep_client::dogs::probe::<MyConfig>()` as the first line of `main` answers both `--version` and `--schema`. It replaces the four lines of hand-rolled argv matching `docs/dogs.md` used to tell authors to copy, which is a contract the docs published and shep did not own
- `#[shep(secret)]` marks a bearer credential, so a pane can render `<set>` rather than a webhook URL. It lives in a new `shep-macros` crate because the schemars extension key it expands to is a string the author types, and one transposed letter compiles, validates, marks nothing, and paints the token on screen
- a marked field the schema does not have is a refusal, which is what a `#[serde(rename)]` on it produces
- `BusEvent::DogConfigChanged` on topic `config.dog.<name>`, so a running dog can re-ask instead of being stopped and started. Bark subscribes
- both built-in dogs publish schemas. Bark marks its `sinks` map whole rather than each URL, and the reason is a real limit: a mark names a field of the type shep asked about, so a credential one type down is not covered by a mark down there
- `docs/dogs.md` and the docs site say all of it. Answering stays optional and a silent dog is refused nothing, which is every dog written before this

**`BusEvent::topic` returns `Cow<'static, str>` instead of `&'static str`.** A per-dog topic cannot be a `&'static str`. Every fixed variant still returns `Cow::Borrowed`, so nothing allocates per event. `PROTOCOL_VERSION` does not move: the variant is additive and `BusEvent` is `#[non_exhaustive]`. This is a source break for an out-of-tree consumer, not a wire one. What makes the next release a minor bump rather than a patch is the `!` in this PR's title, and nothing else: `merge_commit_title` is `PR_TITLE` with a blank body, so that subject is the only conventional commit release-plz reads. Retitle on merge without the `!` and the break ships as `0.2.1`. `cargo-semver-checks` does not cover it, which I checked rather than assumed: against `origin/main` as the baseline it reports 196 checks passing and no update required, so the tool is not a second net here.

The whole-branch review found a hole in the credential marking worth writing down, because the mechanism looked right and its own guard was what failed. Marking was by name across the whole schema document, and so was the check: a name reached anywhere went into the `found` set that `SecretFieldMissing` tests. So a marked field renamed out from under its Rust identifier passed the guard whenever any other type in the document happened to carry a property of that name. Proven by probe, not by reading: `#[shep(secret)] #[serde(rename = "api_token")] token` beside an unmarked nested `Inner { token }` returned `Ok`, shipped the real credential unmarked, and marked the innocent one. The same bug pointing outward was already live here: `$defs/Rule/properties/sinks` in bark is a `Vec<String>` of sink names and it came out carrying the credential marker, so every rule's sink list would have rendered write-only in a built-in dog.

The cut is to skip the `$defs` key, since that is where other types live, while still descending through `oneOf`, `anyOf` and `allOf`, which is what a tagged enum's schema needs. That was a guess in the fix brief, flagged as one, and dumping real schemars output found a shape it had not named: an adjacently tagged enum keeps its variant fields under a content property, so a cut that also stopped at `properties` would have broken it. The one shape that does put a root under `$defs` is a newtype tuple struct, and `shep-macros` already refuses `#[shep(secret)]` on an unnamed field, so that edge is unreachable rather than merely unprobed.

`cargo test -p shep-client --no-default-features` was broken and nothing could see it. `schema` became a default feature here, and the test module named schemars in a build with no schemars. The task gate is `--all-features`, which never turns a feature off, and CI's only opt-out leg was `-p shep-daemon`. There is a leg for it now. Two halves: the unit tests, and the module doc example, which rustdoc compiles as its own crate and which no `--all-targets` command reads. The re-review reproduced both against the new leg separately.

Two things accepted rather than fixed, so you can disagree. Decision 8 also asks for a publish on a rescan at `shep daemon reload`, and only the boot migration publishes today, because the reload pre-flight runs in a CLI process with no bus to publish onto. The docs say what is true rather than what the spec says. And a dog name is unvalidated and now reaches `Glob::new` on the subscribe side, so a dog adopted as `a*` over-subscribes to config frames that carry only names. Neither is new to this branch's own work.

Known and filed rather than fixed: a `#[shep(secret)]` on a nested type is inert and silent. Bark works around it by marking the map whole, both doc pages warn, and closing it needs a design pass, because a derive cannot ask whether a field's type implements a trait and the generated schema records no Rust types.

Every new test proven non-vacuous by mutating what it protects and watching that one test go red, with a grep after each patch to confirm it applied: deleting the topic from bark's subscribe vec, making `spawn_firings` a no-op, restoring the `$defs` walk twice, dropping the secret marker, dropping all three `url` marks, marking every property, and removing each serde attribute in turn. One earlier round is worth naming: two tests hung rather than failed under mutation, because `tokio::time::start_paused` with a `spawn_blocking` bridge inhibits auto-advance, so the helper's own doc claimed a wall-clock timeout it could not enforce. The helper is gone.

Gate, each command's `$?` captured directly rather than through a pipe, on the rebased branch: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`, `cargo test --workspace --all-features`, `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features`, `cargo test -p shep-client --no-default-features`, all EXIT=0. `cargo build --release` and `./web/scripts/generate-cli-reference.sh` EXIT=0 with no diff, so no verb's help text moved. `astro build` and `astro check` EXIT=0, 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Dogs can provide optional JSON Schemas describing their configuration.
  - Configuration secrets are identified and protected in generated schemas.
  - Bark refreshes its configuration live when dog settings change, without restarting.
  - Dog adoption validates version and schema responses with bounded, safer probing.
  - Added configuration-change notifications across the daemon and dog clients.
  - Schema support can be disabled for client setups that do not require it.

- **Documentation**
  - Expanded dog authoring and configuration guidance, including schema probes, secret handling, subscriptions, and reload behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->