### PR TITLE
chore: release v0.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2058,7 +2058,7 @@ dependencies = [
 
 [[package]]
 name = "shep"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anstyle",
  "assert_cmd",
@@ -2096,11 +2096,11 @@ dependencies = [
 
 [[package]]
 name = "shep-cli"
-version = "0.2.0"
+version = "0.2.1"
 
 [[package]]
 name = "shep-client"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "futures-util",
  "nix 0.29.0",
@@ -2116,7 +2116,7 @@ dependencies = [
 
 [[package]]
 name = "shep-core"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "annotate-snippets",
  "anstyle",
@@ -2146,7 +2146,7 @@ dependencies = [
 
 [[package]]
 name = "shep-daemon"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "bytes",
  "chrono",
@@ -2175,14 +2175,14 @@ dependencies = [
 
 [[package]]
 name = "shep-examples"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "nix 0.29.0",
 ]
 
 [[package]]
 name = "shep-macros"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "proc-macro2",
  "quote 1.0.47",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 # 1.88 forced by serde-saphyr (let-chains, stabilized 1.88) — a current dep,
 # not a future one. Also the floor for ratatui/sysinfo/rmcp in later phases.
@@ -32,10 +32,10 @@ license = "MIT OR Apache-2.0"
 # the `[package]` table. This literal is not sourced from
 # `workspace.package.version` above and a release bump has to touch both
 # places by hand. If that drifts, `cargo-release` is the mechanical fix.
-shep-core = { path = "crates/shep-core", version = "0.2.0" }
-shep-daemon = { path = "crates/shep-daemon", version = "0.2.0" }
-shep-client = { path = "crates/shep-client", version = "0.2.0" }
-shep-macros = { path = "crates/shep-macros", version = "0.2.0" }
+shep-core = { path = "crates/shep-core", version = "0.2.1" }
+shep-daemon = { path = "crates/shep-daemon", version = "0.2.1" }
+shep-client = { path = "crates/shep-client", version = "0.2.1" }
+shep-macros = { path = "crates/shep-macros", version = "0.2.1" }
 serde = { version = "1", default-features = false, features = ["derive"] }
 serde_json = { version = "1", default-features = false, features = ["std"] }
 toml = { version = "0.8", default-features = false, features = ["parse", "display"] }

--- a/crates/shep-cli/CHANGELOG.md
+++ b/crates/shep-cli/CHANGELOG.md
@@ -13,6 +13,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1] - 2026-09-04
+
+### Changed
+
+- One name reaches both the topic and the re-read request
+
+
 ## [0.2.0] - 2026-09-04
 
 ### Added

--- a/crates/shep-client/CHANGELOG.md
+++ b/crates/shep-client/CHANGELOG.md
@@ -10,6 +10,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1] - 2026-09-04
+
+### Fixed
+
+- Keep a secret mark on the type shep asked about
+- Gate the schema tests on the feature that supplies them
+
+
 ## [0.2.0] - 2026-09-04
 
 

--- a/crates/shep-core/CHANGELOG.md
+++ b/crates/shep-core/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1] - 2026-09-04
+
+
 ## [0.2.0] - 2026-09-04
 
 ### Changed

--- a/crates/shep-daemon/CHANGELOG.md
+++ b/crates/shep-daemon/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1] - 2026-09-04
+
+
 ## [0.2.0] - 2026-09-04
 
 ### Added

--- a/crates/shep-macros/CHANGELOG.md
+++ b/crates/shep-macros/CHANGELOG.md
@@ -6,3 +6,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.2.1] - 2026-09-04
+


### PR DESCRIPTION



## 🤖 New release

* `shep-core`: 0.2.0 -> 0.2.1 (✓ API compatible changes)
* `shep-daemon`: 0.2.0 -> 0.2.1 (✓ API compatible changes)
* `shep-macros`: 0.2.0 -> 0.2.1
* `shep-client`: 0.2.0 -> 0.2.1 (✓ API compatible changes)
* `shep`: 0.2.0 -> 0.2.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>




## `shep-client`

<blockquote>

## [0.2.1] - 2026-09-04

### Fixed

- Keep a secret mark on the type shep asked about
- Gate the schema tests on the feature that supplies them
</blockquote>

## `shep`

<blockquote>

## [0.2.1] - 2026-09-04

### Changed

- One name reaches both the topic and the re-read request
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).