### PR TITLE
feat(lookout): a settings screen for shep.toml, behind --allow-control

### DIFF
--- a/crates/shep-cli/src/commands/dogs.rs
+++ b/crates/shep-cli/src/commands/dogs.rs
@@ -162,7 +162,8 @@ async fn connect_or_absent(
 /// [`ShepToml::try_edit`] is generic over the closure's error precisely so
 /// a verb whose refusal is its own thing does not have to dress it up as a
 /// [`ShepTomlError`] it is not.
-enum EnableRefusal {
+#[derive(Debug)]
+pub(crate) enum EnableRefusal {
     /// The read-modify-write underneath the closure failed; rendered by
     /// [`fail_config`], exactly as [`ShepToml::edit`]'s `Err` always was.
     Config(ShepTomlError),
@@ -180,8 +181,10 @@ impl From<ShepTomlError> for EnableRefusal {
     }
 }
 
-/// `shep enable <name>`: writes the config, and starts the dog if a
-/// shepherd is running.
+/// `enable`'s config half: which [`DogSource`] `name` resolves to, whether
+/// it names a dog at all, and the write itself. Split out from [`enable`]
+/// so a caller with no rows to print -- the settings screen -- can reuse
+/// the decision without reusing the reporting.
 ///
 /// A name that is neither built-in nor adopted is refused before anything
 /// is written. [`dog_source`] reads that distinction as an absence — a
@@ -191,20 +194,25 @@ impl From<ShepTomlError> for EnableRefusal {
 /// <typo>` on a restart ladder that cannot ever succeed: `dog::run_dog`
 /// refuses the name once per attempt until the budget is spent, while
 /// `shep dogs` reports the dog's `SOURCE` as `built-in`, which it is not.
-pub async fn enable(streams: &mut Streams<'_>, paths: &ShepPaths, name: &str) -> ExitCode {
-    // `try_edit` rather than `edit`, and the check inside the closure
-    // rather than before the call: the refusal must skip `save` entirely
-    // (a refused enable leaves `shep.toml` untouched, down to its inode),
-    // and the adopted-name lookup it turns on must happen under the lock
-    // that keeps a concurrent `shep adopt` from landing between the check
-    // and the write.
-    // `result_large_err` on the closure, for the same reason and on the same
-    // platform as the module-wide allow in `commands::shep_toml` -- see the
-    // banner there. `EnableRefusal::Config` carries that module's error, so
-    // this closure is measured against the same 128-byte threshold the
-    // `try_edit` call in `lib.rs`'s `shep style` arm already allows for.
-    #[cfg_attr(windows, allow(clippy::result_large_err))]
-    let source = match ShepToml::try_edit(&paths.daemon_config, |cfg| {
+///
+/// `try_edit` rather than `edit`, and the check inside the closure rather
+/// than before the call: the refusal must skip `save` entirely (a refused
+/// enable leaves `shep.toml` untouched, down to its inode), and the
+/// adopted-name lookup it turns on must happen under the lock that keeps a
+/// concurrent `shep adopt` from landing between the check and the write.
+/// `result_large_err` on the closure, for the same reason and on the same
+/// platform as the module-wide allow in `commands::shep_toml` -- see the
+/// banner there. `EnableRefusal::Config` carries that module's error, so
+/// this closure is measured against the same 128-byte threshold the
+/// `try_edit` call in `lib.rs`'s `shep style` arm already allows for.
+///
+/// # Errors
+/// [`EnableRefusal::Config`] if the read-modify-write underneath the
+/// closure failed. [`EnableRefusal::UnknownDog`] if `name` is neither one
+/// of [`crate::dog::BUILT_IN_DOGS`] nor a key of `[daemon] adopted_dogs`.
+#[cfg_attr(windows, allow(clippy::result_large_err))]
+pub(crate) fn enable_in_config(path: &Path, name: &str) -> Result<DogSource, EnableRefusal> {
+    ShepToml::try_edit(path, |cfg| {
         // Read from the config rather than assumed: `shep adopt` records
         // the binary and `shep enable` is what starts it afterwards, so a
         // hardcoded `BuiltIn` here sends the shepherd off to spawn `shep
@@ -217,7 +225,13 @@ pub async fn enable(streams: &mut Streams<'_>, paths: &ShepPaths, name: &str) ->
         }
         cfg.enable_dog(name);
         Ok(source)
-    }) {
+    })
+}
+
+/// `shep enable <name>`: writes the config, and starts the dog if a
+/// shepherd is running.
+pub async fn enable(streams: &mut Streams<'_>, paths: &ShepPaths, name: &str) -> ExitCode {
+    let source = match enable_in_config(&paths.daemon_config, name) {
         Ok(source) => source,
         Err(EnableRefusal::Config(err)) => return fail_config(streams, &err),
         Err(EnableRefusal::UnknownDog { adopted }) => {
@@ -345,18 +359,30 @@ async fn enable_after_config(
     }
 }
 
-/// `shep disable <name>`: removes it from the config, and stops it if a
-/// shepherd is running.
-pub async fn disable(streams: &mut Streams<'_>, paths: &ShepPaths, name: &str) -> ExitCode {
-    let source = match ShepToml::edit(&paths.daemon_config, |cfg| {
-        // `disable_dog` leaves `[daemon] adopted_dogs` alone — that is the
-        // difference between `disable` and `rehome` — so this reads the
-        // same answer before or after the edit. It is read for the report
-        // only: `DisableDog` carries a name and nothing else.
+/// `disable`'s config half: which [`DogSource`] `name` resolved to, and
+/// the removal from `[daemon] enabled_dogs`. Split out from [`disable`]
+/// so a caller with no rows to print -- the settings screen -- can reuse
+/// the decision without reusing the reporting.
+///
+/// `disable_dog` leaves `[daemon] adopted_dogs` alone — that is the
+/// difference between `disable` and `rehome` — so this reads the same
+/// answer before or after the edit. It is read for the report only:
+/// `DisableDog` carries a name and nothing else.
+///
+/// # Errors
+/// [`ShepTomlError`] if the read-modify-write underneath the edit failed.
+pub(crate) fn disable_in_config(path: &Path, name: &str) -> Result<DogSource, ShepTomlError> {
+    ShepToml::edit(path, |cfg| {
         let source = dog_source(cfg, name);
         cfg.disable_dog(name);
         source
-    }) {
+    })
+}
+
+/// `shep disable <name>`: removes it from the config, and stops it if a
+/// shepherd is running.
+pub async fn disable(streams: &mut Streams<'_>, paths: &ShepPaths, name: &str) -> ExitCode {
+    let source = match disable_in_config(&paths.daemon_config, name) {
         Ok(source) => source,
         Err(err) => return fail_config(streams, &err),
     };
@@ -1918,6 +1944,60 @@ mod tests {
             style: crate::style::Presentation::BARE,
             fmt: Format::Table,
         }
+    }
+
+    #[test]
+    fn enable_in_config_writes_the_name_and_reports_a_built_in_source() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("shep.toml");
+
+        let source = enable_in_config(&path, "metrics").unwrap();
+
+        assert!(matches!(source, DogSource::BuiltIn));
+        assert!(
+            ShepToml::read_only(&path)
+                .unwrap()
+                .enabled_dog_names()
+                .contains(&"metrics".to_string())
+        );
+    }
+
+    #[test]
+    fn enable_in_config_refuses_a_name_that_is_no_dog_and_writes_nothing() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("shep.toml");
+        std::fs::write(&path, "").unwrap();
+
+        let refusal = enable_in_config(&path, "nonsense");
+
+        assert!(matches!(refusal, Err(EnableRefusal::UnknownDog { .. })));
+        assert_eq!(
+            std::fs::read_to_string(&path).unwrap(),
+            "",
+            "a refused enable leaves shep.toml untouched"
+        );
+    }
+
+    #[test]
+    fn disable_in_config_removes_the_name_and_keeps_the_adoption() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("shep.toml");
+        std::fs::write(
+            &path,
+            "[daemon]\nenabled_dogs = [\"otel\"]\n\n[daemon.adopted_dogs]\notel = \"/usr/local/bin/shep-otel\"\n",
+        )
+        .unwrap();
+
+        let source = disable_in_config(&path, "otel").unwrap();
+
+        assert!(matches!(source, DogSource::Adopted { .. }));
+        let cfg = ShepToml::read_only(&path).unwrap();
+        assert!(cfg.enabled_dog_names().is_empty());
+        assert_eq!(
+            cfg.adopted_dog_names(),
+            vec!["otel".to_string()],
+            "disable is not rehome, so the adoption survives"
+        );
     }
 
     /// fails if `enable` sends anything but `EnableDog` with the name and

--- a/crates/shep-cli/src/commands/dogs.rs
+++ b/crates/shep-cli/src/commands/dogs.rs
@@ -162,6 +162,12 @@ async fn connect_or_absent(
 /// [`ShepToml::try_edit`] is generic over the closure's error precisely so
 /// a verb whose refusal is its own thing does not have to dress it up as a
 /// [`ShepTomlError`] it is not.
+///
+/// `Debug` is derived rather than redacted (IR-41): [`Self::Config`]
+/// forwards to [`ShepTomlError`]'s own manually redacted `Debug`, which is
+/// where a secret in the document would surface, and
+/// [`Self::UnknownDog`] carries dog names that this same refusal already
+/// prints to the operator on its way out.
 #[derive(Debug)]
 pub(crate) enum EnableRefusal {
     /// The read-modify-write underneath the closure failed; rendered by
@@ -364,8 +370,8 @@ async fn enable_after_config(
 /// so a caller with no rows to print -- the settings screen -- can reuse
 /// the decision without reusing the reporting.
 ///
-/// `disable_dog` leaves `[daemon] adopted_dogs` alone — that is the
-/// difference between `disable` and `rehome` — so this reads the same
+/// `disable_dog` leaves `[daemon] adopted_dogs` alone, which is the
+/// difference between `disable` and `rehome`, so this reads the same
 /// answer before or after the edit. It is read for the report only:
 /// `DisableDog` carries a name and nothing else.
 ///

--- a/crates/shep-cli/src/commands/dogs.rs
+++ b/crates/shep-cli/src/commands/dogs.rs
@@ -1940,6 +1940,55 @@ mod tests {
     use super::*;
     use crate::cli::Format;
 
+    /// The redaction IR-41 requires of [`EnableRefusal`], pinned as exact
+    /// strings rather than as a "contains no secret" probe: this type
+    /// derives `Debug`, so what it prints is decided half by the derive and
+    /// half by [`ShepTomlError`]'s own manual impl, and a change to either
+    /// one alone could start printing the document. `shep.toml` can hold a
+    /// dog's webhook token in an un-migrated `[dog.<name>]` table, which is
+    /// exactly what a `toml_edit` parse error quotes into its `Display`.
+    ///
+    /// The three cases are the two the wrapper can be built from and the
+    /// one it owns: a `WrongShape` (no document anywhere in it), a `Parse`
+    /// (the one that has a document to leak), and an `UnknownDog` (names
+    /// the refusal prints to the operator anyway).
+    #[test]
+    fn enable_refusal_debug_never_prints_the_document() {
+        let path = std::path::PathBuf::from("/home/ada/.shep/shep.toml");
+        let secret = "https://hooks.example.com/services/T00/B00/super-secret-token";
+        let broken = format!("[dog.bark]\nwebhook = \"{secret}\"\n[daemon\n");
+        let source = broken.parse::<toml_edit::DocumentMut>().unwrap_err();
+
+        let wrong_shape = EnableRefusal::Config(ShepTomlError::WrongShape {
+            path: path.clone(),
+            key: "style",
+            found: "string",
+        });
+        assert_eq!(
+            format!("{wrong_shape:?}"),
+            "Config(WrongShape { path: \"/home/ada/.shep/shep.toml\", key: \"style\", \
+             found: \"string\" })"
+        );
+
+        let parse = EnableRefusal::Config(ShepTomlError::Parse { path, source });
+        let debug = format!("{parse:?}");
+        assert!(
+            !debug.contains(secret),
+            "the document must never reach Debug: {debug}"
+        );
+        assert!(!debug.contains("webhook"), "{debug}");
+        assert_eq!(
+            debug,
+            "Config(Parse { path: \"/home/ada/.shep/shep.toml\", message: \"invalid table \
+             header\\nexpected `.`, `]`\" })"
+        );
+
+        let unknown = EnableRefusal::UnknownDog {
+            adopted: vec!["otel".to_string()],
+        };
+        assert_eq!(format!("{unknown:?}"), "UnknownDog { adopted: [\"otel\"] }");
+    }
+
     /// Every test in this module drives one of the dog verbs under
     /// `--format table` -- none of them exercises the JSON envelope -- so
     /// `fmt` is fixed here rather than threaded through every call site.

--- a/crates/shep-cli/src/commands/mod.rs
+++ b/crates/shep-cli/src/commands/mod.rs
@@ -1,8 +1,13 @@
-//! Per-verb command implementations, `daemon` first. OS tier: gated
-//! `#[cfg(unix)]` at this module's own declaration in `lib.rs`, so nothing
-//! declared beneath it needs a `cfg` of its own -- and nothing under it is
-//! compiled on Windows at all, which is why the tests here reach for `sh`
-//! and `sleep` without a portability dance.
+//! Per-verb command implementations, `daemon` first.
+//!
+//! `mod commands;` at `lib.rs` carries no platform gate -- commit
+//! `6c2f44e` (2026-08-26) removed the blanket `#[cfg(unix)]` this doc used
+//! to claim, along with the Windows arm that refused every verb before
+//! reaching any of them, once the Windows tier became real. Every module
+//! under this one compiles on every platform; a Unix API call site gates
+//! itself individually instead (ten files in this crate hold one), the
+//! same way `commands::shep_toml`'s own module doc now describes for
+//! itself.
 
 pub mod admin;
 pub mod bleats;

--- a/crates/shep-cli/src/commands/mod.rs
+++ b/crates/shep-cli/src/commands/mod.rs
@@ -34,6 +34,7 @@ pub mod runtime;
 pub mod schema;
 pub(crate) mod selector;
 pub mod serve;
+pub(crate) mod settings;
 pub(crate) mod shep_toml;
 pub mod signal;
 // Unix only, and this is the Windows tier's largest deliberate omission

--- a/crates/shep-cli/src/commands/settings.rs
+++ b/crates/shep-cli/src/commands/settings.rs
@@ -1,0 +1,564 @@
+//! The settings screen's own reader and writer: the one place `shep.toml`'s
+//! raw text meets [`DaemonConfig`]'s opinion about whether a value is legal.
+//!
+//! `shep_toml`'s own module doc says [`DaemonConfig::load`] is "the one
+//! place the SHAPE of the file is decided" and that `shep_toml` "only ever
+//! adds or removes the handful of keys each verb owns". Validation
+//! therefore does not go there, and it does not go here as a change to
+//! either type -- it goes in [`apply_setting`], which is the one function
+//! that ever puts a mutated [`ShepToml`] and a real [`DaemonConfig::load`]
+//! in the same place.
+//!
+//! [`load_settings`] answers the opposite question, and answers it from the
+//! document, not from [`DaemonConfig`]: every `[daemon]` and `[whistle]`
+//! section is `#[serde(default)]`, so a loaded config cannot tell "the
+//! operator wrote this at its own default value" from "nobody ever wrote
+//! it" -- see `shep_toml::ShepToml::style_level`'s own doc for that
+//! argument in full. Reading a value out of a loaded [`DaemonConfig`] and
+//! calling it the file's would silently destroy the distinction this
+//! screen exists to show.
+
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+
+use shep_core::config::daemon::{DaemonSection, WhistleSection};
+use shep_core::config::{DaemonConfig, DaemonConfigError};
+use shep_core::values::UpDuration;
+
+use crate::commands::shep_toml::{ShepToml, ShepTomlError};
+use crate::dog::BUILT_IN_DOGS;
+use crate::style::{StyleLevel, StyleSource};
+
+// No new source enum. `crate::style::StyleSource` already has exactly
+// `Flag`, `Env`, `Config`, `Default`, and "which layer decided" is one
+// concept, so this reuses it rather than declaring a twin. Its `Display`
+// spells `Flag` and `Env` as `--style` and `$SHEP_STYLE`, which are
+// style-specific, and that is correct here because only `style_level`
+// ever produces those two variants: the shepherd's own env and flags are
+// invisible to this process, so a `[daemon]` field is only ever `Config`
+// or `Default`.
+//
+// `Config` is not a claim that the shepherd is using the value. It says
+// the key is in the file. See the design spec, "Two things decision 11
+// does not cover".
+
+/// One scalar as the screen shows it.
+///
+/// `Debug` is derived rather than redacted (IR-41): a rendered string and
+/// a layer name, no secret, nothing a `{:?}` could leak.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ScalarView {
+    /// Already rendered for display, defaults resolved.
+    pub value: String,
+    /// Which layer this value came from.
+    pub source: StyleSource,
+}
+
+/// Which scalar an edit names.
+///
+/// `Debug` is derived rather than redacted (IR-41): a bare field name, no
+/// secret, nothing a `{:?}` could leak.
+///
+/// Only [`Self::MaxCronSleep`] is constructed today, by this module's own
+/// tests. The other five are the lookout settings screen's own vocabulary
+/// for its other five fields, not yet wired to a keypress.
+/// `#[allow(dead_code)]` for the same reason [`load_settings`] carries it.
+#[allow(dead_code)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SettingField {
+    /// `[daemon] log_level`.
+    LogLevel,
+    /// `[daemon] log_json`.
+    LogJson,
+    /// `[daemon] socket`.
+    Socket,
+    /// `[daemon] max_cron_sleep`.
+    MaxCronSleep,
+    /// `[whistle] allow_control`.
+    AllowControl,
+    /// `[style] level`.
+    StyleLevel,
+}
+
+/// One edit, ready to apply.
+///
+/// `Debug` is derived rather than redacted (IR-41): the field name and the
+/// text an operator typed into the screen's own editor, no secret among
+/// the six scalars this reaches.
+///
+/// Constructed only by [`apply_setting`]'s own tests today.
+/// `#[allow(dead_code)]` for the same reason [`load_settings`] carries it.
+#[allow(dead_code)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SettingEdit {
+    /// Write `field` to `value`.
+    Set {
+        /// Which scalar.
+        field: SettingField,
+        /// The text as typed or chosen -- unparsed until [`apply_setting`]
+        /// validates it.
+        value: String,
+    },
+    /// Remove `field`'s key, returning it to the compiled default.
+    ///
+    /// Only [`SettingField::Socket`] and [`SettingField::MaxCronSleep`]
+    /// reach this: [`SettingField::StyleLevel`] is owned by `shep style`,
+    /// which cannot clear it either, and the other three are not optional
+    /// (design spec decision 5).
+    Unset {
+        /// Which scalar.
+        field: SettingField,
+    },
+}
+
+/// Everything the screen reads off disk in one go.
+///
+/// `Debug` is derived rather than redacted (IR-41): every field here is
+/// already a rendered [`ScalarView`] or a [`DogView`], neither of which
+/// carries a secret -- a dog's own webhook token lives in `dogs.toml`,
+/// which this type never reads.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SettingsSnapshot {
+    /// `[daemon] log_level`.
+    pub log_level: ScalarView,
+    /// `[daemon] log_json`.
+    pub log_json: ScalarView,
+    /// `[daemon] socket`.
+    pub socket: ScalarView,
+    /// `[daemon] max_cron_sleep`.
+    pub max_cron_sleep: ScalarView,
+    /// `[whistle] allow_control`.
+    pub allow_control: ScalarView,
+    /// `[style] level`, resolved.
+    pub style_level: ScalarView,
+    /// Every candidate dog: [`BUILT_IN_DOGS`] plus every `adopted_dogs`
+    /// key, sorted, deduplicated.
+    pub dogs: Vec<DogView>,
+}
+
+/// One row of the dogs table.
+///
+/// `Debug` is derived rather than redacted (IR-41): a name, a bool and an
+/// adopted binary's path, none of which is a secret -- the dog's own
+/// config, which can be, lives in `dogs.toml` and this type never touches
+/// it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DogView {
+    /// The dog's name.
+    pub name: String,
+    /// Whether `[daemon] enabled_dogs` names it.
+    pub enabled: bool,
+    /// `None` for a built-in dog; the adopted binary's path otherwise.
+    pub adopted_path: Option<PathBuf>,
+}
+
+/// What [`apply_setting`] can fail with.
+#[derive(Debug)]
+pub enum SettingError {
+    /// [`ShepToml::try_edit`]'s own setup or write failed -- the lock, the
+    /// read, or the rename.
+    Config(ShepTomlError),
+    /// [`DaemonConfig::load`] refused the document this edit would have
+    /// written, or the edit itself was not a legal value for its field
+    /// (an unparseable boolean, an unrecognised style level). Carries the
+    /// loader's own message, or this function's own, so the operator is
+    /// told which key and why.
+    Invalid(String),
+}
+
+impl std::fmt::Display for SettingError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Config(err) => write!(f, "{err}"),
+            Self::Invalid(message) => write!(f, "{message}"),
+        }
+    }
+}
+
+impl core::error::Error for SettingError {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
+        match self {
+            Self::Config(err) => Some(err),
+            Self::Invalid(_) => None,
+        }
+    }
+}
+
+impl From<ShepTomlError> for SettingError {
+    fn from(err: ShepTomlError) -> Self {
+        Self::Config(err)
+    }
+}
+
+/// Reads the snapshot. Takes no lock -- see [`ShepToml::read_only`], the
+/// door this reads through.
+///
+/// `socket_default` is the socket this lookout is connected over
+/// (`ShepPaths::socket`), so an absent `[daemon] socket` shows the live
+/// answer by construction rather than a recomputed guess. `style` is the
+/// already-resolved pair `lib.rs`'s `resolve_style` returns: every
+/// `[daemon]`/`[whistle]` field can only ever read as [`StyleSource::Config`]
+/// or [`StyleSource::Default`], because the layers that would make it
+/// [`StyleSource::Env`] or [`StyleSource::Flag`] belong to a different
+/// process, but `[style] level` is lookout's own and can be either of
+/// those two as well.
+///
+/// # Errors
+/// [`ShepTomlError::Io`] if `path` exists and could not be read.
+/// [`ShepTomlError::Parse`] if `path` exists and is not valid TOML.
+///
+/// Not called outside this module's own tests yet: the lookout settings
+/// screen (later tasks in this feature, wiring this module into `App` and
+/// its reducer) is the caller. Same precedent this crate already carries
+/// twice (`style::Presentation::BARE`, `output::OutputEnvelope`):
+/// `#[allow(dead_code)]` says so explicitly rather than inventing a call
+/// site nothing needs yet.
+#[allow(dead_code)]
+pub fn load_settings(
+    path: &Path,
+    socket_default: &Path,
+    style: (StyleLevel, StyleSource),
+) -> Result<SettingsSnapshot, ShepTomlError> {
+    let doc = ShepToml::read_only(path)?;
+    let daemon_default = DaemonSection::default();
+    let whistle_default = WhistleSection::default();
+
+    let log_level = match doc.daemon_log_level() {
+        Some(value) => ScalarView {
+            value,
+            source: StyleSource::Config,
+        },
+        None => ScalarView {
+            value: daemon_default.log_level.as_str().to_string(),
+            source: StyleSource::Default,
+        },
+    };
+    let log_json = match doc.daemon_log_json() {
+        Some(value) => ScalarView {
+            value: value.to_string(),
+            source: StyleSource::Config,
+        },
+        None => ScalarView {
+            value: daemon_default.log_json.to_string(),
+            source: StyleSource::Default,
+        },
+    };
+    let socket = match doc.daemon_socket() {
+        Some(value) => ScalarView {
+            value: value.display().to_string(),
+            source: StyleSource::Config,
+        },
+        None => ScalarView {
+            value: socket_default.display().to_string(),
+            source: StyleSource::Default,
+        },
+    };
+    let max_cron_sleep = match doc.daemon_max_cron_sleep() {
+        Some(value) => ScalarView {
+            value,
+            source: StyleSource::Config,
+        },
+        None => ScalarView {
+            value: render_compiled_max_cron_sleep(daemon_default.max_cron_sleep),
+            source: StyleSource::Default,
+        },
+    };
+    let allow_control = match doc.whistle_allow_control() {
+        Some(value) => ScalarView {
+            value: value.to_string(),
+            source: StyleSource::Config,
+        },
+        None => ScalarView {
+            value: whistle_default.allow_control.to_string(),
+            source: StyleSource::Default,
+        },
+    };
+    let (level, source) = style;
+    let style_level = ScalarView {
+        value: level.to_string(),
+        source,
+    };
+
+    Ok(SettingsSnapshot {
+        log_level,
+        log_json,
+        socket,
+        max_cron_sleep,
+        allow_control,
+        style_level,
+        dogs: dog_candidates(&doc),
+    })
+}
+
+/// [`DaemonSection::default`]'s own `max_cron_sleep`, rendered for the
+/// screen's default row. Read straight off the compiled struct rather than
+/// a typed literal (this module's own instruction, and a real one: the
+/// floor and the daemon's own fallback both live in `shep-daemon`, outside
+/// this crate). Today that default is `None` -- the daemon falls back to
+/// its own private `DEFAULT_MAX_CRON_SLEEP`, unreachable from here -- so
+/// "not set" is the honest answer rather than a guessed duration; a
+/// [`Some`] compiled default would render through [`UpDuration`]'s own
+/// `Display` unchanged.
+fn render_compiled_max_cron_sleep(default: Option<UpDuration>) -> String {
+    default.map_or_else(|| "not set".to_string(), |value| value.to_string())
+}
+
+/// Every candidate dog: [`BUILT_IN_DOGS`] plus every name
+/// [`ShepToml::adopted_dog_names`] returns, sorted and deduplicated by
+/// [`BTreeSet`], each paired with whether [`ShepToml::enabled_dog_names`]
+/// names it and its adopted path if it has one.
+fn dog_candidates(doc: &ShepToml) -> Vec<DogView> {
+    let enabled = doc.enabled_dog_names();
+    let mut names: BTreeSet<String> = BUILT_IN_DOGS
+        .iter()
+        .map(|name| (*name).to_string())
+        .collect();
+    names.extend(doc.adopted_dog_names());
+    names
+        .into_iter()
+        .map(|name| {
+            let adopted_path = doc.adopted_dog_path(&name);
+            let is_enabled = enabled.contains(&name);
+            DogView {
+                name,
+                enabled: is_enabled,
+                adopted_path,
+            }
+        })
+        .collect()
+}
+
+/// Applies one edit under the config lock, validating before it saves.
+///
+/// Goes through [`ShepToml::try_edit`]: the task-2 setter or unsetter runs
+/// first, then the mutated document is rendered
+/// ([`ShepToml::rendered`]) and handed to [`DaemonConfig::load`] with
+/// `&|_| None` in place of an env layer -- the same reasoning
+/// `commands::daemon`'s `reload_with_wait` already gives at its own
+/// pre-flight check: this process's environment is not the shepherd's, so
+/// layering it would refuse a file the shepherd would have survived and
+/// pass one it would not. A loader `Err` becomes
+/// [`SettingError::Invalid`] and returns from the closure before
+/// [`ShepToml::try_edit`] ever calls its own `save`, which is what leaves
+/// the file untouched down to its inode.
+///
+/// # Errors
+/// [`SettingError::Config`] -- the lock, the read or the write itself
+/// failed, or the field this document already held the key as a shape
+/// the setter cannot write into (see [`ShepTomlError::WrongShape`]).
+/// [`SettingError::Invalid`] -- the value is not legal for its field
+/// (an unparseable boolean, an unrecognised style level, a duration
+/// [`DaemonConfig::load`] refuses), or [`SettingEdit::Unset`] named a
+/// field that has no unset form.
+///
+/// Not called outside this module's own tests yet: see [`load_settings`]'s
+/// own note. `#[allow(dead_code)]` for the same reason.
+#[allow(dead_code)]
+pub fn apply_setting(path: &Path, edit: &SettingEdit) -> Result<(), SettingError> {
+    ShepToml::try_edit(path, |doc| -> Result<(), SettingError> {
+        match edit {
+            SettingEdit::Set { field, value } => set_field(doc, *field, value)?,
+            SettingEdit::Unset { field } => unset_field(doc, *field)?,
+        }
+        let rendered = doc.rendered();
+        DaemonConfig::load(Some(&rendered), &|_| None)
+            .map_err(|err: DaemonConfigError| SettingError::Invalid(err.to_string()))?;
+        Ok(())
+    })
+}
+
+/// The `Set` half of [`apply_setting`]'s match, factored out for
+/// readability: one field per arm, each reaching straight for its own
+/// task-2 setter.
+fn set_field(doc: &mut ShepToml, field: SettingField, value: &str) -> Result<(), SettingError> {
+    match field {
+        SettingField::LogLevel => doc.set_daemon_log_level(value)?,
+        SettingField::LogJson => doc.set_daemon_log_json(parse_bool_field(value)?)?,
+        SettingField::Socket => doc.set_daemon_socket(Path::new(value))?,
+        SettingField::MaxCronSleep => doc.set_daemon_max_cron_sleep(value)?,
+        SettingField::AllowControl => doc.set_whistle_allow_control(parse_bool_field(value)?)?,
+        SettingField::StyleLevel => {
+            let level = StyleLevel::parse(value).ok_or_else(|| {
+                SettingError::Invalid(format!("{value} does not name a style level"))
+            })?;
+            doc.set_style_level(level)?;
+        }
+    }
+    Ok(())
+}
+
+/// The `Unset` half of [`apply_setting`]'s match. Only
+/// [`SettingField::Socket`] and [`SettingField::MaxCronSleep`] have an
+/// unsetter to reach; every other field refuses, per [`SettingEdit::Unset`]'s
+/// own doc.
+fn unset_field(doc: &mut ShepToml, field: SettingField) -> Result<(), SettingError> {
+    match field {
+        SettingField::Socket => doc.unset_daemon_socket(),
+        SettingField::MaxCronSleep => doc.unset_daemon_max_cron_sleep(),
+        _ => {
+            return Err(SettingError::Invalid(
+                "this field has no unset form".to_string(),
+            ));
+        }
+    }
+    Ok(())
+}
+
+/// `"true"`/`"false"` only -- the same closed grammar
+/// [`shep_core::config::parse_daemon_bool`] accepts for `SHEP_LOG_JSON`,
+/// so a boolean typed into this screen and one set through the
+/// environment never silently disagree on what counts as valid.
+fn parse_bool_field(value: &str) -> Result<bool, SettingError> {
+    match value {
+        "true" => Ok(true),
+        "false" => Ok(false),
+        _ => Err(SettingError::Invalid(format!(
+            "{value} is not true or false"
+        ))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::os::unix::fs::MetadataExt as _;
+
+    use super::*;
+
+    /// The style pair every test that does not care about `[style]` uses:
+    /// a resolved level with the source the config layer would report.
+    fn style_fixture() -> (StyleLevel, StyleSource) {
+        (StyleLevel::Full, StyleSource::Config)
+    }
+
+    fn socket_default_fixture() -> PathBuf {
+        PathBuf::from("/var/run/shep-settings-fixture.sock")
+    }
+
+    #[test]
+    fn a_fresh_home_reads_every_scalar_as_the_default() {
+        // What `scaffold_first_run_interpreters` actually leaves behind, and
+        // the state most operators open this screen in.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("shep.toml");
+        ShepToml::edit(&path, ShepToml::write_starter_interpreters).unwrap();
+
+        let snap = load_settings(&path, &socket_default_fixture(), style_fixture()).unwrap();
+        assert_eq!(snap.log_level.source, StyleSource::Default);
+        assert_eq!(snap.log_level.value, "warn");
+        assert_eq!(snap.log_json.source, StyleSource::Default);
+        assert_eq!(snap.allow_control.source, StyleSource::Default);
+        assert_eq!(snap.max_cron_sleep.source, StyleSource::Default);
+    }
+
+    #[test]
+    fn a_declared_scalar_reads_as_config_even_at_its_default_value() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("shep.toml");
+        std::fs::write(&path, "[daemon]\nlog_level = \"warn\"\n").unwrap();
+
+        let snap = load_settings(&path, &socket_default_fixture(), style_fixture()).unwrap();
+        assert_eq!(snap.log_level.value, "warn");
+        assert_eq!(
+            snap.log_level.source,
+            StyleSource::Config,
+            "a key written to its own default is still a key someone wrote"
+        );
+    }
+
+    #[test]
+    fn a_value_the_loader_refuses_leaves_the_file_byte_identical() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("shep.toml");
+        let before = "# mine\n[daemon]\nlog_level = \"debug\"\n";
+        std::fs::write(&path, before).unwrap();
+        let inode_before = std::fs::metadata(&path).unwrap().ino();
+
+        let refusal = apply_setting(
+            &path,
+            &SettingEdit::Set {
+                field: SettingField::MaxCronSleep,
+                value: "500ms".into(),
+            },
+        );
+
+        assert!(matches!(refusal, Err(SettingError::Invalid(_))));
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), before);
+        assert_eq!(
+            std::fs::metadata(&path).unwrap().ino(),
+            inode_before,
+            "a refusal must not stage and rename, which is what try_edit buys"
+        );
+    }
+
+    #[test]
+    fn the_refusal_carries_the_loaders_own_message() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("shep.toml");
+        std::fs::write(&path, "").unwrap();
+
+        let Err(SettingError::Invalid(message)) = apply_setting(
+            &path,
+            &SettingEdit::Set {
+                field: SettingField::MaxCronSleep,
+                value: "500ms".into(),
+            },
+        ) else {
+            panic!("a value under the floor must be refused");
+        };
+        assert!(
+            message.contains("max_cron_sleep"),
+            "the operator has to be told which key: {message}"
+        );
+    }
+
+    #[test]
+    fn unsetting_an_optional_field_returns_it_to_the_default() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("shep.toml");
+        std::fs::write(&path, "[daemon]\nmax_cron_sleep = \"30s\"\n").unwrap();
+
+        apply_setting(
+            &path,
+            &SettingEdit::Unset {
+                field: SettingField::MaxCronSleep,
+            },
+        )
+        .unwrap();
+
+        let snap = load_settings(&path, &socket_default_fixture(), style_fixture()).unwrap();
+        assert_eq!(snap.max_cron_sleep.source, StyleSource::Default);
+    }
+
+    #[test]
+    fn every_built_in_dog_is_a_candidate_even_when_nothing_is_enabled() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("shep.toml");
+        std::fs::write(&path, "").unwrap();
+
+        let snap = load_settings(&path, &socket_default_fixture(), style_fixture()).unwrap();
+        let names: Vec<&str> = snap.dogs.iter().map(|d| d.name.as_str()).collect();
+        assert_eq!(names, vec!["bark", "metrics"]);
+        assert!(snap.dogs.iter().all(|d| !d.enabled));
+    }
+
+    #[test]
+    fn an_adopted_dog_joins_the_candidates_and_carries_its_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("shep.toml");
+        std::fs::write(
+            &path,
+            "[daemon]\nenabled_dogs = [\"otel\"]\n\n[daemon.adopted_dogs]\notel = \"/usr/local/bin/shep-otel\"\n",
+        )
+        .unwrap();
+
+        let snap = load_settings(&path, &socket_default_fixture(), style_fixture()).unwrap();
+        let otel = snap.dogs.iter().find(|d| d.name == "otel").unwrap();
+        assert!(otel.enabled);
+        assert_eq!(
+            otel.adopted_path.as_deref(),
+            Some(Path::new("/usr/local/bin/shep-otel"))
+        );
+        let metrics = snap.dogs.iter().find(|d| d.name == "metrics").unwrap();
+        assert_eq!(metrics.adopted_path, None, "a built-in dog has no path");
+    }
+}

--- a/crates/shep-cli/src/commands/settings.rs
+++ b/crates/shep-cli/src/commands/settings.rs
@@ -59,11 +59,9 @@ pub struct ScalarView {
 /// `Debug` is derived rather than redacted (IR-41): a bare field name, no
 /// secret, nothing a `{:?}` could leak.
 ///
-/// Only [`Self::MaxCronSleep`] is constructed today, by this module's own
-/// tests. The other five are the lookout settings screen's own vocabulary
-/// for its other five fields, not yet wired to a keypress.
-/// `#[allow(dead_code)]` for the same reason [`load_settings`] carries it.
-#[allow(dead_code)]
+/// All six variants are constructed by the lookout settings screen's own
+/// `Settings::rows`, one per scalar row, in the fixed order they appear
+/// below.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SettingField {
     /// `[daemon] log_level`.
@@ -221,13 +219,8 @@ impl From<ShepTomlError> for SettingError {
 /// [`ShepTomlError::Io`] if `path` exists and could not be read.
 /// [`ShepTomlError::Parse`] if `path` exists and is not valid TOML.
 ///
-/// Not called outside this module's own tests yet: the lookout settings
-/// screen (later tasks in this feature, wiring this module into `App` and
-/// its reducer) is the caller. Same precedent this crate already carries
-/// twice (`style::Presentation::BARE`, `output::OutputEnvelope`):
-/// `#[allow(dead_code)]` says so explicitly rather than inventing a call
-/// site nothing needs yet.
-#[allow(dead_code)]
+/// Called by `lookout::mod::run_ui`'s `Effect::LoadSettings` arm, inside the
+/// `spawn_blocking` closure that arm runs the whole read through.
 pub fn load_settings(
     path: &Path,
     socket_default: &Path,

--- a/crates/shep-cli/src/commands/settings.rs
+++ b/crates/shep-cli/src/commands/settings.rs
@@ -84,9 +84,10 @@ pub enum SettingField {
 /// text an operator typed into the screen's own editor, no secret among
 /// the six scalars this reaches.
 ///
-/// Constructed only by [`apply_setting`]'s own tests today.
-/// `#[allow(dead_code)]` for the same reason [`load_settings`] carries it.
-#[allow(dead_code)]
+/// Constructed by `lookout::app`: `App::cycle_setting` for the four cycled
+/// scalars, and `App::on_settings_text_key`'s `TextApply` arm for `socket`
+/// and `max_cron_sleep`, the two this crate's free-text editor can also
+/// [`Self::Unset`].
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum SettingEdit {
     /// Write `field` to `value`.
@@ -358,9 +359,8 @@ fn dog_candidates(doc: &ShepToml) -> Vec<DogView> {
 /// [`DaemonConfig::load`] refuses), or [`SettingEdit::Unset`] named a
 /// field that has no unset form.
 ///
-/// Not called outside this module's own tests yet: see [`load_settings`]'s
-/// own note. `#[allow(dead_code)]` for the same reason.
-#[allow(dead_code)]
+/// Called by `lookout::mod::run_ui`'s `Effect::WriteSetting` arm, the same
+/// `spawn_blocking` shape [`load_settings`]'s own note describes.
 pub fn apply_setting(path: &Path, edit: &SettingEdit) -> Result<(), SettingError> {
     ShepToml::try_edit(path, |doc| -> Result<(), SettingError> {
         match edit {

--- a/crates/shep-cli/src/commands/settings.rs
+++ b/crates/shep-cli/src/commands/settings.rs
@@ -13,7 +13,7 @@
 //! document, not from [`DaemonConfig`]: every `[daemon]` and `[whistle]`
 //! section is `#[serde(default)]`, so a loaded config cannot tell "the
 //! operator wrote this at its own default value" from "nobody ever wrote
-//! it" -- see `shep_toml::ShepToml::style_level`'s own doc for that
+//! it" -- see `shep_toml::ShepToml::daemon_log_json`'s own doc for that
 //! argument in full. Reading a value out of a loaded [`DaemonConfig`] and
 //! calling it the file's would silently destroy the distinction this
 //! screen exists to show.
@@ -22,7 +22,7 @@ use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 
 use shep_core::config::daemon::{DaemonSection, WhistleSection};
-use shep_core::config::{DaemonConfig, DaemonConfigError};
+use shep_core::config::{DaemonConfig, DaemonConfigError, parse_daemon_bool};
 use shep_core::values::UpDuration;
 
 use crate::commands::shep_toml::{ShepToml, ShepTomlError};
@@ -153,6 +153,20 @@ pub struct DogView {
 }
 
 /// What [`apply_setting`] can fail with.
+///
+/// `Debug` is derived rather than redacted (IR-41): [`Self::Config`]
+/// forwards to [`ShepTomlError`]'s own manually redacted `Debug`, which is
+/// where a secret in the document (a dog's webhook token in an
+/// un-migrated `[dog.<name>]` table) would actually surface, and
+/// [`Self::Invalid`] carries either `DaemonConfig::load`'s own refusal
+/// message or this module's own -- both describe a key and a rule, never
+/// a value read back out of the file.
+///
+/// Not `#[non_exhaustive]`, the same reasoning [`ShepTomlError`] states
+/// for itself in this same crate: shep-cli has no published surface, so
+/// there is no downstream `match` outside this binary for the attribute
+/// to protect, and every exhaustive `match` on this enum is one we want
+/// the compiler to break the moment a new failure mode is added.
 #[derive(Debug)]
 pub enum SettingError {
     /// [`ShepToml::try_edit`]'s own setup or write failed -- the lock, the
@@ -404,24 +418,20 @@ fn unset_field(doc: &mut ShepToml, field: SettingField) -> Result<(), SettingErr
     Ok(())
 }
 
-/// `"true"`/`"false"` only -- the same closed grammar
-/// [`shep_core::config::parse_daemon_bool`] accepts for `SHEP_LOG_JSON`,
-/// so a boolean typed into this screen and one set through the
-/// environment never silently disagree on what counts as valid.
+/// Delegates to [`parse_daemon_bool`] rather than hand-rolling a near
+/// duplicate: that function already accepts `"1"`/`"0"`/`"true"`/`"false"`
+/// for `SHEP_LOG_JSON`, and [`StyleLevel::parse`]'s own doc states the
+/// principle this follows -- the screen's grammar and the environment's
+/// grammar for the same field must never be able to silently disagree on
+/// what counts as valid input. An operator who knows `SHEP_LOG_JSON=1`
+/// works must not be refused typing `1` here.
 fn parse_bool_field(value: &str) -> Result<bool, SettingError> {
-    match value {
-        "true" => Ok(true),
-        "false" => Ok(false),
-        _ => Err(SettingError::Invalid(format!(
-            "{value} is not true or false"
-        ))),
-    }
+    parse_daemon_bool(value)
+        .ok_or_else(|| SettingError::Invalid(format!("{value} is not a valid boolean")))
 }
 
 #[cfg(test)]
 mod tests {
-    use std::os::unix::fs::MetadataExt as _;
-
     use super::*;
 
     /// The style pair every test that does not care about `[style]` uses:
@@ -465,8 +475,13 @@ mod tests {
         );
     }
 
+    // `.ino()` needs `std::os::unix::fs::MetadataExt`, so this one test is
+    // unix-only; the CI Windows leg still runs the other six.
+    #[cfg(unix)]
     #[test]
     fn a_value_the_loader_refuses_leaves_the_file_byte_identical() {
+        use std::os::unix::fs::MetadataExt as _;
+
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("shep.toml");
         let before = "# mine\n[daemon]\nlog_level = \"debug\"\n";

--- a/crates/shep-cli/src/commands/settings.rs
+++ b/crates/shep-cli/src/commands/settings.rs
@@ -130,6 +130,20 @@ pub struct SettingsSnapshot {
     pub allow_control: ScalarView,
     /// `[style] level`, resolved.
     pub style_level: ScalarView,
+    /// What `[style] level` says in the DOCUMENT, or `None` when the
+    /// document never wrote it.
+    ///
+    /// The only field on this screen that needs both halves. Every
+    /// `[daemon]`/`[whistle]` field's [`ScalarView::value`] is already the
+    /// document's own value, because the layers that could outrank it
+    /// belong to the shepherd's process and this one cannot see them.
+    /// `[style]`'s can be `--style` or `$SHEP_STYLE`, which are lookout's
+    /// own, so `style_level.value` is the level in FORCE and this is the
+    /// level on DISK. `Settings::next_candidate` cycles from this one: with
+    /// `$SHEP_STYLE=bare` over a file saying `full`, cycling the resolved
+    /// value proposes `full` again, which is a no-op write reported as a
+    /// change.
+    pub style_level_in_file: Option<String>,
     /// Every candidate dog: [`BUILT_IN_DOGS`] plus every `adopted_dogs`
     /// key, sorted, deduplicated.
     pub dogs: Vec<DogView>,
@@ -286,6 +300,7 @@ pub fn load_settings(
         value: level.to_string(),
         source,
     };
+    let style_level_in_file = doc.style_level();
 
     Ok(SettingsSnapshot {
         log_level,
@@ -294,6 +309,7 @@ pub fn load_settings(
         max_cron_sleep,
         allow_control,
         style_level,
+        style_level_in_file,
         dogs: dog_candidates(&doc),
     })
 }

--- a/crates/shep-cli/src/commands/settings.rs
+++ b/crates/shep-cli/src/commands/settings.rs
@@ -467,13 +467,21 @@ mod tests {
         assert_eq!(snap.log_json.source, StyleSource::Default);
         assert_eq!(snap.allow_control.source, StyleSource::Default);
         assert_eq!(snap.max_cron_sleep.source, StyleSource::Default);
+        assert_eq!(
+            snap.style_level_in_file, None,
+            "a fresh home has never written [style], so the reader must say so"
+        );
     }
 
     #[test]
     fn a_declared_scalar_reads_as_config_even_at_its_default_value() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("shep.toml");
-        std::fs::write(&path, "[daemon]\nlog_level = \"warn\"\n").unwrap();
+        std::fs::write(
+            &path,
+            "[daemon]\nlog_level = \"warn\"\n\n[style]\nlevel = \"bare\"\n",
+        )
+        .unwrap();
 
         let snap = load_settings(&path, &socket_default_fixture(), style_fixture()).unwrap();
         assert_eq!(snap.log_level.value, "warn");
@@ -481,6 +489,12 @@ mod tests {
             snap.log_level.source,
             StyleSource::Config,
             "a key written to its own default is still a key someone wrote"
+        );
+        assert_eq!(
+            snap.style_level_in_file,
+            Some("bare".to_string()),
+            "load_settings must read [style] level off the real document, \
+             not just carry the resolved level `style_fixture` supplies"
         );
     }
 

--- a/crates/shep-cli/src/commands/shep_toml.rs
+++ b/crates/shep-cli/src/commands/shep_toml.rs
@@ -566,6 +566,23 @@ impl ShepToml {
         Ok(())
     }
 
+    /// `[style] level`, or `None` when the document never wrote it, as the
+    /// raw string on disk.
+    ///
+    /// The twin of [`Self::daemon_log_level`], and it exists for a sharper
+    /// reason than symmetry: `[style]` is the one field on the settings
+    /// screen whose value in force can come from a layer ABOVE the file
+    /// (`--style`, `$SHEP_STYLE`), so the resolved level and the level the
+    /// document declares are two different facts. Cycling a candidate from
+    /// the resolved one proposes a no-op write whenever they disagree.
+    #[must_use]
+    pub fn style_level(&self) -> Option<String> {
+        self.table("style")?
+            .get("level")?
+            .as_str()
+            .map(String::from)
+    }
+
     /// `[daemon] log_json`, or `None` when the document never wrote it --
     /// the distinction the whole settings screen rests on. A key written
     /// to its own default is still `Some`, because [`DaemonConfig::load`]'s

--- a/crates/shep-cli/src/commands/shep_toml.rs
+++ b/crates/shep-cli/src/commands/shep_toml.rs
@@ -22,9 +22,16 @@
 //! after the same bug: two writers racing on `barks.jsonl` silently lost
 //! half of each other's records until an advisory lock landed there.
 //!
-//! `#[cfg(unix)]` wholesale, at `commands`' own declaration in `main.rs` —
-//! `flock(2)` and unix mode bits are both Unix-only, and Windows is shep's
-//! 0% tier where no verb runs at all.
+//! `commands` itself carries no platform gate -- `mod commands;` at
+//! `lib.rs` is unconditional, and there is no `main.rs` in this crate;
+//! Phase 15 made `shep` a library with three thin `[[bin]]` targets over
+//! it. `flock(2)` and unix mode bits are Unix-only, so each call site that
+//! needs one gates itself individually and carries a real Windows arm
+//! rather than an unimplemented one: [`ConfigLock`] and
+//! [`ConfigLock::acquire`] below are each `#[cfg(unix)]`/`#[cfg(windows)]`
+//! pairs (`flock(2)` against `share_mode(0)`), and [`create_home_dir`]
+//! folds a unix-only `.mode()` call into an otherwise portable
+//! `DirBuilder`.
 
 // `clippy::result_large_err` fires on every `Result<_, ShepTomlError>`
 // signature in this module on Windows, and on none of them on macOS or
@@ -559,38 +566,13 @@ impl ShepToml {
         Ok(())
     }
 
-    /// `[style] level`, or `None` when the document never wrote it -- the
-    /// distinction the whole settings screen rests on. A key written to
-    /// its own default is still `Some`, because [`DaemonConfig::load`]'s
+    /// `[daemon] log_json`, or `None` when the document never wrote it --
+    /// the distinction the whole settings screen rests on. A key written
+    /// to its own default is still `Some`, because [`DaemonConfig::load`]'s
     /// `#[serde(default)]` on every section makes that fact unrecoverable
     /// once the file is parsed into a config: only reading the document
-    /// directly, the way this reader and the five below it do, can still
-    /// tell "the operator wrote this" from "nobody ever did".
-    ///
-    /// The raw string as written -- `full`, `plain`, `bare`, or whatever
-    /// else an operator typed. Whether it names a real [`StyleLevel`] is
-    /// [`DaemonConfig::load`]'s question, not this reader's.
-    ///
-    /// `commands::settings` (task 3) turned out not to need this. The
-    /// screen's `[style]` row reads the already-resolved
-    /// `(StyleLevel, StyleSource)` pair `lib.rs`'s `resolve_style` hands
-    /// it, which is a stronger answer than re-parsing the document: it is
-    /// exactly the value and layer a running `shep style` would report,
-    /// and this reader cannot see `$SHEP_STYLE` or `--style` shadowing it.
-    /// No caller is scheduled yet. `#[allow(dead_code)]` says so
-    /// explicitly rather than inventing a call site nothing needs.
-    #[allow(dead_code)]
-    #[must_use]
-    pub fn style_level(&self) -> Option<String> {
-        self.table("style")?
-            .get("level")?
-            .as_str()
-            .map(String::from)
-    }
-
-    /// `[daemon] log_json`, or `None` when the document never wrote it.
-    /// See [`Self::style_level`] for why absence and a written default are
-    /// two different facts, not one.
+    /// directly, the way this reader and its four siblings below do, can
+    /// still tell "the operator wrote this" from "nobody ever did".
     #[must_use]
     pub fn daemon_log_json(&self) -> Option<bool> {
         self.table("daemon")?.get("log_json")?.as_bool()
@@ -1490,7 +1472,6 @@ mod tests {
         assert_eq!(cfg.daemon_socket(), None);
         assert_eq!(cfg.daemon_max_cron_sleep(), None);
         assert_eq!(cfg.whistle_allow_control(), None);
-        assert_eq!(cfg.style_level(), None);
     }
 
     /// The distinction the screen rests on: a key written to its own default is

--- a/crates/shep-cli/src/commands/shep_toml.rs
+++ b/crates/shep-cli/src/commands/shep_toml.rs
@@ -274,6 +274,11 @@ impl ShepToml {
     /// # Errors
     /// [`ShepTomlError::Io`] if `path` exists and could not be read.
     /// [`ShepTomlError::Parse`] if `path` exists and is not valid TOML.
+    ///
+    /// Not called outside this module's own tests yet: `commands::settings`
+    /// (task 3) is the caller. `#[allow(dead_code)]` says so explicitly
+    /// rather than inventing a call site nothing needs yet.
+    #[allow(dead_code)]
     pub fn read_only(path: &Path) -> Result<Self, ShepTomlError> {
         Self::open(path)
     }
@@ -435,6 +440,11 @@ impl ShepToml {
     /// distinct from [`Self::adopted_dog_names`]: a dog can be adopted and
     /// not enabled, or (for one of the six built into the daemon) enabled
     /// without ever being adopted.
+    ///
+    /// Not called outside this module's own tests yet: `commands::settings`
+    /// (task 3) is the caller. `#[allow(dead_code)]` says so explicitly
+    /// rather than inventing a call site nothing needs yet.
+    #[allow(dead_code)]
     #[must_use]
     pub fn enabled_dog_names(&self) -> Vec<String> {
         self.table("daemon")
@@ -552,6 +562,11 @@ impl ShepToml {
     /// The raw string as written -- `full`, `plain`, `bare`, or whatever
     /// else an operator typed. Whether it names a real [`StyleLevel`] is
     /// [`DaemonConfig::load`]'s question, not this reader's.
+    ///
+    /// Not called outside this module's own tests yet: `commands::settings`
+    /// (task 3) is the caller. `#[allow(dead_code)]` says so explicitly
+    /// rather than inventing a call site nothing needs yet.
+    #[allow(dead_code)]
     #[must_use]
     pub fn style_level(&self) -> Option<String> {
         self.table("style")?
@@ -563,6 +578,11 @@ impl ShepToml {
     /// `[daemon] log_json`, or `None` when the document never wrote it.
     /// See [`Self::style_level`] for why absence and a written default are
     /// two different facts, not one.
+    ///
+    /// Not called outside this module's own tests yet: `commands::settings`
+    /// (task 3) is the caller. `#[allow(dead_code)]` says so explicitly
+    /// rather than inventing a call site nothing needs yet.
+    #[allow(dead_code)]
     #[must_use]
     pub fn daemon_log_json(&self) -> Option<bool> {
         self.table("daemon")?.get("log_json")?.as_bool()
@@ -571,6 +591,11 @@ impl ShepToml {
     /// `[daemon] log_level`, or `None` when the document never wrote it,
     /// as the raw string on disk. Whether it names a real `LogLevel` is
     /// [`DaemonConfig::load`]'s question, not this reader's.
+    ///
+    /// Not called outside this module's own tests yet: `commands::settings`
+    /// (task 3) is the caller. `#[allow(dead_code)]` says so explicitly
+    /// rather than inventing a call site nothing needs yet.
+    #[allow(dead_code)]
     #[must_use]
     pub fn daemon_log_level(&self) -> Option<String> {
         self.table("daemon")?
@@ -580,6 +605,11 @@ impl ShepToml {
     }
 
     /// `[daemon] socket`, or `None` when the document never wrote it.
+    ///
+    /// Not called outside this module's own tests yet: `commands::settings`
+    /// (task 3) is the caller. `#[allow(dead_code)]` says so explicitly
+    /// rather than inventing a call site nothing needs yet.
+    #[allow(dead_code)]
     #[must_use]
     pub fn daemon_socket(&self) -> Option<PathBuf> {
         self.table("daemon")?
@@ -592,6 +622,11 @@ impl ShepToml {
     /// it, as the raw string on disk -- not the parsed `UpDuration`. The
     /// settings screen shows what the file says; parsing it here would
     /// put a second opinion about the grammar next to `DaemonConfig`'s.
+    ///
+    /// Not called outside this module's own tests yet: `commands::settings`
+    /// (task 3) is the caller. `#[allow(dead_code)]` says so explicitly
+    /// rather than inventing a call site nothing needs yet.
+    #[allow(dead_code)]
     #[must_use]
     pub fn daemon_max_cron_sleep(&self) -> Option<String> {
         self.table("daemon")?
@@ -602,6 +637,11 @@ impl ShepToml {
 
     /// `[whistle] allow_control`, or `None` when the document never wrote
     /// it.
+    ///
+    /// Not called outside this module's own tests yet: `commands::settings`
+    /// (task 3) is the caller. `#[allow(dead_code)]` says so explicitly
+    /// rather than inventing a call site nothing needs yet.
+    #[allow(dead_code)]
     #[must_use]
     pub fn whistle_allow_control(&self) -> Option<bool> {
         self.table("whistle")?.get("allow_control")?.as_bool()
@@ -614,6 +654,11 @@ impl ShepToml {
     /// [`ShepTomlError::WrongShape`] -- `daemon` is already there as
     /// something other than a table. See [`Self::set_style_level`], the
     /// setter this one and its four siblings below are modelled on.
+    ///
+    /// Not called outside this module's own tests yet: `commands::settings`
+    /// (task 3) is the caller. `#[allow(dead_code)]` says so explicitly
+    /// rather than inventing a call site nothing needs yet.
+    #[allow(dead_code)]
     pub fn set_daemon_log_json(&mut self, value: bool) -> Result<(), ShepTomlError> {
         self.section_table_mut("daemon")?
             .insert("log_json", Item::Value(value.into()));
@@ -628,6 +673,11 @@ impl ShepToml {
     /// # Errors
     /// [`ShepTomlError::WrongShape`] -- `daemon` is already there as
     /// something other than a table.
+    ///
+    /// Not called outside this module's own tests yet: `commands::settings`
+    /// (task 3) is the caller. `#[allow(dead_code)]` says so explicitly
+    /// rather than inventing a call site nothing needs yet.
+    #[allow(dead_code)]
     pub fn set_daemon_log_level(&mut self, value: &str) -> Result<(), ShepTomlError> {
         self.section_table_mut("daemon")?
             .insert("log_level", Item::Value(value.into()));
@@ -640,6 +690,11 @@ impl ShepToml {
     /// # Errors
     /// [`ShepTomlError::WrongShape`] -- `daemon` is already there as
     /// something other than a table.
+    ///
+    /// Not called outside this module's own tests yet: `commands::settings`
+    /// (task 3) is the caller. `#[allow(dead_code)]` says so explicitly
+    /// rather than inventing a call site nothing needs yet.
+    #[allow(dead_code)]
     pub fn set_daemon_socket(&mut self, value: &Path) -> Result<(), ShepTomlError> {
         self.section_table_mut("daemon")?.insert(
             "socket",
@@ -656,6 +711,11 @@ impl ShepToml {
     /// # Errors
     /// [`ShepTomlError::WrongShape`] -- `daemon` is already there as
     /// something other than a table.
+    ///
+    /// Not called outside this module's own tests yet: `commands::settings`
+    /// (task 3) is the caller. `#[allow(dead_code)]` says so explicitly
+    /// rather than inventing a call site nothing needs yet.
+    #[allow(dead_code)]
     pub fn set_daemon_max_cron_sleep(&mut self, value: &str) -> Result<(), ShepTomlError> {
         self.section_table_mut("daemon")?
             .insert("max_cron_sleep", Item::Value(value.into()));
@@ -668,6 +728,11 @@ impl ShepToml {
     /// # Errors
     /// [`ShepTomlError::WrongShape`] -- `whistle` is already there as
     /// something other than a table.
+    ///
+    /// Not called outside this module's own tests yet: `commands::settings`
+    /// (task 3) is the caller. `#[allow(dead_code)]` says so explicitly
+    /// rather than inventing a call site nothing needs yet.
+    #[allow(dead_code)]
     pub fn set_whistle_allow_control(&mut self, value: bool) -> Result<(), ShepTomlError> {
         self.section_table_mut("whistle")?
             .insert("allow_control", Item::Value(value.into()));
@@ -679,6 +744,11 @@ impl ShepToml {
     /// table. Unlike the setters above, there is no shape for this to
     /// refuse: removing a key from a table that is not a table is already
     /// a no-op.
+    ///
+    /// Not called outside this module's own tests yet: `commands::settings`
+    /// (task 3) is the caller. `#[allow(dead_code)]` says so explicitly
+    /// rather than inventing a call site nothing needs yet.
+    #[allow(dead_code)]
     pub fn unset_daemon_socket(&mut self) {
         if let Some(daemon) = self.doc.get_mut("daemon").and_then(Item::as_table_mut) {
             daemon.remove("socket");
@@ -687,6 +757,11 @@ impl ShepToml {
 
     /// Removes `[daemon] max_cron_sleep` if it is set. See
     /// [`Self::unset_daemon_socket`] for why this has no `Result`.
+    ///
+    /// Not called outside this module's own tests yet: `commands::settings`
+    /// (task 3) is the caller. `#[allow(dead_code)]` says so explicitly
+    /// rather than inventing a call site nothing needs yet.
+    #[allow(dead_code)]
     pub fn unset_daemon_max_cron_sleep(&mut self) {
         if let Some(daemon) = self.doc.get_mut("daemon").and_then(Item::as_table_mut) {
             daemon.remove("max_cron_sleep");
@@ -778,6 +853,11 @@ impl ShepToml {
     /// shape case, which is fine for a reader (there is nothing to refuse,
     /// only nothing to report) even though a setter cannot let that same
     /// silence stand.
+    ///
+    /// Not called outside this module's own tests yet: `commands::settings`
+    /// (task 3) is the caller. `#[allow(dead_code)]` says so explicitly
+    /// rather than inventing a call site nothing needs yet.
+    #[allow(dead_code)]
     fn table(&self, section: &str) -> Option<&Table> {
         self.doc.get(section).and_then(Item::as_table)
     }
@@ -788,6 +868,11 @@ impl ShepToml {
     /// scalar setter above shares, factored out rather than repeated five
     /// times. [`Self::set_style_level`] carries this same shape inline,
     /// for one key rather than five.
+    ///
+    /// Not called outside this module's own tests yet: `commands::settings`
+    /// (task 3) is the caller. `#[allow(dead_code)]` says so explicitly
+    /// rather than inventing a call site nothing needs yet.
+    #[allow(dead_code)]
     fn section_table_mut(&mut self, section: &'static str) -> Result<&mut Table, ShepTomlError> {
         let item = self
             .doc
@@ -1506,6 +1591,16 @@ mod tests {
         assert!(text.contains("enabled_dogs = [\"metrics\"]"), "got: {text}");
         assert!(text.contains("level = \"full\""), "got: {text}");
         assert!(text.contains("log_level = \"debug\""), "got: {text}");
+
+        // The four checks above are substring checks against the whole file
+        // and cannot tell `log_level = "debug"` landing under `[daemon]`
+        // from the same bytes landing under `[style]` or anywhere else --
+        // reading it back through the section-aware reader is what pins
+        // the section, since `daemon_log_level` walks the `[daemon]` table
+        // specifically and would read `None` if the setter had written
+        // into a different one.
+        let cfg = ShepToml::read_only(&path).unwrap();
+        assert_eq!(cfg.daemon_log_level().as_deref(), Some("debug"));
     }
 
     #[test]
@@ -1547,6 +1642,106 @@ mod tests {
             std::fs::read_to_string(&path).unwrap(),
             "daemon = \"loud\"\n"
         );
+    }
+
+    /// `enabled_dog_names` is `adopted_dog_names`'s sibling and was left
+    /// untouched by the brief's own six tests. A dog can be adopted and not
+    /// enabled, or (for a built-in) enabled without ever being adopted, so
+    /// this reads `[daemon] enabled_dogs` specifically, in file order.
+    #[test]
+    fn enabled_dog_names_reads_the_array_in_file_order() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("shep.toml");
+        std::fs::write(&path, "[daemon]\nenabled_dogs = [\"metrics\", \"bark\"]\n").unwrap();
+
+        let cfg = ShepToml::read_only(&path).unwrap();
+        assert_eq!(cfg.enabled_dog_names(), vec!["metrics", "bark"]);
+    }
+
+    /// A document with no `[daemon] enabled_dogs` at all reads as empty,
+    /// never a panic or a default entry invented on its behalf.
+    #[test]
+    fn enabled_dog_names_is_empty_when_the_document_never_wrote_it() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("shep.toml");
+        std::fs::write(&path, "[daemon]\nlog_level = \"debug\"\n").unwrap();
+
+        let cfg = ShepToml::read_only(&path).unwrap();
+        assert_eq!(cfg.enabled_dog_names(), Vec::<String>::new());
+    }
+
+    /// `set_daemon_socket` has no caller until the settings screen lands,
+    /// so this is the only thing that exercises it before then. Reads back
+    /// through `daemon_socket`, which is what actually pins that the value
+    /// landed under `[daemon] socket` rather than merely appearing
+    /// somewhere in the file (the gap `setting_a_scalar_keeps_the_comments_
+    /// and_the_keys_around_it` had before this same fix round).
+    #[test]
+    fn setting_the_socket_reads_back_through_daemon_socket() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("shep.toml");
+        std::fs::write(&path, "[daemon]\nlog_level = \"debug\"\n").unwrap();
+
+        ShepToml::try_edit(&path, |cfg| {
+            cfg.set_daemon_socket(Path::new("/tmp/shep.sock"))
+        })
+        .unwrap();
+
+        let cfg = ShepToml::read_only(&path).unwrap();
+        assert_eq!(cfg.daemon_socket(), Some(PathBuf::from("/tmp/shep.sock")));
+        assert_eq!(cfg.daemon_log_level().as_deref(), Some("debug"));
+    }
+
+    /// `unset_daemon_socket`'s own sibling test, pinning the same thing
+    /// `unsetting_removes_the_key_and_leaves_its_neighbours` pins for
+    /// `max_cron_sleep`: the key goes, its neighbours stay.
+    #[test]
+    fn unsetting_the_socket_removes_the_key_and_leaves_its_neighbours() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("shep.toml");
+        std::fs::write(
+            &path,
+            "[daemon]\nlog_level = \"debug\"\nsocket = \"/tmp/shep.sock\"\n",
+        )
+        .unwrap();
+
+        ShepToml::edit(&path, ShepToml::unset_daemon_socket).unwrap();
+
+        let cfg = ShepToml::read_only(&path).unwrap();
+        assert_eq!(cfg.daemon_socket(), None);
+        assert_eq!(cfg.daemon_log_level().as_deref(), Some("debug"));
+    }
+
+    /// `set_daemon_max_cron_sleep` has no caller until the settings screen
+    /// lands. Reads back through `daemon_max_cron_sleep`, the raw string as
+    /// written, not a parsed `UpDuration`.
+    #[test]
+    fn setting_max_cron_sleep_reads_back_through_daemon_max_cron_sleep() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("shep.toml");
+        std::fs::write(&path, "[daemon]\nlog_level = \"debug\"\n").unwrap();
+
+        ShepToml::try_edit(&path, |cfg| cfg.set_daemon_max_cron_sleep("45s")).unwrap();
+
+        let cfg = ShepToml::read_only(&path).unwrap();
+        assert_eq!(cfg.daemon_max_cron_sleep().as_deref(), Some("45s"));
+        assert_eq!(cfg.daemon_log_level().as_deref(), Some("debug"));
+    }
+
+    /// `set_whistle_allow_control` has no caller until the settings screen
+    /// lands. Reads back through `whistle_allow_control`, which is what
+    /// pins the value under `[whistle]` rather than `[daemon]`.
+    #[test]
+    fn setting_whistle_allow_control_reads_back_through_whistle_allow_control() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("shep.toml");
+        std::fs::write(&path, "[daemon]\nlog_level = \"debug\"\n").unwrap();
+
+        ShepToml::try_edit(&path, |cfg| cfg.set_whistle_allow_control(true)).unwrap();
+
+        let cfg = ShepToml::read_only(&path).unwrap();
+        assert_eq!(cfg.whistle_allow_control(), Some(true));
+        assert_eq!(cfg.daemon_log_level().as_deref(), Some("debug"));
     }
 
     /// fails if the first `shep enable` on a host that has never booted a

--- a/crates/shep-cli/src/commands/shep_toml.rs
+++ b/crates/shep-cli/src/commands/shep_toml.rs
@@ -274,13 +274,26 @@ impl ShepToml {
     /// # Errors
     /// [`ShepTomlError::Io`] if `path` exists and could not be read.
     /// [`ShepTomlError::Parse`] if `path` exists and is not valid TOML.
-    ///
-    /// Not called outside this module's own tests yet: `commands::settings`
-    /// (task 3) is the caller. `#[allow(dead_code)]` says so explicitly
-    /// rather than inventing a call site nothing needs yet.
-    #[allow(dead_code)]
     pub fn read_only(path: &Path) -> Result<Self, ShepTomlError> {
         Self::open(path)
+    }
+
+    /// Renders the in-memory document exactly as [`Self::save`] would
+    /// write it, without touching disk.
+    ///
+    /// `commands::settings::apply_setting`'s own validation step: mutate,
+    /// render, and hand the text to [`DaemonConfig::load`](shep_core::config::DaemonConfig::load)
+    /// before ever calling [`Self::save`], so a refusal never stages or
+    /// renames. `pub(crate)` rather than `pub`, and named `rendered`
+    /// rather than implementing `Display`: this document can hold a
+    /// dog's webhook token in an un-migrated `[dog.<name>]` table (see
+    /// this type's own `Debug` impl above), and a `Display` impl is the
+    /// kind of thing a future `format!("{doc}")` reaches for without
+    /// thinking about that -- a named method one caller reaches for on
+    /// purpose is the safer shape for the same text.
+    #[must_use]
+    pub(crate) fn rendered(&self) -> String {
+        self.doc.to_string()
     }
 
     /// Adds `name` to `[daemon] enabled_dogs` (idempotently), and writes
@@ -440,11 +453,6 @@ impl ShepToml {
     /// distinct from [`Self::adopted_dog_names`]: a dog can be adopted and
     /// not enabled, or (for one of the six built into the daemon) enabled
     /// without ever being adopted.
-    ///
-    /// Not called outside this module's own tests yet: `commands::settings`
-    /// (task 3) is the caller. `#[allow(dead_code)]` says so explicitly
-    /// rather than inventing a call site nothing needs yet.
-    #[allow(dead_code)]
     #[must_use]
     pub fn enabled_dog_names(&self) -> Vec<String> {
         self.table("daemon")
@@ -563,9 +571,14 @@ impl ShepToml {
     /// else an operator typed. Whether it names a real [`StyleLevel`] is
     /// [`DaemonConfig::load`]'s question, not this reader's.
     ///
-    /// Not called outside this module's own tests yet: `commands::settings`
-    /// (task 3) is the caller. `#[allow(dead_code)]` says so explicitly
-    /// rather than inventing a call site nothing needs yet.
+    /// `commands::settings` (task 3) turned out not to need this. The
+    /// screen's `[style]` row reads the already-resolved
+    /// `(StyleLevel, StyleSource)` pair `lib.rs`'s `resolve_style` hands
+    /// it, which is a stronger answer than re-parsing the document: it is
+    /// exactly the value and layer a running `shep style` would report,
+    /// and this reader cannot see `$SHEP_STYLE` or `--style` shadowing it.
+    /// No caller is scheduled yet. `#[allow(dead_code)]` says so
+    /// explicitly rather than inventing a call site nothing needs.
     #[allow(dead_code)]
     #[must_use]
     pub fn style_level(&self) -> Option<String> {
@@ -578,11 +591,6 @@ impl ShepToml {
     /// `[daemon] log_json`, or `None` when the document never wrote it.
     /// See [`Self::style_level`] for why absence and a written default are
     /// two different facts, not one.
-    ///
-    /// Not called outside this module's own tests yet: `commands::settings`
-    /// (task 3) is the caller. `#[allow(dead_code)]` says so explicitly
-    /// rather than inventing a call site nothing needs yet.
-    #[allow(dead_code)]
     #[must_use]
     pub fn daemon_log_json(&self) -> Option<bool> {
         self.table("daemon")?.get("log_json")?.as_bool()
@@ -591,11 +599,6 @@ impl ShepToml {
     /// `[daemon] log_level`, or `None` when the document never wrote it,
     /// as the raw string on disk. Whether it names a real `LogLevel` is
     /// [`DaemonConfig::load`]'s question, not this reader's.
-    ///
-    /// Not called outside this module's own tests yet: `commands::settings`
-    /// (task 3) is the caller. `#[allow(dead_code)]` says so explicitly
-    /// rather than inventing a call site nothing needs yet.
-    #[allow(dead_code)]
     #[must_use]
     pub fn daemon_log_level(&self) -> Option<String> {
         self.table("daemon")?
@@ -605,11 +608,6 @@ impl ShepToml {
     }
 
     /// `[daemon] socket`, or `None` when the document never wrote it.
-    ///
-    /// Not called outside this module's own tests yet: `commands::settings`
-    /// (task 3) is the caller. `#[allow(dead_code)]` says so explicitly
-    /// rather than inventing a call site nothing needs yet.
-    #[allow(dead_code)]
     #[must_use]
     pub fn daemon_socket(&self) -> Option<PathBuf> {
         self.table("daemon")?
@@ -622,11 +620,6 @@ impl ShepToml {
     /// it, as the raw string on disk -- not the parsed `UpDuration`. The
     /// settings screen shows what the file says; parsing it here would
     /// put a second opinion about the grammar next to `DaemonConfig`'s.
-    ///
-    /// Not called outside this module's own tests yet: `commands::settings`
-    /// (task 3) is the caller. `#[allow(dead_code)]` says so explicitly
-    /// rather than inventing a call site nothing needs yet.
-    #[allow(dead_code)]
     #[must_use]
     pub fn daemon_max_cron_sleep(&self) -> Option<String> {
         self.table("daemon")?
@@ -637,11 +630,6 @@ impl ShepToml {
 
     /// `[whistle] allow_control`, or `None` when the document never wrote
     /// it.
-    ///
-    /// Not called outside this module's own tests yet: `commands::settings`
-    /// (task 3) is the caller. `#[allow(dead_code)]` says so explicitly
-    /// rather than inventing a call site nothing needs yet.
-    #[allow(dead_code)]
     #[must_use]
     pub fn whistle_allow_control(&self) -> Option<bool> {
         self.table("whistle")?.get("allow_control")?.as_bool()
@@ -654,11 +642,6 @@ impl ShepToml {
     /// [`ShepTomlError::WrongShape`] -- `daemon` is already there as
     /// something other than a table. See [`Self::set_style_level`], the
     /// setter this one and its four siblings below are modelled on.
-    ///
-    /// Not called outside this module's own tests yet: `commands::settings`
-    /// (task 3) is the caller. `#[allow(dead_code)]` says so explicitly
-    /// rather than inventing a call site nothing needs yet.
-    #[allow(dead_code)]
     pub fn set_daemon_log_json(&mut self, value: bool) -> Result<(), ShepTomlError> {
         self.section_table_mut("daemon")?
             .insert("log_json", Item::Value(value.into()));
@@ -673,11 +656,6 @@ impl ShepToml {
     /// # Errors
     /// [`ShepTomlError::WrongShape`] -- `daemon` is already there as
     /// something other than a table.
-    ///
-    /// Not called outside this module's own tests yet: `commands::settings`
-    /// (task 3) is the caller. `#[allow(dead_code)]` says so explicitly
-    /// rather than inventing a call site nothing needs yet.
-    #[allow(dead_code)]
     pub fn set_daemon_log_level(&mut self, value: &str) -> Result<(), ShepTomlError> {
         self.section_table_mut("daemon")?
             .insert("log_level", Item::Value(value.into()));
@@ -690,11 +668,6 @@ impl ShepToml {
     /// # Errors
     /// [`ShepTomlError::WrongShape`] -- `daemon` is already there as
     /// something other than a table.
-    ///
-    /// Not called outside this module's own tests yet: `commands::settings`
-    /// (task 3) is the caller. `#[allow(dead_code)]` says so explicitly
-    /// rather than inventing a call site nothing needs yet.
-    #[allow(dead_code)]
     pub fn set_daemon_socket(&mut self, value: &Path) -> Result<(), ShepTomlError> {
         self.section_table_mut("daemon")?.insert(
             "socket",
@@ -711,11 +684,6 @@ impl ShepToml {
     /// # Errors
     /// [`ShepTomlError::WrongShape`] -- `daemon` is already there as
     /// something other than a table.
-    ///
-    /// Not called outside this module's own tests yet: `commands::settings`
-    /// (task 3) is the caller. `#[allow(dead_code)]` says so explicitly
-    /// rather than inventing a call site nothing needs yet.
-    #[allow(dead_code)]
     pub fn set_daemon_max_cron_sleep(&mut self, value: &str) -> Result<(), ShepTomlError> {
         self.section_table_mut("daemon")?
             .insert("max_cron_sleep", Item::Value(value.into()));
@@ -728,11 +696,6 @@ impl ShepToml {
     /// # Errors
     /// [`ShepTomlError::WrongShape`] -- `whistle` is already there as
     /// something other than a table.
-    ///
-    /// Not called outside this module's own tests yet: `commands::settings`
-    /// (task 3) is the caller. `#[allow(dead_code)]` says so explicitly
-    /// rather than inventing a call site nothing needs yet.
-    #[allow(dead_code)]
     pub fn set_whistle_allow_control(&mut self, value: bool) -> Result<(), ShepTomlError> {
         self.section_table_mut("whistle")?
             .insert("allow_control", Item::Value(value.into()));
@@ -744,11 +707,6 @@ impl ShepToml {
     /// table. Unlike the setters above, there is no shape for this to
     /// refuse: removing a key from a table that is not a table is already
     /// a no-op.
-    ///
-    /// Not called outside this module's own tests yet: `commands::settings`
-    /// (task 3) is the caller. `#[allow(dead_code)]` says so explicitly
-    /// rather than inventing a call site nothing needs yet.
-    #[allow(dead_code)]
     pub fn unset_daemon_socket(&mut self) {
         if let Some(daemon) = self.doc.get_mut("daemon").and_then(Item::as_table_mut) {
             daemon.remove("socket");
@@ -757,11 +715,6 @@ impl ShepToml {
 
     /// Removes `[daemon] max_cron_sleep` if it is set. See
     /// [`Self::unset_daemon_socket`] for why this has no `Result`.
-    ///
-    /// Not called outside this module's own tests yet: `commands::settings`
-    /// (task 3) is the caller. `#[allow(dead_code)]` says so explicitly
-    /// rather than inventing a call site nothing needs yet.
-    #[allow(dead_code)]
     pub fn unset_daemon_max_cron_sleep(&mut self) {
         if let Some(daemon) = self.doc.get_mut("daemon").and_then(Item::as_table_mut) {
             daemon.remove("max_cron_sleep");
@@ -853,11 +806,6 @@ impl ShepToml {
     /// shape case, which is fine for a reader (there is nothing to refuse,
     /// only nothing to report) even though a setter cannot let that same
     /// silence stand.
-    ///
-    /// Not called outside this module's own tests yet: `commands::settings`
-    /// (task 3) is the caller. `#[allow(dead_code)]` says so explicitly
-    /// rather than inventing a call site nothing needs yet.
-    #[allow(dead_code)]
     fn table(&self, section: &str) -> Option<&Table> {
         self.doc.get(section).and_then(Item::as_table)
     }
@@ -868,11 +816,6 @@ impl ShepToml {
     /// scalar setter above shares, factored out rather than repeated five
     /// times. [`Self::set_style_level`] carries this same shape inline,
     /// for one key rather than five.
-    ///
-    /// Not called outside this module's own tests yet: `commands::settings`
-    /// (task 3) is the caller. `#[allow(dead_code)]` says so explicitly
-    /// rather than inventing a call site nothing needs yet.
-    #[allow(dead_code)]
     fn section_table_mut(&mut self, section: &'static str) -> Result<&mut Table, ShepTomlError> {
         let item = self
             .doc

--- a/crates/shep-cli/src/commands/shep_toml.rs
+++ b/crates/shep-cli/src/commands/shep_toml.rs
@@ -260,6 +260,24 @@ impl ShepToml {
         })
     }
 
+    /// Reads `path` for a caller that only wants the answer -- the settings
+    /// screen's own door into this type, and the shape every reader below
+    /// is reached through.
+    ///
+    /// Takes no lock, unlike [`Self::edit`]/[`Self::try_edit`]:
+    /// [`Self::save`]'s rename onto `path` is atomic, so a concurrent
+    /// writer can only ever make this read observe the document just
+    /// before or just after that write, never a torn one. The same
+    /// argument [`Self::adopted_dog_path_readonly`] already makes for
+    /// itself.
+    ///
+    /// # Errors
+    /// [`ShepTomlError::Io`] if `path` exists and could not be read.
+    /// [`ShepTomlError::Parse`] if `path` exists and is not valid TOML.
+    pub fn read_only(path: &Path) -> Result<Self, ShepTomlError> {
+        Self::open(path)
+    }
+
     /// Adds `name` to `[daemon] enabled_dogs` (idempotently), and writes
     /// nothing else anywhere.
     ///
@@ -412,6 +430,25 @@ impl ShepToml {
             .unwrap_or_default()
     }
 
+    /// The names in `[daemon] enabled_dogs`, in file order -- the flock a
+    /// dog's silence or a boot-time skip can be checked against, and
+    /// distinct from [`Self::adopted_dog_names`]: a dog can be adopted and
+    /// not enabled, or (for one of the six built into the daemon) enabled
+    /// without ever being adopted.
+    #[must_use]
+    pub fn enabled_dog_names(&self) -> Vec<String> {
+        self.table("daemon")
+            .and_then(|daemon| daemon.get("enabled_dogs"))
+            .and_then(Item::as_array)
+            .map(|names| {
+                names
+                    .iter()
+                    .filter_map(|v| v.as_str().map(String::from))
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
     /// [`Self::adopted_dog_path`] without [`Self::edit`]'s write side --
     /// for a caller that only wants the answer, such as `lib.rs`'s
     /// `dispatch_adopted_dog`, which runs on every unrecognized verb, most
@@ -504,6 +541,158 @@ impl ShepToml {
         Ok(())
     }
 
+    /// `[style] level`, or `None` when the document never wrote it -- the
+    /// distinction the whole settings screen rests on. A key written to
+    /// its own default is still `Some`, because [`DaemonConfig::load`]'s
+    /// `#[serde(default)]` on every section makes that fact unrecoverable
+    /// once the file is parsed into a config: only reading the document
+    /// directly, the way this reader and the five below it do, can still
+    /// tell "the operator wrote this" from "nobody ever did".
+    ///
+    /// The raw string as written -- `full`, `plain`, `bare`, or whatever
+    /// else an operator typed. Whether it names a real [`StyleLevel`] is
+    /// [`DaemonConfig::load`]'s question, not this reader's.
+    #[must_use]
+    pub fn style_level(&self) -> Option<String> {
+        self.table("style")?
+            .get("level")?
+            .as_str()
+            .map(String::from)
+    }
+
+    /// `[daemon] log_json`, or `None` when the document never wrote it.
+    /// See [`Self::style_level`] for why absence and a written default are
+    /// two different facts, not one.
+    #[must_use]
+    pub fn daemon_log_json(&self) -> Option<bool> {
+        self.table("daemon")?.get("log_json")?.as_bool()
+    }
+
+    /// `[daemon] log_level`, or `None` when the document never wrote it,
+    /// as the raw string on disk. Whether it names a real `LogLevel` is
+    /// [`DaemonConfig::load`]'s question, not this reader's.
+    #[must_use]
+    pub fn daemon_log_level(&self) -> Option<String> {
+        self.table("daemon")?
+            .get("log_level")?
+            .as_str()
+            .map(String::from)
+    }
+
+    /// `[daemon] socket`, or `None` when the document never wrote it.
+    #[must_use]
+    pub fn daemon_socket(&self) -> Option<PathBuf> {
+        self.table("daemon")?
+            .get("socket")?
+            .as_str()
+            .map(PathBuf::from)
+    }
+
+    /// `[daemon] max_cron_sleep`, or `None` when the document never wrote
+    /// it, as the raw string on disk -- not the parsed `UpDuration`. The
+    /// settings screen shows what the file says; parsing it here would
+    /// put a second opinion about the grammar next to `DaemonConfig`'s.
+    #[must_use]
+    pub fn daemon_max_cron_sleep(&self) -> Option<String> {
+        self.table("daemon")?
+            .get("max_cron_sleep")?
+            .as_str()
+            .map(String::from)
+    }
+
+    /// `[whistle] allow_control`, or `None` when the document never wrote
+    /// it.
+    #[must_use]
+    pub fn whistle_allow_control(&self) -> Option<bool> {
+        self.table("whistle")?.get("allow_control")?.as_bool()
+    }
+
+    /// Writes `[daemon] log_json = <value>`, creating `[daemon]` when this
+    /// document has none yet.
+    ///
+    /// # Errors
+    /// [`ShepTomlError::WrongShape`] -- `daemon` is already there as
+    /// something other than a table. See [`Self::set_style_level`], the
+    /// setter this one and its four siblings below are modelled on.
+    pub fn set_daemon_log_json(&mut self, value: bool) -> Result<(), ShepTomlError> {
+        self.section_table_mut("daemon")?
+            .insert("log_json", Item::Value(value.into()));
+        Ok(())
+    }
+
+    /// Writes `[daemon] log_level = "<value>"`, creating `[daemon]` when
+    /// this document has none yet. `value` is written as given, unchecked
+    /// -- [`DaemonConfig::load`] is what refuses a name that is not a real
+    /// `LogLevel`.
+    ///
+    /// # Errors
+    /// [`ShepTomlError::WrongShape`] -- `daemon` is already there as
+    /// something other than a table.
+    pub fn set_daemon_log_level(&mut self, value: &str) -> Result<(), ShepTomlError> {
+        self.section_table_mut("daemon")?
+            .insert("log_level", Item::Value(value.into()));
+        Ok(())
+    }
+
+    /// Writes `[daemon] socket = "<value>"`, creating `[daemon]` when this
+    /// document has none yet.
+    ///
+    /// # Errors
+    /// [`ShepTomlError::WrongShape`] -- `daemon` is already there as
+    /// something other than a table.
+    pub fn set_daemon_socket(&mut self, value: &Path) -> Result<(), ShepTomlError> {
+        self.section_table_mut("daemon")?.insert(
+            "socket",
+            Item::Value(value.to_string_lossy().into_owned().into()),
+        );
+        Ok(())
+    }
+
+    /// Writes `[daemon] max_cron_sleep = "<value>"`, creating `[daemon]`
+    /// when this document has none yet. `value` is written as given,
+    /// unchecked -- [`DaemonConfig::load`] is what refuses a duration
+    /// below the floor or one that does not parse at all.
+    ///
+    /// # Errors
+    /// [`ShepTomlError::WrongShape`] -- `daemon` is already there as
+    /// something other than a table.
+    pub fn set_daemon_max_cron_sleep(&mut self, value: &str) -> Result<(), ShepTomlError> {
+        self.section_table_mut("daemon")?
+            .insert("max_cron_sleep", Item::Value(value.into()));
+        Ok(())
+    }
+
+    /// Writes `[whistle] allow_control = <value>`, creating `[whistle]`
+    /// when this document has none yet.
+    ///
+    /// # Errors
+    /// [`ShepTomlError::WrongShape`] -- `whistle` is already there as
+    /// something other than a table.
+    pub fn set_whistle_allow_control(&mut self, value: bool) -> Result<(), ShepTomlError> {
+        self.section_table_mut("whistle")?
+            .insert("allow_control", Item::Value(value.into()));
+        Ok(())
+    }
+
+    /// Removes `[daemon] socket` if it is set, and does nothing --
+    /// neither error nor write -- if `[daemon]` is absent or is not a
+    /// table. Unlike the setters above, there is no shape for this to
+    /// refuse: removing a key from a table that is not a table is already
+    /// a no-op.
+    pub fn unset_daemon_socket(&mut self) {
+        if let Some(daemon) = self.doc.get_mut("daemon").and_then(Item::as_table_mut) {
+            daemon.remove("socket");
+        }
+    }
+
+    /// Removes `[daemon] max_cron_sleep` if it is set. See
+    /// [`Self::unset_daemon_socket`] for why this has no `Result`.
+    pub fn unset_daemon_max_cron_sleep(&mut self) {
+        if let Some(daemon) = self.doc.get_mut("daemon").and_then(Item::as_table_mut) {
+            daemon.remove("max_cron_sleep");
+        }
+    }
+
     /// Writes the starter `[interpreters]` mapping (task 47) -- a script
     /// extension to the interpreter shep runs it with, active from the
     /// moment it lands rather than commented into inertness, with an
@@ -581,6 +770,35 @@ impl ShepToml {
             path: self.path.clone(),
             source,
         }
+    }
+
+    /// `section` as a table, or `None` if this document never wrote it, or
+    /// wrote it as something else. The read side every scalar reader above
+    /// shares -- `Item::as_table` already answers `None` for the wrong-
+    /// shape case, which is fine for a reader (there is nothing to refuse,
+    /// only nothing to report) even though a setter cannot let that same
+    /// silence stand.
+    fn table(&self, section: &str) -> Option<&Table> {
+        self.doc.get(section).and_then(Item::as_table)
+    }
+
+    /// `section` as a table, creating it (empty) if this document has none
+    /// yet, and refusing with [`ShepTomlError::WrongShape`] if `section`
+    /// is already occupied by something else -- the write side every
+    /// scalar setter above shares, factored out rather than repeated five
+    /// times. [`Self::set_style_level`] carries this same shape inline,
+    /// for one key rather than five.
+    fn section_table_mut(&mut self, section: &'static str) -> Result<&mut Table, ShepTomlError> {
+        let item = self
+            .doc
+            .entry(section)
+            .or_insert_with(|| Item::Table(Table::new()));
+        let found = item.type_name();
+        item.as_table_mut().ok_or(ShepTomlError::WrongShape {
+            path: self.path.clone(),
+            key: section,
+            found,
+        })
     }
 
     /// `[daemon]`, creating it (empty) if this document has none yet.
@@ -771,7 +989,8 @@ pub enum ShepTomlError {
         /// The file that holds the wrongly-shaped value.
         path: PathBuf,
         /// The table key that was expected -- `"style"` for
-        /// [`ShepToml::set_style_level`], the only caller today.
+        /// [`ShepToml::set_style_level`], `"daemon"` or `"whistle"` for
+        /// the settings-screen setters that share [`ShepToml::section_table_mut`].
         key: &'static str,
         /// What TOML actually found there ([`Item::type_name`]) --
         /// `"string"`, `"array"`, and so on; never `"table"`, since that
@@ -1228,6 +1447,105 @@ mod tests {
             before.mode() & 0o777,
             after.mode() & 0o777,
             "a refused write must not touch the file's mode"
+        );
+    }
+
+    #[test]
+    fn a_document_with_no_daemon_section_reads_every_scalar_as_absent() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("shep.toml");
+        std::fs::write(&path, "[interpreters]\njs = \"node\"\n").unwrap();
+
+        let cfg = ShepToml::read_only(&path).unwrap();
+        assert_eq!(cfg.daemon_log_json(), None);
+        assert_eq!(cfg.daemon_log_level(), None);
+        assert_eq!(cfg.daemon_socket(), None);
+        assert_eq!(cfg.daemon_max_cron_sleep(), None);
+        assert_eq!(cfg.whistle_allow_control(), None);
+        assert_eq!(cfg.style_level(), None);
+    }
+
+    /// The distinction the screen rests on: a key written to its own default is
+    /// not the same fact as a key nobody wrote, and `DaemonConfig::load` cannot
+    /// tell them apart because every section is `serde(default)`.
+    #[test]
+    fn a_scalar_written_to_its_default_still_reads_as_present() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("shep.toml");
+        std::fs::write(&path, "[daemon]\nlog_level = \"warn\"\nlog_json = false\n").unwrap();
+
+        let cfg = ShepToml::read_only(&path).unwrap();
+        assert_eq!(cfg.daemon_log_level().as_deref(), Some("warn"));
+        assert_eq!(cfg.daemon_log_json(), Some(false));
+    }
+
+    #[test]
+    fn a_missing_file_reads_as_an_empty_document_and_creates_nothing() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("shep.toml");
+
+        let cfg = ShepToml::read_only(&path).unwrap();
+        assert_eq!(cfg.daemon_log_level(), None);
+        assert!(!path.exists(), "a read must never create the file");
+    }
+
+    #[test]
+    fn setting_a_scalar_keeps_the_comments_and_the_keys_around_it() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("shep.toml");
+        std::fs::write(
+            &path,
+            "# keep me\n[daemon]\nenabled_dogs = [\"metrics\"]\n\n[style]\nlevel = \"full\"\n",
+        )
+        .unwrap();
+
+        ShepToml::try_edit(&path, |cfg| cfg.set_daemon_log_level("debug")).unwrap();
+
+        let text = std::fs::read_to_string(&path).unwrap();
+        assert!(text.starts_with("# keep me\n"), "got: {text}");
+        assert!(text.contains("enabled_dogs = [\"metrics\"]"), "got: {text}");
+        assert!(text.contains("level = \"full\""), "got: {text}");
+        assert!(text.contains("log_level = \"debug\""), "got: {text}");
+    }
+
+    #[test]
+    fn unsetting_removes_the_key_and_leaves_its_neighbours() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("shep.toml");
+        std::fs::write(
+            &path,
+            "[daemon]\nlog_level = \"debug\"\nmax_cron_sleep = \"30s\"\n",
+        )
+        .unwrap();
+
+        ShepToml::edit(&path, ShepToml::unset_daemon_max_cron_sleep).unwrap();
+
+        let cfg = ShepToml::read_only(&path).unwrap();
+        assert_eq!(cfg.daemon_max_cron_sleep(), None);
+        assert_eq!(cfg.daemon_log_level().as_deref(), Some("debug"));
+    }
+
+    #[test]
+    fn a_daemon_key_of_the_wrong_shape_is_refused_rather_than_clobbered() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("shep.toml");
+        std::fs::write(&path, "daemon = \"loud\"\n").unwrap();
+
+        // `try_edit`, not `edit`. `edit` runs `save` whatever the closure
+        // returned, so a refusal through it would still stage and rename a
+        // byte-identical copy, landing a fresh inode on a file the refusal never
+        // touched. That is the failure `try_edit` exists for, and it is why
+        // every setter on this screen goes through it.
+        let refusal: Result<(), ShepTomlError> =
+            ShepToml::try_edit(&path, |cfg| cfg.set_daemon_log_json(true));
+
+        assert!(matches!(
+            refusal,
+            Err(ShepTomlError::WrongShape { key: "daemon", .. })
+        ));
+        assert_eq!(
+            std::fs::read_to_string(&path).unwrap(),
+            "daemon = \"loud\"\n"
         );
     }
 

--- a/crates/shep-cli/src/completions.rs
+++ b/crates/shep-cli/src/completions.rs
@@ -18,10 +18,10 @@ use crate::exit::ExitCode;
 
 /// Writes the completion script for `args.shell` to `out`.
 ///
-/// Its own tests call it on every target, but the Windows build's `run`
-/// wires up no verb yet (spec §11's functional tier), so production code
-/// never reaches it there — same reasoning as `main.rs`'s `resolve_paths`.
-#[cfg_attr(windows, allow(dead_code))]
+/// Its own tests call it on every target, and `run`'s `Commands::Completions`
+/// arm calls it unconditionally too: there is one `run`, not a per-platform
+/// pair, so production code reaches this function on every target the crate
+/// ships for.
 pub fn completions(out: &mut dyn std::io::Write, args: &CompletionArgs) -> ExitCode {
     clap_complete::aot::generate(args.shell, &mut Cli::command(), "shep", out);
     ExitCode::Success

--- a/crates/shep-cli/src/lib.rs
+++ b/crates/shep-cli/src/lib.rs
@@ -2322,11 +2322,12 @@ mod tests {
     #[test]
     fn the_alias_vector_parses_to_the_expected_command() {
         use clap::Parser;
-        // `Commands` is imported here and not via `super::*`: the top-level
-        // `use cli::Commands` is `#[cfg(unix)]`-gated alongside every verb
-        // module, and this test — like every other one in this file — must
-        // still compile under the Windows cross-check. Matches
-        // `save_parses_to_its_own_command`'s existing shape.
+        // Named explicitly rather than leaned on through `use super::*`,
+        // matching `save_parses_to_its_own_command` and every other
+        // dispatch test in this file. The reason given here used to be a
+        // `#[cfg(unix)]` gate on a top-level `use cli::Commands` in
+        // `main.rs`; there is no such gate, and no such file since Phase 15
+        // extracted the library.
         use cli::Commands;
         let argv = alias_argv(
             "dog",
@@ -2367,11 +2368,13 @@ mod tests {
     /// dispatch arms carried no unit coverage at all until recently, and a
     /// verb pointed at the wrong handler was invisible workspace-wide.
     ///
-    /// `Commands` is imported locally rather than via `super::*`: the
-    /// top-level `use cli::Commands` (main.rs:31) is `#[cfg(unix)]`-gated
-    /// alongside every verb module, but this test — like every other one in
-    /// this file — must still compile on the Windows target, where that
-    /// import does not exist.
+    /// `Commands` is named explicitly rather than leaned on through
+    /// `use super::*`, matching every other dispatch test in this file.
+    /// This said it was working around a `#[cfg(unix)]` gate on a
+    /// `use cli::Commands` at `main.rs:31`. That gate does not exist, the
+    /// import at the top of this file is unconditional, and `main.rs` has
+    /// not existed since Phase 15 turned this crate into a library with
+    /// three thin `[[bin]]` targets over it.
     #[test]
     fn save_parses_to_its_own_command() {
         use clap::Parser;
@@ -2950,18 +2953,20 @@ mod tests {
     /// daemon dispatch arm for real belongs in the e2e tier
     /// (`tests/cli_e2e.rs`), against an isolated `--home`, not here.
     ///
-    /// `#[cfg(unix)]`: what this proves is specific to the unix arm's
-    /// early-dispatch shape — that `Completions` is one of the handful of
-    /// verbs routed around `resolve_paths` rather than through it. The
-    /// windows arm has no such split to prove anything about: it refuses
-    /// every verb unconditionally, `completions` included, before it can
-    /// even become a question of whether paths were resolved. Windows is
-    /// shep's 0% tier by deliberate, standing decision (`CLAUDE.md`: "every
-    /// verb prints \"not yet supported\" and exits") — carving out
-    /// `completions` as the one working verb there is a real product
-    /// decision, not one this test should make unilaterally by asserting
-    /// `Success` against an arm that was never built to return it.
-    #[cfg(unix)]
+    /// Runs on every platform, deliberately. This carried a
+    /// `#[cfg(unix)]` whose stated reason was that "the windows arm
+    /// refuses every verb unconditionally, `completions` included" and
+    /// that Windows is shep's 0% tier. Both halves are stale: there is one
+    /// `run`, not a unix arm and a windows arm, `Commands::Completions` is
+    /// not gated in it, and the Windows tier is built and runs against a
+    /// live flock. Correcting the prose and keeping the gate would have
+    /// left a gate with no reason, so the gate goes.
+    ///
+    /// What it proves is portable: that `Completions` is one of the handful
+    /// of verbs routed around `resolve_paths` rather than through it, so it
+    /// answers with no `$SHEP_HOME` at all. Everything on that path is
+    /// platform-neutral -- `resolve_paths`, `ShepherdStatus::probe` (which
+    /// fails to connect and reports no shepherd), and `completions` itself.
     #[tokio::test]
     async fn completions_never_resolves_paths() {
         use clap::Parser;

--- a/crates/shep-cli/src/lib.rs
+++ b/crates/shep-cli/src/lib.rs
@@ -194,9 +194,10 @@ fn run_argv(argv: Vec<OsString>) -> std::process::ExitCode {
             err.exit();
         }
     };
-    // Resolved once, here, and passed down rather than re-derived at each of
-    // the two `run` arms (`cfg(unix)`/`cfg(windows)`) or at every `Streams`
-    // construction inside them — see `resolve_style` and `must_render_bare`
+    // Resolved once, here, and passed down rather than re-derived inside
+    // `run` itself (there is one `run`, unconditional on platform, not a
+    // `cfg(unix)`/`cfg(windows)` pair) or at every `Streams` construction
+    // inside it — see `resolve_style` and `must_render_bare`
     // for why the two steps (what is configured, and whether the hard rule
     // overrides it) are kept separate. `style_source` rides all the way
     // down to `lookout::lookout`, which is the one caller that reports it
@@ -445,11 +446,11 @@ async fn print_shepherd_status(argv: &[OsString]) {
 /// `--home` invocation still works in an environment with no `$HOME` at all.
 ///
 /// Pure tier on purpose (no `#[cfg(unix)]`): its own test runs on every
-/// target, and [`resolve_style`] below calls it from `run_argv` — shared,
-/// unconditional code — to find `shep.toml` for the style level's config
-/// layer. That is the one Windows call site today; the Windows build's `run`
-/// itself still does not call it, since refusing outright is the whole
-/// Windows deliverable for now.
+/// target, and `run` calls it on every target too, since it has no
+/// platform split of its own. [`resolve_style`] reaches it through
+/// `run_argv` to find `shep.toml` for the style level's config layer, and
+/// `ensure_home` and every dispatch arm that needs `$SHEP_HOME` before
+/// doing its own work reach it the same way.
 fn resolve_paths(global: &GlobalArgs) -> Result<ShepPaths, ExitCode> {
     let env = |key: &str| match key {
         "SHEP_HOME" => global
@@ -2846,12 +2847,14 @@ mod tests {
     /// or if what it writes is not what `style_from_config` (the same
     /// reader `resolve_style` uses) reads back.
     ///
-    /// `#[cfg(unix)]` because every verb refuses on Windows with "shep does
-    /// not yet support Windows", so there is no write to observe there. This
-    /// gate was missing when the test landed and turned CI's two Windows legs
-    /// red; the local gate could not see it, because a macOS `cargo test`
-    /// never compiles a Windows arm and the windows-gnu cross-check is
-    /// `cargo check`, which does not run anything.
+    /// `#[cfg(unix)]`: `shep style <level>` genuinely runs on Windows now
+    /// (only `startup`/`unstartup` refuse there), but this test drives that
+    /// write through `commands::shep_toml`'s `ConfigLock`, and nothing in
+    /// this crate has ever compiled or run that lock's `cfg(windows)` arm --
+    /// a macOS `cargo test` never reaches it and the windows-gnu cross-check
+    /// is `cargo check`, which does not run anything. Gating this test
+    /// unix-only says so plainly rather than asserting a Windows write this
+    /// worktree cannot actually observe.
     #[cfg(unix)]
     #[tokio::test]
     async fn style_with_a_level_writes_shep_toml_and_the_config_reads_it_back() {
@@ -2889,8 +2892,11 @@ mod tests {
     /// no-arg form is a report, and only a report, the same guarantee
     /// `resolve_style_reads_the_flag_and_the_real_shep_toml_it_names`
     /// above pins for what it *reads*.
-    /// `#[cfg(unix)]` for the same reason as the test above: the verb
-    /// refuses on Windows before it can report anything.
+    /// `#[cfg(unix)]` to stay paired with the test above rather than for a
+    /// reason of its own: it drives the same `run` dispatch through the
+    /// same real `$SHEP_HOME`, and keeping both gated the same way keeps
+    /// the pair's Windows coverage (or the lack of it) legible in one
+    /// place instead of one gated and one not for no visible reason.
     #[cfg(unix)]
     #[tokio::test]
     async fn style_with_no_level_reports_and_writes_nothing() {

--- a/crates/shep-cli/src/lib.rs
+++ b/crates/shep-cli/src/lib.rs
@@ -198,8 +198,13 @@ fn run_argv(argv: Vec<OsString>) -> std::process::ExitCode {
     // the two `run` arms (`cfg(unix)`/`cfg(windows)`) or at every `Streams`
     // construction inside them — see `resolve_style` and `must_render_bare`
     // for why the two steps (what is configured, and whether the hard rule
-    // overrides it) are kept separate.
-    let (configured, _source) = resolve_style(&cli.global);
+    // overrides it) are kept separate. `style_source` rides all the way
+    // down to `lookout::lookout`, which is the one caller that reports it
+    // rather than only consuming the level: the settings screen's own
+    // STYLE LEVEL row needs to say which layer won, and it has to be this
+    // same resolution rather than a second one, so the screen and the rest
+    // of the CLI can never disagree.
+    let (configured, style_source) = resolve_style(&cli.global);
     let level = if must_render_bare(std::io::stdout().is_terminal(), cli.global.format) {
         style::StyleLevel::Bare
     } else {
@@ -220,7 +225,9 @@ fn run_argv(argv: Vec<OsString>) -> std::process::ExitCode {
         std::env::var_os("COLORTERM").as_deref(),
         output::terminal_width(),
     );
-    std::process::ExitCode::from(runtime.block_on(run(cli, style)) as u8)
+    std::process::ExitCode::from(
+        runtime.block_on(run(cli, style, (configured, style_source))) as u8,
+    )
 }
 
 /// Before clap's own "unrecognized subcommand" error (suggestions and
@@ -834,7 +841,19 @@ fn scaffold_first_run_interpreters(paths: &ShepPaths) {
 /// the same way, so it can tell the operator whether the value it just
 /// wrote is what will actually run or whether `--style`/`$SHEP_STYLE`
 /// still outranks it.
-async fn run(cli: Cli, style: style::Presentation) -> ExitCode {
+///
+/// `resolved_style` is [`run_argv`]'s own `resolve_style(&cli.global)`
+/// call, the unforced pair `style` above is partly built from. The one
+/// caller that needs the pair itself rather than only the level is the
+/// lookout dispatch: the settings screen's own STYLE LEVEL row reports
+/// which layer won, and reading that back from the same resolution this
+/// function already holds is what keeps the screen and the rest of the
+/// CLI from ever disagreeing about it.
+async fn run(
+    cli: Cli,
+    style: style::Presentation,
+    resolved_style: (style::StyleLevel, style::StyleSource),
+) -> ExitCode {
     let fmt = cli.global.format;
     // Resolved once, here, rather than at each of the seventeen call sites
     // that reach a shepherd: `cli.command` is partially moved by the
@@ -1096,7 +1115,7 @@ async fn run(cli: Cli, style: style::Presentation) -> ExitCode {
             style,
             fmt,
         };
-        return lookout::lookout(&mut streams, &paths, args).await;
+        return lookout::lookout(&mut streams, &paths, args, resolved_style).await;
     }
 
     // Not in the locked block below, for the reason `lookout`'s own comment
@@ -2623,14 +2642,24 @@ mod tests {
 
         let cli = Cli::try_parse_from(["shep", "--home", missing, "startup"]).unwrap();
         assert_eq!(
-            run(cli, style::Presentation::BARE).await,
+            run(
+                cli,
+                style::Presentation::BARE,
+                (style::StyleLevel::Full, style::StyleSource::Default),
+            )
+            .await,
             ExitCode::Usage,
             "startup must refuse a $SHEP_HOME that is not there"
         );
 
         let cli = Cli::try_parse_from(["shep", "--home", missing, "unstartup"]).unwrap();
         assert_ne!(
-            run(cli, style::Presentation::BARE).await,
+            run(
+                cli,
+                style::Presentation::BARE,
+                (style::StyleLevel::Full, style::StyleSource::Default),
+            )
+            .await,
             ExitCode::Usage,
             "unstartup removes a unit and never reads the home a --home names"
         );
@@ -2834,7 +2863,12 @@ mod tests {
             let home = dir.path().to_str().unwrap();
             let cli = Cli::try_parse_from(["shep", "--home", home, "style", raw]).unwrap();
             assert_eq!(
-                run(cli, style::Presentation::BARE).await,
+                run(
+                    cli,
+                    style::Presentation::BARE,
+                    (style::StyleLevel::Full, style::StyleSource::Default),
+                )
+                .await,
                 ExitCode::Success,
                 "style {raw}"
             );
@@ -2862,7 +2896,15 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let home = dir.path().to_str().unwrap();
         let cli = Cli::try_parse_from(["shep", "--home", home, "style"]).unwrap();
-        assert_eq!(run(cli, style::Presentation::BARE).await, ExitCode::Success);
+        assert_eq!(
+            run(
+                cli,
+                style::Presentation::BARE,
+                (style::StyleLevel::Full, style::StyleSource::Default),
+            )
+            .await,
+            ExitCode::Success
+        );
 
         assert!(
             !dir.path().join("shep.toml").exists(),
@@ -2925,7 +2967,15 @@ mod tests {
         use clap::Parser;
         let argv = ["shep", "completions", "bash"];
         let cli = Cli::try_parse_from(argv).unwrap_or_else(|e| panic!("{argv:?} failed: {e}"));
-        assert_eq!(run(cli, style::Presentation::BARE).await, ExitCode::Success);
+        assert_eq!(
+            run(
+                cli,
+                style::Presentation::BARE,
+                (style::StyleLevel::Full, style::StyleSource::Default),
+            )
+            .await,
+            ExitCode::Success
+        );
     }
 
     /// fails if the absent-socket case stops naming the next command, or if a
@@ -3271,7 +3321,12 @@ mod tests {
         let cli = Cli::try_parse_from(argv).unwrap_or_else(|e| panic!("{argv:?} failed: {e}"));
 
         assert_eq!(
-            run(cli, style::Presentation::BARE).await,
+            run(
+                cli,
+                style::Presentation::BARE,
+                (style::StyleLevel::Full, style::StyleSource::Default),
+            )
+            .await,
             ExitCode::DaemonUnreachable,
             "`kill` against an unowned home must reach its own socket-free path"
         );

--- a/crates/shep-cli/src/lookout/app.rs
+++ b/crates/shep-cli/src/lookout/app.rs
@@ -270,8 +270,17 @@ pub enum Msg {
 /// later walked straight around it: a read-only lookout could type a new
 /// `socket` and apply it. A fourth door added tomorrow cannot repeat that,
 /// because it cannot construct the effect it would have to return.
+///
+/// [`WriteAuthority::granted`] takes `&App` rather than a bare [`Control`]
+/// on purpose: a bare `Control` can be built anywhere (`Control::Allowed`
+/// is a unit variant, not a secret), so a call site free to hand in a
+/// literal `Control::Allowed` instead of the app's own field would grant
+/// itself the token by construction, which is exactly the shape the first
+/// review mutation of this gate took, and it compiled. Reading the field
+/// off `App` closes that: the only `Control` `granted` ever sees is the one
+/// the app was actually built with.
 mod authority {
-    use super::Control;
+    use super::App;
 
     /// Proof that `--allow-control` was on when a settings write was built.
     ///
@@ -281,16 +290,20 @@ mod authority {
     pub struct WriteAuthority(());
 
     impl WriteAuthority {
-        /// A token when `control` permits writing, [`None`] otherwise.
+        /// A token when `app`'s own [`Control`](super::Control) permits
+        /// writing, [`None`] otherwise.
         ///
         /// The sole constructor. The unit field above is private to this
         /// module, so every other module in this crate reaches a
-        /// [`WriteAuthority`] through here or not at all.
+        /// [`WriteAuthority`] through here or not at all. Takes `&App`
+        /// rather than a `Control` so the only reachable answer is the
+        /// app's own gate -- see this module's own doc for what a bare
+        /// `Control` parameter let slip past review once already.
         #[must_use]
-        pub const fn granted(control: Control) -> Option<Self> {
-            match control {
-                Control::ReadOnly => None,
-                Control::Allowed => Some(Self(())),
+        pub fn granted(app: &App) -> Option<Self> {
+            match app.control {
+                super::Control::ReadOnly => None,
+                super::Control::Allowed => Some(Self(())),
             }
         }
     }
@@ -2079,7 +2092,7 @@ impl App {
     /// See [`WriteAuthority`]'s own doc for why the gate is shaped this way
     /// rather than as a check per key.
     fn authorize_write(&mut self) -> Option<WriteAuthority> {
-        let authority = WriteAuthority::granted(self.control);
+        let authority = WriteAuthority::granted(self);
         if authority.is_none() {
             self.notice = Some(Notice {
                 text: READ_ONLY_REFUSAL.to_string(),

--- a/crates/shep-cli/src/lookout/app.rs
+++ b/crates/shep-cli/src/lookout/app.rs
@@ -795,7 +795,7 @@ impl Settings {
             _ => None,
         };
         let in_file = (field == SettingField::StyleLevel)
-            .then(|| self.snapshot.style_level_in_file.as_deref())
+            .then_some(self.snapshot.style_level_in_file.as_deref())
             .flatten();
         let base: String = match (armed_here, in_file) {
             (Some(value), _) | (None, Some(value)) => value.to_string(),

--- a/crates/shep-cli/src/lookout/app.rs
+++ b/crates/shep-cli/src/lookout/app.rs
@@ -529,12 +529,11 @@ pub struct Settings {
 #[derive(Debug, Clone)]
 enum Pending {
     /// A free-text edit under construction. Only [`SettingField::Socket`]
-    /// and [`SettingField::MaxCronSleep`] ever reach this -- task 8's own
-    /// territory. Nothing in this task constructs it; the variant exists now
-    /// so [`Settings::pending`] and [`App::confirm_setting`] have a shape to
-    /// pass a non-`Armed`, non-`Sent` state through rather than gaining a
-    /// second `Option` the day it lands.
-    #[allow(dead_code)]
+    /// and [`SettingField::MaxCronSleep`] ever reach this: `Enter` on
+    /// either row opens it, seeded with that field's own on-disk value
+    /// ([`App::confirm_setting`]), and [`App::on_settings_text_key`] is
+    /// the only place a [`KeyPress::TextChar`] or [`KeyPress::TextBackspace`]
+    /// ever reaches it while [`Settings`] owns the keyboard.
     Typing {
         /// Which scalar.
         field: SettingField,
@@ -554,11 +553,12 @@ enum Pending {
         at: Instant,
     },
     /// Sent: [`Effect::WriteSetting`] is in flight, waiting on
-    /// [`Msg::SettingWritten`].
+    /// [`Msg::SettingWritten`]. Carries no `edit`: nothing reads the sent
+    /// candidate back off `Pending` -- `Msg::SettingWritten`'s own `edit`
+    /// (the one [`Effect::WriteSetting`] round-trips) is what every match
+    /// site actually uses, so this variant only ever needs the rendered
+    /// question.
     Sent {
-        /// The edit that was sent.
-        #[allow(dead_code)]
-        edit: SettingEdit,
         /// The same rendered question, so the prompt line does not change
         /// wording between the question and its own answer.
         text: String,
@@ -595,6 +595,20 @@ impl Settings {
             Some(Pending::Armed { text, .. }) => Some(SettingsPrompt { text, sent: false }),
             Some(Pending::Sent { text, .. }) => Some(SettingsPrompt { text, sent: true }),
             Some(Pending::Typing { .. }) | None => None,
+        }
+    }
+
+    /// The field and buffer of an in-flight free-text edit, or `None` --
+    /// including while nothing is armed, while a cycled candidate is
+    /// `Armed` or `Sent`, and once the screen is closed. The view's own
+    /// window into [`Pending::Typing`], the same way [`Self::pending`] is
+    /// its window into `Armed`/`Sent`; the two never overlap; see
+    /// [`Self::pending`]'s own `Typing` arm.
+    #[must_use]
+    pub fn typing(&self) -> Option<(&SettingField, &str)> {
+        match &self.pending {
+            Some(Pending::Typing { field, buffer }) => Some((field, buffer.as_str())),
+            _ => None,
         }
     }
 
@@ -646,12 +660,34 @@ impl Settings {
         })
     }
 
+    /// The snapshot's own rendered value for one of the two free-text
+    /// fields [`Self::current_value`] does not cover -- what
+    /// [`App::confirm_setting`] seeds [`Pending::Typing`]'s buffer with.
+    /// Only ever called with [`SettingField::Socket`] or
+    /// [`SettingField::MaxCronSleep`]: the other four are cycled, not
+    /// typed, and never open an editor.
+    fn text_seed(&self, field: SettingField) -> &str {
+        match field {
+            SettingField::Socket => self.snapshot.socket.value.as_str(),
+            SettingField::MaxCronSleep => self.snapshot.max_cron_sleep.value.as_str(),
+            SettingField::LogLevel
+            | SettingField::LogJson
+            | SettingField::AllowControl
+            | SettingField::StyleLevel => {
+                unreachable!("text_seed only ever reaches the two free-text fields")
+            }
+        }
+    }
+
     /// Folds a landed write back into the row it changed: the snapshot's
     /// own [`ScalarView`] for `field` becomes `value`, sourced
-    /// [`StyleSource::Config`] -- the write just put it in the file.
-    /// [`SettingEdit::Unset`] never reaches here (this task only ever
-    /// arms `Set`), and the two fields this task never cycles are matched
-    /// out for exhaustiveness rather than reached.
+    /// [`StyleSource::Config`] -- the write just put it in the file. A
+    /// landed [`SettingEdit::Unset`] (`socket` or `max_cron_sleep`, task
+    /// 8's own) is matched out and does nothing rather than reverting the
+    /// row to `the default`: this reducer has no way to render that
+    /// value without re-reading the document, and `r` already does that.
+    /// The row is stale until then, the same way a dog write already
+    /// leaves the RUNNING column until the next poll.
     fn record_written(&mut self, edit: &SettingEdit) {
         let SettingEdit::Set { field, value } = edit else {
             return;
@@ -812,6 +848,63 @@ fn confirm_text(field: SettingField, value: &str) -> String {
         SettingField::Socket | SettingField::MaxCronSleep => unreachable!(
             "Settings::next_candidate never arms these two -- they are task 8's Pending::Typing"
         ),
+    }
+}
+
+/// The confirm sentence for a free-text edit -- verbatim, per the design
+/// spec's own table, and the pair this repository's voice review already
+/// signed off on. Only ever built from [`App::on_settings_text_key`]'s
+/// `TextApply` arm, and only ever with an edit naming
+/// [`SettingField::Socket`] or [`SettingField::MaxCronSleep`]: the other
+/// four fields build their sentence through [`confirm_text`] instead,
+/// which never sees an [`SettingEdit::Unset`] because none of the four is
+/// optional. The `Socket` sentence says both halves on purpose: that a
+/// reload will not move it, and that an env var or a boot flag may shadow
+/// it anyway even after this edit lands.
+fn confirm_text_for_edit(edit: &SettingEdit) -> String {
+    match edit {
+        SettingEdit::Set {
+            field: SettingField::Socket,
+            value,
+        } => format!(
+            "set socket to {value}? needs the shepherd stopped and started; a reload will not move it, and it will not apply if the shepherd was booted with SHEP_SOCKET or --socket"
+        ),
+        SettingEdit::Set {
+            field: SettingField::MaxCronSleep,
+            value,
+        } => format!(
+            "set max_cron_sleep to {value}? needs shep daemon reload, and will not apply if the shepherd was booted with SHEP_MAX_CRON_SLEEP or --max-cron-sleep"
+        ),
+        SettingEdit::Unset {
+            field: SettingField::Socket,
+        } => "unset socket? it goes back to the default under $SHEP_HOME, and needs the shepherd stopped and started"
+            .to_string(),
+        SettingEdit::Unset {
+            field: SettingField::MaxCronSleep,
+        } => "unset max_cron_sleep? it goes back to the daemon's own default, and needs shep daemon reload"
+            .to_string(),
+        SettingEdit::Set { .. } | SettingEdit::Unset { .. } => unreachable!(
+            "on_settings_text_key only ever builds an edit for socket or max_cron_sleep"
+        ),
+    }
+}
+
+/// What [`App`]'s `Msg::SettingWritten` `Err` arm reopens
+/// [`Pending::Typing`] with, for the two free-text fields: the field and
+/// the text the operator typed, recovered from the edit
+/// [`Effect::WriteSetting`] carried. `None` for the four cycled fields,
+/// which reopen nothing -- a refusal there clears the row's pending state
+/// and raises the notice on its own, same as before this task.
+fn typed_text_of(edit: &SettingEdit) -> Option<(SettingField, String)> {
+    match edit {
+        SettingEdit::Set {
+            field: field @ (SettingField::Socket | SettingField::MaxCronSleep),
+            value,
+        } => Some((*field, value.clone())),
+        SettingEdit::Unset {
+            field: field @ (SettingField::Socket | SettingField::MaxCronSleep),
+        } => Some((*field, String::new())),
+        _ => None,
     }
 }
 
@@ -1221,11 +1314,21 @@ impl App {
             // notice with the refusal's own words rather than a generic
             // one -- the same "say why" rule `arm`'s refusal ladder follows.
             //
-            // Both arms clear `pending` on the settings screen alone, in two
-            // separate blocks rather than one shared borrow of `self`: this
-            // arm needs to set `self.notice` on the `Err` path, and Rust
-            // will not let a `&mut self.settings` borrow stay live across
-            // that assignment to a different field of the same `self`.
+            // For the two free-text fields, `Err` also reopens
+            // [`Pending::Typing`] with the text the operator typed
+            // ([`typed_text_of`]) and switches [`InputMode::Text`] back on:
+            // the refusal is discovered under `apply_setting`'s own lock,
+            // after the confirm, so it has to land as a re-opened editor
+            // rather than a blank row -- an operator who typed a long path
+            // must not have to retype it to fix one character. The four
+            // cycled fields have nothing to reopen; their `Err` matches the
+            // behaviour this arm already had.
+            //
+            // Both arms touch the settings screen and `self.notice` (and,
+            // on a text-field refusal, `self.mode`) in separate blocks
+            // rather than one shared borrow of `self`: Rust will not let a
+            // `&mut self.settings` borrow stay live across an assignment to
+            // a different field of the same `self`.
             Msg::SettingWritten { edit, result } => {
                 match result {
                     Ok(()) => {
@@ -1235,8 +1338,14 @@ impl App {
                         }
                     }
                     Err(message) => {
+                        let reopened = typed_text_of(&edit);
                         if let Some(settings) = self.settings.as_mut() {
-                            settings.pending = None;
+                            settings.pending = reopened
+                                .clone()
+                                .map(|(field, buffer)| Pending::Typing { field, buffer });
+                        }
+                        if reopened.is_some() {
+                            self.mode = InputMode::Text;
                         }
                         self.notice = Some(Notice {
                             text: message,
@@ -1562,24 +1671,29 @@ impl App {
                     self.settings = None;
                 }
             }
-            KeyPress::SelectUp => {
+            // An armed candidate eats the FIRST movement key rather than
+            // also moving the cursor -- the same cancel-before-act rule
+            // `on_key`'s own dashboard branch already follows for
+            // `x`/`R`/`L` (see its "A stray `j` during a pending confirm"
+            // comment): without it, the operator would see the prompt
+            // vanish and the cursor move on the same keypress, and the
+            // next reflexive Enter would apply an edit to a row they had
+            // already lost track of. `Sent` is untouched, same as the
+            // dashboard's own guard, which only fires on `Stage::Armed`:
+            // a request already in flight is not cancellable by a keypress.
+            KeyPress::SelectUp | KeyPress::SelectDown | KeyPress::SelectFirst | KeyPress::SelectLast => {
                 if let Some(settings) = self.settings.as_mut() {
-                    settings.move_by(-1);
-                }
-            }
-            KeyPress::SelectDown => {
-                if let Some(settings) = self.settings.as_mut() {
-                    settings.move_by(1);
-                }
-            }
-            KeyPress::SelectFirst => {
-                if let Some(settings) = self.settings.as_mut() {
-                    settings.move_to_first();
-                }
-            }
-            KeyPress::SelectLast => {
-                if let Some(settings) = self.settings.as_mut() {
-                    settings.move_to_last();
+                    if matches!(settings.pending, Some(Pending::Armed { .. })) {
+                        settings.pending = None;
+                    } else {
+                        match key {
+                            KeyPress::SelectUp => settings.move_by(-1),
+                            KeyPress::SelectDown => settings.move_by(1),
+                            KeyPress::SelectFirst => settings.move_to_first(),
+                            KeyPress::SelectLast => settings.move_to_last(),
+                            _ => unreachable!(),
+                        }
+                    }
                 }
             }
             KeyPress::Cycle => return self.cycle_setting(),
@@ -1639,19 +1753,34 @@ impl App {
         Effect::None
     }
 
-    /// The operator's `Enter` on the settings screen. Sends an armed
-    /// candidate and moves it to [`Pending::Sent`]; leaves anything else
-    /// (nothing armed, or a `Typing` edit task 8 owns) untouched.
+    /// The operator's `Enter` on the settings screen. Three meanings,
+    /// picked in this order:
+    ///
+    /// - Nothing is pending and the cursor sits on [`SettingField::Socket`]
+    ///   or [`SettingField::MaxCronSleep`]: opens [`Pending::Typing`],
+    ///   seeded with that field's own on-disk value, and switches
+    ///   [`InputMode::Text`] on -- [`Self::on_settings_text_key`] is what
+    ///   answers every key from here on, not this function again.
+    /// - Something is [`Pending::Armed`]: sends it and moves it to
+    ///   [`Pending::Sent`], same as before this task.
+    /// - Anything else (nothing pending on a cycled row, or already
+    ///   `Sent`): untouched.
     fn confirm_setting(&mut self) -> Effect {
         let Some(settings) = self.settings.as_mut() else {
             return Effect::None;
         };
+        if settings.pending.is_none()
+            && let Some(SettingsRow::Scalar(field @ (SettingField::Socket | SettingField::MaxCronSleep))) =
+                settings.cursor()
+        {
+            let buffer = settings.text_seed(field).to_string();
+            settings.pending = Some(Pending::Typing { field, buffer });
+            self.mode = InputMode::Text;
+            return Effect::None;
+        }
         match settings.pending.take() {
             Some(Pending::Armed { edit, text, .. }) => {
-                settings.pending = Some(Pending::Sent {
-                    edit: edit.clone(),
-                    text,
-                });
+                settings.pending = Some(Pending::Sent { text });
                 Effect::WriteSetting(edit)
             }
             other => {
@@ -1805,6 +1934,19 @@ impl App {
         }
     }
 
+    /// The one text keymap's own router: the filter box while the
+    /// settings screen is closed, [`Self::on_settings_text_key`]'s editor
+    /// while it is open. A previous task closed the window where the two
+    /// could both own [`InputMode::Text`] at once -- see `Msg::Settings`'s
+    /// own arm -- so this split is total: exactly one of the two ever
+    /// answers a given keypress.
+    fn on_text_key(&mut self, key: KeyPress) -> Effect {
+        if self.settings.is_some() {
+            return self.on_settings_text_key(key);
+        }
+        self.on_filter_text_key(key)
+    }
+
     /// The filter box's keymap.
     ///
     /// Ctrl-C still quits: in raw mode it is a key event and not a signal,
@@ -1819,7 +1961,7 @@ impl App {
     /// somebody was mid-word. The status bar hides it under the box instead
     /// and shows it when the box closes. See the phase plan's "Shapes the
     /// design named" #2.
-    fn on_text_key(&mut self, key: KeyPress) -> Effect {
+    fn on_filter_text_key(&mut self, key: KeyPress) -> Effect {
         match key {
             KeyPress::Quit => Effect::Quit,
             KeyPress::TextChar(typed) => {
@@ -1842,6 +1984,62 @@ impl App {
             }
             _ => Effect::None,
         }
+    }
+
+    /// The settings editor's own text keymap, in force for as long as a
+    /// [`Pending::Typing`] owns [`InputMode::Text`].
+    ///
+    /// Does not trim the buffer, on `TextChar` or on `TextBackspace`
+    /// alike: this repository does not widen an accepted input grammar
+    /// without a basis in the spec, the same rule
+    /// [`Self::on_filter_text_key`]'s own filter buffer carries.
+    ///
+    /// `TextApply` arms rather than writes: an empty buffer becomes
+    /// [`SettingEdit::Unset`], anything else becomes [`SettingEdit::Set`],
+    /// and either way the edit moves to [`Pending::Armed`] rather than
+    /// going out -- the operator's next `Enter`, on the now-closed editor,
+    /// is what sends it, the same second-`Enter` shape every other confirm
+    /// on this screen already uses.
+    ///
+    /// `TextAbandon` drops [`Pending::Typing`] back to `None` and leaves
+    /// the screen open, matching [`KeyPress::Escape`]'s own doc: the
+    /// cascade backs out of the innermost thing first.
+    fn on_settings_text_key(&mut self, key: KeyPress) -> Effect {
+        let now = self.now;
+        let Some(settings) = self.settings.as_mut() else {
+            return Effect::None;
+        };
+        match key {
+            KeyPress::Quit => return Effect::Quit,
+            KeyPress::TextChar(typed) => {
+                if let Some(Pending::Typing { buffer, .. }) = settings.pending.as_mut() {
+                    buffer.push(typed);
+                }
+            }
+            KeyPress::TextBackspace => {
+                if let Some(Pending::Typing { buffer, .. }) = settings.pending.as_mut() {
+                    buffer.pop();
+                }
+            }
+            KeyPress::TextApply => {
+                if let Some(Pending::Typing { field, buffer }) = settings.pending.take() {
+                    let edit = if buffer.is_empty() {
+                        SettingEdit::Unset { field }
+                    } else {
+                        SettingEdit::Set { field, value: buffer }
+                    };
+                    let text = confirm_text_for_edit(&edit);
+                    settings.pending = Some(Pending::Armed { edit, text, at: now });
+                }
+                self.mode = InputMode::Normal;
+            }
+            KeyPress::TextAbandon => {
+                settings.pending = None;
+                self.mode = InputMode::Normal;
+            }
+            _ => {}
+        }
+        Effect::None
     }
 
     /// The rows the table draws, in `(name, instance, id)` order: the whole
@@ -4543,5 +4741,129 @@ mod tests {
             "the flag beats the file rather than being dropped by it"
         );
         assert_eq!(row.value, "plain");
+    }
+
+    #[test]
+    fn enter_on_a_text_row_opens_the_editor_seeded_with_the_current_value() {
+        let mut app = fixtures::app_in_settings_on(SettingField::MaxCronSleep);
+        let _ = app.update(Msg::Key(KeyPress::Confirm));
+        let (field, buffer) = app.settings().unwrap().typing().expect("the editor opens");
+        assert_eq!(*field, SettingField::MaxCronSleep);
+        assert_eq!(buffer, "30s");
+    }
+
+    #[test]
+    fn typing_then_enter_arms_rather_than_writing() {
+        let mut app = fixtures::app_in_settings_on(SettingField::MaxCronSleep);
+        let _ = app.update(Msg::Key(KeyPress::Confirm));
+        for _ in 0..3 {
+            let _ = app.update(Msg::Key(KeyPress::TextBackspace));
+        }
+        for c in "45s".chars() {
+            let _ = app.update(Msg::Key(KeyPress::TextChar(c)));
+        }
+        assert_eq!(app.update(Msg::Key(KeyPress::TextApply)), Effect::None);
+        let prompt = app.settings().unwrap().pending().unwrap();
+        assert!(!prompt.sent, "the editor arms; a second Enter is what sends");
+        assert!(prompt.text.contains("45s"), "got: {}", prompt.text);
+        assert!(
+            prompt.text.contains("SHEP_MAX_CRON_SLEEP"),
+            "got: {}",
+            prompt.text
+        );
+    }
+
+    #[test]
+    fn an_empty_editor_arms_an_unset() {
+        let mut app = fixtures::app_in_settings_on(SettingField::MaxCronSleep);
+        let _ = app.update(Msg::Key(KeyPress::Confirm));
+        for _ in 0..8 {
+            let _ = app.update(Msg::Key(KeyPress::TextBackspace));
+        }
+        let _ = app.update(Msg::Key(KeyPress::TextApply));
+        let text = app.settings().unwrap().pending().unwrap().text.to_string();
+        assert!(text.starts_with("unset max_cron_sleep?"), "got: {text}");
+    }
+
+    #[test]
+    fn the_socket_confirm_rules_out_the_reload_it_would_otherwise_imply() {
+        let mut app = fixtures::app_in_settings_on(SettingField::Socket);
+        let _ = app.update(Msg::Key(KeyPress::Confirm));
+        let _ = app.update(Msg::Key(KeyPress::TextApply));
+        let text = app.settings().unwrap().pending().unwrap().text.to_string();
+        assert!(text.contains("stopped and started"), "got: {text}");
+        assert!(text.contains("a reload will not move it"), "got: {text}");
+    }
+
+    /// A refusal is discovered under the lock, so it lands after the confirm.
+    /// The typed text has to survive it, or the operator retypes a path to fix
+    /// one character.
+    #[test]
+    fn a_refused_write_reopens_the_editor_with_the_text_intact() {
+        let mut app = fixtures::app_in_settings_on(SettingField::MaxCronSleep);
+        let _ = app.update(Msg::Key(KeyPress::Confirm));
+        for _ in 0..3 {
+            let _ = app.update(Msg::Key(KeyPress::TextBackspace));
+        }
+        for c in "500ms".chars() {
+            let _ = app.update(Msg::Key(KeyPress::TextChar(c)));
+        }
+        let _ = app.update(Msg::Key(KeyPress::TextApply));
+        let Effect::WriteSetting(edit) = app.update(Msg::Key(KeyPress::Confirm)) else {
+            panic!("Enter must send");
+        };
+        let _ = app.update(Msg::SettingWritten {
+            edit,
+            result: Err("max_cron_sleep is 500ms, below the 1s floor".into()),
+        });
+
+        let (_, buffer) = app.settings().unwrap().typing().expect("the editor reopens");
+        assert_eq!(buffer, "500ms");
+        assert!(app.notice().unwrap().to_string().contains("below the 1s floor"));
+    }
+
+    #[test]
+    fn escape_abandons_the_editor_and_keeps_the_screen_open() {
+        let mut app = fixtures::app_in_settings_on(SettingField::Socket);
+        let _ = app.update(Msg::Key(KeyPress::Confirm));
+        let _ = app.update(Msg::Key(KeyPress::TextAbandon));
+        assert!(app.settings().unwrap().typing().is_none());
+        assert!(app.settings().is_some());
+    }
+
+    #[test]
+    fn a_closed_scalar_has_no_editor() {
+        let mut app = fixtures::app_in_settings_with_control(); // on log_level
+        let _ = app.update(Msg::Key(KeyPress::Confirm));
+        assert!(
+            app.settings().unwrap().typing().is_none(),
+            "log_level is a cycle, not a text field"
+        );
+    }
+
+    /// fails if an armed candidate survives a movement key. `space` on
+    /// `log_level` arms it; `j` must cancel that arm instead of also
+    /// moving the cursor to `log_json` -- the same cancel-before-act rule
+    /// the dashboard's `x`/`R`/`L` already follow (task 7 review finding
+    /// A).
+    #[test]
+    fn movement_cancels_an_armed_candidate_rather_than_also_moving() {
+        let mut app = fixtures::app_in_settings_with_control(); // cursor on log_level
+        let before = app.settings().unwrap().cursor();
+        let _ = app.update(Msg::Key(KeyPress::Cycle));
+        assert!(
+            app.settings().unwrap().pending().is_some(),
+            "space must arm before this test means anything"
+        );
+        let _ = app.update(Msg::Key(KeyPress::SelectDown));
+        assert!(
+            app.settings().unwrap().pending().is_none(),
+            "the armed candidate must not survive the movement key"
+        );
+        assert_eq!(
+            app.settings().unwrap().cursor(),
+            before,
+            "the cursor must not also move on the same keypress"
+        );
     }
 }

--- a/crates/shep-cli/src/lookout/app.rs
+++ b/crates/shep-cli/src/lookout/app.rs
@@ -774,6 +774,14 @@ impl Settings {
     /// fourth unreachable without a cancel in between. An armed candidate
     /// for a DIFFERENT field (the cursor moved after arming) is not a base:
     /// this starts fresh from the snapshot instead.
+    ///
+    /// From nothing armed, the base is what the FILE says, which is
+    /// [`Self::current_value`] for five of the six fields and
+    /// [`SettingsSnapshot::style_level_in_file`] for `[style] level`. That
+    /// one field's [`ScalarView::value`] is the level in force rather than
+    /// the level on disk, so with `$SHEP_STYLE=bare` over a file saying
+    /// `full` a cycle from the resolved value proposes `full` -- a write
+    /// that changes nothing, reported to the operator as a change.
     fn next_candidate(&self, field: SettingField) -> Option<String> {
         let armed_here = match &self.pending {
             Some(Pending::Armed {
@@ -786,14 +794,21 @@ impl Settings {
             }) if *armed_field == field => Some(value.as_str()),
             _ => None,
         };
-        let base = match armed_here {
-            Some(value) => value,
-            None => self.current_value(field)?,
+        let in_file = (field == SettingField::StyleLevel)
+            .then(|| self.snapshot.style_level_in_file.as_deref())
+            .flatten();
+        let base: String = match (armed_here, in_file) {
+            (Some(value), _) | (None, Some(value)) => value.to_string(),
+            // A `[style]` document that declares nothing falls back to
+            // `StyleLevel`'s own compiled default, which is what
+            // `style::resolve` returns for the same absence.
+            (None, None) if field == SettingField::StyleLevel => STYLE_LEVEL_ORDER[0].to_string(),
+            (None, None) => self.current_value(field)?.to_string(),
         };
         Some(match field {
-            SettingField::LogLevel => next_log_level(base),
-            SettingField::LogJson | SettingField::AllowControl => next_bool(base),
-            SettingField::StyleLevel => next_style_level(base),
+            SettingField::LogLevel => next_log_level(&base),
+            SettingField::LogJson | SettingField::AllowControl => next_bool(&base),
+            SettingField::StyleLevel => next_style_level(&base),
             SettingField::Socket | SettingField::MaxCronSleep => return None,
         })
     }
@@ -808,6 +823,20 @@ impl Settings {
             SettingField::StyleLevel => self.snapshot.style_level.value.as_str(),
             SettingField::Socket | SettingField::MaxCronSleep => return None,
         })
+    }
+
+    /// Which layer `field`'s value came from, off the snapshot. Only
+    /// [`confirm_text`] reads it, and only its `[style]` arm does anything
+    /// with it -- see [`style_confirm_text`].
+    fn source_of(&self, field: SettingField) -> StyleSource {
+        match field {
+            SettingField::LogLevel => self.snapshot.log_level.source,
+            SettingField::LogJson => self.snapshot.log_json.source,
+            SettingField::Socket => self.snapshot.socket.source,
+            SettingField::MaxCronSleep => self.snapshot.max_cron_sleep.source,
+            SettingField::AllowControl => self.snapshot.allow_control.source,
+            SettingField::StyleLevel => self.snapshot.style_level.source,
+        }
     }
 
     /// The snapshot's own rendered value for one of the two free-text
@@ -956,7 +985,16 @@ fn next_style_level(current: &str) -> String {
 /// for, so [`SettingField::Socket`] and [`SettingField::MaxCronSleep`]
 /// never reach the two arms below -- named rather than wildcarded so a
 /// future field added to the match cannot fall through unnoticed.
-fn confirm_text(field: SettingField, value: &str) -> String {
+///
+/// `source` is the field's own [`ScalarView::source`], and only
+/// [`SettingField::StyleLevel`] reads it. The other three carry a caveat
+/// about a layer lookout CANNOT see (the shepherd's env and flags), and a
+/// caveat is all they can carry. `[style]`'s layers are lookout's own
+/// process, so this is the one field where the screen knows -- and it was
+/// the one field promising "the next command reads it" unconditionally,
+/// which is false the moment `$SHEP_STYLE` or `--style` is set. See
+/// [`style_confirm_text`].
+fn confirm_text(field: SettingField, value: &str, source: StyleSource) -> String {
     match field {
         SettingField::LogLevel => format!(
             "set log_level to {value}? needs shep daemon reload, and will not apply if the shepherd was booted with SHEP_LOG_LEVEL or --log-level"
@@ -968,11 +1006,38 @@ fn confirm_text(field: SettingField, value: &str) -> String {
             let word = if value == "true" { "on" } else { "off" };
             format!("turn whistle control tools {word}? needs shep whistle restarted")
         }
-        SettingField::StyleLevel => {
-            format!("set style level to {value}? the next command reads it")
-        }
+        SettingField::StyleLevel => style_confirm_text(value, source),
         SettingField::Socket | SettingField::MaxCronSleep => unreachable!(
             "Settings::next_candidate never arms these two -- they are task 8's Pending::Typing"
+        ),
+    }
+}
+
+/// The `[style] level` half of [`confirm_text`], split out because it is
+/// the only arm that reads a second fact.
+///
+/// `StyleSource` is what `shep style` already reports and what the row's
+/// own SOURCE cell already shows, so this sentence never tells an operator
+/// something the screen contradicts two lines above it. The split is by
+/// what the layer above the file DOES, not by which layer it is:
+///
+/// - `Config`, `Default` -- nothing outranks the file, so the write is the
+///   whole story and the sentence says so, as it always did.
+/// - `Env`, `Flag` -- the write lands and the level in force does not
+///   move. Naming the layer is the point: the failure this avoids is the
+///   one `StyleSource`'s own doc exists for, an operator editing
+///   `shep.toml`, seeing nothing change, and never thinking of the
+///   `$SHEP_STYLE` in a shell profile they have forgotten about.
+fn style_confirm_text(value: &str, source: StyleSource) -> String {
+    match source {
+        StyleSource::Config | StyleSource::Default => {
+            format!("set style level to {value}? the next command reads it")
+        }
+        StyleSource::Env => format!(
+            "set style level to {value}? it goes in the file, but $SHEP_STYLE is set and keeps winning until it is unset"
+        ),
+        StyleSource::Flag => format!(
+            "set style level to {value}? it goes in the file, but --style was passed to this lookout and keeps winning for as long as it runs"
         ),
     }
 }
@@ -2060,7 +2125,8 @@ impl App {
         let Some(value) = settings.next_candidate(field) else {
             return Effect::None;
         };
-        let text = confirm_text(field, &value);
+        let source = settings.source_of(field);
+        let text = confirm_text(field, &value, source);
         settings.pending = Some(Pending::Armed {
             edit: SettingEdit::Set { field, value },
             text,
@@ -5063,6 +5129,54 @@ mod tests {
         let _ = app.update(Msg::Key(KeyPress::Cycle));
         let text = app.settings().unwrap().pending().unwrap().text.to_string();
         assert!(text.contains("the next command reads it"), "got: {text}");
+    }
+
+    /// fails if the style confirm keeps promising "the next command reads
+    /// it" while a layer above the file is set.
+    ///
+    /// `style::resolve` is flag over env over config, so with `$SHEP_STYLE`
+    /// or `--style` in play the write lands and nothing changes. This is
+    /// the one field where lookout KNOWS -- the SOURCE cell on the same row
+    /// already reads `$SHEP_STYLE` or `--style` -- and it was the one field
+    /// whose confirm said nothing about it, while the other three carry a
+    /// caveat about layers lookout cannot see at all.
+    #[test]
+    fn a_shadowed_style_confirm_names_the_layer_that_keeps_winning() {
+        for (source, layer) in [
+            (StyleSource::Env, "$SHEP_STYLE"),
+            (StyleSource::Flag, "--style"),
+        ] {
+            let mut app = fixtures::app_in_settings_with_shadowed_style(source);
+            let _ = app.update(Msg::Key(KeyPress::Cycle));
+            let text = app.settings().unwrap().pending().unwrap().text.to_string();
+            assert!(text.contains(layer), "{source} must name itself: {text}");
+            assert!(
+                text.contains("keeps winning"),
+                "{source} must say what it does: {text}"
+            );
+            assert!(
+                !text.contains("the next command reads it"),
+                "{source}: the next command reads {source}, not the file: {text}"
+            );
+        }
+    }
+
+    /// fails if `space` on the style row cycles from the level in FORCE
+    /// rather than the level on DISK.
+    ///
+    /// With `$SHEP_STYLE=bare` over a file saying `full`, cycling the
+    /// resolved value walks `bare -> full` and proposes `full`, which is
+    /// what the file already holds: a no-op write, reported to the operator
+    /// as a change. From the file it walks `full -> plain`.
+    #[test]
+    fn the_style_cycle_starts_from_the_file_and_not_the_level_in_force() {
+        let mut app = fixtures::app_in_settings_with_shadowed_style(StyleSource::Env);
+        let _ = app.update(Msg::Key(KeyPress::Cycle));
+        let text = app.settings().unwrap().pending().unwrap().text.to_string();
+        assert!(
+            text.contains("set style level to plain"),
+            "the file says full, so one step is plain: {text}"
+        );
     }
 
     #[test]

--- a/crates/shep-cli/src/lookout/app.rs
+++ b/crates/shep-cli/src/lookout/app.rs
@@ -38,6 +38,7 @@ use shep_core::status::ProcStatus;
 
 use super::theme::Palette;
 use crate::commands::settings::{SettingField, SettingsSnapshot};
+use crate::style::{StyleLevel, StyleSource};
 use crate::vocabulary::Reported;
 
 /// Whether this lookout may act on a sheep.
@@ -728,6 +729,14 @@ pub struct App {
     /// The settings screen's own state. `None` is the dashboard; `Some` is
     /// the screen, open over it.
     settings: Option<Settings>,
+    /// The resolved style level and which layer chose it, from
+    /// `run_argv`'s own `resolve_style`. `App::new` defaults it to
+    /// `(StyleLevel::Full, StyleSource::Default)`; `run_argv`'s `lookout`
+    /// dispatch immediately overrides it with the real resolution through
+    /// `Self::set_style`, so the settings screen's own STYLE LEVEL row
+    /// reads the same answer the rest of the CLI does rather than a second,
+    /// independently derived one.
+    style: (StyleLevel, StyleSource),
 }
 
 impl App {
@@ -751,6 +760,7 @@ impl App {
             lambs: None,
             action: None,
             settings: None,
+            style: (StyleLevel::Full, StyleSource::Default),
         }
     }
 
@@ -891,7 +901,24 @@ impl App {
             // nothing to show.
             Msg::Settings { result } => {
                 match result {
-                    Ok(snapshot) => self.settings = Some(Settings::new(snapshot)),
+                    Ok(snapshot) => {
+                        // Clears an action that armed while the read was in
+                        // flight (`s`, then `x`, then this landing): once
+                        // this branch runs, `on_key`'s settings short
+                        // circuit intercepts every key ahead of the
+                        // armed-confirm cancel block, and `on_settings_key`
+                        // no-ops `Confirm`. Without this, the prompt would
+                        // sit on screen, unreachable by Enter or by any
+                        // other key, until `CONFIRM_EXPIRY`. This is the
+                        // same closing-by-construction `on_key`'s own
+                        // comment already argues for `/` and the filter
+                        // box: a sheep confirm and the settings screen can
+                        // never coexist, and this is the one place
+                        // `self.settings` becomes `Some`, so clearing here
+                        // covers both the keypress and the race.
+                        self.action = None;
+                        self.settings = Some(Settings::new(snapshot));
+                    }
                     Err(message) => {
                         self.notice = Some(Notice {
                             text: message,
@@ -1905,6 +1932,24 @@ impl App {
     #[must_use]
     pub fn settings(&self) -> Option<&Settings> {
         self.settings.as_ref()
+    }
+
+    /// The resolved style level and which layer chose it. What
+    /// `Effect::LoadSettings` hands `commands::settings::load_settings`
+    /// for the STYLE LEVEL row, so the screen never re-resolves on its own.
+    #[must_use]
+    pub fn style(&self) -> (StyleLevel, StyleSource) {
+        self.style
+    }
+
+    /// Sets the resolved style level and its source. Called exactly once,
+    /// by `run_argv`'s `lookout` dispatch, right after construction: `App`
+    /// has no way to resolve this itself (it holds no `GlobalArgs` and
+    /// reads no files), so the caller that already computed it hands it
+    /// over rather than this type inventing a second, divergent way to get
+    /// one.
+    pub(crate) fn set_style(&mut self, style: (StyleLevel, StyleSource)) {
+        self.style = style;
     }
 
     /// Overrides the control gate a fixture built with. `App::new` takes
@@ -3850,5 +3895,78 @@ mod tests {
         let _ = app.update(Msg::Key(KeyPress::Cycle));
         let notice = app.notice().expect("the refusal has to say why");
         assert!(notice.is_grave());
+    }
+
+    /// fails if an action armed while the read is still in flight survives
+    /// the screen opening. `s` raises `Effect::LoadSettings` while
+    /// `self.settings` is still `None`, so `x` reaches `arm()` normally and
+    /// succeeds; once the read lands, `on_key`'s settings branch runs ahead
+    /// of the armed-confirm cancel block and `on_settings_key` no-ops
+    /// `Confirm`, so nothing would ever reach the code that resolves an
+    /// armed action. The fix is the same closing-by-construction `on_key`'s
+    /// own comment already argues for `/` and the filter box.
+    #[test]
+    fn opening_the_screen_clears_an_action_armed_while_the_read_was_in_flight() {
+        let mut app = fixtures::allowed_app();
+        let _ = app.update(Msg::Key(KeyPress::Settings));
+        let _ = app.update(Msg::Key(KeyPress::Action(ActionVerb::Stop)));
+        assert!(
+            app.action().is_some(),
+            "the arm must still succeed before the read lands"
+        );
+        let _ = app.update(Msg::Settings {
+            result: Ok(fixtures::settings_snapshot()),
+        });
+        assert!(
+            app.action().is_none(),
+            "no armed action may survive the screen opening"
+        );
+    }
+
+    /// fails if `App::set_style` does not round trip exactly: the flag
+    /// source in particular, since that is the layer the settings screen's
+    /// own STYLE LEVEL row was silently dropping before this was wired
+    /// through `App` at all.
+    #[test]
+    fn set_style_round_trips_exactly() {
+        let mut app = fixtures::full_app();
+        assert_eq!(
+            app.style(),
+            (StyleLevel::Full, StyleSource::Default),
+            "the default before anyone calls set_style"
+        );
+        app.set_style((StyleLevel::Bare, StyleSource::Flag));
+        assert_eq!(app.style(), (StyleLevel::Bare, StyleSource::Flag));
+    }
+
+    /// fails if the settings screen's own STYLE LEVEL row can disagree with
+    /// the style `App` was told to carry. Drives the exact call
+    /// `Effect::LoadSettings` makes (`load_settings(path, socket_default,
+    /// app.style())`) against a real file on disk whose own `[style]
+    /// level` names a THIRD, different level -- proving the row reports
+    /// the value threaded onto `App`, not one re-derived from the file,
+    /// which is what a flag "reaching the row" rather than being dropped
+    /// actually means.
+    #[test]
+    fn the_style_set_on_the_app_reaches_the_settings_row_undropped() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("shep.toml");
+        std::fs::write(&path, "[style]\nlevel = \"bare\"\n").unwrap();
+        let socket_default = dir.path().join("run").join("shep.sock");
+
+        let mut app = fixtures::full_app();
+        app.set_style((StyleLevel::Plain, StyleSource::Flag));
+
+        let result = crate::commands::settings::load_settings(&path, &socket_default, app.style())
+            .map_err(|err| err.to_string());
+        let _ = app.update(Msg::Settings { result });
+
+        let row = &app.settings().unwrap().snapshot().style_level;
+        assert_eq!(
+            row.source,
+            StyleSource::Flag,
+            "the flag beats the file rather than being dropped by it"
+        );
+        assert_eq!(row.value, "plain");
     }
 }

--- a/crates/shep-cli/src/lookout/app.rs
+++ b/crates/shep-cli/src/lookout/app.rs
@@ -253,6 +253,51 @@ pub enum Msg {
     },
 }
 
+/// The one gate on writing `shep.toml` from the settings screen.
+///
+/// Lives in its own module with a private field so that [`Control`] is
+/// checked ONCE, structurally, rather than remembered key by key. Nothing
+/// outside this module can build a [`WriteAuthority`] -- not `App`, not the
+/// key handlers, not the tests -- so the only way to reach it is
+/// [`WriteAuthority::granted`], which hands back [`None`] for
+/// [`Control::ReadOnly`]. [`Effect::WriteSetting`] and [`Effect::WriteDog`]
+/// each carry one, so a settings write is not something a handler is
+/// trusted to check before performing: it is something the handler cannot
+/// name without having passed the check.
+///
+/// That matters because the first version of this gate was a check on one
+/// key (`space`, [`App::cycle_setting`]), and the editor `Enter` added
+/// later walked straight around it: a read-only lookout could type a new
+/// `socket` and apply it. A fourth door added tomorrow cannot repeat that,
+/// because it cannot construct the effect it would have to return.
+mod authority {
+    use super::Control;
+
+    /// Proof that `--allow-control` was on when a settings write was built.
+    ///
+    /// `Debug` is derived rather than redacted (IR-41): a zero-sized token
+    /// with no field a `{:?}` could print.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub struct WriteAuthority(());
+
+    impl WriteAuthority {
+        /// A token when `control` permits writing, [`None`] otherwise.
+        ///
+        /// The sole constructor. The unit field above is private to this
+        /// module, so every other module in this crate reaches a
+        /// [`WriteAuthority`] through here or not at all.
+        #[must_use]
+        pub const fn granted(control: Control) -> Option<Self> {
+            match control {
+                Control::ReadOnly => None,
+                Control::Allowed => Some(Self(())),
+            }
+        }
+    }
+}
+
+pub use authority::WriteAuthority;
+
 /// What the caller has to do after an update.
 ///
 /// Not `Copy`: [`Self::Send`] carries a [`Sent`], whose `Sent::Action`
@@ -303,7 +348,11 @@ pub enum Effect {
     /// (`FlockArg::LockExclusive`), so a concurrent `shep adopt` on the same
     /// file would freeze the UI task's redraw, its tick and its bus drain
     /// right along with the write.
-    WriteSetting(SettingEdit),
+    ///
+    /// The [`WriteAuthority`] is not decoration: it is the only thing that
+    /// makes `--allow-control` a property of this effect rather than a
+    /// check each key handler has to remember. See its own doc.
+    WriteSetting(SettingEdit, WriteAuthority),
     /// Apply one dog's file half; the result lands as [`Msg::DogWritten`].
     ///
     /// Raised by [`App::confirm_setting`] once an armed dog row's Enter
@@ -313,7 +362,10 @@ pub enum Effect {
     /// notice, a dog write ends in a request to the shepherd
     /// ([`Sent::Dog`]). `super::run_ui` runs this on `spawn_blocking`, the
     /// same reason [`Self::WriteSetting`]'s own doc gives.
-    WriteDog(DogEdit),
+    ///
+    /// Carries a [`WriteAuthority`] for the same reason
+    /// [`Self::WriteSetting`] does.
+    WriteDog(DogEdit, WriteAuthority),
 }
 
 /// The connection's state, as the dashboard reports it.
@@ -1072,6 +1124,12 @@ pub const CONFIRM_EXPIRY: Duration = Duration::from_secs(10);
 /// The sentence `r` gives when the link is gone. The action keys refuse with
 /// the same one, so the two cannot drift apart.
 const LINK_GONE: &str = "the shepherd is gone — nothing left to ask";
+
+/// The sentence every closed-gate refusal gives, on the dashboard and on
+/// the settings screen alike. One string, so an operator who has met it
+/// once on `x` recognises it on `space` -- and so the two cannot drift
+/// apart the way the checks behind them once did.
+const READ_ONLY_REFUSAL: &str = "read-only: actions need --allow-control";
 
 /// The whole dashboard's state.
 #[derive(Debug)]
@@ -1932,19 +1990,37 @@ impl App {
         Effect::None
     }
 
-    /// `space` on the settings screen. Arms a candidate for the cursor's
-    /// row, or refuses and says why the same way an action key does; the
-    /// gate is the same read-only check `arm` makes for a sheep action,
-    /// because a keystroke that mutates `shep.toml` needs the same fat-finger
-    /// catch a keystroke that stops a sheep does. Dispatches by row kind:
-    /// [`Self::cycle_scalar`] for one of the six fields,
-    /// [`Self::cycle_dog`] for a [`SettingsRow::Dog`] row.
-    fn cycle_setting(&mut self) -> Effect {
-        if self.control == Control::ReadOnly {
+    /// The [`WriteAuthority`] every settings write path has to hold, or
+    /// [`None`] with the refusal already raised.
+    ///
+    /// The one place [`Control`] is read on this screen. Every door that
+    /// can end in a changed `shep.toml` -- `space` on a scalar, `space` on
+    /// a dog, `Enter` opening the free-text editor, `Enter` applying an
+    /// armed candidate -- comes through here, and it is not a convention
+    /// they are trusted to follow: [`Effect::WriteSetting`] and
+    /// [`Effect::WriteDog`] cannot be built without the token this returns.
+    /// See [`WriteAuthority`]'s own doc for why the gate is shaped this way
+    /// rather than as a check per key.
+    fn authorize_write(&mut self) -> Option<WriteAuthority> {
+        let authority = WriteAuthority::granted(self.control);
+        if authority.is_none() {
             self.notice = Some(Notice {
-                text: "read-only: actions need --allow-control".to_string(),
+                text: READ_ONLY_REFUSAL.to_string(),
                 grave: true,
             });
+        }
+        authority
+    }
+
+    /// `space` on the settings screen. Arms a candidate for the cursor's
+    /// row, or refuses and says why the same way an action key does; the
+    /// gate is [`Self::authorize_write`], the same one every other door on
+    /// this screen passes, because a keystroke that mutates `shep.toml`
+    /// needs the same fat-finger catch a keystroke that stops a sheep does.
+    /// Dispatches by row kind: [`Self::cycle_scalar`] for one of the six
+    /// fields, [`Self::cycle_dog`] for a [`SettingsRow::Dog`] row.
+    fn cycle_setting(&mut self) -> Effect {
+        if self.authorize_write().is_none() {
             return Effect::None;
         }
         let Some(cursor) = self.settings.as_ref().and_then(Settings::cursor) else {
@@ -2034,15 +2110,37 @@ impl App {
     ///   doc for why they are not the same effect.
     /// - Anything else (nothing pending on a cycled row, or already
     ///   `Sent`): untouched.
+    ///
+    /// The first two both go through [`Self::authorize_write`] and refuse
+    /// under [`Control::ReadOnly`]; the third does nothing, so it raises no
+    /// refusal for a key that was never going to act. Opening the editor is
+    /// gated as well as applying it, because an editor a read-only operator
+    /// can type a whole socket path into before being told no is a worse
+    /// refusal than one that arrives on the keypress that asked.
     fn confirm_setting(&mut self) -> Effect {
+        let Some(settings) = self.settings.as_ref() else {
+            return Effect::None;
+        };
+        let opens_editor = settings.pending.is_none()
+            && matches!(
+                settings.cursor(),
+                Some(SettingsRow::Scalar(
+                    SettingField::Socket | SettingField::MaxCronSleep
+                ))
+            );
+        if !opens_editor && !settings.is_armed() {
+            return Effect::None;
+        }
+        let Some(authority) = self.authorize_write() else {
+            return Effect::None;
+        };
         let Some(settings) = self.settings.as_mut() else {
             return Effect::None;
         };
-        if settings.pending.is_none()
-            && let Some(SettingsRow::Scalar(
-                field @ (SettingField::Socket | SettingField::MaxCronSleep),
-            )) = settings.cursor()
-        {
+        if opens_editor {
+            let Some(SettingsRow::Scalar(field)) = settings.cursor() else {
+                return Effect::None;
+            };
             let buffer = settings.text_seed(field).to_string();
             settings.pending = Some(Pending::Typing { field, buffer });
             self.mode = InputMode::Text;
@@ -2051,11 +2149,11 @@ impl App {
         match settings.pending.take() {
             Some(Pending::Armed { edit, text, .. }) => {
                 settings.pending = Some(Pending::Sent { text });
-                Effect::WriteSetting(edit)
+                Effect::WriteSetting(edit, authority)
             }
             Some(Pending::DogArmed { edit, text, .. }) => {
                 settings.pending = Some(Pending::Sent { text });
-                Effect::WriteDog(edit)
+                Effect::WriteDog(edit, authority)
             }
             other => {
                 settings.pending = other;
@@ -2077,7 +2175,7 @@ impl App {
     /// approved table.
     fn arm(&mut self, verb: ActionVerb) -> Effect {
         let refusal = if self.control == Control::ReadOnly {
-            Some("read-only: actions need --allow-control".to_string())
+            Some(READ_ONLY_REFUSAL.to_string())
         } else if let Link::Retrying { attempt } = self.link {
             // NOT `LINK_GONE` here: that sentence says the shepherd is gone,
             // which is false while it is still being redialled, and a
@@ -4755,6 +4853,140 @@ mod tests {
         assert!(app.action().is_none(), "no sheep confirm can arm from here");
     }
 
+    /// fails if ANY key route on the settings screen reaches a write while
+    /// the gate is closed.
+    ///
+    /// Not "the cycle key refuses", which is all
+    /// `a_read_only_lookout_opens_the_screen_and_refuses_the_edit_key`
+    /// below ever checked. `space` was the only door the first version of
+    /// this gate guarded, and the free-text editor added a task later
+    /// walked straight around it: `SelectDown, SelectDown, Confirm,
+    /// TextChar, TextChar, TextApply, Confirm` on a `Control::ReadOnly`
+    /// lookout came back `WriteSetting(Set { field: Socket, .. })`. So this
+    /// walks every sequence that ends in a write instead of naming one key,
+    /// and asserts the two write effects never come back.
+    ///
+    /// The refusal is checked per keypress rather than at the end because
+    /// `on_settings_key` clears `self.notice` on every key: a route whose
+    /// last press is a no-op `Enter` has already had the sentence wiped by
+    /// the time the walk finishes.
+    #[test]
+    fn no_key_route_writes_the_config_while_the_gate_is_closed() {
+        use KeyPress::{Confirm, Cycle, SelectDown, TextApply, TextChar};
+
+        // The six scalars come first in `Settings::rows`, in the order
+        // `log_level, log_json, socket, max_cron_sleep, allow_control,
+        // level`, and `fixtures::settings_snapshot` carries two dogs after
+        // them -- so two `SelectDown`s reach `socket` and six reach the
+        // first dog row.
+        let routes: &[(&str, &[KeyPress])] = &[
+            ("space on a cycled scalar", &[Cycle, Confirm]),
+            (
+                "the socket editor",
+                &[
+                    SelectDown,
+                    SelectDown,
+                    Confirm,
+                    TextChar('/'),
+                    TextChar('x'),
+                    TextApply,
+                    Confirm,
+                ],
+            ),
+            (
+                "the max_cron_sleep editor",
+                &[
+                    SelectDown,
+                    SelectDown,
+                    SelectDown,
+                    Confirm,
+                    TextChar('9'),
+                    TextChar('s'),
+                    TextApply,
+                    Confirm,
+                ],
+            ),
+            (
+                "the whistle gate",
+                &[
+                    SelectDown, SelectDown, SelectDown, SelectDown, Cycle, Confirm,
+                ],
+            ),
+            (
+                "space on a dog row",
+                &[
+                    SelectDown, SelectDown, SelectDown, SelectDown, SelectDown, SelectDown, Cycle,
+                    Confirm,
+                ],
+            ),
+        ];
+
+        for (what, keys) in routes {
+            let mut app = fixtures::app_in_settings(); // Control::ReadOnly
+            let mut refused = false;
+            for key in *keys {
+                let effect = app.update(Msg::Key(*key));
+                assert!(
+                    !matches!(effect, Effect::WriteSetting(..) | Effect::WriteDog(..)),
+                    "{what}: a read-only lookout reached {effect:?}"
+                );
+                refused |= app.notice().is_some_and(Notice::is_grave);
+            }
+            assert!(refused, "{what}: the refusal has to say why");
+            assert!(
+                app.settings().unwrap().pending().is_none(),
+                "{what}: nothing is left armed"
+            );
+            assert!(
+                app.settings().unwrap().typing().is_none(),
+                "{what}: no editor is left open"
+            );
+        }
+    }
+
+    /// fails if the same five routes stop reaching a write once the gate is
+    /// open. The twin of
+    /// `no_key_route_writes_the_config_while_the_gate_is_closed`, and the
+    /// half that keeps it honest: a gate that refused everything would pass
+    /// that test and be useless.
+    #[test]
+    fn every_one_of_those_routes_writes_once_the_gate_is_open() {
+        use KeyPress::{Confirm, Cycle, SelectDown, TextApply, TextChar};
+
+        let routes: &[(&str, &[KeyPress])] = &[
+            ("space on a cycled scalar", &[Cycle, Confirm]),
+            (
+                "the socket editor",
+                &[
+                    SelectDown,
+                    SelectDown,
+                    Confirm,
+                    TextChar('/'),
+                    TextChar('x'),
+                    TextApply,
+                    Confirm,
+                ],
+            ),
+            (
+                "space on a dog row",
+                &[
+                    SelectDown, SelectDown, SelectDown, SelectDown, SelectDown, SelectDown, Cycle,
+                    Confirm,
+                ],
+            ),
+        ];
+
+        for (what, keys) in routes {
+            let mut app = fixtures::app_in_settings_with_control();
+            let mut wrote = false;
+            for key in *keys {
+                let effect = app.update(Msg::Key(*key));
+                wrote |= matches!(effect, Effect::WriteSetting(..) | Effect::WriteDog(..));
+            }
+            assert!(wrote, "{what}: an open gate has to reach the write");
+        }
+    }
+
     #[test]
     fn a_read_only_lookout_opens_the_screen_and_refuses_the_edit_key() {
         let mut app = fixtures::app_in_settings(); // Control::ReadOnly
@@ -4828,10 +5060,13 @@ mod tests {
         let effect = app.update(Msg::Key(KeyPress::Confirm));
         assert!(matches!(
             effect,
-            Effect::WriteSetting(SettingEdit::Set {
-                field: SettingField::LogLevel,
-                ..
-            })
+            Effect::WriteSetting(
+                SettingEdit::Set {
+                    field: SettingField::LogLevel,
+                    ..
+                },
+                _
+            )
         ));
         assert!(app.settings().unwrap().pending().unwrap().sent);
     }
@@ -4840,7 +5075,7 @@ mod tests {
     fn a_written_edit_updates_the_row_and_its_source() {
         let mut app = fixtures::app_in_settings_with_control();
         let _ = app.update(Msg::Key(KeyPress::Cycle));
-        let Effect::WriteSetting(edit) = app.update(Msg::Key(KeyPress::Confirm)) else {
+        let Effect::WriteSetting(edit, _) = app.update(Msg::Key(KeyPress::Confirm)) else {
             panic!("Enter must send");
         };
         let SettingEdit::Set {
@@ -4889,7 +5124,7 @@ mod tests {
             let _ = app.update(Msg::Key(KeyPress::TextBackspace));
         }
         let _ = app.update(Msg::Key(KeyPress::TextApply));
-        let Effect::WriteSetting(edit) = app.update(Msg::Key(KeyPress::Confirm)) else {
+        let Effect::WriteSetting(edit, _) = app.update(Msg::Key(KeyPress::Confirm)) else {
             panic!("Enter must send");
         };
         assert!(matches!(
@@ -4925,7 +5160,7 @@ mod tests {
         let before = app.settings().unwrap().cursor();
         let _ = app.update(Msg::Key(KeyPress::Confirm));
         let _ = app.update(Msg::Key(KeyPress::TextApply));
-        let Effect::WriteSetting(edit) = app.update(Msg::Key(KeyPress::Confirm)) else {
+        let Effect::WriteSetting(edit, _) = app.update(Msg::Key(KeyPress::Confirm)) else {
             panic!("Enter must send");
         };
         let _ = app.update(Msg::SettingWritten {
@@ -4959,7 +5194,7 @@ mod tests {
         let mut app = fixtures::app_in_settings_with_control();
         let before = app.settings().unwrap().snapshot().log_level.clone();
         let _ = app.update(Msg::Key(KeyPress::Cycle));
-        let Effect::WriteSetting(edit) = app.update(Msg::Key(KeyPress::Confirm)) else {
+        let Effect::WriteSetting(edit, _) = app.update(Msg::Key(KeyPress::Confirm)) else {
             panic!("Enter must send");
         };
         let _ = app.update(Msg::SettingWritten {
@@ -5193,7 +5428,7 @@ mod tests {
             let _ = app.update(Msg::Key(KeyPress::TextChar(c)));
         }
         let _ = app.update(Msg::Key(KeyPress::TextApply));
-        let Effect::WriteSetting(edit) = app.update(Msg::Key(KeyPress::Confirm)) else {
+        let Effect::WriteSetting(edit, _) = app.update(Msg::Key(KeyPress::Confirm)) else {
             panic!("Enter must send");
         };
         let _ = app.update(Msg::SettingWritten {
@@ -5306,7 +5541,7 @@ mod tests {
     fn a_written_dog_toggle_raises_the_daemon_half() {
         let mut app = fixtures::app_in_settings_on_dog("metrics");
         let _ = app.update(Msg::Key(KeyPress::Cycle));
-        let Effect::WriteDog(edit) = app.update(Msg::Key(KeyPress::Confirm)) else {
+        let Effect::WriteDog(edit, _) = app.update(Msg::Key(KeyPress::Confirm)) else {
             panic!("Enter must send the file half first");
         };
         let effect = app.update(Msg::DogWritten {
@@ -5323,7 +5558,7 @@ mod tests {
     fn a_refused_file_half_never_reaches_the_shepherd() {
         let mut app = fixtures::app_in_settings_on_dog("metrics");
         let _ = app.update(Msg::Key(KeyPress::Cycle));
-        let Effect::WriteDog(edit) = app.update(Msg::Key(KeyPress::Confirm)) else {
+        let Effect::WriteDog(edit, _) = app.update(Msg::Key(KeyPress::Confirm)) else {
             panic!("Enter must send the file half first");
         };
         let effect = app.update(Msg::DogWritten {
@@ -5372,7 +5607,7 @@ mod tests {
     fn armed_and_sent_dog(name: &str) -> (App, Sent) {
         let mut app = fixtures::app_in_settings_on_dog(name);
         let _ = app.update(Msg::Key(KeyPress::Cycle));
-        let Effect::WriteDog(edit) = app.update(Msg::Key(KeyPress::Confirm)) else {
+        let Effect::WriteDog(edit, _) = app.update(Msg::Key(KeyPress::Confirm)) else {
             panic!("Enter must send the file half first");
         };
         let Effect::Send(sent) = app.update(Msg::DogWritten {

--- a/crates/shep-cli/src/lookout/app.rs
+++ b/crates/shep-cli/src/lookout/app.rs
@@ -1616,16 +1616,23 @@ impl App {
         match result {
             Ok(Response::DogStarted(_)) if enable => {
                 self.notice = Some(Notice {
-                    text: format!("{prefix}: done"),
+                    text: format!("{prefix}: the shepherd started it"),
                     grave: false,
                 });
             }
             Ok(Response::Deleted(_)) if !enable => {
                 self.notice = Some(Notice {
-                    text: format!("{prefix}: done"),
+                    text: format!("{prefix}: the shepherd stopped and deregistered it"),
                     grave: false,
                 });
             }
+            // Also reached by a mismatched guard above -- an `EnableDog`
+            // that somehow answered `Response::Deleted`, or a `DisableDog`
+            // that somehow answered `Response::DogStarted`. Neither reply
+            // agrees with the request this reducer sent, so this is the
+            // right arm for both: "something this lookout does not
+            // understand" is true of an answer to the wrong verb too, not
+            // only of a variant this binary has never heard of.
             Ok(_unrecognised) => {
                 self.notice = Some(Notice {
                     text: format!(
@@ -5355,5 +5362,115 @@ mod tests {
             app.settings().unwrap().pending().is_some(),
             "a scalar is local file I/O and needs no shepherd"
         );
+    }
+
+    /// Drives a dog toggle all the way to `Effect::Send`, the setup every
+    /// `on_dog_reply` test below shares: arm, confirm (the file half),
+    /// `Msg::DogWritten` landing `Ok` (the daemon half goes out). Panics
+    /// with a message naming which step failed, rather than an unwrap,
+    /// since every caller is a test asserting on what happens next.
+    fn armed_and_sent_dog(name: &str) -> (App, Sent) {
+        let mut app = fixtures::app_in_settings_on_dog(name);
+        let _ = app.update(Msg::Key(KeyPress::Cycle));
+        let Effect::WriteDog(edit) = app.update(Msg::Key(KeyPress::Confirm)) else {
+            panic!("Enter must send the file half first");
+        };
+        let Effect::Send(sent) = app.update(Msg::DogWritten {
+            edit,
+            result: Ok(DogSource::BuiltIn),
+        }) else {
+            panic!("a landed write must raise the daemon half");
+        };
+        (app, sent)
+    }
+
+    /// `EnableDog` answers `Response::DogStarted`, and the reply's own
+    /// sentence names what the shepherd did rather than a bare "done" --
+    /// the same convention `on_action_reply`'s own `outcome()` sets for a
+    /// sheep action.
+    #[test]
+    fn a_landed_enable_names_what_the_shepherd_did() {
+        let (mut app, sent) = armed_and_sent_dog("metrics");
+        assert!(
+            app.settings().unwrap().pending().is_some(),
+            "the sent line stays up until the reply lands"
+        );
+        let info = ProcessInfo::builder(50, "metrics", ProcStatus::Online)
+            .pid(Some(50_000))
+            .dog(Some(DogSource::BuiltIn))
+            .build();
+        app.update(Msg::Replied {
+            sent,
+            result: Ok(Response::DogStarted(info)),
+        });
+        assert_eq!(
+            app.notice().map(ToString::to_string).as_deref(),
+            Some("enable metrics: the shepherd started it")
+        );
+        assert!(!app.notice().unwrap().is_grave());
+        assert!(
+            app.settings().unwrap().pending().is_none(),
+            "the sent line clears once the reply lands"
+        );
+    }
+
+    /// `DisableDog` answers `Response::Deleted`, the same reply `Delete`
+    /// gives -- and disable's own reply names the deregistration, the
+    /// sharpest fact on this screen, since the confirm that said so is
+    /// gone by the time this lands.
+    #[test]
+    fn a_landed_disable_names_the_deregistration() {
+        let (mut app, sent) = armed_and_sent_dog("otel");
+        app.update(Msg::Replied {
+            sent,
+            result: Ok(Response::Deleted(vec![50])),
+        });
+        assert_eq!(
+            app.notice().map(ToString::to_string).as_deref(),
+            Some("disable otel: the shepherd stopped and deregistered it")
+        );
+        assert!(!app.notice().unwrap().is_grave());
+    }
+
+    /// fails if a reply this binary does not understand -- or the RIGHT
+    /// SHAPE for the WRONG verb -- reads as success. `metrics` is armed as
+    /// an `enable`, so `Response::Deleted` (the shape a `DisableDog` gets)
+    /// is a mismatched guard rather than a recognised reply, and
+    /// `Response::Pong` is a reply this binary has genuinely never heard of
+    /// -- both must land in the same refusal, the same pairing
+    /// `an_unrecognised_reply_says_so_rather_than_reading_as_success` makes
+    /// for a sheep action.
+    #[test]
+    fn an_unrecognised_dog_reply_says_so_rather_than_reading_as_success() {
+        for reply in [Response::Pong, Response::Deleted(vec![1])] {
+            let (mut app, sent) = armed_and_sent_dog("metrics");
+            app.update(Msg::Replied {
+                sent,
+                result: Ok(reply),
+            });
+            assert_eq!(
+                app.notice().map(ToString::to_string).as_deref(),
+                Some(
+                    "enable metrics: the shepherd answered something this lookout does not understand"
+                )
+            );
+            assert!(app.notice().unwrap().is_grave());
+        }
+    }
+
+    /// fails if a connection that died mid-request reports as anything
+    /// else, the same claim
+    /// `a_connection_that_died_mid_request_says_so_under_the_same_prefix`
+    /// makes for a sheep action.
+    #[test]
+    fn a_dog_reply_that_failed_to_send_says_so_under_the_same_prefix() {
+        let (mut app, sent) = armed_and_sent_dog("metrics");
+        app.update(Msg::Replied {
+            sent,
+            result: Err(RequestError::Closed),
+        });
+        let said = app.notice().map(ToString::to_string).unwrap_or_default();
+        assert!(said.starts_with("enable metrics: "), "got {said:?}");
+        assert!(said.contains(&RequestError::Closed.to_string()));
     }
 }

--- a/crates/shep-cli/src/lookout/app.rs
+++ b/crates/shep-cli/src/lookout/app.rs
@@ -33,7 +33,7 @@ use std::time::{Duration, Instant};
 use shep_client::RequestError;
 use shep_core::config::LogLevel;
 use shep_core::protocol::{
-    BusEvent, Lamb, ProcessEventKind, ProcessInfo, Request, Response, SelectorSpec,
+    BusEvent, DogSource, Lamb, ProcessEventKind, ProcessInfo, Request, Response, SelectorSpec,
 };
 use shep_core::status::ProcStatus;
 
@@ -234,6 +234,23 @@ pub enum Msg {
         /// Whether the write landed, or why it did not.
         result: Result<(), String>,
     },
+    /// An [`Effect::WriteDog`] this reducer asked for has landed.
+    ///
+    /// `Result<DogSource, String>` rather than the config commands' own
+    /// error types, for the same reason [`Self::SettingWritten`]'s own doc
+    /// gives: `super::run_ui` is what calls `to_string()` on the way in.
+    /// `Ok` carries the [`DogSource`] the write resolved, which is what
+    /// [`Sent::Dog`] rides to the shepherd -- the request cannot disagree
+    /// with the file this way.
+    DogWritten {
+        /// The toggle that was sent, echoed back the same reason
+        /// [`Self::SettingWritten`]'s own `edit` is: the cursor, and what
+        /// is armed, can both have moved on while the write was in flight.
+        edit: DogEdit,
+        /// Whether the write landed and what it resolved to, or why it did
+        /// not.
+        result: Result<DogSource, String>,
+    },
 }
 
 /// What the caller has to do after an update.
@@ -287,6 +304,16 @@ pub enum Effect {
     /// file would freeze the UI task's redraw, its tick and its bus drain
     /// right along with the write.
     WriteSetting(SettingEdit),
+    /// Apply one dog's file half; the result lands as [`Msg::DogWritten`].
+    ///
+    /// Raised by [`App::confirm_setting`] once an armed dog row's Enter
+    /// lands. Its own [`Effect`], not [`Self::WriteSetting`] again: the two
+    /// carry different payloads (a [`DogEdit`] rather than a
+    /// [`SettingEdit`]) and end differently -- a scalar write ends in a
+    /// notice, a dog write ends in a request to the shepherd
+    /// ([`Sent::Dog`]). `super::run_ui` runs this on `spawn_blocking`, the
+    /// same reason [`Self::WriteSetting`]'s own doc gives.
+    WriteDog(DogEdit),
 }
 
 /// The connection's state, as the dashboard reports it.
@@ -397,6 +424,18 @@ pub enum Sent {
         /// Its name at arm time.
         name: String,
     },
+    /// One dog's daemon half, after its file half landed. `source` is what
+    /// the write returned, so the request cannot disagree with the file --
+    /// see [`DogEdit`]'s own doc for the file half this follows.
+    Dog {
+        /// The dog's name.
+        name: String,
+        /// `true` to start it, `false` to stop and deregister it.
+        enable: bool,
+        /// Where the binary comes from, exactly as the config write
+        /// answered.
+        source: DogSource,
+    },
 }
 
 impl Sent {
@@ -418,8 +457,35 @@ impl Sent {
                     ActionVerb::Reload => Request::Reload { selector },
                 }
             }
+            Self::Dog {
+                name,
+                enable: true,
+                source,
+            } => Request::EnableDog {
+                name: name.clone(),
+                source: source.clone(),
+            },
+            Self::Dog {
+                name,
+                enable: false,
+                ..
+            } => Request::DisableDog { name: name.clone() },
         }
     }
+}
+
+/// One dog toggle, ready for the file half: [`Effect::WriteDog`] carries
+/// one, and [`Msg::DogWritten`] echoes it back once
+/// `dogs::enable_in_config`/`dogs::disable_in_config` has answered.
+///
+/// `Debug` is derived rather than redacted (IR-41): a bare name and a bool,
+/// nothing a `{:?}` could leak.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DogEdit {
+    /// The dog's name.
+    pub name: String,
+    /// `true` to enable, `false` to disable.
+    pub enable: bool,
 }
 
 /// What the cursor can sit on: one sheep, or the header above an app's
@@ -552,12 +618,27 @@ enum Pending {
         /// `Msg::Tick` arm.
         at: Instant,
     },
-    /// Sent: [`Effect::WriteSetting`] is in flight, waiting on
-    /// [`Msg::SettingWritten`]. Carries no `edit`: nothing reads the sent
-    /// candidate back off `Pending` -- `Msg::SettingWritten`'s own `edit`
-    /// (the one [`Effect::WriteSetting`] round-trips) is what every match
-    /// site actually uses, so this variant only ever needs the rendered
-    /// question.
+    /// Armed on a [`SettingsRow::Dog`] row instead: waiting for the
+    /// operator's `Enter`, same as [`Self::Armed`], but for a [`DogEdit`]
+    /// rather than a [`SettingEdit`] -- the two carry different payloads and
+    /// [`App::confirm_setting`] sends them through different effects
+    /// ([`Effect::WriteDog`] rather than [`Effect::WriteSetting`]).
+    DogArmed {
+        /// The candidate toggle, ready to send.
+        edit: DogEdit,
+        /// The question this candidate reads as, rendered once at arm time,
+        /// same as [`Self::Armed`]'s own `text`.
+        text: String,
+        /// When it was armed. Only an armed edit expires -- see the
+        /// `Msg::Tick` arm.
+        at: Instant,
+    },
+    /// Sent: [`Effect::WriteSetting`] or [`Effect::WriteDog`] is in flight,
+    /// waiting on [`Msg::SettingWritten`] or [`Msg::DogWritten`]. Carries no
+    /// `edit`: nothing reads the sent candidate back off `Pending` -- the
+    /// landing message's own `edit` (the one the effect round-trips) is what
+    /// every match site actually uses, so this variant only ever needs the
+    /// rendered question, and one variant covers both origins.
     Sent {
         /// The same rendered question, so the prompt line does not change
         /// wording between the question and its own answer.
@@ -592,10 +673,27 @@ impl Settings {
     #[must_use]
     pub fn pending(&self) -> Option<SettingsPrompt<'_>> {
         match &self.pending {
-            Some(Pending::Armed { text, .. }) => Some(SettingsPrompt { text, sent: false }),
+            Some(Pending::Armed { text, .. } | Pending::DogArmed { text, .. }) => {
+                Some(SettingsPrompt { text, sent: false })
+            }
             Some(Pending::Sent { text, .. }) => Some(SettingsPrompt { text, sent: true }),
             Some(Pending::Typing { .. }) | None => None,
         }
+    }
+
+    /// Whether an [`Pending::Armed`] or [`Pending::DogArmed`] candidate is
+    /// waiting on `Enter` -- the one state a stray key on this screen
+    /// (movement, `Escape`, `Settings`, `Refresh`) has to eat rather than
+    /// also doing its ordinary job. `Pending::Typing` and `Pending::Sent`
+    /// are both left out on purpose: a free-text edit has its own keymap
+    /// ([`App::on_settings_text_key`]), and a request already sent is not
+    /// cancellable by a keypress, the same rule the sheep confirm's own
+    /// `Stage::Sent` follows.
+    fn is_armed(&self) -> bool {
+        matches!(
+            self.pending,
+            Some(Pending::Armed { .. } | Pending::DogArmed { .. })
+        )
     }
 
     /// The field and buffer of an in-flight free-text edit, or `None` --
@@ -1157,7 +1255,7 @@ impl App {
                 if let Some(settings) = self.settings.as_mut() {
                     let expired = matches!(
                         settings.pending,
-                        Some(Pending::Armed { at, .. })
+                        Some(Pending::Armed { at, .. } | Pending::DogArmed { at, .. })
                             if now.saturating_duration_since(at) >= CONFIRM_EXPIRY
                     );
                     if expired {
@@ -1206,6 +1304,7 @@ impl App {
                 Sent::Action { verb, target, name } => {
                     self.on_action_reply(verb, target, &name, result)
                 }
+                Sent::Dog { name, enable, .. } => self.on_dog_reply(name, enable, result),
             },
             Msg::Unsent { sent } => match sent {
                 Sent::Action { verb, target, name } => {
@@ -1227,6 +1326,20 @@ impl App {
                 // is what the pane says. Nothing to report and nothing to
                 // clear.
                 Sent::Lambs { .. } => Effect::None,
+                // Same shape as `Sent::Action`'s own arm above, aimed at the
+                // settings screen's own pending line instead of the sheep
+                // confirm.
+                Sent::Dog { name, enable, .. } => {
+                    if let Some(settings) = self.settings.as_mut() {
+                        settings.pending = None;
+                    }
+                    let verb = if enable { "enable" } else { "disable" };
+                    self.notice = Some(Notice {
+                        text: format!("{verb} {name}: it was not sent"),
+                        grave: true,
+                    });
+                    Effect::None
+                }
             },
             // The file can have changed since `s` asked for it, and the
             // screen opens on whatever this read found -- never on stale or
@@ -1351,6 +1464,31 @@ impl App {
                     Effect::None
                 }
             },
+            // An [`Effect::WriteDog`] landed. `Ok` clears the prompt and
+            // raises the daemon half -- one message still yields one
+            // effect, so the chain is `Cycle` arms, `Confirm` writes the
+            // file, this arm asks the shepherd. `Err` raises a grave notice
+            // with the refusal's own words, the same "say why" rule
+            // `Msg::SettingWritten`'s own `Err` arm follows, and never
+            // reaches the shepherd: the file half failed, so there is
+            // nothing yet for the daemon half to agree or disagree with.
+            Msg::DogWritten { edit, result } => match result {
+                Ok(source) => Effect::Send(Sent::Dog {
+                    name: edit.name,
+                    enable: edit.enable,
+                    source,
+                }),
+                Err(message) => {
+                    if let Some(settings) = self.settings.as_mut() {
+                        settings.pending = None;
+                    }
+                    self.notice = Some(Notice {
+                        text: message,
+                        grave: true,
+                    });
+                    Effect::None
+                }
+            },
         }
     }
 
@@ -1449,6 +1587,65 @@ impl App {
         });
         if was_empty && self.reseat(None) {
             return Effect::RefreshSelected;
+        }
+        Effect::None
+    }
+
+    /// One dog toggle's answer: the settings screen's `Pending::Sent` line
+    /// clears, and one sentence lands in the status bar.
+    ///
+    /// No row is upserted here from `Response::DogStarted`'s own
+    /// `ProcessInfo`, unlike [`Self::on_action_reply`]: the RUNNING column
+    /// this reply would feed repairs itself off the next `ListFlock`, two
+    /// seconds later, the same as every other flock fact this screen shows.
+    fn on_dog_reply(
+        &mut self,
+        name: String,
+        enable: bool,
+        result: Result<Response, RequestError>,
+    ) -> Effect {
+        if let Some(settings) = self.settings.as_mut() {
+            settings.pending = None;
+        }
+        let verb = if enable { "enable" } else { "disable" };
+        let prefix = format!("{verb} {name}");
+        // `EnableDog` answers `Response::DogStarted`; `DisableDog` answers
+        // `Response::Deleted`, the same reply `Delete` gives -- see that
+        // variant's own doc in shep-core for why it carries no dedicated
+        // shape.
+        match result {
+            Ok(Response::DogStarted(_)) if enable => {
+                self.notice = Some(Notice {
+                    text: format!("{prefix}: done"),
+                    grave: false,
+                });
+            }
+            Ok(Response::Deleted(_)) if !enable => {
+                self.notice = Some(Notice {
+                    text: format!("{prefix}: done"),
+                    grave: false,
+                });
+            }
+            Ok(_unrecognised) => {
+                self.notice = Some(Notice {
+                    text: format!(
+                        "{prefix}: the shepherd answered something this lookout does not understand"
+                    ),
+                    grave: true,
+                });
+            }
+            Err(RequestError::Rpc(err)) => {
+                self.notice = Some(Notice {
+                    text: format!("{prefix}: {}", err.message),
+                    grave: true,
+                });
+            }
+            Err(other) => {
+                self.notice = Some(Notice {
+                    text: format!("{prefix}: {other}"),
+                    grave: true,
+                });
+            }
         }
         Effect::None
     }
@@ -1656,9 +1853,7 @@ impl App {
             // quitting is the one place this screen swaps the dashboard's
             // own cascade.
             KeyPress::Settings | KeyPress::Escape => {
-                let armed = self.settings.as_ref().is_some_and(|settings| {
-                    matches!(settings.pending, Some(Pending::Armed { .. }))
-                });
+                let armed = self.settings.as_ref().is_some_and(Settings::is_armed);
                 if armed {
                     if let Some(settings) = self.settings.as_mut() {
                         settings.pending = None;
@@ -1682,7 +1877,7 @@ impl App {
             | KeyPress::SelectFirst
             | KeyPress::SelectLast => {
                 if let Some(settings) = self.settings.as_mut() {
-                    if matches!(settings.pending, Some(Pending::Armed { .. })) {
+                    if settings.is_armed() {
                         settings.pending = None;
                     } else {
                         match key {
@@ -1701,7 +1896,21 @@ impl App {
             // the design spec's own table entry for `r`. `Msg::Settings`'s
             // own doc is what keeps the cursor from resetting to the first
             // row on the way back, the same as a landed write's reload.
-            KeyPress::Refresh => return Effect::LoadSettings,
+            //
+            // An armed candidate eats this one too, the same cancel-before-act
+            // rule the movement keys and `Escape`/`Settings` already follow
+            // above: without the guard, `space` then a reflexive `r` would
+            // silently drop the question and never send the edit, with
+            // nothing on screen to say so.
+            KeyPress::Refresh => {
+                if let Some(settings) = self.settings.as_mut()
+                    && settings.is_armed()
+                {
+                    settings.pending = None;
+                    return Effect::None;
+                }
+                return Effect::LoadSettings;
+            }
             // Unreachable from here, and named rather than wildcarded so a
             // future variant does not fall silently into an arm that
             // ignores it: an action key in particular must never be
@@ -1720,16 +1929,9 @@ impl App {
     /// row, or refuses and says why the same way an action key does; the
     /// gate is the same read-only check `arm` makes for a sheep action,
     /// because a keystroke that mutates `shep.toml` needs the same fat-finger
-    /// catch a keystroke that stops a sheep does. Re-arms rather than
-    /// no-opping when a candidate is already armed for this row, so a
-    /// second `space` walks one step further along the cycle -- see
-    /// [`Settings::next_candidate`]'s own doc.
-    ///
-    /// Silently does nothing on [`SettingField::Socket`],
-    /// [`SettingField::MaxCronSleep`] and a [`SettingsRow::Dog`] row: none
-    /// of the three is this task's job, and a screen the operator can
-    /// already read gives no sign that `space` was ever going to do
-    /// anything there.
+    /// catch a keystroke that stops a sheep does. Dispatches by row kind:
+    /// [`Self::cycle_scalar`] for one of the six fields,
+    /// [`Self::cycle_dog`] for a [`SettingsRow::Dog`] row.
     fn cycle_setting(&mut self) -> Effect {
         if self.control == Control::ReadOnly {
             self.notice = Some(Notice {
@@ -1738,10 +1940,26 @@ impl App {
             });
             return Effect::None;
         }
-        let Some(settings) = self.settings.as_mut() else {
+        let Some(cursor) = self.settings.as_ref().and_then(Settings::cursor) else {
             return Effect::None;
         };
-        let Some(SettingsRow::Scalar(field)) = settings.cursor() else {
+        match cursor {
+            SettingsRow::Scalar(field) => self.cycle_scalar(field),
+            SettingsRow::Dog(index) => self.cycle_dog(index),
+        }
+    }
+
+    /// `space` on one of the six scalar rows. Re-arms rather than no-opping
+    /// when a candidate is already armed for this field, so a second
+    /// `space` walks one step further along the cycle -- see
+    /// [`Settings::next_candidate`]'s own doc.
+    ///
+    /// Silently does nothing on [`SettingField::Socket`] and
+    /// [`SettingField::MaxCronSleep`]: free text is not this function's job,
+    /// and a screen the operator can already read gives no sign that
+    /// `space` was ever going to do anything there.
+    fn cycle_scalar(&mut self, field: SettingField) -> Effect {
+        let Some(settings) = self.settings.as_mut() else {
             return Effect::None;
         };
         let Some(value) = settings.next_candidate(field) else {
@@ -1756,6 +1974,45 @@ impl App {
         Effect::None
     }
 
+    /// `space` on a [`SettingsRow::Dog`] row: refuses while the link is
+    /// gone, with [`LINK_GONE`]'s own sentence rather than a second one for
+    /// the same fact, then arms the opposite of the file's own `enabled`
+    /// bit -- one `space` always proposes a toggle, never a cycle, because
+    /// there are only two states.
+    ///
+    /// The link check is this row's own, unlike [`Self::cycle_scalar`]: an
+    /// enable/disable is a request to the shepherd once confirmed, and a
+    /// scalar edit is local file I/O the shepherd never sees, so only the
+    /// dog row needs the shepherd reachable to be worth arming at all.
+    fn cycle_dog(&mut self, index: usize) -> Effect {
+        if matches!(self.link, Link::Lost { .. }) {
+            self.notice = Some(Notice {
+                text: LINK_GONE.to_string(),
+                grave: true,
+            });
+            return Effect::None;
+        }
+        let Some(settings) = self.settings.as_mut() else {
+            return Effect::None;
+        };
+        let Some(dog) = settings.snapshot.dogs.get(index) else {
+            return Effect::None;
+        };
+        let name = dog.name.clone();
+        let enable = !dog.enabled;
+        let text = if enable {
+            format!("enable {name}? it starts now, no reload")
+        } else {
+            format!("disable {name}? it stops now and is deregistered")
+        };
+        settings.pending = Some(Pending::DogArmed {
+            edit: DogEdit { name, enable },
+            text,
+            at: self.now,
+        });
+        Effect::None
+    }
+
     /// The operator's `Enter` on the settings screen. Three meanings,
     /// picked in this order:
     ///
@@ -1764,8 +2021,10 @@ impl App {
     ///   seeded with that field's own on-disk value, and switches
     ///   [`InputMode::Text`] on -- [`Self::on_settings_text_key`] is what
     ///   answers every key from here on, not this function again.
-    /// - Something is [`Pending::Armed`]: sends it and moves it to
-    ///   [`Pending::Sent`], same as before this task.
+    /// - Something is [`Pending::Armed`] or [`Pending::DogArmed`]: sends it
+    ///   and moves it to [`Pending::Sent`] -- [`Effect::WriteSetting`] for
+    ///   the former, [`Effect::WriteDog`] for the latter, per each one's own
+    ///   doc for why they are not the same effect.
     /// - Anything else (nothing pending on a cycled row, or already
     ///   `Sent`): untouched.
     fn confirm_setting(&mut self) -> Effect {
@@ -1786,6 +2045,10 @@ impl App {
             Some(Pending::Armed { edit, text, .. }) => {
                 settings.pending = Some(Pending::Sent { text });
                 Effect::WriteSetting(edit)
+            }
+            Some(Pending::DogArmed { edit, text, .. }) => {
+                settings.pending = Some(Pending::Sent { text });
+                Effect::WriteDog(edit)
             }
             other => {
                 settings.pending = other;
@@ -4987,6 +5250,110 @@ mod tests {
             app.settings().unwrap().cursor(),
             before,
             "the cursor must not also move on the same keypress"
+        );
+    }
+
+    /// fails if an armed candidate survives `r`. `space` arms; `r` must
+    /// cancel that arm instead of silently dropping it while reloading the
+    /// screen underneath it -- the same cancel-before-act rule every other
+    /// key on this screen already follows.
+    #[test]
+    fn refresh_cancels_an_armed_candidate_rather_than_silently_dropping_it() {
+        let mut app = fixtures::app_in_settings_with_control(); // cursor on log_level
+        let _ = app.update(Msg::Key(KeyPress::Cycle));
+        assert!(
+            app.settings().unwrap().pending().is_some(),
+            "space must arm before this test means anything"
+        );
+        let effect = app.update(Msg::Key(KeyPress::Refresh));
+        assert_eq!(
+            effect,
+            Effect::None,
+            "a cancel must not also raise a reload"
+        );
+        assert!(
+            app.settings().unwrap().pending().is_none(),
+            "the armed candidate must not survive `r`"
+        );
+    }
+
+    #[test]
+    fn arming_a_dog_names_the_live_apply_and_not_a_reload() {
+        let mut app = fixtures::app_in_settings_on_dog("metrics");
+        let _ = app.update(Msg::Key(KeyPress::Cycle));
+        let text = app.settings().unwrap().pending().unwrap().text.to_string();
+        assert!(text.contains("it starts now, no reload"), "got: {text}");
+    }
+
+    #[test]
+    fn disabling_says_it_deregisters() {
+        let mut app = fixtures::app_in_settings_on_enabled_dog("otel");
+        let _ = app.update(Msg::Key(KeyPress::Cycle));
+        let text = app.settings().unwrap().pending().unwrap().text.to_string();
+        assert!(text.contains("deregistered"), "got: {text}");
+    }
+
+    /// The chain: the write lands, and the reducer raises the daemon half.
+    /// One message still yields one effect.
+    #[test]
+    fn a_written_dog_toggle_raises_the_daemon_half() {
+        let mut app = fixtures::app_in_settings_on_dog("metrics");
+        let _ = app.update(Msg::Key(KeyPress::Cycle));
+        let Effect::WriteDog(edit) = app.update(Msg::Key(KeyPress::Confirm)) else {
+            panic!("Enter must send the file half first");
+        };
+        let effect = app.update(Msg::DogWritten {
+            edit,
+            result: Ok(DogSource::BuiltIn),
+        });
+        assert!(matches!(
+            effect,
+            Effect::Send(Sent::Dog { enable: true, .. })
+        ));
+    }
+
+    #[test]
+    fn a_refused_file_half_never_reaches_the_shepherd() {
+        let mut app = fixtures::app_in_settings_on_dog("metrics");
+        let _ = app.update(Msg::Key(KeyPress::Cycle));
+        let Effect::WriteDog(edit) = app.update(Msg::Key(KeyPress::Confirm)) else {
+            panic!("Enter must send the file half first");
+        };
+        let effect = app.update(Msg::DogWritten {
+            edit,
+            result: Err("permission denied".into()),
+        });
+        assert_eq!(
+            effect,
+            Effect::None,
+            "a failed write must not ask the shepherd"
+        );
+        assert!(app.notice().unwrap().is_grave());
+    }
+
+    /// The scalars never leave the machine; a dog's second half does.
+    #[test]
+    fn a_dog_toggle_refuses_while_the_link_is_gone() {
+        let mut app = fixtures::app_in_settings_on_dog("metrics");
+        let _ = app.update(Msg::Frozen {
+            at_local: "12:00:00".into(),
+        });
+        let effect = app.update(Msg::Key(KeyPress::Cycle));
+        assert_eq!(effect, Effect::None);
+        assert!(app.settings().unwrap().pending().is_none(), "nothing arms");
+        assert!(app.notice().unwrap().is_grave());
+    }
+
+    #[test]
+    fn a_scalar_still_edits_while_the_link_is_gone() {
+        let mut app = fixtures::app_in_settings_with_control(); // on log_level
+        let _ = app.update(Msg::Frozen {
+            at_local: "12:00:00".into(),
+        });
+        let _ = app.update(Msg::Key(KeyPress::Cycle));
+        assert!(
+            app.settings().unwrap().pending().is_some(),
+            "a scalar is local file I/O and needs no shepherd"
         );
     }
 }

--- a/crates/shep-cli/src/lookout/app.rs
+++ b/crates/shep-cli/src/lookout/app.rs
@@ -917,6 +917,27 @@ impl App {
                         // `self.settings` becomes `Some`, so clearing here
                         // covers both the keypress and the race.
                         self.action = None;
+                        // The sibling race: `s`, then `/`, then a snapshot
+                        // landing while the box is still open. `on_key`
+                        // checks `self.mode == InputMode::Text` ahead of the
+                        // settings check, and `on_text_key` never consults
+                        // `self.settings`, so an open box would survive the
+                        // screen opening and keep eating every keystroke the
+                        // settings keymap was meant to own. Leaving text
+                        // mode here makes that state unrepresentable, the
+                        // same way clearing `self.action` above does for a
+                        // confirm.
+                        //
+                        // The query itself is kept, not cleared: this is
+                        // `TextApply`'s reading (Enter), not
+                        // `TextAbandon`'s (Esc). The operator was watching
+                        // the dashboard filter live while `/` was open --
+                        // the read had not landed yet -- so the characters
+                        // they typed are a real query they chose to build,
+                        // not a stray keystroke. Discarding it on the way
+                        // out would be the one filter edit in this whole
+                        // screen that vanishes without an Esc.
+                        self.mode = InputMode::Normal;
                         self.settings = Some(Settings::new(snapshot));
                     }
                     Err(message) => {
@@ -3920,6 +3941,39 @@ mod tests {
         assert!(
             app.action().is_none(),
             "no armed action may survive the screen opening"
+        );
+    }
+
+    /// fails if the filter box survives the screen opening the same way an
+    /// armed action almost did. `s` raises `Effect::LoadSettings` while
+    /// `self.settings` is still `None`, so `/` reaches `on_key`'s ordinary
+    /// dispatch and opens the box; once the read lands, `on_key`'s
+    /// `self.mode == InputMode::Text` check runs ahead of the settings
+    /// branch, so every key after this would keep landing in
+    /// `on_text_key` and never reach `on_settings_key` at all. The query
+    /// is kept rather than cleared -- `TextApply`'s reading, argued at the
+    /// fix's own call site.
+    #[test]
+    fn opening_the_screen_closes_a_filter_box_left_open_while_the_read_was_in_flight() {
+        let mut app = fixtures::allowed_app();
+        let _ = app.update(Msg::Key(KeyPress::Settings));
+        let _ = app.update(Msg::Key(KeyPress::FilterStart));
+        let _ = app.update(Msg::Key(KeyPress::TextChar('w')));
+        let _ = app.update(Msg::Key(KeyPress::TextChar('e')));
+        assert_eq!(app.mode(), InputMode::Text, "the box is open before the read lands");
+        let _ = app.update(Msg::Settings {
+            result: Ok(fixtures::settings_snapshot()),
+        });
+        assert!(app.settings().is_some(), "the screen opened");
+        assert_eq!(
+            app.mode(),
+            InputMode::Normal,
+            "the box must not survive the screen opening"
+        );
+        assert_eq!(
+            app.filter(),
+            "we",
+            "the typed query is kept, not discarded"
         );
     }
 

--- a/crates/shep-cli/src/lookout/app.rs
+++ b/crates/shep-cli/src/lookout/app.rs
@@ -3960,7 +3960,11 @@ mod tests {
         let _ = app.update(Msg::Key(KeyPress::FilterStart));
         let _ = app.update(Msg::Key(KeyPress::TextChar('w')));
         let _ = app.update(Msg::Key(KeyPress::TextChar('e')));
-        assert_eq!(app.mode(), InputMode::Text, "the box is open before the read lands");
+        assert_eq!(
+            app.mode(),
+            InputMode::Text,
+            "the box is open before the read lands"
+        );
         let _ = app.update(Msg::Settings {
             result: Ok(fixtures::settings_snapshot()),
         });
@@ -3970,11 +3974,7 @@ mod tests {
             InputMode::Normal,
             "the box must not survive the screen opening"
         );
-        assert_eq!(
-            app.filter(),
-            "we",
-            "the typed query is kept, not discarded"
-        );
+        assert_eq!(app.filter(), "we", "the typed query is kept, not discarded");
     }
 
     /// fails if `App::set_style` does not round trip exactly: the flag

--- a/crates/shep-cli/src/lookout/app.rs
+++ b/crates/shep-cli/src/lookout/app.rs
@@ -31,13 +31,14 @@ use std::collections::BTreeMap;
 use std::time::{Duration, Instant};
 
 use shep_client::RequestError;
+use shep_core::config::LogLevel;
 use shep_core::protocol::{
     BusEvent, Lamb, ProcessEventKind, ProcessInfo, Request, Response, SelectorSpec,
 };
 use shep_core::status::ProcStatus;
 
 use super::theme::Palette;
-use crate::commands::settings::{SettingField, SettingsSnapshot};
+use crate::commands::settings::{ScalarView, SettingEdit, SettingField, SettingsSnapshot};
 use crate::style::{StyleLevel, StyleSource};
 use crate::vocabulary::Reported;
 
@@ -218,6 +219,21 @@ pub enum Msg {
         /// The rendered snapshot, or why it could not be read.
         result: Result<SettingsSnapshot, String>,
     },
+    /// An [`Effect::WriteSetting`] this reducer asked for has landed.
+    ///
+    /// `Result<(), String>` for the same reason [`Self::Settings`]'s own doc
+    /// gives: this reducer holds no error types from `commands`, and
+    /// `super::run_ui` is what calls `to_string()` on a
+    /// `commands::settings::SettingError` on the way in.
+    SettingWritten {
+        /// The edit that was sent, echoed back so the reducer can update the
+        /// right row without re-deriving it from whatever is armed now: the
+        /// cursor, and what is armed, can both have moved on while the write
+        /// was in flight.
+        edit: SettingEdit,
+        /// Whether the write landed, or why it did not.
+        result: Result<(), String>,
+    },
 }
 
 /// What the caller has to do after an update.
@@ -260,6 +276,17 @@ pub enum Effect {
     /// Raised by the dashboard's own `s`, never by the settings screen's:
     /// once the screen is open, `s` closes it instead. See [`App::on_key`].
     LoadSettings,
+    /// Apply one edit to `shep.toml`; the result lands as
+    /// [`Msg::SettingWritten`].
+    ///
+    /// Raised by [`App::confirm_setting`] once an armed scalar's Enter
+    /// lands. `super::run_ui` runs it on `spawn_blocking`, and that is
+    /// load-bearing rather than a convention: `commands::settings`'s
+    /// `ConfigLock::acquire` blocks with no deadline
+    /// (`FlockArg::LockExclusive`), so a concurrent `shep adopt` on the same
+    /// file would freeze the UI task's redraw, its tick and its bus drain
+    /// right along with the write.
+    WriteSetting(SettingEdit),
 }
 
 /// The connection's state, as the dashboard reports it.
@@ -487,6 +514,68 @@ pub struct Settings {
     /// pre-clamped: a later task's refresh can shrink the dog list out from
     /// under a cursor already sitting past its new end.
     cursor: usize,
+    /// The screen's one in-flight edit, or `None`. One field rather than
+    /// several `Option`s, so typing, armed and sent cannot overlap -- the
+    /// same claim [`Action`]'s own doc makes for the sheep confirm, made in
+    /// the type instead of in a guard.
+    pending: Option<Pending>,
+}
+
+/// The settings screen's own in-flight edit.
+///
+/// `Debug` is derived rather than redacted (IR-41): a field name, a
+/// candidate value and the rendered prompt sentence built from it -- none of
+/// the four scalars this task reaches carries a secret.
+#[derive(Debug, Clone)]
+enum Pending {
+    /// A free-text edit under construction. Only [`SettingField::Socket`]
+    /// and [`SettingField::MaxCronSleep`] ever reach this -- task 8's own
+    /// territory. Nothing in this task constructs it; the variant exists now
+    /// so [`Settings::pending`] and [`App::confirm_setting`] have a shape to
+    /// pass a non-`Armed`, non-`Sent` state through rather than gaining a
+    /// second `Option` the day it lands.
+    #[allow(dead_code)]
+    Typing {
+        /// Which scalar.
+        field: SettingField,
+        /// What the operator has typed so far.
+        buffer: String,
+    },
+    /// Armed: waiting for the operator's `Enter`. Nothing has gone out yet.
+    Armed {
+        /// The candidate, ready to send.
+        edit: SettingEdit,
+        /// The question this candidate reads as, rendered once at arm time
+        /// so [`Settings::pending`] can hand back a borrowed `&str` without
+        /// re-rendering it on every read.
+        text: String,
+        /// When it was armed. Only an armed edit expires -- see the
+        /// `Msg::Tick` arm.
+        at: Instant,
+    },
+    /// Sent: [`Effect::WriteSetting`] is in flight, waiting on
+    /// [`Msg::SettingWritten`].
+    Sent {
+        /// The edit that was sent.
+        #[allow(dead_code)]
+        edit: SettingEdit,
+        /// The same rendered question, so the prompt line does not change
+        /// wording between the question and its own answer.
+        text: String,
+    },
+}
+
+/// What the settings screen's status line shows for its one in-flight edit.
+///
+/// `Debug` is derived rather than redacted (IR-41): a rendered sentence and
+/// a bool, nothing a `{:?}` could leak.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SettingsPrompt<'a> {
+    /// The confirm sentence: what will change, and what applying it does
+    /// and does not do.
+    pub text: &'a str,
+    /// False while it is a question, true once it has gone out.
+    pub sent: bool,
 }
 
 impl Settings {
@@ -495,19 +584,96 @@ impl Settings {
         Self {
             snapshot,
             cursor: 0,
+            pending: None,
         }
     }
 
-    /// What the screen reads off disk.
+    /// The armed candidate and its prompt, or `None`.
+    #[must_use]
+    pub fn pending(&self) -> Option<SettingsPrompt<'_>> {
+        match &self.pending {
+            Some(Pending::Armed { text, .. }) => Some(SettingsPrompt { text, sent: false }),
+            Some(Pending::Sent { text, .. }) => Some(SettingsPrompt { text, sent: true }),
+            Some(Pending::Typing { .. }) | None => None,
+        }
+    }
+
+    /// The next candidate for `field`, or `None` for a field this task does
+    /// not cycle ([`SettingField::Socket`], [`SettingField::MaxCronSleep`]
+    /// -- free text, task 8's own `Pending::Typing`) and for a
+    /// [`SettingsRow::Dog`] row, which is never a [`SettingField`] at all.
     ///
-    /// Not called outside this module's own tests yet: `view::settings`'s
-    /// `draw_settings` (a later task) is the real caller, reading it to
-    /// render every row's value and source. Same precedent this crate
-    /// already carries (`style::Presentation::BARE`,
-    /// `output::OutputEnvelope`, `commands::settings::load_settings`):
-    /// `#[allow(dead_code)]` says so explicitly rather than inventing a call
-    /// site nothing needs yet.
-    #[allow(dead_code)]
+    /// Advances from whatever is already armed for THIS field, so a second
+    /// `space` walks one step further along the cycle rather than
+    /// re-deriving the same next value the file itself would produce --
+    /// without that, six log levels behind one cycle key would leave the
+    /// fourth unreachable without a cancel in between. An armed candidate
+    /// for a DIFFERENT field (the cursor moved after arming) is not a base:
+    /// this starts fresh from the snapshot instead.
+    fn next_candidate(&self, field: SettingField) -> Option<String> {
+        let armed_here = match &self.pending {
+            Some(Pending::Armed {
+                edit:
+                    SettingEdit::Set {
+                        field: armed_field,
+                        value,
+                    },
+                ..
+            }) if *armed_field == field => Some(value.as_str()),
+            _ => None,
+        };
+        let base = match armed_here {
+            Some(value) => value,
+            None => self.current_value(field)?,
+        };
+        Some(match field {
+            SettingField::LogLevel => next_log_level(base),
+            SettingField::LogJson | SettingField::AllowControl => next_bool(base),
+            SettingField::StyleLevel => next_style_level(base),
+            SettingField::Socket | SettingField::MaxCronSleep => return None,
+        })
+    }
+
+    /// The snapshot's own rendered value for one of the four scalars this
+    /// task cycles. `None` for the two this task does not.
+    fn current_value(&self, field: SettingField) -> Option<&str> {
+        Some(match field {
+            SettingField::LogLevel => self.snapshot.log_level.value.as_str(),
+            SettingField::LogJson => self.snapshot.log_json.value.as_str(),
+            SettingField::AllowControl => self.snapshot.allow_control.value.as_str(),
+            SettingField::StyleLevel => self.snapshot.style_level.value.as_str(),
+            SettingField::Socket | SettingField::MaxCronSleep => return None,
+        })
+    }
+
+    /// Folds a landed write back into the row it changed: the snapshot's
+    /// own [`ScalarView`] for `field` becomes `value`, sourced
+    /// [`StyleSource::Config`] -- the write just put it in the file.
+    /// [`SettingEdit::Unset`] never reaches here (this task only ever
+    /// arms `Set`), and the two fields this task never cycles are matched
+    /// out for exhaustiveness rather than reached.
+    fn record_written(&mut self, edit: &SettingEdit) {
+        let SettingEdit::Set { field, value } = edit else {
+            return;
+        };
+        let view = ScalarView {
+            value: value.clone(),
+            source: StyleSource::Config,
+        };
+        match field {
+            SettingField::LogLevel => self.snapshot.log_level = view,
+            SettingField::LogJson => self.snapshot.log_json = view,
+            SettingField::AllowControl => self.snapshot.allow_control = view,
+            SettingField::StyleLevel => self.snapshot.style_level = view,
+            SettingField::Socket | SettingField::MaxCronSleep => {}
+        }
+    }
+
+    /// What the screen reads off disk. `view::settings::content_lines` is
+    /// the real caller, reading it to render every row's value and source
+    /// -- `Settings::record_written` is what keeps it current once a write
+    /// lands, so a read here after a landed edit shows the new value, not
+    /// the one `Effect::LoadSettings` last found on disk.
     #[must_use]
     pub fn snapshot(&self) -> &SettingsSnapshot {
         &self.snapshot
@@ -533,11 +699,10 @@ impl Settings {
     /// empty, which cannot happen today (the six scalars are unconditional),
     /// but the type stays honest about it rather than asserting.
     ///
-    /// Not called outside this module's own tests yet: `view::settings`'s
-    /// `draw_settings` (a later task) is the real caller, reading it to
-    /// highlight the selected row. `#[allow(dead_code)]` for the same
-    /// reason [`Self::snapshot`] carries it.
-    #[allow(dead_code)]
+    /// `view::settings::content_lines` is the real caller, reading it to
+    /// highlight the selected row -- and [`App::cycle_setting`] reads it
+    /// through this same accessor to decide which field, if any, `space`
+    /// arms.
     #[must_use]
     pub fn cursor(&self) -> Option<SettingsRow> {
         let rows = self.rows();
@@ -565,6 +730,88 @@ impl Settings {
     /// Moves the cursor to the last row.
     fn move_to_last(&mut self) {
         self.cursor = self.rows().len().saturating_sub(1);
+    }
+}
+
+/// `Off, Error, Warn, Info, Debug, Trace`, [`LogLevel`]'s own declared
+/// order, wrapping from `Trace` back to `Off`.
+const LOG_LEVEL_ORDER: [LogLevel; 6] = [
+    LogLevel::Off,
+    LogLevel::Error,
+    LogLevel::Warn,
+    LogLevel::Info,
+    LogLevel::Debug,
+    LogLevel::Trace,
+];
+
+/// One step along [`LOG_LEVEL_ORDER`] from `current`. A string this crate
+/// did not itself render (should not happen -- every candidate and every
+/// snapshot value comes from [`LogLevel::as_str`]) reads as
+/// [`LogLevel::default`]'s own place in the ladder (`Warn`), so a corrupt
+/// value still produces a legal next one rather than panicking.
+fn next_log_level(current: &str) -> String {
+    let index = LogLevel::from_name(current)
+        .and_then(|level| {
+            LOG_LEVEL_ORDER
+                .iter()
+                .position(|candidate| *candidate == level)
+        })
+        .unwrap_or(2);
+    LOG_LEVEL_ORDER[(index + 1) % LOG_LEVEL_ORDER.len()]
+        .as_str()
+        .to_string()
+}
+
+/// Flips `"true"`/`"false"`. Anything else (should not happen, the same
+/// reason [`next_log_level`] states) reads as `false` and flips to `true`.
+fn next_bool(current: &str) -> String {
+    (current != "true").to_string()
+}
+
+/// `Full, Plain, Bare`, [`StyleLevel`]'s own declared order, wrapping from
+/// `Bare` back to `Full`.
+const STYLE_LEVEL_ORDER: [StyleLevel; 3] = [StyleLevel::Full, StyleLevel::Plain, StyleLevel::Bare];
+
+/// One step along [`STYLE_LEVEL_ORDER`] from `current`, the same fallback
+/// [`next_log_level`] takes for an unparseable value.
+fn next_style_level(current: &str) -> String {
+    let index = StyleLevel::parse(current)
+        .and_then(|level| {
+            STYLE_LEVEL_ORDER
+                .iter()
+                .position(|candidate| *candidate == level)
+        })
+        .unwrap_or(0);
+    STYLE_LEVEL_ORDER[(index + 1) % STYLE_LEVEL_ORDER.len()].to_string()
+}
+
+/// The confirm sentence for `field`'s candidate `value` -- verbatim, per the
+/// task 7 spec's own table. `value` is always the candidate a
+/// `next_*` function above just produced, never re-derived here: this
+/// function only ever renders it into the sentence.
+///
+/// Called only with a field [`Settings::next_candidate`] returned `Some`
+/// for, so [`SettingField::Socket`] and [`SettingField::MaxCronSleep`]
+/// never reach the two arms below -- named rather than wildcarded so a
+/// future field added to the match cannot fall through unnoticed.
+fn confirm_text(field: SettingField, value: &str) -> String {
+    match field {
+        SettingField::LogLevel => format!(
+            "set log_level to {value}? needs shep daemon reload, and will not apply if the shepherd was booted with SHEP_LOG_LEVEL or --log-level"
+        ),
+        SettingField::LogJson => format!(
+            "set log_json to {value}? needs shep daemon reload, and will not apply if the shepherd was booted with SHEP_LOG_JSON or --log-json"
+        ),
+        SettingField::AllowControl => {
+            let word = if value == "true" { "on" } else { "off" };
+            format!("turn whistle control tools {word}? needs shep whistle restarted")
+        }
+        SettingField::StyleLevel => {
+            format!("set style level to {value}? the next command reads it")
+        }
+        SettingField::Socket | SettingField::MaxCronSleep => unreachable!(
+            "Settings::next_candidate never arms these two -- they are task 8's Pending::Typing"
+        ),
     }
 }
 
@@ -829,6 +1076,25 @@ impl App {
                         self.action = None;
                     }
                 }
+                // The settings screen's own expiry sits OUTSIDE the guard
+                // above, and compares against `now` -- the tick's own
+                // instant -- rather than `self.now`, which that guard stops
+                // advancing once the link is lost. The sheep confirm freezes
+                // with everything else on a dead link because every word of
+                // it describes the shepherd, which the dashboard can no
+                // longer see; a settings edit describes a local file that is
+                // not stale just because the shepherd stopped answering, so
+                // it keeps its own clock running.
+                if let Some(settings) = self.settings.as_mut() {
+                    let expired = matches!(
+                        settings.pending,
+                        Some(Pending::Armed { at, .. })
+                            if now.saturating_duration_since(at) >= CONFIRM_EXPIRY
+                    );
+                    if expired {
+                        settings.pending = None;
+                    }
+                }
                 Effect::None
             }
             Msg::Resize => Effect::None,
@@ -941,6 +1207,37 @@ impl App {
                         self.settings = Some(Settings::new(snapshot));
                     }
                     Err(message) => {
+                        self.notice = Some(Notice {
+                            text: message,
+                            grave: true,
+                        });
+                    }
+                }
+                Effect::None
+            }
+            // An [`Effect::WriteSetting`] landed. `Ok` folds the value into
+            // the row it changed and clears the prompt; `Err` leaves the row
+            // exactly as it read before the write, and raises a grave
+            // notice with the refusal's own words rather than a generic
+            // one -- the same "say why" rule `arm`'s refusal ladder follows.
+            //
+            // Both arms clear `pending` on the settings screen alone, in two
+            // separate blocks rather than one shared borrow of `self`: this
+            // arm needs to set `self.notice` on the `Err` path, and Rust
+            // will not let a `&mut self.settings` borrow stay live across
+            // that assignment to a different field of the same `self`.
+            Msg::SettingWritten { edit, result } => {
+                match result {
+                    Ok(()) => {
+                        if let Some(settings) = self.settings.as_mut() {
+                            settings.pending = None;
+                            settings.record_written(&edit);
+                        }
+                    }
+                    Err(message) => {
+                        if let Some(settings) = self.settings.as_mut() {
+                            settings.pending = None;
+                        }
                         self.notice = Some(Notice {
                             text: message,
                             grave: true,
@@ -1242,12 +1539,29 @@ impl App {
         self.notice = None;
         match key {
             KeyPress::Quit => return Effect::Quit,
-            // Both close. `s` toggling shut is the dashboard's own `s`
-            // meaning something different once the screen is open, the same
-            // division `Escape`'s doc argues for; `Escape` closing rather
-            // than quitting is the one place this screen swaps the
-            // dashboard's own cascade.
-            KeyPress::Settings | KeyPress::Escape => self.settings = None,
+            // Both close -- but an armed confirm eats the FIRST one instead,
+            // the same cancel-before-act rule `on_key`'s own dashboard
+            // branch already follows for `x`/`R`/`L`. Without this, `space`
+            // then a reflexive `Escape` would close the whole screen on top
+            // of a question the operator only meant to back out of.
+            //
+            // `s` toggling shut is the dashboard's own `s` meaning something
+            // different once the screen is open, the same division
+            // `Escape`'s doc argues for; `Escape` closing rather than
+            // quitting is the one place this screen swaps the dashboard's
+            // own cascade.
+            KeyPress::Settings | KeyPress::Escape => {
+                let armed = self.settings.as_ref().is_some_and(|settings| {
+                    matches!(settings.pending, Some(Pending::Armed { .. }))
+                });
+                if armed {
+                    if let Some(settings) = self.settings.as_mut() {
+                        settings.pending = None;
+                    }
+                } else {
+                    self.settings = None;
+                }
+            }
             KeyPress::SelectUp => {
                 if let Some(settings) = self.settings.as_mut() {
                     settings.move_by(-1);
@@ -1268,19 +1582,9 @@ impl App {
                     settings.move_to_last();
                 }
             }
-            // Nothing to cycle yet: writing lands in a later task. The
-            // refusal is the one thing that has to exist today: an operator
-            // running a read-only lookout must be told why `space` did
-            // nothing, exactly as an action key already is.
-            KeyPress::Cycle => {
-                if self.control == Control::ReadOnly {
-                    self.notice = Some(Notice {
-                        text: "read-only: actions need --allow-control".to_string(),
-                        grave: true,
-                    });
-                }
-            }
-            KeyPress::Confirm | KeyPress::Refresh => {}
+            KeyPress::Cycle => return self.cycle_setting(),
+            KeyPress::Confirm => return self.confirm_setting(),
+            KeyPress::Refresh => {}
             // Unreachable from here, and named rather than wildcarded so a
             // future variant does not fall silently into an arm that
             // ignores it: an action key in particular must never be
@@ -1293,6 +1597,68 @@ impl App {
             | KeyPress::TextAbandon => {}
         }
         Effect::None
+    }
+
+    /// `space` on the settings screen. Arms a candidate for the cursor's
+    /// row, or refuses and says why the same way an action key does; the
+    /// gate is the same read-only check `arm` makes for a sheep action,
+    /// because a keystroke that mutates `shep.toml` needs the same fat-finger
+    /// catch a keystroke that stops a sheep does. Re-arms rather than
+    /// no-opping when a candidate is already armed for this row, so a
+    /// second `space` walks one step further along the cycle -- see
+    /// [`Settings::next_candidate`]'s own doc.
+    ///
+    /// Silently does nothing on [`SettingField::Socket`],
+    /// [`SettingField::MaxCronSleep`] and a [`SettingsRow::Dog`] row: none
+    /// of the three is this task's job, and a screen the operator can
+    /// already read gives no sign that `space` was ever going to do
+    /// anything there.
+    fn cycle_setting(&mut self) -> Effect {
+        if self.control == Control::ReadOnly {
+            self.notice = Some(Notice {
+                text: "read-only: actions need --allow-control".to_string(),
+                grave: true,
+            });
+            return Effect::None;
+        }
+        let Some(settings) = self.settings.as_mut() else {
+            return Effect::None;
+        };
+        let Some(SettingsRow::Scalar(field)) = settings.cursor() else {
+            return Effect::None;
+        };
+        let Some(value) = settings.next_candidate(field) else {
+            return Effect::None;
+        };
+        let text = confirm_text(field, &value);
+        settings.pending = Some(Pending::Armed {
+            edit: SettingEdit::Set { field, value },
+            text,
+            at: self.now,
+        });
+        Effect::None
+    }
+
+    /// The operator's `Enter` on the settings screen. Sends an armed
+    /// candidate and moves it to [`Pending::Sent`]; leaves anything else
+    /// (nothing armed, or a `Typing` edit task 8 owns) untouched.
+    fn confirm_setting(&mut self) -> Effect {
+        let Some(settings) = self.settings.as_mut() else {
+            return Effect::None;
+        };
+        match settings.pending.take() {
+            Some(Pending::Armed { edit, text, .. }) => {
+                settings.pending = Some(Pending::Sent {
+                    edit: edit.clone(),
+                    text,
+                });
+                Effect::WriteSetting(edit)
+            }
+            other => {
+                settings.pending = other;
+                Effect::None
+            }
+        }
     }
 
     /// Arms a confirm, or refuses and says why.
@@ -3916,6 +4282,161 @@ mod tests {
         let _ = app.update(Msg::Key(KeyPress::Cycle));
         let notice = app.notice().expect("the refusal has to say why");
         assert!(notice.is_grave());
+    }
+
+    #[test]
+    fn space_arms_a_candidate_without_changing_the_row() {
+        let mut app = fixtures::app_in_settings_with_control();
+        let before = app.settings().unwrap().snapshot().log_level.value.clone();
+
+        assert_eq!(app.update(Msg::Key(KeyPress::Cycle)), Effect::None);
+
+        assert_eq!(
+            app.settings().unwrap().snapshot().log_level.value,
+            before,
+            "arming is a question, so the row still shows what the file says"
+        );
+        assert!(app.settings().unwrap().pending().is_some());
+    }
+
+    /// Six log levels and one cycle key. Without re-arming, the fourth is
+    /// unreachable without cancelling in between.
+    #[test]
+    fn space_advances_the_candidate_rather_than_needing_a_cancel() {
+        let mut app = fixtures::app_in_settings_with_control();
+        let _ = app.update(Msg::Key(KeyPress::Cycle));
+        let first = app.settings().unwrap().pending().unwrap().text.to_string();
+        let _ = app.update(Msg::Key(KeyPress::Cycle));
+        let second = app.settings().unwrap().pending().unwrap().text.to_string();
+        assert_ne!(first, second);
+    }
+
+    #[test]
+    fn the_daemon_confirm_names_both_layers_lookout_cannot_see() {
+        let mut app = fixtures::app_in_settings_with_control();
+        let _ = app.update(Msg::Key(KeyPress::Cycle));
+        let text = app.settings().unwrap().pending().unwrap().text.to_string();
+        assert!(text.contains("shep daemon reload"), "got: {text}");
+        assert!(text.contains("SHEP_LOG_LEVEL"), "got: {text}");
+        assert!(text.contains("--log-level"), "got: {text}");
+    }
+
+    #[test]
+    fn the_whistle_confirm_names_a_whistle_restart_and_not_a_reload() {
+        let mut app = fixtures::app_in_settings_on(SettingField::AllowControl);
+        let _ = app.update(Msg::Key(KeyPress::Cycle));
+        let text = app.settings().unwrap().pending().unwrap().text.to_string();
+        assert!(text.contains("shep whistle restarted"), "got: {text}");
+        assert!(
+            !text.contains("daemon reload"),
+            "a whistle key needs no reload: {text}"
+        );
+    }
+
+    #[test]
+    fn the_style_confirm_promises_nothing_beyond_the_next_command() {
+        let mut app = fixtures::app_in_settings_on(SettingField::StyleLevel);
+        let _ = app.update(Msg::Key(KeyPress::Cycle));
+        let text = app.settings().unwrap().pending().unwrap().text.to_string();
+        assert!(text.contains("the next command reads it"), "got: {text}");
+    }
+
+    #[test]
+    fn enter_sends_the_armed_edit() {
+        let mut app = fixtures::app_in_settings_with_control();
+        let _ = app.update(Msg::Key(KeyPress::Cycle));
+        let effect = app.update(Msg::Key(KeyPress::Confirm));
+        assert!(matches!(
+            effect,
+            Effect::WriteSetting(SettingEdit::Set {
+                field: SettingField::LogLevel,
+                ..
+            })
+        ));
+        assert!(app.settings().unwrap().pending().unwrap().sent);
+    }
+
+    #[test]
+    fn a_written_edit_updates_the_row_and_its_source() {
+        let mut app = fixtures::app_in_settings_with_control();
+        let _ = app.update(Msg::Key(KeyPress::Cycle));
+        let Effect::WriteSetting(edit) = app.update(Msg::Key(KeyPress::Confirm)) else {
+            panic!("Enter must send");
+        };
+        let _ = app.update(Msg::SettingWritten {
+            edit,
+            result: Ok(()),
+        });
+
+        assert_eq!(
+            app.settings().unwrap().snapshot().log_level.source,
+            StyleSource::Config
+        );
+        assert!(app.settings().unwrap().pending().is_none());
+    }
+
+    #[test]
+    fn a_refused_write_says_why_and_leaves_the_row_alone() {
+        let mut app = fixtures::app_in_settings_with_control();
+        let before = app.settings().unwrap().snapshot().log_level.clone();
+        let _ = app.update(Msg::Key(KeyPress::Cycle));
+        let Effect::WriteSetting(edit) = app.update(Msg::Key(KeyPress::Confirm)) else {
+            panic!("Enter must send");
+        };
+        let _ = app.update(Msg::SettingWritten {
+            edit,
+            result: Err("max_cron_sleep is 500ms, below the 1s floor".into()),
+        });
+
+        assert_eq!(app.settings().unwrap().snapshot().log_level, before);
+        let notice = app.notice().unwrap();
+        assert!(notice.is_grave());
+        assert!(notice.to_string().contains("below the 1s floor"));
+    }
+
+    /// The divergence from the sheep confirm, which `disarm_on_link_change`
+    /// clears. A settings edit is local file I/O over a file that is not
+    /// stale.
+    #[test]
+    fn a_lost_link_leaves_a_scalar_confirm_armed() {
+        let mut app = fixtures::app_in_settings_with_control();
+        let _ = app.update(Msg::Key(KeyPress::Cycle));
+        let _ = app.update(Msg::Frozen {
+            at_local: "12:00:00".into(),
+        });
+        assert!(
+            app.settings().unwrap().pending().is_some(),
+            "a scalar never leaves the machine, so a dead shepherd is irrelevant to it"
+        );
+    }
+
+    /// And it still expires, off the raw tick rather than `self.now`, which
+    /// stops advancing once the link is lost.
+    #[test]
+    fn a_settings_confirm_expires_on_a_frozen_dashboard() {
+        let (mut app, start) = fixtures::app_in_settings_at();
+        let _ = app.update(Msg::Key(KeyPress::Cycle));
+        let _ = app.update(Msg::Frozen {
+            at_local: "12:00:00".into(),
+        });
+        let _ = app.update(Msg::Tick {
+            now: start + CONFIRM_EXPIRY,
+        });
+        assert!(app.settings().unwrap().pending().is_none());
+    }
+
+    #[test]
+    fn escape_cancels_the_confirm_before_it_closes_the_screen() {
+        let mut app = fixtures::app_in_settings_with_control();
+        let _ = app.update(Msg::Key(KeyPress::Cycle));
+        let _ = app.update(Msg::Key(KeyPress::Escape));
+        assert!(app.settings().unwrap().pending().is_none());
+        assert!(
+            app.settings().is_some(),
+            "the first Esc cancels, it does not close"
+        );
+        let _ = app.update(Msg::Key(KeyPress::Escape));
+        assert!(app.settings().is_none());
     }
 
     /// fails if an action armed while the read is still in flight survives

--- a/crates/shep-cli/src/lookout/app.rs
+++ b/crates/shep-cli/src/lookout/app.rs
@@ -38,7 +38,7 @@ use shep_core::protocol::{
 use shep_core::status::ProcStatus;
 
 use super::theme::Palette;
-use crate::commands::settings::{ScalarView, SettingEdit, SettingField, SettingsSnapshot};
+use crate::commands::settings::{SettingEdit, SettingField, SettingsSnapshot};
 use crate::style::{StyleLevel, StyleSource};
 use crate::vocabulary::Reported;
 
@@ -679,37 +679,13 @@ impl Settings {
         }
     }
 
-    /// Folds a landed write back into the row it changed: the snapshot's
-    /// own [`ScalarView`] for `field` becomes `value`, sourced
-    /// [`StyleSource::Config`] -- the write just put it in the file. A
-    /// landed [`SettingEdit::Unset`] (`socket` or `max_cron_sleep`, task
-    /// 8's own) is matched out and does nothing rather than reverting the
-    /// row to `the default`: this reducer has no way to render that
-    /// value without re-reading the document, and `r` already does that.
-    /// The row is stale until then, the same way a dog write already
-    /// leaves the RUNNING column until the next poll.
-    fn record_written(&mut self, edit: &SettingEdit) {
-        let SettingEdit::Set { field, value } = edit else {
-            return;
-        };
-        let view = ScalarView {
-            value: value.clone(),
-            source: StyleSource::Config,
-        };
-        match field {
-            SettingField::LogLevel => self.snapshot.log_level = view,
-            SettingField::LogJson => self.snapshot.log_json = view,
-            SettingField::AllowControl => self.snapshot.allow_control = view,
-            SettingField::StyleLevel => self.snapshot.style_level = view,
-            SettingField::Socket | SettingField::MaxCronSleep => {}
-        }
-    }
-
     /// What the screen reads off disk. `view::settings::content_lines` is
-    /// the real caller, reading it to render every row's value and source
-    /// -- `Settings::record_written` is what keeps it current once a write
-    /// lands, so a read here after a landed edit shows the new value, not
-    /// the one `Effect::LoadSettings` last found on disk.
+    /// the real caller, reading it to render every row's value and source.
+    /// A landed write does not update this in place any more: `App`'s own
+    /// `Msg::SettingWritten` `Ok` arm raises a fresh [`Effect::LoadSettings`]
+    /// instead, the same read `r` and the initial `s` both already go
+    /// through, so `Set` and `Unset` land the same way and neither can
+    /// drift from whatever else changed in the document meanwhile.
     #[must_use]
     pub fn snapshot(&self) -> &SettingsSnapshot {
         &self.snapshot
@@ -1258,7 +1234,16 @@ impl App {
             // opening immediately. A failed read leaves the dashboard up: an
             // empty settings screen would say nothing about why it has
             // nothing to show.
+            //
+            // This is also where a landed write's own re-read lands
+            // (`Msg::SettingWritten`'s `Ok` arm raises `Effect::LoadSettings`
+            // rather than hand-updating one row) and where `r` lands. Both
+            // arrive with `self.settings` already `Some`, and the cursor is
+            // preserved across them rather than reset: `opening` below is
+            // true only the first time, when `s` itself is what raised the
+            // read.
             Msg::Settings { result } => {
+                let opening = self.settings.is_none();
                 match result {
                     Ok(snapshot) => {
                         // Clears an action that armed while the read was in
@@ -1297,7 +1282,17 @@ impl App {
                         // out would be the one filter edit in this whole
                         // screen that vanishes without an Esc.
                         self.mode = InputMode::Normal;
-                        self.settings = Some(Settings::new(snapshot));
+                        // The cursor: reset to the first row only while
+                        // `opening`. `Settings::cursor` clamps on every
+                        // read, so a preserved cursor sitting past a
+                        // shorter dogs list still lands somewhere real
+                        // rather than out of bounds.
+                        let cursor = self.settings.as_ref().map_or(0, |settings| settings.cursor);
+                        let mut settings = Settings::new(snapshot);
+                        if !opening {
+                            settings.cursor = cursor;
+                        }
+                        self.settings = Some(settings);
                     }
                     Err(message) => {
                         self.notice = Some(Notice {
@@ -1308,8 +1303,14 @@ impl App {
                 }
                 Effect::None
             }
-            // An [`Effect::WriteSetting`] landed. `Ok` folds the value into
-            // the row it changed and clears the prompt; `Err` leaves the row
+            // An [`Effect::WriteSetting`] landed. `Ok` clears the prompt and
+            // raises a fresh [`Effect::LoadSettings`] rather than folding
+            // the write into the row by hand: that covers `Set` and
+            // `Unset` uniformly (an `Unset` has no local value to fold in,
+            // only the document does), picks up anything else that changed
+            // on disk in the meantime, and is the same read `r` and the
+            // initial `s` already go through -- see [`Msg::Settings`]'s own
+            // doc for how the cursor survives it. `Err` leaves the row
             // exactly as it read before the write, and raises a grave
             // notice with the refusal's own words rather than a generic
             // one -- the same "say why" rule `arm`'s refusal ladder follows.
@@ -1323,38 +1324,33 @@ impl App {
             // must not have to retype it to fix one character. The four
             // cycled fields have nothing to reopen; their `Err` matches the
             // behaviour this arm already had.
-            //
-            // Both arms touch the settings screen and `self.notice` (and,
-            // on a text-field refusal, `self.mode`) in separate blocks
-            // rather than one shared borrow of `self`: Rust will not let a
-            // `&mut self.settings` borrow stay live across an assignment to
-            // a different field of the same `self`.
-            Msg::SettingWritten { edit, result } => {
-                match result {
-                    Ok(()) => {
-                        if let Some(settings) = self.settings.as_mut() {
-                            settings.pending = None;
-                            settings.record_written(&edit);
-                        }
+            Msg::SettingWritten { edit, result } => match result {
+                Ok(()) => {
+                    if let Some(settings) = self.settings.as_mut() {
+                        settings.pending = None;
                     }
-                    Err(message) => {
-                        let reopened = typed_text_of(&edit);
-                        if let Some(settings) = self.settings.as_mut() {
-                            settings.pending = reopened
-                                .clone()
-                                .map(|(field, buffer)| Pending::Typing { field, buffer });
-                        }
-                        if reopened.is_some() {
-                            self.mode = InputMode::Text;
-                        }
-                        self.notice = Some(Notice {
-                            text: message,
-                            grave: true,
-                        });
-                    }
+                    Effect::LoadSettings
                 }
-                Effect::None
-            }
+                Err(message) => {
+                    // `typed_text_of` names the field, so the two branches
+                    // below never share a borrow of `self.settings` that
+                    // would fight the `self.notice` assignment beneath
+                    // them.
+                    if let Some((field, buffer)) = typed_text_of(&edit) {
+                        if let Some(settings) = self.settings.as_mut() {
+                            settings.pending = Some(Pending::Typing { field, buffer });
+                        }
+                        self.mode = InputMode::Text;
+                    } else if let Some(settings) = self.settings.as_mut() {
+                        settings.pending = None;
+                    }
+                    self.notice = Some(Notice {
+                        text: message,
+                        grave: true,
+                    });
+                    Effect::None
+                }
+            },
         }
     }
 
@@ -1681,7 +1677,10 @@ impl App {
             // already lost track of. `Sent` is untouched, same as the
             // dashboard's own guard, which only fires on `Stage::Armed`:
             // a request already in flight is not cancellable by a keypress.
-            KeyPress::SelectUp | KeyPress::SelectDown | KeyPress::SelectFirst | KeyPress::SelectLast => {
+            KeyPress::SelectUp
+            | KeyPress::SelectDown
+            | KeyPress::SelectFirst
+            | KeyPress::SelectLast => {
                 if let Some(settings) = self.settings.as_mut() {
                     if matches!(settings.pending, Some(Pending::Armed { .. })) {
                         settings.pending = None;
@@ -1698,7 +1697,11 @@ impl App {
             }
             KeyPress::Cycle => return self.cycle_setting(),
             KeyPress::Confirm => return self.confirm_setting(),
-            KeyPress::Refresh => {}
+            // Re-reads `shep.toml`, so another process's write shows up --
+            // the design spec's own table entry for `r`. `Msg::Settings`'s
+            // own doc is what keeps the cursor from resetting to the first
+            // row on the way back, the same as a landed write's reload.
+            KeyPress::Refresh => return Effect::LoadSettings,
             // Unreachable from here, and named rather than wildcarded so a
             // future variant does not fall silently into an arm that
             // ignores it: an action key in particular must never be
@@ -1770,8 +1773,9 @@ impl App {
             return Effect::None;
         };
         if settings.pending.is_none()
-            && let Some(SettingsRow::Scalar(field @ (SettingField::Socket | SettingField::MaxCronSleep))) =
-                settings.cursor()
+            && let Some(SettingsRow::Scalar(
+                field @ (SettingField::Socket | SettingField::MaxCronSleep),
+            )) = settings.cursor()
         {
             let buffer = settings.text_seed(field).to_string();
             settings.pending = Some(Pending::Typing { field, buffer });
@@ -2026,10 +2030,17 @@ impl App {
                     let edit = if buffer.is_empty() {
                         SettingEdit::Unset { field }
                     } else {
-                        SettingEdit::Set { field, value: buffer }
+                        SettingEdit::Set {
+                            field,
+                            value: buffer,
+                        }
                     };
                     let text = confirm_text_for_edit(&edit);
-                    settings.pending = Some(Pending::Armed { edit, text, at: now });
+                    settings.pending = Some(Pending::Armed {
+                        edit,
+                        text,
+                        at: now,
+                    });
                 }
                 self.mode = InputMode::Normal;
             }
@@ -2605,6 +2616,7 @@ mod tests {
     use shep_core::protocol::{ProcessEventKind, RpcError, RpcErrorCode};
 
     use super::super::view::fixtures;
+    use crate::commands::settings::ScalarView;
 
     fn sheep(id: u32, name: &str, status: ProcStatus) -> ProcessInfo {
         ProcessInfo::builder(id, name, status)
@@ -4561,16 +4573,115 @@ mod tests {
         let Effect::WriteSetting(edit) = app.update(Msg::Key(KeyPress::Confirm)) else {
             panic!("Enter must send");
         };
+        let SettingEdit::Set {
+            value: candidate, ..
+        } = edit.clone()
+        else {
+            panic!("cycling only ever arms Set");
+        };
+
+        let effect = app.update(Msg::SettingWritten {
+            edit,
+            result: Ok(()),
+        });
+        assert_eq!(
+            effect,
+            Effect::LoadSettings,
+            "a landed write re-reads rather than hand-folding the row"
+        );
+        assert!(app.settings().unwrap().pending().is_none());
+
+        // The re-read itself: `run_ui` drives this through `spawn_blocking`
+        // and `load_settings`; this test drives the landing message
+        // directly, the same way the fixtures that open the screen already
+        // do for the initial `s`.
+        let mut updated = fixtures::settings_snapshot();
+        updated.log_level = ScalarView {
+            value: candidate,
+            source: StyleSource::Config,
+        };
+        let _ = app.update(Msg::Settings {
+            result: Ok(updated.clone()),
+        });
+
+        assert_eq!(app.settings().unwrap().snapshot(), &updated);
+    }
+
+    /// The other half of the row-update story: an `Unset` has no local
+    /// value to fold in (only the document does), which is exactly why the
+    /// fix routes both through the same re-read rather than growing a
+    /// second, `Unset`-shaped folding path.
+    #[test]
+    fn an_unset_write_returns_the_row_to_the_default() {
+        let mut app = fixtures::app_in_settings_on(SettingField::MaxCronSleep);
+        let _ = app.update(Msg::Key(KeyPress::Confirm));
+        for _ in 0..8 {
+            let _ = app.update(Msg::Key(KeyPress::TextBackspace));
+        }
+        let _ = app.update(Msg::Key(KeyPress::TextApply));
+        let Effect::WriteSetting(edit) = app.update(Msg::Key(KeyPress::Confirm)) else {
+            panic!("Enter must send");
+        };
+        assert!(matches!(
+            edit,
+            SettingEdit::Unset {
+                field: SettingField::MaxCronSleep
+            }
+        ));
+
+        let effect = app.update(Msg::SettingWritten {
+            edit,
+            result: Ok(()),
+        });
+        assert_eq!(effect, Effect::LoadSettings);
+
+        let mut updated = fixtures::settings_snapshot();
+        updated.max_cron_sleep = ScalarView {
+            value: "30s".to_string(),
+            source: StyleSource::Default,
+        };
+        let _ = app.update(Msg::Settings {
+            result: Ok(updated.clone()),
+        });
+
+        assert_eq!(app.settings().unwrap().snapshot(), &updated);
+    }
+
+    /// fails if a landed write's own reload throws the cursor back to the
+    /// first row -- `Msg::Settings`'s `opening` check is what this pins.
+    #[test]
+    fn the_cursor_survives_a_landed_writes_reload() {
+        let mut app = fixtures::app_in_settings_on(SettingField::MaxCronSleep);
+        let before = app.settings().unwrap().cursor();
+        let _ = app.update(Msg::Key(KeyPress::Confirm));
+        let _ = app.update(Msg::Key(KeyPress::TextApply));
+        let Effect::WriteSetting(edit) = app.update(Msg::Key(KeyPress::Confirm)) else {
+            panic!("Enter must send");
+        };
         let _ = app.update(Msg::SettingWritten {
             edit,
             result: Ok(()),
         });
+        let _ = app.update(Msg::Settings {
+            result: Ok(fixtures::settings_snapshot()),
+        });
+        assert_eq!(app.settings().unwrap().cursor(), before);
+    }
 
+    /// fails if `r` throws the cursor back to the first row the same way a
+    /// landed write's own reload almost did.
+    #[test]
+    fn the_cursor_survives_a_refresh() {
+        let mut app = fixtures::app_in_settings_on(SettingField::MaxCronSleep);
+        let before = app.settings().unwrap().cursor();
         assert_eq!(
-            app.settings().unwrap().snapshot().log_level.source,
-            StyleSource::Config
+            app.update(Msg::Key(KeyPress::Refresh)),
+            Effect::LoadSettings
         );
-        assert!(app.settings().unwrap().pending().is_none());
+        let _ = app.update(Msg::Settings {
+            result: Ok(fixtures::settings_snapshot()),
+        });
+        assert_eq!(app.settings().unwrap().cursor(), before);
     }
 
     #[test]
@@ -4764,7 +4875,10 @@ mod tests {
         }
         assert_eq!(app.update(Msg::Key(KeyPress::TextApply)), Effect::None);
         let prompt = app.settings().unwrap().pending().unwrap();
-        assert!(!prompt.sent, "the editor arms; a second Enter is what sends");
+        assert!(
+            !prompt.sent,
+            "the editor arms; a second Enter is what sends"
+        );
         assert!(prompt.text.contains("45s"), "got: {}", prompt.text);
         assert!(
             prompt.text.contains("SHEP_MAX_CRON_SLEEP"),
@@ -4817,9 +4931,18 @@ mod tests {
             result: Err("max_cron_sleep is 500ms, below the 1s floor".into()),
         });
 
-        let (_, buffer) = app.settings().unwrap().typing().expect("the editor reopens");
+        let (_, buffer) = app
+            .settings()
+            .unwrap()
+            .typing()
+            .expect("the editor reopens");
         assert_eq!(buffer, "500ms");
-        assert!(app.notice().unwrap().to_string().contains("below the 1s floor"));
+        assert!(
+            app.notice()
+                .unwrap()
+                .to_string()
+                .contains("below the 1s floor")
+        );
     }
 
     #[test]

--- a/crates/shep-cli/src/lookout/app.rs
+++ b/crates/shep-cli/src/lookout/app.rs
@@ -1650,12 +1650,24 @@ impl App {
     }
 
     /// One dog toggle's answer: the settings screen's `Pending::Sent` line
-    /// clears, and one sentence lands in the status bar.
+    /// clears, one sentence lands in the status bar, and the screen
+    /// re-reads `shep.toml`.
     ///
     /// No row is upserted here from `Response::DogStarted`'s own
     /// `ProcessInfo`, unlike [`Self::on_action_reply`]: the RUNNING column
     /// this reply would feed repairs itself off the next `ListFlock`, two
     /// seconds later, the same as every other flock fact this screen shows.
+    ///
+    /// [`Effect::LoadSettings`] on every arm, `Err` included, for the same
+    /// reason `Msg::SettingWritten`'s own `Ok` arm raises it: the FILE half
+    /// has already landed by the time this reply arrives (that is what
+    /// `Msg::DogWritten`'s `Ok` sent the request on), so `DogView.enabled`
+    /// is stale here whatever the shepherd went on to say. Without the
+    /// re-read the IN FILE cell kept its pre-write value while RUNNING
+    /// updated off the two-second poll, so a landed `enable metrics` read
+    /// `metrics | no | online` -- the dogs table manufacturing the exact
+    /// drift it exists to reveal, and reading as the one row the docs page
+    /// teaches an operator to treat as "running with nothing enabling it".
     fn on_dog_reply(
         &mut self,
         name: String,
@@ -1712,7 +1724,7 @@ impl App {
                 });
             }
         }
-        Effect::None
+        Effect::LoadSettings
     }
 
     fn on_event(&mut self, event: BusEvent) -> Effect {
@@ -5665,6 +5677,91 @@ mod tests {
             Some("disable otel: the shepherd stopped and deregistered it")
         );
         assert!(!app.notice().unwrap().is_grave());
+    }
+
+    /// Whether the settings screen's own dogs list still says `name` is
+    /// enabled. Reads the snapshot the screen is rendering from, not the
+    /// file, which is the whole point: the two can disagree.
+    #[track_caller]
+    fn dog_enabled_in_view(app: &App, name: &str) -> bool {
+        app.settings()
+            .expect("the settings screen is open")
+            .snapshot()
+            .dogs
+            .iter()
+            .find(|dog| dog.name == name)
+            .expect("the fixture carries this dog")
+            .enabled
+    }
+
+    /// fails if a landed dog toggle leaves the dogs table showing what the
+    /// file said BEFORE the write.
+    ///
+    /// The file half lands first and the daemon half second, so by the time
+    /// this reply arrives `DogView.enabled` is already stale while RUNNING
+    /// keeps updating off the two-second poll. Nothing raised a re-read, so
+    /// a landed `enable metrics` sat there reading `metrics | no | online`
+    /// -- the dogs table manufacturing the one drift row the docs page
+    /// teaches an operator to read as "running with nothing enabling it".
+    /// The scalar path already solved this: `Msg::SettingWritten`'s `Ok`
+    /// arm raises `Effect::LoadSettings` rather than folding the write into
+    /// the row by hand, and this inherits it.
+    ///
+    /// Both directions, because an enable and a disable answer with
+    /// different replies (`DogStarted` and `Deleted`) down two different
+    /// arms of `on_dog_reply`'s own match.
+    #[test]
+    fn a_landed_toggle_re_reads_the_file_in_both_directions() {
+        for (name, enable) in [("metrics", true), ("otel", false)] {
+            let (mut app, sent) = armed_and_sent_dog(name);
+            assert_eq!(
+                dog_enabled_in_view(&app, name),
+                !enable,
+                "{name}: the fixture starts on the other bit"
+            );
+            let reply = if enable {
+                Response::DogStarted(
+                    ProcessInfo::builder(50, name, ProcStatus::Online)
+                        .pid(Some(50_000))
+                        .dog(Some(DogSource::BuiltIn))
+                        .build(),
+                )
+            } else {
+                Response::Deleted(vec![50])
+            };
+
+            let effect = app.update(Msg::Replied {
+                sent,
+                result: Ok(reply),
+            });
+
+            assert_eq!(
+                effect,
+                Effect::LoadSettings,
+                "{name}: a landed toggle has to re-read the file it changed"
+            );
+            assert_eq!(
+                dog_enabled_in_view(&app, name),
+                !enable,
+                "{name}: nothing is folded into the row by hand -- the re-read is the repair"
+            );
+
+            // The re-read landing, with the bit the write actually put in
+            // the file.
+            let mut fresh = app.settings().unwrap().snapshot().clone();
+            for dog in &mut fresh.dogs {
+                if dog.name == name {
+                    dog.enabled = enable;
+                }
+            }
+            app.update(Msg::Settings { result: Ok(fresh) });
+
+            assert_eq!(
+                dog_enabled_in_view(&app, name),
+                enable,
+                "{name}: and the row agrees with the file once it lands"
+            );
+        }
     }
 
     /// fails if a reply this binary does not understand -- or the RIGHT

--- a/crates/shep-cli/src/lookout/app.rs
+++ b/crates/shep-cli/src/lookout/app.rs
@@ -37,6 +37,7 @@ use shep_core::protocol::{
 use shep_core::status::ProcStatus;
 
 use super::theme::Palette;
+use crate::commands::settings::{SettingField, SettingsSnapshot};
 use crate::vocabulary::Reported;
 
 /// Whether this lookout may act on a sheep.
@@ -115,6 +116,14 @@ pub enum KeyPress {
     TextApply,
     /// `Esc` in whichever text field is open: abandon the edit and leave.
     TextAbandon,
+    /// `s`: open the settings screen from the dashboard, or close it again
+    /// from inside the screen. The reducer decides which, the same division
+    /// [`Self::Escape`]'s own doc argues for.
+    Settings,
+    /// `space`: cycle the value under the settings screen's own cursor.
+    /// Meaningless from the dashboard; refuses the same way an action key
+    /// does when the control gate is closed.
+    Cycle,
 }
 
 /// Everything that can change the dashboard.
@@ -197,6 +206,17 @@ pub enum Msg {
         /// What could not be sent.
         sent: Sent,
     },
+    /// The settings screen's read of `shep.toml` landed, in answer to an
+    /// [`Effect::LoadSettings`] this reducer asked for.
+    ///
+    /// `Result<_, String>` rather than `commands::settings::SettingError`,
+    /// because this reducer holds no error types from `commands` and a
+    /// notice needs a rendered sentence anyway: `super::run_ui` is what
+    /// calls `to_string()` on the way in.
+    Settings {
+        /// The rendered snapshot, or why it could not be read.
+        result: Result<SettingsSnapshot, String>,
+    },
 }
 
 /// What the caller has to do after an update.
@@ -233,6 +253,12 @@ pub enum Effect {
     Send(Sent),
     /// Leave.
     Quit,
+    /// Read `shep.toml`'s settings snapshot; the result lands as
+    /// [`Msg::Settings`].
+    ///
+    /// Raised by the dashboard's own `s`, never by the settings screen's:
+    /// once the screen is open, `s` closes it instead. See [`App::on_key`].
+    LoadSettings,
 }
 
 /// The connection's state, as the dashboard reports it.
@@ -436,6 +462,111 @@ impl fmt::Display for Notice {
     }
 }
 
+/// One row the settings screen's cursor can sit on.
+///
+/// `Debug` is derived rather than redacted (IR-41): a bare field name or a
+/// bare index, nothing a `{:?}` could leak.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SettingsRow {
+    /// One of the six scalar fields, in [`Settings::rows`]'s fixed order.
+    Scalar(SettingField),
+    /// Index into [`SettingsSnapshot::dogs`].
+    Dog(usize),
+}
+
+/// The settings screen's own state. `None` on [`App`] is the dashboard.
+///
+/// `Debug` is derived rather than redacted (IR-41): the snapshot underneath
+/// carries no secret ([`SettingsSnapshot`]'s own note says why) and the
+/// cursor is a bare index.
+#[derive(Debug, Clone)]
+pub struct Settings {
+    snapshot: SettingsSnapshot,
+    /// An index into [`Self::rows`], clamped on every read rather than kept
+    /// pre-clamped: a later task's refresh can shrink the dog list out from
+    /// under a cursor already sitting past its new end.
+    cursor: usize,
+}
+
+impl Settings {
+    /// A freshly opened screen, cursor on the first row.
+    fn new(snapshot: SettingsSnapshot) -> Self {
+        Self {
+            snapshot,
+            cursor: 0,
+        }
+    }
+
+    /// What the screen reads off disk.
+    ///
+    /// Not called outside this module's own tests yet: `view::settings`'s
+    /// `draw_settings` (a later task) is the real caller, reading it to
+    /// render every row's value and source. Same precedent this crate
+    /// already carries (`style::Presentation::BARE`,
+    /// `output::OutputEnvelope`, `commands::settings::load_settings`):
+    /// `#[allow(dead_code)]` says so explicitly rather than inventing a call
+    /// site nothing needs yet.
+    #[allow(dead_code)]
+    #[must_use]
+    pub fn snapshot(&self) -> &SettingsSnapshot {
+        &self.snapshot
+    }
+
+    /// Every row the cursor can sit on: the six scalars in their fixed
+    /// order, then one row per candidate dog.
+    #[must_use]
+    pub fn rows(&self) -> Vec<SettingsRow> {
+        let mut rows = vec![
+            SettingsRow::Scalar(SettingField::LogLevel),
+            SettingsRow::Scalar(SettingField::LogJson),
+            SettingsRow::Scalar(SettingField::Socket),
+            SettingsRow::Scalar(SettingField::MaxCronSleep),
+            SettingsRow::Scalar(SettingField::AllowControl),
+            SettingsRow::Scalar(SettingField::StyleLevel),
+        ];
+        rows.extend((0..self.snapshot.dogs.len()).map(SettingsRow::Dog));
+        rows
+    }
+
+    /// The row the cursor sits on. `None` only if [`Self::rows`] is somehow
+    /// empty, which cannot happen today (the six scalars are unconditional),
+    /// but the type stays honest about it rather than asserting.
+    ///
+    /// Not called outside this module's own tests yet: `view::settings`'s
+    /// `draw_settings` (a later task) is the real caller, reading it to
+    /// highlight the selected row. `#[allow(dead_code)]` for the same
+    /// reason [`Self::snapshot`] carries it.
+    #[allow(dead_code)]
+    #[must_use]
+    pub fn cursor(&self) -> Option<SettingsRow> {
+        let rows = self.rows();
+        rows.get(self.cursor.min(rows.len().saturating_sub(1)))
+            .copied()
+    }
+
+    /// Moves the cursor by `delta` rows, clamped to [`Self::rows`] rather
+    /// than wrapping, the same rule the flock table's own cursor follows.
+    fn move_by(&mut self, delta: isize) {
+        let len = self.rows().len();
+        if len == 0 {
+            self.cursor = 0;
+            return;
+        }
+        let next = self.cursor as isize + delta;
+        self.cursor = next.clamp(0, len as isize - 1) as usize;
+    }
+
+    /// Moves the cursor to the first row.
+    fn move_to_first(&mut self) {
+        self.cursor = 0;
+    }
+
+    /// Moves the cursor to the last row.
+    fn move_to_last(&mut self) {
+        self.cursor = self.rows().len().saturating_sub(1);
+    }
+}
+
 /// What an action key does.
 ///
 /// Three verbs, and deliberately not four: `start` is whistle's and the CLI's,
@@ -594,6 +725,9 @@ pub struct App {
     lambs: Option<LambReading>,
     /// The one action this dashboard is in the middle of, or `None`.
     action: Option<Action>,
+    /// The settings screen's own state. `None` is the dashboard; `Some` is
+    /// the screen, open over it.
+    settings: Option<Settings>,
 }
 
 impl App {
@@ -616,6 +750,7 @@ impl App {
             feed: super::tail::Tail::default(),
             lambs: None,
             action: None,
+            settings: None,
         }
     }
 
@@ -748,6 +883,24 @@ impl App {
                 // clear.
                 Sent::Lambs { .. } => Effect::None,
             },
+            // The file can have changed since `s` asked for it, and the
+            // screen opens on whatever this read found -- never on stale or
+            // empty state, which is exactly why `s` asks first rather than
+            // opening immediately. A failed read leaves the dashboard up: an
+            // empty settings screen would say nothing about why it has
+            // nothing to show.
+            Msg::Settings { result } => {
+                match result {
+                    Ok(snapshot) => self.settings = Some(Settings::new(snapshot)),
+                    Err(message) => {
+                        self.notice = Some(Notice {
+                            text: message,
+                            grave: true,
+                        });
+                    }
+                }
+                Effect::None
+            }
         }
     }
 
@@ -928,6 +1081,13 @@ impl App {
         if self.mode == InputMode::Text {
             return self.on_text_key(key);
         }
+        // The settings screen owns its own keymap while it is open, ahead of
+        // the armed-confirm check below: no sheep action can be armed from
+        // in here (`s` reaches the dashboard only after the screen closes),
+        // so the ordering is a documentation choice, not a correctness one.
+        if self.settings.is_some() {
+            return self.on_settings_key(key);
+        }
         // Checked BEFORE the ordinary dispatch, and a cancelling keypress is
         // CONSUMED. A stray `j` during a pending confirm cancels it and does
         // not also move the selection: if it did both, the operator would see
@@ -1016,7 +1176,75 @@ impl App {
             | KeyPress::TextBackspace
             | KeyPress::TextApply
             | KeyPress::TextAbandon => Effect::None,
+            // The read, not the open: the screen opens only once
+            // `Msg::Settings` lands. See that arm's own doc for why.
+            KeyPress::Settings => Effect::LoadSettings,
+            // Meaningless from the dashboard; the settings screen is the
+            // only thing `space` does anything for, and this branch is only
+            // reached when that screen is not open.
+            KeyPress::Cycle => Effect::None,
         }
+    }
+
+    /// The settings screen's own keymap, in force for as long as
+    /// [`Self::settings`] is `Some`. Everything not named here is ignored,
+    /// in particular an action key: no sheep action can arm while this
+    /// screen owns the keyboard.
+    fn on_settings_key(&mut self, key: KeyPress) -> Effect {
+        self.notice = None;
+        match key {
+            KeyPress::Quit => return Effect::Quit,
+            // Both close. `s` toggling shut is the dashboard's own `s`
+            // meaning something different once the screen is open, the same
+            // division `Escape`'s doc argues for; `Escape` closing rather
+            // than quitting is the one place this screen swaps the
+            // dashboard's own cascade.
+            KeyPress::Settings | KeyPress::Escape => self.settings = None,
+            KeyPress::SelectUp => {
+                if let Some(settings) = self.settings.as_mut() {
+                    settings.move_by(-1);
+                }
+            }
+            KeyPress::SelectDown => {
+                if let Some(settings) = self.settings.as_mut() {
+                    settings.move_by(1);
+                }
+            }
+            KeyPress::SelectFirst => {
+                if let Some(settings) = self.settings.as_mut() {
+                    settings.move_to_first();
+                }
+            }
+            KeyPress::SelectLast => {
+                if let Some(settings) = self.settings.as_mut() {
+                    settings.move_to_last();
+                }
+            }
+            // Nothing to cycle yet: writing lands in a later task. The
+            // refusal is the one thing that has to exist today: an operator
+            // running a read-only lookout must be told why `space` did
+            // nothing, exactly as an action key already is.
+            KeyPress::Cycle => {
+                if self.control == Control::ReadOnly {
+                    self.notice = Some(Notice {
+                        text: "read-only: actions need --allow-control".to_string(),
+                        grave: true,
+                    });
+                }
+            }
+            KeyPress::Confirm | KeyPress::Refresh => {}
+            // Unreachable from here, and named rather than wildcarded so a
+            // future variant does not fall silently into an arm that
+            // ignores it: an action key in particular must never be
+            // mistaken for one this screen answers.
+            KeyPress::Action(_)
+            | KeyPress::FilterStart
+            | KeyPress::TextChar(_)
+            | KeyPress::TextBackspace
+            | KeyPress::TextApply
+            | KeyPress::TextAbandon => {}
+        }
+        Effect::None
     }
 
     /// Arms a confirm, or refuses and says why.
@@ -1672,6 +1900,13 @@ impl App {
         })
     }
 
+    /// The settings screen's own state, or `None` while the dashboard is
+    /// showing.
+    #[must_use]
+    pub fn settings(&self) -> Option<&Settings> {
+        self.settings.as_ref()
+    }
+
     /// Overrides the control gate a fixture built with. `App::new` takes
     /// [`Control`] and every shipped fixture hard-codes [`Control::ReadOnly`];
     /// this is the one line that lets the action-key tests build a dashboard
@@ -1738,6 +1973,8 @@ const fn outcome(verb: ActionVerb) -> &'static str {
 mod tests {
     use super::*;
     use shep_core::protocol::{ProcessEventKind, RpcError, RpcErrorCode};
+
+    use super::super::view::fixtures;
 
     fn sheep(id: u32, name: &str, status: ProcStatus) -> ProcessInfo {
         ProcessInfo::builder(id, name, status)
@@ -3483,5 +3720,135 @@ mod tests {
             );
             assert!(app.notice().is_some_and(Notice::is_grave));
         }
+    }
+
+    /// `s` asks for the read rather than opening on stale or empty state: the
+    /// file can have changed since the last look, and an empty screen while the
+    /// read is in flight is a screen that lies for one frame.
+    #[test]
+    fn s_asks_for_the_file_before_the_screen_opens() {
+        let mut app = fixtures::full_app();
+        assert_eq!(
+            app.update(Msg::Key(KeyPress::Settings)),
+            Effect::LoadSettings
+        );
+        assert!(
+            app.settings().is_none(),
+            "nothing opens until the read lands"
+        );
+    }
+
+    #[test]
+    fn the_screen_opens_when_the_read_lands() {
+        let mut app = fixtures::full_app();
+        let _ = app.update(Msg::Key(KeyPress::Settings));
+        let _ = app.update(Msg::Settings {
+            result: Ok(fixtures::settings_snapshot()),
+        });
+        assert!(app.settings().is_some());
+    }
+
+    #[test]
+    fn a_read_that_failed_says_so_and_leaves_the_dashboard_up() {
+        let mut app = fixtures::full_app();
+        let _ = app.update(Msg::Key(KeyPress::Settings));
+        let _ = app.update(Msg::Settings {
+            result: Err("no such file".into()),
+        });
+        assert!(app.settings().is_none());
+        let notice = app.notice().expect("a failed read has to say so");
+        assert!(notice.is_grave());
+        assert!(notice.to_string().contains("no such file"));
+    }
+
+    #[test]
+    fn s_closes_the_screen_again() {
+        let mut app = fixtures::app_in_settings();
+        let _ = app.update(Msg::Key(KeyPress::Settings));
+        assert!(app.settings().is_none());
+    }
+
+    /// The one arm of the `Escape` cascade this screen swaps. From the dashboard
+    /// with no filter, `Esc` quits; from here it must not.
+    #[test]
+    fn escape_closes_the_screen_and_never_quits() {
+        let mut app = fixtures::app_in_settings();
+        assert_eq!(app.update(Msg::Key(KeyPress::Escape)), Effect::None);
+        assert!(app.settings().is_none());
+    }
+
+    #[test]
+    fn the_flock_cursor_and_the_filter_survive_the_swap() {
+        let mut app = fixtures::full_app();
+        let _ = app.update(Msg::Key(KeyPress::FilterStart));
+        for c in "web".chars() {
+            let _ = app.update(Msg::Key(KeyPress::TextChar(c)));
+        }
+        let _ = app.update(Msg::Key(KeyPress::TextApply));
+        // `selected()` hands back an owned `Option<RowKey>` (app.rs:1436), so
+        // there is nothing to clone.
+        let selected = app.selected();
+        let filter = app.filter().to_string();
+
+        let _ = app.update(Msg::Key(KeyPress::Settings));
+        let _ = app.update(Msg::Settings {
+            result: Ok(fixtures::settings_snapshot()),
+        });
+        let _ = app.update(Msg::Key(KeyPress::Settings));
+
+        assert_eq!(app.selected(), selected);
+        assert_eq!(app.filter(), filter);
+    }
+
+    #[test]
+    fn the_settings_cursor_starts_at_the_first_row_on_every_open() {
+        let mut app = fixtures::app_in_settings();
+        let _ = app.update(Msg::Key(KeyPress::SelectDown));
+        let _ = app.update(Msg::Key(KeyPress::SelectDown));
+        let _ = app.update(Msg::Key(KeyPress::Settings));
+        let _ = app.update(Msg::Key(KeyPress::Settings));
+        let _ = app.update(Msg::Settings {
+            result: Ok(fixtures::settings_snapshot()),
+        });
+
+        let first = app.settings().unwrap().rows()[0];
+        assert_eq!(app.settings().unwrap().cursor(), Some(first));
+    }
+
+    #[test]
+    fn the_cursor_moves_through_the_scalars_and_into_the_dogs() {
+        let mut app = fixtures::app_in_settings();
+        let rows = app.settings().unwrap().rows();
+        for _ in 0..rows.len() - 1 {
+            let _ = app.update(Msg::Key(KeyPress::SelectDown));
+        }
+        assert_eq!(
+            app.settings().unwrap().cursor(),
+            Some(*rows.last().unwrap())
+        );
+        // and it stops rather than wrapping, the way the flock table does
+        let _ = app.update(Msg::Key(KeyPress::SelectDown));
+        assert_eq!(
+            app.settings().unwrap().cursor(),
+            Some(*rows.last().unwrap())
+        );
+    }
+
+    #[test]
+    fn an_action_key_from_the_dashboard_is_unreachable_while_the_screen_is_up() {
+        let mut app = fixtures::app_in_settings_with_control();
+        // `x` is the stop key on the dashboard. In here it is not an action at all.
+        let _ = app.update(Msg::Key(KeyPress::Action(ActionVerb::Stop)));
+        // The accessor is `App::action()` (app.rs:1662).
+        assert!(app.action().is_none(), "no sheep confirm can arm from here");
+    }
+
+    #[test]
+    fn a_read_only_lookout_opens_the_screen_and_refuses_the_edit_key() {
+        let mut app = fixtures::app_in_settings(); // Control::ReadOnly
+        assert!(app.settings().is_some(), "reading shep.toml is not gated");
+        let _ = app.update(Msg::Key(KeyPress::Cycle));
+        let notice = app.notice().expect("the refusal has to say why");
+        assert!(notice.is_grave());
     }
 }

--- a/crates/shep-cli/src/lookout/app.rs
+++ b/crates/shep-cli/src/lookout/app.rs
@@ -105,14 +105,16 @@ pub enum KeyPress {
     Confirm,
     /// `/` — open the filter box, carrying whatever query is already set.
     FilterStart,
-    /// One printable character typed into the box.
-    FilterChar(char),
-    /// `Backspace` in the box.
-    FilterBackspace,
-    /// `Enter` in the box: apply and leave.
-    FilterApply,
-    /// `Esc` in the box: clear the filter and leave.
-    FilterAbandon,
+    /// One printable character typed into whichever text field is open.
+    /// The reducer decides which that is, the same division `Escape`'s own
+    /// doc argues for, because the keymap cannot see it.
+    TextChar(char),
+    /// `Backspace` in whichever text field is open.
+    TextBackspace,
+    /// `Enter` in whichever text field is open: apply and leave.
+    TextApply,
+    /// `Esc` in whichever text field is open: abandon the edit and leave.
+    TextAbandon,
 }
 
 /// Everything that can change the dashboard.
@@ -1010,10 +1012,10 @@ impl App {
             // the top of this function has already taken. Named rather than
             // wildcarded so a future variant does not fall silently into an
             // arm that ignores it.
-            KeyPress::FilterChar(_)
-            | KeyPress::FilterBackspace
-            | KeyPress::FilterApply
-            | KeyPress::FilterAbandon => Effect::None,
+            KeyPress::TextChar(_)
+            | KeyPress::TextBackspace
+            | KeyPress::TextApply
+            | KeyPress::TextAbandon => Effect::None,
         }
     }
 
@@ -1178,21 +1180,21 @@ impl App {
     fn on_text_key(&mut self, key: KeyPress) -> Effect {
         match key {
             KeyPress::Quit => Effect::Quit,
-            KeyPress::FilterChar(typed) => {
+            KeyPress::TextChar(typed) => {
                 let mut query = self.filter.clone();
                 query.push(typed);
                 self.set_filter(query)
             }
-            KeyPress::FilterBackspace => {
+            KeyPress::TextBackspace => {
                 let mut query = self.filter.clone();
                 query.pop();
                 self.set_filter(query)
             }
-            KeyPress::FilterApply => {
+            KeyPress::TextApply => {
                 self.mode = InputMode::Normal;
                 Effect::None
             }
-            KeyPress::FilterAbandon => {
+            KeyPress::TextAbandon => {
                 self.mode = InputMode::Normal;
                 self.set_filter(String::new())
             }
@@ -2697,10 +2699,10 @@ mod tests {
         app.update(Msg::Key(KeyPress::FilterStart));
         assert_eq!(app.mode(), InputMode::Text);
         for letter in ['w', 'e', 'b'] {
-            app.update(Msg::Key(KeyPress::FilterChar(letter)));
+            app.update(Msg::Key(KeyPress::TextChar(letter)));
         }
         assert_eq!(app.rows().len(), 1, "narrowed before Enter");
-        app.update(Msg::Key(KeyPress::FilterApply));
+        app.update(Msg::Key(KeyPress::TextApply));
         assert_eq!(app.mode(), InputMode::Normal);
         assert_eq!(
             app.rows().len(),
@@ -2714,10 +2716,10 @@ mod tests {
     fn backspace_widens_the_table_back_out() {
         let (mut app, _t0) = started();
         app.update(Msg::Key(KeyPress::FilterStart));
-        app.update(Msg::Key(KeyPress::FilterChar('w')));
-        app.update(Msg::Key(KeyPress::FilterChar('z')));
+        app.update(Msg::Key(KeyPress::TextChar('w')));
+        app.update(Msg::Key(KeyPress::TextChar('z')));
         assert_eq!(app.rows().len(), 0);
-        app.update(Msg::Key(KeyPress::FilterBackspace));
+        app.update(Msg::Key(KeyPress::TextBackspace));
         assert_eq!(
             app.rows().len(),
             2,
@@ -2731,8 +2733,8 @@ mod tests {
     fn esc_while_editing_clears_the_filter_and_leaves_the_box() {
         let (mut app, _t0) = started();
         app.update(Msg::Key(KeyPress::FilterStart));
-        app.update(Msg::Key(KeyPress::FilterChar('w')));
-        app.update(Msg::Key(KeyPress::FilterAbandon));
+        app.update(Msg::Key(KeyPress::TextChar('w')));
+        app.update(Msg::Key(KeyPress::TextAbandon));
         assert_eq!(app.mode(), InputMode::Normal);
         assert_eq!(app.filter(), "");
         assert_eq!(app.rows().len(), 3);
@@ -2768,9 +2770,9 @@ mod tests {
     fn a_notice_raised_while_typing_is_deferred_and_not_destroyed() {
         let (mut app, _t0) = started();
         app.update(Msg::Key(KeyPress::FilterStart));
-        app.update(Msg::Key(KeyPress::FilterChar('w')));
+        app.update(Msg::Key(KeyPress::TextChar('w')));
         app.update(Msg::Event(BusEvent::DaemonShutdown));
-        app.update(Msg::Key(KeyPress::FilterChar('e')));
+        app.update(Msg::Key(KeyPress::TextChar('e')));
         assert!(
             app.notice().is_some(),
             "typing did not wipe the shepherd's announcement"

--- a/crates/shep-cli/src/lookout/frames.rs
+++ b/crates/shep-cli/src/lookout/frames.rs
@@ -33,6 +33,7 @@
 //! build, and cost nothing when they run under `cargo test`.
 
 use std::fmt::Write as _;
+use std::path::PathBuf;
 use std::time::{Duration, Instant};
 
 use ratatui::Terminal;
@@ -1306,15 +1307,24 @@ fn settings_snapshot_for_gallery() -> SettingsSnapshot {
 fn settings_snapshot_with_dog_drift() -> SettingsSnapshot {
     SettingsSnapshot {
         dogs: vec![
+            // Both carry a real path, and they have to: `BUILT_IN_DOGS` is
+            // `["metrics", "bark"]`, and `dog_candidates` builds every
+            // other name out of `[daemon] adopted_dogs`, whose values ARE
+            // the paths. So a non-built-in dog with `adopted_path: None`
+            // is a row `load_settings` cannot produce from a document
+            // shep wrote (only a hand-edited non-string value could), and
+            // it rendered
+            // `built-in` for two dogs that are not. The spec's own decision
+            // 9 mockup gives these two paths.
             DogView {
                 name: "otel".to_string(),
                 enabled: false,
-                adopted_path: None,
+                adopted_path: Some(PathBuf::from("/usr/local/bin/shep-otel")),
             },
             DogView {
                 name: "ledger".to_string(),
                 enabled: true,
-                adopted_path: None,
+                adopted_path: Some(PathBuf::from("/opt/ledger/bin/dog")),
             },
             DogView {
                 name: "bark".to_string(),

--- a/crates/shep-cli/src/lookout/frames.rs
+++ b/crates/shep-cli/src/lookout/frames.rs
@@ -41,14 +41,21 @@ use ratatui::buffer::Buffer;
 use ratatui::style::Color;
 
 use shep_client::RequestError;
-use shep_core::protocol::{ExitInfo, Lamb, ProcessInfo, Response, RpcError, RpcErrorCode};
+use shep_core::protocol::{
+    DogSource, ExitInfo, Lamb, ProcessInfo, Response, RpcError, RpcErrorCode,
+};
 use shep_core::status::ProcStatus;
 
-use super::app::{ActionVerb, App, Control, KeyPress, Msg, RowKey, Sent};
+use super::app::{ActionVerb, App, Control, KeyPress, Msg, RowKey, Sent, SettingsRow};
 use super::source::HostSample;
 use super::tail::{Stream, Tail, TailLine};
 use super::theme::Palette;
 use super::view::draw;
+use crate::commands::settings::{
+    DogView, ScalarView, SettingField, SettingsSnapshot, load_settings,
+};
+use crate::commands::shep_toml::ShepToml;
+use crate::style::{StyleLevel, StyleSource};
 
 /// One rendered buffer as plain text: one line per row, trailing spaces
 /// kept, no escapes.
@@ -181,6 +188,21 @@ pub enum Scene {
     ActionAccepted,
     /// An action key pressed while the link is coming back.
     ActionRefusedOffline,
+    /// The settings screen on a fresh `$SHEP_HOME`: only `[interpreters]` on
+    /// disk, so every scalar reads its compiled default. The state most
+    /// operators open the screen in.
+    SettingsFresh,
+    /// The settings screen with some scalars declared, so `shep.toml` and
+    /// the default sit side by side.
+    SettingsSet,
+    /// The settings screen with a `[daemon]` confirm armed, naming the
+    /// variable and the flag it cannot see.
+    SettingsConfirm,
+    /// The settings screen with the `socket` editor open mid-path.
+    SettingsTyping,
+    /// The settings screen's dogs table, showing the drift it exists to
+    /// make visible.
+    SettingsDogs,
 }
 
 impl Scene {
@@ -211,6 +233,11 @@ impl Scene {
         Self::ActionRefused,
         Self::ActionAccepted,
         Self::ActionRefusedOffline,
+        Self::SettingsFresh,
+        Self::SettingsSet,
+        Self::SettingsConfirm,
+        Self::SettingsTyping,
+        Self::SettingsDogs,
     ];
 
     /// The snapshot name and the gallery heading.
@@ -242,11 +269,16 @@ impl Scene {
             Self::ActionRefused => "action_refused",
             Self::ActionAccepted => "action_accepted",
             Self::ActionRefusedOffline => "action_refused_offline",
+            Self::SettingsFresh => "settings_fresh",
+            Self::SettingsSet => "settings_set",
+            Self::SettingsConfirm => "settings_confirm",
+            Self::SettingsTyping => "settings_typing",
+            Self::SettingsDogs => "settings_dogs",
         }
     }
 
     /// One sentence saying what this frame is for, printed above it in the
-    /// gallery so the maintainer does not have to hold twenty-five of them in her head.
+    /// gallery so the maintainer does not have to hold thirty of them in her head.
     ///
     /// Every clause here is pinned by an assertion in
     /// `every_scene_shows_the_thing_it_is_named_for` — a caption may not say
@@ -329,6 +361,21 @@ impl Scene {
             Self::ActionRefusedOffline => {
                 "An action key pressed while the link is coming back. The refusal names the same reconnect attempt the banner above it does, rather than the exhausted-ladder sentence — Phase 16 review Minor #8 caught the two disagreeing on one frame."
             }
+            Self::SettingsFresh => {
+                "The settings screen on a fresh $SHEP_HOME: shep.toml holds only [interpreters], so every scalar's SOURCE column reads `the default` and its VALUE is the compiled fallback. The state most operators open this screen in."
+            }
+            Self::SettingsSet => {
+                "The settings screen with some scalars declared. `shep.toml` and `the default` sit side by side in the SOURCE column, so what the operator wrote and what shep assumes are both visible at once."
+            }
+            Self::SettingsConfirm => {
+                "A [daemon] confirm armed on log_level, naming the variable and the flag it cannot see: SHEP_LOG_LEVEL and --log-level, and the shep daemon reload the edit needs."
+            }
+            Self::SettingsTyping => {
+                "The socket editor open mid-path. The status bar names the field being typed, not the dashboard's own filter box, which is what it showed here before the fix this frame now pins."
+            }
+            Self::SettingsDogs => {
+                "The dogs table showing the drift it exists to reveal: otel running while disabled in the file, ledger enabled and absent, and bark enabled, running, and silent."
+            }
         }
     }
 
@@ -345,7 +392,9 @@ impl Scene {
             | Self::ActionRefused
             | Self::ActionAccepted
             | Self::ActionRefusedOffline
-            | Self::Lambs => Control::Allowed,
+            | Self::Lambs
+            | Self::SettingsConfirm
+            | Self::SettingsTyping => Control::Allowed,
             _ => Control::ReadOnly,
         }
     }
@@ -374,6 +423,12 @@ impl Scene {
             | Self::ActionRefused
             | Self::ActionAccepted
             | Self::ActionRefusedOffline => (100, 14),
+            // 180: the `log_level` confirm's own sentence -- naming both
+            // `SHEP_LOG_LEVEL` and `--log-level` plus "enter confirms, any
+            // other key cancels" -- runs to 170 columns, past every other
+            // scene's width. A narrower frame would truncate the very flag
+            // this scene exists to show.
+            Self::SettingsConfirm => (180, 30),
             // HealthyWide, Errored, Grouped, Retrying, Frozen, Refused, FeedGap,
             // FeedMissing, HostUnknown, Lambs, LambsUnknown: every scene that
             // carries all three optional panes at their ordinary rows.
@@ -543,6 +598,15 @@ fn scene_with(which: Scene, age: Duration) -> Buffer {
                 None,
             ),
         ],
+        // Two dog processes only -- the dashboard flock is invisible behind
+        // the settings screen this scene draws, so what matters is what
+        // `dog_rows`'s own join sees: `otel` up and healthy, `bark` up but
+        // never handshook. `ledger` (armed enabled in the snapshot below)
+        // has no row here at all, which is what "enabled and absent" means.
+        Scene::SettingsDogs => vec![
+            dog_sheep(90, "otel", None),
+            dog_sheep(91, "bark", Some(false)),
+        ],
         _ => vec![
             sheep(
                 0,
@@ -629,9 +693,18 @@ fn scene_with(which: Scene, age: Duration) -> Buffer {
     // moving the cursor in them would change a snapshot for no reason.
     // `Grouped` is excluded for a fifth reason: its cursor belongs on the
     // group header, which is the whole scene, and it goes there below.
+    // `SettingsDogs` is excluded for a sixth: its flock has no id 2 at all
+    // -- the dashboard behind it is invisible once the settings screen
+    // draws over the whole body, so there is nothing for a cursor there to
+    // do.
     if !matches!(
         which,
-        Scene::Empty | Scene::Narrow | Scene::TooNarrow | Scene::TableOnly | Scene::Grouped
+        Scene::Empty
+            | Scene::Narrow
+            | Scene::TooNarrow
+            | Scene::TableOnly
+            | Scene::Grouped
+            | Scene::SettingsDogs
     ) {
         select_id(&mut app, 2);
     }
@@ -833,6 +906,71 @@ fn scene_with(which: Scene, age: Duration) -> Buffer {
                     })),
                 });
             }
+        }
+        _ => {}
+    }
+
+    // The five settings scenes, applied last for the same reason the five
+    // action scenes above are: `SettingsConfirm` arms a candidate, and
+    // `Settings::pending` expires on the same `CONFIRM_EXPIRY` the
+    // dashboard's own action confirm does, so arming it before the tick at
+    // `age` (600s in `scene()`) would already show it expired by the time
+    // this function draws.
+    match which {
+        Scene::SettingsFresh => {
+            // A genuinely fresh document, not a hand-edited snapshot: the
+            // scaffold every first run leaves is `[interpreters]` alone, and
+            // `load_settings` is the same reader `run_ui` calls, so this is
+            // what an operator's very first `s` actually shows.
+            let dir = tempfile::tempdir().unwrap();
+            let path = dir.path().join("shep.toml");
+            ShepToml::edit(&path, ShepToml::write_starter_interpreters).unwrap();
+            let snapshot = load_settings(
+                &path,
+                std::path::Path::new("/home/ada/.shep/run/shep.sock"),
+                (StyleLevel::Full, StyleSource::Default),
+            )
+            .unwrap();
+            app.update(Msg::Key(KeyPress::Settings));
+            app.update(Msg::Settings {
+                result: Ok(snapshot),
+            });
+        }
+        Scene::SettingsSet => {
+            app.update(Msg::Key(KeyPress::Settings));
+            app.update(Msg::Settings {
+                result: Ok(settings_snapshot_for_gallery()),
+            });
+        }
+        Scene::SettingsConfirm => {
+            app.update(Msg::Key(KeyPress::Settings));
+            app.update(Msg::Settings {
+                result: Ok(settings_snapshot_for_gallery()),
+            });
+            // The cursor already sits on `log_level`, `Settings::rows`'s
+            // first row, so arming it needs no `SelectDown` at all.
+            app.update(Msg::Key(KeyPress::Cycle));
+        }
+        Scene::SettingsTyping => {
+            app.update(Msg::Key(KeyPress::Settings));
+            app.update(Msg::Settings {
+                result: Ok(settings_snapshot_for_gallery()),
+            });
+            move_settings_cursor_to(&mut app, SettingField::Socket);
+            // Opens the editor, seeded with the on-disk value.
+            app.update(Msg::Key(KeyPress::Confirm));
+            // Trims the seeded value back to a partial path, so the frame
+            // shows the editor genuinely mid-type rather than holding the
+            // whole, untouched value it opened with.
+            for _ in 0..8 {
+                app.update(Msg::Key(KeyPress::TextBackspace));
+            }
+        }
+        Scene::SettingsDogs => {
+            app.update(Msg::Key(KeyPress::Settings));
+            app.update(Msg::Settings {
+                result: Ok(settings_snapshot_with_dog_drift()),
+            });
         }
         _ => {}
     }
@@ -1070,6 +1208,105 @@ fn flock_without_api() -> Vec<ProcessInfo> {
     ]
 }
 
+/// One dog process: `id` and `name` as `dog_rows`'s join key, `handshook`
+/// carrying the same three-state signal a real listing does -- `None` reads
+/// `online`, `Some(false)` reads `silent`, per [`crate::vocabulary::Reported::of`].
+/// [`Scene::SettingsDogs`] is the only scene that calls this.
+fn dog_sheep(id: u32, name: &str, handshook: Option<bool>) -> ProcessInfo {
+    ProcessInfo::builder(id, name, ProcStatus::Online)
+        .pid(Some(90_000 + id))
+        .dog(Some(DogSource::BuiltIn))
+        .handshook(handshook)
+        .build()
+}
+
+/// Walks the settings screen's cursor onto `field`'s row by real
+/// `SelectDown` keypresses, the same real-path rule
+/// `view::fixtures::app_in_settings_on` follows for its own tests.
+///
+/// # Panics
+///
+/// If the settings screen is not open. Gallery scaffolding: a scene that
+/// called this before `Msg::Settings` landed is a defect in the scene, not
+/// in the screen.
+fn move_settings_cursor_to(app: &mut App, field: SettingField) {
+    let target = app
+        .settings()
+        .expect("the settings screen must already be open")
+        .rows()
+        .iter()
+        .position(|row| *row == SettingsRow::Scalar(field))
+        .expect("field is one of the six scalar rows Settings::rows always carries");
+    for _ in 0..target {
+        app.update(Msg::Key(KeyPress::SelectDown));
+    }
+}
+
+/// A settings snapshot with `log_level`, `socket`, `max_cron_sleep` and
+/// `style_level` declared in `shep.toml`, and `log_json`/`allow_control`
+/// left at their compiled defaults -- the mixed state
+/// [`Scene::SettingsSet`]'s own caption shows, and the fixture
+/// [`Scene::SettingsConfirm`] and [`Scene::SettingsTyping`] both build on.
+fn settings_snapshot_for_gallery() -> SettingsSnapshot {
+    let config = |value: &str| ScalarView {
+        value: value.to_string(),
+        source: StyleSource::Config,
+    };
+    let default = |value: &str| ScalarView {
+        value: value.to_string(),
+        source: StyleSource::Default,
+    };
+    SettingsSnapshot {
+        log_level: config("warn"),
+        log_json: default("false"),
+        socket: config("/home/ada/.shep/run/shep.sock"),
+        max_cron_sleep: config("30s"),
+        allow_control: default("false"),
+        style_level: config("full"),
+        dogs: vec![
+            DogView {
+                name: "bark".to_string(),
+                enabled: false,
+                adopted_path: None,
+            },
+            DogView {
+                name: "metrics".to_string(),
+                enabled: true,
+                adopted_path: None,
+            },
+        ],
+    }
+}
+
+/// [`settings_snapshot_for_gallery`]'s own scalars, with `dogs` replaced by
+/// the three-way drift [`Scene::SettingsDogs`] shows: `otel` running while
+/// the file disables it, `ledger` enabled and absent from
+/// [`Scene::SettingsDogs`]'s own flock, and `bark` enabled and running --
+/// [`dog_sheep`] gives it `handshook: Some(false)`, so the join reads it
+/// `silent` rather than `online`.
+fn settings_snapshot_with_dog_drift() -> SettingsSnapshot {
+    SettingsSnapshot {
+        dogs: vec![
+            DogView {
+                name: "otel".to_string(),
+                enabled: false,
+                adopted_path: None,
+            },
+            DogView {
+                name: "ledger".to_string(),
+                enabled: true,
+                adopted_path: None,
+            },
+            DogView {
+                name: "bark".to_string(),
+                enabled: true,
+                adopted_path: None,
+            },
+        ],
+        ..settings_snapshot_for_gallery()
+    }
+}
+
 /// The header both gallery files open with.
 ///
 /// Not a doc comment on the test: this text is read by a person opening
@@ -1084,7 +1321,7 @@ These are real frames, rendered headlessly through ratatui's TestBackend by
 
 Nothing here is a mockup.
 
-frames.ansi is the same twenty-five frames with colour; read it with `less -R`.
+frames.ansi is the same thirty frames with colour; read it with `less -R`.
 
 All four panes are here: the flock table (the spine), the host-usage strip,
 the sheep detail pane and the bleats feed. `>` marks the selected sheep, and
@@ -1100,6 +1337,12 @@ When the pane cannot show everything, the header says what went instead. Lines
 it read and dropped are counted exactly; bytes below its 64 KiB window were
 never read at all, so those are reported in bytes, because nothing counted the
 lines in them and guessing would be worse than saying so.
+
+The last five frames are the settings screen, `s` from the dashboard. It owns
+the whole body between the title and the status bar rather than sharing it
+with the flock table, so a fresh $SHEP_HOME, some scalars declared, an armed
+confirm, the socket editor mid-type and the dogs table's own drift each get a
+frame of their own.
 ";
 
 #[cfg(test)]
@@ -1163,6 +1406,15 @@ mod tests {
         })
     }
 
+    /// The dogs table's own row lookup: unlike [`row_for`], a dog row opens
+    /// with `mark` and a name, never a numeric id, so the same "first two
+    /// tokens" shape does not apply.
+    fn dog_row_for<'a>(frame: &'a str, name: &str) -> Option<&'a str> {
+        frame
+            .lines()
+            .find(|line| line.trim_start_matches('>').split_whitespace().next() == Some(name))
+    }
+
     /// Whether the MARKED row's name starts with `prefix`. For a name the
     /// NAME column has truncated, the exact truncated string depends on
     /// terminal width, so a literal expected value would be wrong at any
@@ -1210,7 +1462,7 @@ mod tests {
     /// in this module runs on both platforms, and the dashboard itself was
     /// exercised against a live Windows flock.
     #[cfg(unix)]
-    #[allow(clippy::too_many_lines)] // twenty-five captions, each pinned clause by clause
+    #[allow(clippy::too_many_lines)] // thirty captions, each pinned clause by clause
     fn every_scene_shows_the_thing_it_is_named_for() {
         // "All three panes at 120x30: the host strip under the title, the
         //  detail pane and the bleats feed under the table. `>` marks the
@@ -1677,6 +1929,69 @@ mod tests {
         for key in ["x stop", "R restart", "L reload"] {
             assert!(lambs_bar.contains(key), "the control hint names {key}");
         }
+
+        // "The settings screen on a fresh $SHEP_HOME: shep.toml holds only
+        //  [interpreters], so every scalar's SOURCE column reads `the
+        //  default` and its VALUE is the compiled fallback. The state most
+        //  operators open this screen in."
+        let fresh = render_text(&scene(Scene::SettingsFresh).1);
+        assert_eq!(
+            fresh.matches("the default").count(),
+            6,
+            "all six scalars read the default: {fresh:?}"
+        );
+        assert!(
+            !fresh.contains("shep.toml  "),
+            "a fresh home has declared nothing: {fresh:?}"
+        );
+
+        // "The settings screen with some scalars declared. `shep.toml` and
+        //  `the default` sit side by side in the SOURCE column, so what the
+        //  operator wrote and what shep assumes are both visible at once."
+        let set = render_text(&scene(Scene::SettingsSet).1);
+        assert!(set.contains("shep.toml"), "some scalars are declared");
+        assert!(set.contains("the default"), "and some are not: {set:?}");
+
+        // "A [daemon] confirm armed on log_level, naming the variable and
+        //  the flag it cannot see: SHEP_LOG_LEVEL and --log-level, and the
+        //  shep daemon reload the edit needs."
+        let confirm = render_text(&scene(Scene::SettingsConfirm).1);
+        assert!(confirm.contains("shep daemon reload"), "got: {confirm:?}");
+        assert!(confirm.contains("SHEP_LOG_LEVEL"), "got: {confirm:?}");
+        assert!(confirm.contains("--log-level"), "got: {confirm:?}");
+
+        // "The socket editor open mid-path. The status bar names the field
+        //  being typed, not the dashboard's own filter box, which is what
+        //  it showed here before the fix this frame now pins."
+        let typing = render_text(&scene(Scene::SettingsTyping).1);
+        assert!(
+            typing.contains("editing socket"),
+            "names the field being typed: {typing:?}"
+        );
+        assert!(
+            !typing.contains("filter "),
+            "must not read as the dashboard's own filter box: {typing:?}"
+        );
+
+        // "The dogs table showing the drift it exists to reveal: otel
+        //  running while disabled in the file, ledger enabled and absent,
+        //  and bark enabled, running, and silent."
+        let dogs = render_text(&scene(Scene::SettingsDogs).1);
+        assert!(
+            dog_row_for(&dogs, "otel")
+                .is_some_and(|row| row.contains("no") && row.contains("online")),
+            "otel: disabled in the file, running: {dogs:?}"
+        );
+        assert!(
+            dog_row_for(&dogs, "ledger")
+                .is_some_and(|row| row.contains("yes") && row.contains("not running")),
+            "ledger: enabled, absent from the flock: {dogs:?}"
+        );
+        assert!(
+            dog_row_for(&dogs, "bark")
+                .is_some_and(|row| row.contains("yes") && row.contains("silent")),
+            "bark: enabled, running, never handshook: {dogs:?}"
+        );
     }
 
     /// fails if the gallery's cursor walk budgets by SHEEP rather than by
@@ -1745,7 +2060,7 @@ mod tests {
         // above already guarantees it, so it would be a line that cannot
         // fail. The literal can — it is what catches a scene added to the
         // enum and not to `ALL`, or the reverse.
-        assert_eq!(Scene::ALL.len(), 25);
+        assert_eq!(Scene::ALL.len(), 30);
     }
 
     /// fails if a 12b pane introduced a text MODIFIER. `sgr` renders

--- a/crates/shep-cli/src/lookout/frames.rs
+++ b/crates/shep-cli/src/lookout/frames.rs
@@ -1229,6 +1229,7 @@ fn dog_sheep(id: u32, name: &str, handshook: Option<bool>) -> ProcessInfo {
 /// If the settings screen is not open. Gallery scaffolding: a scene that
 /// called this before `Msg::Settings` landed is a defect in the scene, not
 /// in the screen.
+#[track_caller]
 fn move_settings_cursor_to(app: &mut App, field: SettingField) {
     let target = app
         .settings()

--- a/crates/shep-cli/src/lookout/frames.rs
+++ b/crates/shep-cli/src/lookout/frames.rs
@@ -1264,6 +1264,9 @@ fn settings_snapshot_for_gallery() -> SettingsSnapshot {
         max_cron_sleep: config("30s"),
         allow_control: default("false"),
         style_level: config("full"),
+        // The document declares it, so the file and the resolved value
+        // agree -- see `SettingsSnapshot::style_level_in_file`.
+        style_level_in_file: Some("full".to_string()),
         dogs: vec![
             DogView {
                 name: "bark".to_string(),

--- a/crates/shep-cli/src/lookout/frames.rs
+++ b/crates/shep-cli/src/lookout/frames.rs
@@ -203,6 +203,9 @@ pub enum Scene {
     /// The settings screen's dogs table, showing the drift it exists to
     /// make visible.
     SettingsDogs,
+    /// The settings screen on a narrow terminal, where both of its tables
+    /// have dropped a column.
+    SettingsNarrow,
 }
 
 impl Scene {
@@ -238,6 +241,7 @@ impl Scene {
         Self::SettingsConfirm,
         Self::SettingsTyping,
         Self::SettingsDogs,
+        Self::SettingsNarrow,
     ];
 
     /// The snapshot name and the gallery heading.
@@ -274,11 +278,12 @@ impl Scene {
             Self::SettingsConfirm => "settings_confirm",
             Self::SettingsTyping => "settings_typing",
             Self::SettingsDogs => "settings_dogs",
+            Self::SettingsNarrow => "settings_narrow",
         }
     }
 
     /// One sentence saying what this frame is for, printed above it in the
-    /// gallery so the maintainer does not have to hold thirty of them in her head.
+    /// gallery so the maintainer does not have to hold thirty-one of them in her head.
     ///
     /// Every clause here is pinned by an assertion in
     /// `every_scene_shows_the_thing_it_is_named_for` — a caption may not say
@@ -376,6 +381,9 @@ impl Scene {
             Self::SettingsDogs => {
                 "The dogs table showing the drift it exists to reveal: otel running while disabled in the file, ledger enabled and absent, and bark enabled, running, and silent."
             }
+            Self::SettingsNarrow => {
+                "The same screen at 45 columns. Both of its tables have dropped a column rather than clipping: the scalar rows have lost the apply cost and kept SOURCE, and the dogs table has lost SOURCE and kept RUNNING. Each keeps whichever half is not said anywhere else."
+            }
         }
     }
 
@@ -429,6 +437,12 @@ impl Scene {
             // scene's width. A narrower frame would truncate the very flag
             // this scene exists to show.
             Self::SettingsConfirm => (180, 30),
+            // 45: `SCALAR_TIERS`'s middle tier, and `DOG_TIERS`'s. Wide
+            // enough that both tables still draw a real row, narrow enough
+            // that both have given a column up -- which is the one thing
+            // this frame is here to show, and the axis every other settings
+            // frame (120 and 180) misses.
+            Self::SettingsNarrow => (45, 24),
             // HealthyWide, Errored, Grouped, Retrying, Frozen, Refused, FeedGap,
             // FeedMissing, HostUnknown, Lambs, LambsUnknown: every scene that
             // carries all three optional panes at their ordinary rows.
@@ -603,7 +617,7 @@ fn scene_with(which: Scene, age: Duration) -> Buffer {
         // `dog_rows`'s own join sees: `otel` up and healthy, `bark` up but
         // never handshook. `ledger` (armed enabled in the snapshot below)
         // has no row here at all, which is what "enabled and absent" means.
-        Scene::SettingsDogs => vec![
+        Scene::SettingsDogs | Scene::SettingsNarrow => vec![
             dog_sheep(90, "otel", None),
             dog_sheep(91, "bark", Some(false)),
         ],
@@ -693,10 +707,10 @@ fn scene_with(which: Scene, age: Duration) -> Buffer {
     // moving the cursor in them would change a snapshot for no reason.
     // `Grouped` is excluded for a fifth reason: its cursor belongs on the
     // group header, which is the whole scene, and it goes there below.
-    // `SettingsDogs` is excluded for a sixth: its flock has no id 2 at all
-    // -- the dashboard behind it is invisible once the settings screen
-    // draws over the whole body, so there is nothing for a cursor there to
-    // do.
+    // `SettingsDogs` and `SettingsNarrow` are excluded for a sixth: their
+    // flock has no id 2 at all -- the dashboard behind them is invisible
+    // once the settings screen draws over the whole body, so there is
+    // nothing for a cursor there to do.
     if !matches!(
         which,
         Scene::Empty
@@ -705,6 +719,7 @@ fn scene_with(which: Scene, age: Duration) -> Buffer {
             | Scene::TableOnly
             | Scene::Grouped
             | Scene::SettingsDogs
+            | Scene::SettingsNarrow
     ) {
         select_id(&mut app, 2);
     }
@@ -966,7 +981,7 @@ fn scene_with(which: Scene, age: Duration) -> Buffer {
                 app.update(Msg::Key(KeyPress::TextBackspace));
             }
         }
-        Scene::SettingsDogs => {
+        Scene::SettingsDogs | Scene::SettingsNarrow => {
             app.update(Msg::Key(KeyPress::Settings));
             app.update(Msg::Settings {
                 result: Ok(settings_snapshot_with_dog_drift()),
@@ -1325,7 +1340,7 @@ These are real frames, rendered headlessly through ratatui's TestBackend by
 
 Nothing here is a mockup.
 
-frames.ansi is the same thirty frames with colour; read it with `less -R`.
+frames.ansi is the same thirty-one frames with colour; read it with `less -R`.
 
 All four panes are here: the flock table (the spine), the host-usage strip,
 the sheep detail pane and the bleats feed. `>` marks the selected sheep, and
@@ -1342,11 +1357,11 @@ it read and dropped are counted exactly; bytes below its 64 KiB window were
 never read at all, so those are reported in bytes, because nothing counted the
 lines in them and guessing would be worse than saying so.
 
-The last five frames are the settings screen, `s` from the dashboard. It owns
+The last six frames are the settings screen, `s` from the dashboard. It owns
 the whole body between the title and the status bar rather than sharing it
 with the flock table, so a fresh $SHEP_HOME, some scalars declared, an armed
-confirm, the socket editor mid-type and the dogs table's own drift each get a
-frame of their own.
+confirm, the socket editor mid-type, the dogs table's own drift and the same
+screen at 45 columns each get a frame of their own.
 ";
 
 #[cfg(test)]
@@ -1466,7 +1481,7 @@ mod tests {
     /// in this module runs on both platforms, and the dashboard itself was
     /// exercised against a live Windows flock.
     #[cfg(unix)]
-    #[allow(clippy::too_many_lines)] // thirty captions, each pinned clause by clause
+    #[allow(clippy::too_many_lines)] // thirty-one captions, each pinned clause by clause
     fn every_scene_shows_the_thing_it_is_named_for() {
         // "All three panes at 120x30: the host strip under the title, the
         //  detail pane and the bleats feed under the table. `>` marks the
@@ -1996,6 +2011,26 @@ mod tests {
                 .is_some_and(|row| row.contains("yes") && row.contains("silent")),
             "bark: enabled, running, never handshook: {dogs:?}"
         );
+
+        // "The same screen at 45 columns. Both of its tables have dropped a
+        //  column rather than clipping: the scalar rows have lost the apply
+        //  cost and kept SOURCE, and the dogs table has lost SOURCE and
+        //  kept RUNNING. Each keeps whichever half is not said anywhere
+        //  else."
+        let narrow = render_text(&scene(Scene::SettingsNarrow).1);
+        assert!(
+            narrow.contains("shep.toml"),
+            "the scalar rows keep SOURCE: {narrow:?}"
+        );
+        assert!(
+            !narrow.contains("needs shep daemon reload"),
+            "and lose the apply cost: {narrow:?}"
+        );
+        assert!(
+            dog_row_for(&narrow, "otel").is_some_and(|row| row.contains("online")),
+            "the dogs table keeps RUNNING: {narrow:?}"
+        );
+        assert!(!narrow.contains("built-in"), "and loses SOURCE: {narrow:?}");
     }
 
     /// fails if the gallery's cursor walk budgets by SHEEP rather than by
@@ -2064,7 +2099,7 @@ mod tests {
         // above already guarantees it, so it would be a line that cannot
         // fail. The literal can — it is what catches a scene added to the
         // enum and not to `ALL`, or the reverse.
-        assert_eq!(Scene::ALL.len(), 30);
+        assert_eq!(Scene::ALL.len(), 31);
     }
 
     /// fails if a 12b pane introduced a text MODIFIER. `sgr` renders

--- a/crates/shep-cli/src/lookout/frames.rs
+++ b/crates/shep-cli/src/lookout/frames.rs
@@ -658,10 +658,10 @@ fn scene_with(which: Scene, age: Duration) -> Buffer {
                 "web"
             };
             for typed in query.chars() {
-                app.update(Msg::Key(KeyPress::FilterChar(typed)));
+                app.update(Msg::Key(KeyPress::TextChar(typed)));
             }
             if which == Scene::FilterActive {
-                app.update(Msg::Key(KeyPress::FilterApply));
+                app.update(Msg::Key(KeyPress::TextApply));
             }
         }
         _ => {}

--- a/crates/shep-cli/src/lookout/input.rs
+++ b/crates/shep-cli/src/lookout/input.rs
@@ -43,11 +43,11 @@ pub fn map_key(event: &Event, mode: InputMode) -> Option<KeyPress> {
             // type half the sheep names in a flock. ALT is, because an
             // `Alt-w` is a command somewhere and never a letter here.
             KeyCode::Char(typed) if !key.modifiers.contains(KeyModifiers::ALT) => {
-                Some(KeyPress::FilterChar(typed))
+                Some(KeyPress::TextChar(typed))
             }
-            KeyCode::Backspace => Some(KeyPress::FilterBackspace),
-            KeyCode::Enter => Some(KeyPress::FilterApply),
-            KeyCode::Esc => Some(KeyPress::FilterAbandon),
+            KeyCode::Backspace => Some(KeyPress::TextBackspace),
+            KeyCode::Enter => Some(KeyPress::TextApply),
+            KeyCode::Esc => Some(KeyPress::TextAbandon),
             _ => None,
         };
     }
@@ -217,7 +217,7 @@ mod tests {
     fn typing_q_while_editing_types_a_letter() {
         assert_eq!(
             map_key(&key(KeyCode::Char('q')), InputMode::Text),
-            Some(KeyPress::FilterChar('q'))
+            Some(KeyPress::TextChar('q'))
         );
         assert_eq!(
             map_key(&key(KeyCode::Char('q')), InputMode::Normal),
@@ -233,15 +233,15 @@ mod tests {
     fn the_text_mode_binds_exactly_the_box_s_keys() {
         assert_eq!(
             map_key(&key(KeyCode::Backspace), InputMode::Text),
-            Some(KeyPress::FilterBackspace)
+            Some(KeyPress::TextBackspace)
         );
         assert_eq!(
             map_key(&key(KeyCode::Enter), InputMode::Text),
-            Some(KeyPress::FilterApply)
+            Some(KeyPress::TextApply)
         );
         assert_eq!(
             map_key(&key(KeyCode::Esc), InputMode::Text),
-            Some(KeyPress::FilterAbandon)
+            Some(KeyPress::TextAbandon)
         );
         let ctrl_c = Event::Key(KeyEvent::new(KeyCode::Char('c'), KeyModifiers::CONTROL));
         assert_eq!(map_key(&ctrl_c, InputMode::Text), Some(KeyPress::Quit));
@@ -256,7 +256,7 @@ mod tests {
         let shifted = Event::Key(KeyEvent::new(KeyCode::Char('W'), KeyModifiers::SHIFT));
         assert_eq!(
             map_key(&shifted, InputMode::Text),
-            Some(KeyPress::FilterChar('W'))
+            Some(KeyPress::TextChar('W'))
         );
     }
 

--- a/crates/shep-cli/src/lookout/input.rs
+++ b/crates/shep-cli/src/lookout/input.rs
@@ -63,6 +63,8 @@ pub fn map_key(event: &Event, mode: InputMode) -> Option<KeyPress> {
         KeyCode::Char('x') => Some(KeyPress::Action(ActionVerb::Stop)),
         KeyCode::Char('R') => Some(KeyPress::Action(ActionVerb::Restart)),
         KeyCode::Char('L') => Some(KeyPress::Action(ActionVerb::Reload)),
+        KeyCode::Char('s') => Some(KeyPress::Settings),
+        KeyCode::Char(' ') => Some(KeyPress::Cycle),
         KeyCode::Enter => Some(KeyPress::Confirm),
         _ => None,
     }
@@ -134,6 +136,14 @@ mod tests {
         assert_eq!(
             map_key(&key(KeyCode::Char('L')), InputMode::Normal),
             Some(KeyPress::Action(ActionVerb::Reload))
+        );
+        assert_eq!(
+            map_key(&key(KeyCode::Char('s')), InputMode::Normal),
+            Some(KeyPress::Settings)
+        );
+        assert_eq!(
+            map_key(&key(KeyCode::Char(' ')), InputMode::Normal),
+            Some(KeyPress::Cycle)
         );
         assert_eq!(map_key(&key(KeyCode::Char('z')), InputMode::Normal), None);
     }

--- a/crates/shep-cli/src/lookout/mod.rs
+++ b/crates/shep-cli/src/lookout/mod.rs
@@ -560,6 +560,30 @@ where
                 let _ = app.update(Msg::Settings { result });
                 dirty = true;
             }
+            // The one arm that writes `shep.toml`, and off this task on
+            // purpose: `commands::settings::apply_setting` takes
+            // `ShepToml::try_edit`'s own lock, which blocks with no
+            // deadline. A concurrent `shep adopt` holding it would freeze
+            // this task's redraw, its tick and its bus drain right along
+            // with the write if this ran inline.
+            Effect::WriteSetting(edit) => {
+                let path = daemon_config.clone();
+                let for_msg = edit.clone();
+                let result = tokio::task::spawn_blocking(move || {
+                    crate::commands::settings::apply_setting(&path, &edit)
+                })
+                .await
+                .map_err(|err| err.to_string())
+                .and_then(|inner| inner.map_err(|err| err.to_string()));
+                // `let _`: `Msg::SettingWritten` returns `Effect::None`
+                // unconditionally, the same reason `Msg::Settings`'s own
+                // call site above gives.
+                let _ = app.update(Msg::SettingWritten {
+                    edit: for_msg,
+                    result,
+                });
+                dirty = true;
+            }
             Effect::None => dirty = true,
         }
     }

--- a/crates/shep-cli/src/lookout/mod.rs
+++ b/crates/shep-cli/src/lookout/mod.rs
@@ -566,7 +566,11 @@ where
             // deadline. A concurrent `shep adopt` holding it would freeze
             // this task's redraw, its tick and its bus drain right along
             // with the write if this ran inline.
-            Effect::WriteSetting(edit) => {
+            // The `WriteAuthority` is deliberately dropped here: it is a
+            // proof carried by the effect, not a value this arm reads. Its
+            // job was done in `App::confirm_setting`, which could not have
+            // built this variant without it.
+            Effect::WriteSetting(edit, _authority) => {
                 let path = daemon_config.clone();
                 let for_msg = edit.clone();
                 let result = tokio::task::spawn_blocking(move || {
@@ -589,7 +593,9 @@ where
             // gives: `dogs::enable_in_config`/`dogs::disable_in_config`
             // both take `ShepToml::edit`'s (or `try_edit`'s) lock, which
             // blocks with no deadline.
-            Effect::WriteDog(edit) => {
+            // `_authority`: the same proof, dropped for the same reason
+            // `Effect::WriteSetting`'s own arm gives.
+            Effect::WriteDog(edit, _authority) => {
                 let path = daemon_config.clone();
                 let for_msg = edit.clone();
                 let result = tokio::task::spawn_blocking(move || {

--- a/crates/shep-cli/src/lookout/mod.rs
+++ b/crates/shep-cli/src/lookout/mod.rs
@@ -68,6 +68,7 @@ use self::theme::Palette;
 use crate::cli::LookoutArgs;
 use crate::exit::ExitCode;
 use crate::output::Streams;
+use crate::style::{StyleLevel, StyleSource};
 
 /// How often the uptime column is re-derived.
 ///
@@ -102,7 +103,18 @@ pub const MIN_REDRAW: Duration = Duration::from_millis(33);
 ///
 /// After that it does not exit on its own at all: the ladder and the freeze
 /// take over, and the operator quits.
-pub async fn lookout(streams: &mut Streams<'_>, paths: &ShepPaths, args: &LookoutArgs) -> ExitCode {
+///
+/// `style` is `run_argv`'s own already-resolved `(StyleLevel, StyleSource)`
+/// pair, the same one every other verb's rendering already uses. Handed
+/// straight to `App::set_style` below, so the settings screen's own STYLE
+/// LEVEL row reports the layer that actually won rather than resolving a
+/// second, possibly disagreeing answer of its own.
+pub async fn lookout(
+    streams: &mut Streams<'_>,
+    paths: &ShepPaths,
+    args: &LookoutArgs,
+    style: (StyleLevel, StyleSource),
+) -> ExitCode {
     // A TUI piped into a file is a usage error, not a rendering mode: the
     // alternative is writing alternate-screen escapes into somebody's log.
     // This is also what makes the refusal testable — `assert_cmd` captures
@@ -152,12 +164,13 @@ pub async fn lookout(streams: &mut Streams<'_>, paths: &ShepPaths, args: &Lookou
         std::env::var_os("COLORTERM").as_deref(),
     );
     let control = resolve_control(args.allow_control, &paths.kv);
-    let app = App::new(
+    let mut app = App::new(
         palette,
         control,
         paths.home.to_string_lossy().into_owned(),
         Instant::now(),
     );
+    app.set_style(style);
 
     // Hook first, then the guard, then raw mode, then the alternate screen —
     // nothing that can panic in between. See `term`'s own module doc.
@@ -522,26 +535,20 @@ where
             // rather than as an oversight: `spawn_blocking` even though the
             // read takes no lock, because "no file I/O on the redraw task"
             // is cheaper to hold as a rule than to re-judge at every call
-            // site. The style resolution the settings screen's own STYLE
-            // LEVEL row needs lives inside the same closure for the same
-            // reason -- reading `shep.toml` a second time out here, just to
-            // decide the layer, would be exactly the I/O this arm exists to
-            // avoid.
+            // site.
             //
-            // The flag layer is not resolved here: `shep lookout` carries no
-            // `--style` of its own today (`LookoutArgs` has no such field),
-            // so `crate::style::resolve`'s `flag` argument is `None` rather
-            // than a shortcut -- there is genuinely nothing to read.
+            // The style passed in is `app.style()`, not a fresh resolution:
+            // `run_argv` already resolved `--style`/`$SHEP_STYLE`/
+            // `shep.toml`'s `[style] level` once, before this loop started,
+            // and handed the result to `App::set_style`. Reading it back
+            // here rather than resolving again is what keeps the settings
+            // screen's own STYLE LEVEL row agreeing with the rest of the
+            // CLI about which layer won, flag included.
             Effect::LoadSettings => {
                 let path = daemon_config.clone();
                 let socket_default = socket_default.clone();
+                let style = app.style();
                 let result = tokio::task::spawn_blocking(move || {
-                    let config_text = std::fs::read_to_string(&path).ok();
-                    let style = crate::style::resolve(
-                        None,
-                        std::env::var("SHEP_STYLE").ok().as_deref(),
-                        crate::style_from_config(config_text.as_deref()),
-                    );
                     crate::commands::settings::load_settings(&path, &socket_default, style)
                 })
                 .await

--- a/crates/shep-cli/src/lookout/mod.rs
+++ b/crates/shep-cli/src/lookout/mod.rs
@@ -52,6 +52,8 @@ use std::io::IsTerminal;
 use std::path::Path;
 use std::time::{Duration, Instant};
 
+use futures_util::future::BoxFuture;
+use futures_util::stream::FuturesUnordered;
 use futures_util::{Stream, StreamExt};
 use ratatui::Terminal;
 use ratatui::backend::{Backend, CrosstermBackend};
@@ -270,7 +272,7 @@ pub fn resolve_control(flag: bool, kv: &Path) -> Control {
 /// thing with a `TestBackend` and a finite `Stream` — no terminal, no socket.
 /// Returns the terminal so that test can read the last frame.
 ///
-/// Four arms, `biased` in this order:
+/// Five arms, `biased` in this order:
 ///
 /// 1. **`SIGTERM`.** In raw mode Ctrl-C is a key event, not a signal, so this
 ///    arm is not about the operator — it is a session teardown or a `kill`.
@@ -279,7 +281,12 @@ pub fn resolve_control(flag: bool, kv: &Path) -> Control {
 /// 2. **The keyboard**, for latency: a keypress that waited behind a burst of
 ///    bus events feels like a hung program.
 /// 3. **The link's messages.**
-/// 4. **The heartbeat**, which advances the uptime column and nothing else.
+/// 4. **The settings screen's finished file I/O**, each one a
+///    `spawn_blocking` this loop itself asked for. Above the heartbeat
+///    because a result the operator is waiting on beats a clock tick, and
+///    below the keyboard because `q` must still land while one is in
+///    flight.
+/// 5. **The heartbeat**, which advances the uptime column and nothing else.
 ///
 /// **`biased` makes an exhausted arm a hazard, not a detail.** A `Stream` that
 /// has ended returns `Poll::Ready(None)` immediately and forever, and an `mpsc`
@@ -290,7 +297,12 @@ pub fn resolve_control(flag: bool, kv: &Path) -> Control {
 /// heartbeat never got polled, and a key source that ended would spin this loop
 /// at full tilt forever. So arms 2 and 3 each carry a **branch precondition**
 /// (`, if !keys_done` / `, if !link_done`) that takes them out of the running
-/// for good once their source is done. Arm 4 is unconditional, so the `select!`
+/// for good once their source is done. Arm 4 needs the same guard for a
+/// different reason: an EMPTY `FuturesUnordered` is `Ready(None)` on every
+/// poll, exactly like an ended stream, so `, if !inflight.is_empty()` takes
+/// it out of the running, but only until the next effect pushes into it.
+/// That is why arm 4's condition is live rather than a `done` flag set
+/// once. Arm 5 is unconditional, so the `select!`
 /// always has an enabled branch. Arm 1 needs the same idea in its other form —
 /// `std::future::pending()` — because a missing signal handler is not a
 /// condition that changes.
@@ -298,8 +310,9 @@ pub fn resolve_control(flag: bool, kv: &Path) -> Control {
 /// The redraw is not an arm: it happens after the `select!`, gated on `dirty`
 /// and on [`MIN_REDRAW`] having elapsed.
 ///
-/// **This phase adds no arm to the `select!` above.** The host sample rides
-/// arm 4, the heartbeat: sampling memory and a load average costs
+/// **The settings screen adds arm 4, and it is the only arm this loop has
+/// gained since.** The host sample rides
+/// the heartbeat arm instead: sampling memory and a load average costs
 /// microseconds and no process-table walk, so it rides along for free rather
 /// than re-deriving the arm-retirement reasoning this doc just walked
 /// through. The feed and the lambs both ride the redraw gate below instead of
@@ -356,6 +369,32 @@ where
     // arm, for the reason this function's doc gives about the `biased`
     // select's arm retirement.
     let mut lambs_dirty = false;
+    // The settings screen's file I/O, in flight. Each entry is one
+    // `spawn_blocking` this loop asked for, wrapped so that it resolves to
+    // the `Msg` its result belongs in and nothing else: the arm that drains
+    // this set applies whatever comes out, exactly as it applies a key or a
+    // link message, and never has to remember which effect started it.
+    //
+    // A SET rather than a single slot, because more than one write really
+    // can be in flight once they stop being awaited inline: `cycle_scalar`
+    // and `cycle_dog` overwrite `Settings::pending` unconditionally, so
+    // `space` during a `Pending::Sent` re-arms, and the `Enter` after it
+    // yields a second `Effect::WriteSetting` while the first is still
+    // running. `apply_setting` takes the config lock, so two writes queue
+    // behind each other on disk rather than interleaving, and each lands as
+    // its own `Msg`. `Effect::LoadSettings` shares the set rather than
+    // owning one of its own: it is the same "off this task, back as a
+    // `Msg`" shape, it takes no lock, and a load raised while a write is in
+    // flight is the ordinary case rather than a conflict (the `Ok` arm of
+    // `Msg::SettingWritten` raises exactly that).
+    //
+    // If the loop breaks with entries still here, the set is dropped and
+    // their `JoinHandle`s with it. A `spawn_blocking` task is not cancelled
+    // by dropping its handle: it runs to completion, and the runtime's own
+    // shutdown waits for it. So nothing is half-written, `ShepToml::save`
+    // stages and renames either way, and the only thing lost is the notice
+    // the reducer would have shown on a screen that is already gone.
+    let mut inflight: FuturesUnordered<BoxFuture<'static, Msg>> = FuturesUnordered::new();
     // `Option`, not `Instant::now() - MIN_REDRAW`: subtracting from a fresh
     // `Instant` is a panic on a platform whose monotonic clock starts near
     // zero, and "has never drawn" is what the first iteration actually means.
@@ -459,9 +498,15 @@ where
                     None
                 }
             },
+            // `FuturesUnordered::next` is cancel-safe: the futures live in
+            // the set, not in the future this arm polls, so losing a
+            // `select!` race loses no progress. The branch precondition is
+            // not optional -- see this function's doc for what an empty set
+            // does to a `biased` select.
+            done = inflight.next(), if !inflight.is_empty() => done,
             _ = heartbeat.tick() => {
-                // The host sample rides this arm rather than adding a fifth
-                // one. The `biased` select's arm-retirement reasoning is the
+                // The host sample rides this arm rather than adding one of
+                // its own. The `biased` select's arm-retirement reasoning is the
                 // subtlest thing in this module and this phase deliberately
                 // does not re-derive it; sampling memory and a load average
                 // is microseconds and no process-table walk.
@@ -531,11 +576,12 @@ where
                 }
                 dirty = true;
             }
-            // The one arm that does file I/O off this task on purpose,
-            // rather than as an oversight: `spawn_blocking` even though the
-            // read takes no lock, because "no file I/O on the redraw task"
-            // is cheaper to hold as a rule than to re-judge at every call
-            // site.
+            // The read arm, off this task on purpose rather than as an
+            // oversight: `spawn_blocking` even though the read takes no
+            // lock, because "no file I/O on the redraw task" is cheaper to
+            // hold as a rule than to re-judge at every call site. Pushed
+            // into `inflight` rather than awaited here, for the reason
+            // `Effect::WriteSetting`'s own arm spells out.
             //
             // The style passed in is `app.style()`, not a fresh resolution:
             // `run_argv` already resolved `--style`/`$SHEP_STYLE`/
@@ -548,16 +594,19 @@ where
                 let path = daemon_config.clone();
                 let socket_default = socket_default.clone();
                 let style = app.style();
-                let result = tokio::task::spawn_blocking(move || {
+                let handle = tokio::task::spawn_blocking(move || {
                     crate::commands::settings::load_settings(&path, &socket_default, style)
-                })
-                .await
-                .map_err(|err| err.to_string())
-                .and_then(|inner| inner.map_err(|err| err.to_string()));
-                // `let _`: `Msg::Settings` returns `Effect::None`
-                // unconditionally, the same reason `Msg::Bleats`'s call site
-                // above gives.
-                let _ = app.update(Msg::Settings { result });
+                });
+                // Pushed, not awaited. The `Msg` is built inside the wrapper
+                // so the arm that drains `inflight` stays one line; the
+                // reducer sees exactly what it saw when this was inline.
+                inflight.push(Box::pin(async move {
+                    let result = handle
+                        .await
+                        .map_err(|err| err.to_string())
+                        .and_then(|inner| inner.map_err(|err| err.to_string()));
+                    Msg::Settings { result }
+                }));
                 dirty = true;
             }
             // The one arm that writes `shep.toml`, and off this task on
@@ -565,7 +614,13 @@ where
             // `ShepToml::try_edit`'s own lock, which blocks with no
             // deadline. A concurrent `shep adopt` holding it would freeze
             // this task's redraw, its tick and its bus drain right along
-            // with the write if this ran inline.
+            // with the write if this loop waited for it here. It does not:
+            // the handle goes into `inflight` and the loop is back in the
+            // `select!` before the write has taken the lock. `spawn_blocking`
+            // alone would not have bought that -- it moves the blocking off a
+            // runtime worker, and awaiting the handle in this arm would have
+            // frozen the screen for exactly as long as awaiting the write
+            // itself.
             // The `WriteAuthority` is deliberately dropped here: it is a
             // proof carried by the effect, not a value this arm reads. Its
             // job was done in `App::confirm_setting`, which could not have
@@ -573,32 +628,33 @@ where
             Effect::WriteSetting(edit, _authority) => {
                 let path = daemon_config.clone();
                 let for_msg = edit.clone();
-                let result = tokio::task::spawn_blocking(move || {
+                let handle = tokio::task::spawn_blocking(move || {
                     crate::commands::settings::apply_setting(&path, &edit)
-                })
-                .await
-                .map_err(|err| err.to_string())
-                .and_then(|inner| inner.map_err(|err| err.to_string()));
-                // `let _`: `Msg::SettingWritten` returns `Effect::None`
-                // unconditionally, the same reason `Msg::Settings`'s own
-                // call site above gives.
-                let _ = app.update(Msg::SettingWritten {
-                    edit: for_msg,
-                    result,
                 });
+                inflight.push(Box::pin(async move {
+                    let result = handle
+                        .await
+                        .map_err(|err| err.to_string())
+                        .and_then(|inner| inner.map_err(|err| err.to_string()));
+                    Msg::SettingWritten {
+                        edit: for_msg,
+                        result,
+                    }
+                }));
                 dirty = true;
             }
             // The one arm that writes `shep.toml`'s `enabled_dogs`, off this
-            // task for the same reason `Effect::WriteSetting`'s own arm
-            // gives: `dogs::enable_in_config`/`dogs::disable_in_config`
+            // task and out of this loop's way for the same reason
+            // `Effect::WriteSetting`'s own arm gives:
+            // `dogs::enable_in_config`/`dogs::disable_in_config`
             // both take `ShepToml::edit`'s (or `try_edit`'s) lock, which
-            // blocks with no deadline.
+            // blocks with no deadline, and this arm does not wait for it.
             // `_authority`: the same proof, dropped for the same reason
             // `Effect::WriteSetting`'s own arm gives.
             Effect::WriteDog(edit, _authority) => {
                 let path = daemon_config.clone();
                 let for_msg = edit.clone();
-                let result = tokio::task::spawn_blocking(move || {
+                let handle = tokio::task::spawn_blocking(move || {
                     if edit.enable {
                         crate::commands::dogs::enable_in_config(&path, &edit.name)
                             .map_err(|err| enable_refusal_message(&err, &edit.name))
@@ -606,20 +662,23 @@ where
                         crate::commands::dogs::disable_in_config(&path, &edit.name)
                             .map_err(|err| err.to_string())
                     }
-                })
-                .await
-                .map_err(|err| err.to_string())
-                .and_then(|inner| inner);
-                // `let _`: `Msg::DogWritten` returns either `Effect::Send`
-                // or `Effect::None` -- never something this loop has to act
-                // on inline, the same reason `Msg::SettingWritten`'s own
-                // call site above gives for its own `Effect::None`. A
-                // `Send` reaches the next iteration through `msgs` exactly
-                // as an ordinary key's `Effect::Send` would.
-                let _ = app.update(Msg::DogWritten {
-                    edit: for_msg,
-                    result,
                 });
+                // `Msg::DogWritten` answers with `Effect::Send` on the `Ok`
+                // arm, and it reaches this loop through `inflight` like any
+                // other message: the effect is applied by the `match` below
+                // on the iteration that drains it, so the daemon half of a
+                // dog toggle goes out exactly as an ordinary key's
+                // `Effect::Send` does.
+                inflight.push(Box::pin(async move {
+                    let result = handle
+                        .await
+                        .map_err(|err| err.to_string())
+                        .and_then(|inner| inner);
+                    Msg::DogWritten {
+                        edit: for_msg,
+                        result,
+                    }
+                }));
                 dirty = true;
             }
             Effect::None => dirty = true,
@@ -1192,5 +1251,123 @@ mod tests {
             request_rx.try_recv().is_err(),
             "no lamb request when the detail pane is not drawn"
         );
+    }
+
+    /// fails if a settings write freezes the loop.
+    ///
+    /// The property, not the mechanism: with a write in flight and unable to
+    /// finish, the loop still processes what comes after it. `spawn_blocking`
+    /// on its own does not buy that -- awaiting the handle in the effect arm
+    /// keeps the UI task parked until the write lands, which is the shape
+    /// this test was written against.
+    ///
+    /// The write is held up by taking `shep.toml`'s own lock first, from a
+    /// second file descriptor. `flock(2)` excludes per open file
+    /// description, not per process, so `ShepToml::try_edit`'s
+    /// `FlockArg::LockExclusive` blocks in the daemon-less way a concurrent
+    /// `shep adopt` would make it block, with no deadline and nothing to
+    /// wake it. `q` after the confirm is what has to keep working.
+    ///
+    /// Unix only: the Windows arm of `ConfigLock` polls a `share_mode(0)`
+    /// open instead, and reaching for it from here would test that
+    /// primitive rather than this loop.
+    ///
+    /// IR-46: bounded, by the same `timeout` every other loop test here
+    /// carries -- a loop that never left would otherwise hang the suite.
+    /// The clock is the real one, unlike every other test in this module:
+    /// a paused clock auto-advances only while the runtime has nothing to
+    /// do, and a blocking thread parked on a lock is something to do, so
+    /// the timeout below would never fire and a regression would hang the
+    /// suite instead of failing it. Nothing here waits on the clock in the
+    /// passing case, so the real one costs milliseconds.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn the_loop_keeps_running_while_a_settings_write_is_stuck() {
+        use nix::fcntl::{Flock, FlockArg};
+
+        let dir = tempfile::tempdir().unwrap();
+        let config = dir.path().join("shep.toml");
+        std::fs::write(&config, "[daemon]\nlog_level = \"info\"\n").unwrap();
+        let socket_default = dir.path().join("run/shep.sock");
+
+        // Held for the whole of `run_ui` below, and released only once it
+        // has returned.
+        let lock_file = std::fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(dir.path().join("shep.toml.lock"))
+            .unwrap();
+        let held = Flock::lock(lock_file, FlockArg::LockExclusive).unwrap();
+
+        let (msg_tx, msg_rx) = mpsc::channel(16);
+        let (poll_tx, _poll_rx) = mpsc::channel(4);
+        let (request_tx, _request_rx) = mpsc::channel(4);
+
+        // The screen is opened by handing the reducer the read it would
+        // otherwise have asked for, so the four messages below arrive in a
+        // fixed order: no `Effect::LoadSettings` has to land first for
+        // `space` to find a row.
+        let snapshot = crate::commands::settings::load_settings(
+            &config,
+            &socket_default,
+            (StyleLevel::Full, StyleSource::Default),
+        )
+        .unwrap();
+        msg_tx
+            .send(Msg::Settings {
+                result: Ok(snapshot),
+            })
+            .await
+            .unwrap();
+        // `space` arms the first row (`[daemon] log_level`), `Enter` sends
+        // it, and `q` is the key that must still be answered.
+        msg_tx.send(Msg::Key(KeyPress::Cycle)).await.unwrap();
+        msg_tx.send(Msg::Key(KeyPress::Confirm)).await.unwrap();
+        msg_tx.send(Msg::Key(KeyPress::Quit)).await.unwrap();
+        drop(msg_tx);
+
+        let app = App::new(
+            Palette::detect(None, None, None),
+            Control::Allowed,
+            dir.path().display().to_string(),
+            Instant::now(),
+        );
+        let terminal = Terminal::new(TestBackend::new(120, 30)).unwrap();
+        let _ = tokio::time::timeout(
+            Duration::from_secs(5),
+            run_ui(
+                app,
+                terminal,
+                stream::empty(),
+                msg_rx,
+                poll_tx,
+                request_tx,
+                config.clone(),
+                socket_default,
+                FakeLocal::default(),
+            ),
+        )
+        .await
+        .expect("the loop answered `q` with a write still in flight");
+
+        // The other half of the same property: the write was not cancelled
+        // by the loop leaving. `spawn_blocking` runs its closure to
+        // completion whatever happens to the handle, so releasing the lock
+        // here lets it land -- on a real quit the runtime's own shutdown is
+        // what waits for it. Polled rather than slept on for a fixed
+        // duration: the wait is another thread taking a lock, which is
+        // microseconds, and the ceiling only exists so a failure reports
+        // rather than hangs.
+        drop(held);
+        let mut written = false;
+        for _ in 0..500 {
+            if std::fs::read_to_string(&config).unwrap().contains("debug") {
+                written = true;
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(2));
+        }
+        assert!(written, "the write that was in flight still landed");
     }
 }

--- a/crates/shep-cli/src/lookout/mod.rs
+++ b/crates/shep-cli/src/lookout/mod.rs
@@ -584,11 +584,64 @@ where
                 });
                 dirty = true;
             }
+            // The one arm that writes `shep.toml`'s `enabled_dogs`, off this
+            // task for the same reason `Effect::WriteSetting`'s own arm
+            // gives: `dogs::enable_in_config`/`dogs::disable_in_config`
+            // both take `ShepToml::edit`'s (or `try_edit`'s) lock, which
+            // blocks with no deadline.
+            Effect::WriteDog(edit) => {
+                let path = daemon_config.clone();
+                let for_msg = edit.clone();
+                let result = tokio::task::spawn_blocking(move || {
+                    if edit.enable {
+                        crate::commands::dogs::enable_in_config(&path, &edit.name)
+                            .map_err(|err| enable_refusal_message(&err, &edit.name))
+                    } else {
+                        crate::commands::dogs::disable_in_config(&path, &edit.name)
+                            .map_err(|err| err.to_string())
+                    }
+                })
+                .await
+                .map_err(|err| err.to_string())
+                .and_then(|inner| inner);
+                // `let _`: `Msg::DogWritten` returns either `Effect::Send`
+                // or `Effect::None` -- never something this loop has to act
+                // on inline, the same reason `Msg::SettingWritten`'s own
+                // call site above gives for its own `Effect::None`. A
+                // `Send` reaches the next iteration through `msgs` exactly
+                // as an ordinary key's `Effect::Send` would.
+                let _ = app.update(Msg::DogWritten {
+                    edit: for_msg,
+                    result,
+                });
+                dirty = true;
+            }
             Effect::None => dirty = true,
         }
     }
 
     terminal
+}
+
+/// Renders [`crate::commands::dogs::EnableRefusal`] for the settings
+/// screen's own notice line.
+///
+/// Not that module's own `fail_enable_unknown_dog`: that function writes
+/// straight to a [`crate::output::Streams`] and picks an [`ExitCode`], and
+/// this call site has neither -- it hands a plain sentence to
+/// [`app::Msg::DogWritten`], which is the shape every notice on this screen
+/// already carries. `name` is this closure's own argument rather than
+/// re-derived from the refusal (`EnableRefusal::UnknownDog` does not carry
+/// it), so the wrong name never lands in a sentence about someone else's
+/// dog.
+fn enable_refusal_message(err: &crate::commands::dogs::EnableRefusal, name: &str) -> String {
+    use crate::commands::dogs::EnableRefusal;
+    match err {
+        EnableRefusal::Config(err) => err.to_string(),
+        EnableRefusal::UnknownDog { .. } => {
+            format!("{name} is not a dog shep knows about")
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/shep-cli/src/lookout/mod.rs
+++ b/crates/shep-cli/src/lookout/mod.rs
@@ -218,6 +218,8 @@ pub async fn lookout(streams: &mut Streams<'_>, paths: &ShepPaths, args: &Lookou
         msg_rx,
         poll_tx,
         request_tx,
+        paths.daemon_config.clone(),
+        paths.socket.clone(),
         source::LocalReader::new(),
     )
     .await;
@@ -294,6 +296,14 @@ pub fn resolve_control(flag: bool, kv: &Path) -> Control {
 /// selections into one read and one `Describe` per [`MIN_REDRAW`] window
 /// rather than one per keypress. See the phase plan's design decisions 3
 /// and 11.
+///
+/// `#[allow(clippy::too_many_arguments)]`: this crosses eight with
+/// `daemon_config`/`socket_default`, the settings screen's own read target.
+/// Bundling every existing test call site's positional args into a struct
+/// to duck the lint would touch all seven of them for a cosmetic reason;
+/// `frames::sheep` already carries the same attribute for the same kind of
+/// tradeoff, at eight.
+#[allow(clippy::too_many_arguments)]
 pub async fn run_ui<B: Backend, S, L>(
     mut app: App,
     mut terminal: Terminal<B>,
@@ -301,6 +311,13 @@ pub async fn run_ui<B: Backend, S, L>(
     mut msgs: mpsc::Receiver<Msg>,
     polls: mpsc::Sender<()>,
     requests: mpsc::Sender<self::app::Sent>,
+    // The settings screen's own read target. Carried as two owned `PathBuf`s
+    // rather than `&ShepPaths`, so a test can hand this loop an arbitrary
+    // pair without constructing a real `ShepPaths` -- and cloned into
+    // `Effect::LoadSettings`'s `spawn_blocking` closure each time the screen
+    // opens, since that closure outlives this function's own stack frame.
+    daemon_config: std::path::PathBuf,
+    socket_default: std::path::PathBuf,
     mut local: L,
 ) -> Terminal<B>
 where
@@ -501,6 +518,41 @@ where
                 }
                 dirty = true;
             }
+            // The one arm that does file I/O off this task on purpose,
+            // rather than as an oversight: `spawn_blocking` even though the
+            // read takes no lock, because "no file I/O on the redraw task"
+            // is cheaper to hold as a rule than to re-judge at every call
+            // site. The style resolution the settings screen's own STYLE
+            // LEVEL row needs lives inside the same closure for the same
+            // reason -- reading `shep.toml` a second time out here, just to
+            // decide the layer, would be exactly the I/O this arm exists to
+            // avoid.
+            //
+            // The flag layer is not resolved here: `shep lookout` carries no
+            // `--style` of its own today (`LookoutArgs` has no such field),
+            // so `crate::style::resolve`'s `flag` argument is `None` rather
+            // than a shortcut -- there is genuinely nothing to read.
+            Effect::LoadSettings => {
+                let path = daemon_config.clone();
+                let socket_default = socket_default.clone();
+                let result = tokio::task::spawn_blocking(move || {
+                    let config_text = std::fs::read_to_string(&path).ok();
+                    let style = crate::style::resolve(
+                        None,
+                        std::env::var("SHEP_STYLE").ok().as_deref(),
+                        crate::style_from_config(config_text.as_deref()),
+                    );
+                    crate::commands::settings::load_settings(&path, &socket_default, style)
+                })
+                .await
+                .map_err(|err| err.to_string())
+                .and_then(|inner| inner.map_err(|err| err.to_string()));
+                // `let _`: `Msg::Settings` returns `Effect::None`
+                // unconditionally, the same reason `Msg::Bleats`'s call site
+                // above gives.
+                let _ = app.update(Msg::Settings { result });
+                dirty = true;
+            }
             Effect::None => dirty = true,
         }
     }
@@ -510,7 +562,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use std::path::Path;
+    use std::path::{Path, PathBuf};
     use std::sync::Arc;
     use std::sync::atomic::{AtomicUsize, Ordering};
 
@@ -583,6 +635,8 @@ mod tests {
                 msg_rx,
                 poll_tx,
                 request_tx,
+                PathBuf::from("/tmp/shep-lookout-tests/shep.toml"),
+                PathBuf::from("/tmp/shep-lookout-tests/run/shep.sock"),
                 FakeLocal::default(),
             ),
         )
@@ -633,6 +687,8 @@ mod tests {
                 msg_rx,
                 poll_tx,
                 request_tx,
+                PathBuf::from("/tmp/shep-lookout-tests/shep.toml"),
+                PathBuf::from("/tmp/shep-lookout-tests/run/shep.sock"),
                 FakeLocal::default(),
             ),
         )
@@ -710,6 +766,8 @@ mod tests {
                 msg_rx,
                 poll_tx,
                 request_tx,
+                PathBuf::from("/tmp/shep-lookout-tests/shep.toml"),
+                PathBuf::from("/tmp/shep-lookout-tests/run/shep.sock"),
                 local,
             ),
         )
@@ -786,6 +844,8 @@ mod tests {
                 msg_rx,
                 poll_tx,
                 request_tx,
+                PathBuf::from("/tmp/shep-lookout-tests/shep.toml"),
+                PathBuf::from("/tmp/shep-lookout-tests/run/shep.sock"),
                 local,
             ),
         )
@@ -891,6 +951,8 @@ mod tests {
                 msg_rx,
                 poll_tx,
                 request_tx,
+                PathBuf::from("/tmp/shep-lookout-tests/shep.toml"),
+                PathBuf::from("/tmp/shep-lookout-tests/run/shep.sock"),
                 local,
             ),
         )
@@ -960,6 +1022,8 @@ mod tests {
                 msg_rx,
                 poll_tx,
                 request_tx,
+                PathBuf::from("/tmp/shep-lookout-tests/shep.toml"),
+                PathBuf::from("/tmp/shep-lookout-tests/run/shep.sock"),
                 local,
             ),
         )
@@ -1026,6 +1090,8 @@ mod tests {
                 msg_rx,
                 poll_tx,
                 request_tx,
+                PathBuf::from("/tmp/shep-lookout-tests/shep.toml"),
+                PathBuf::from("/tmp/shep-lookout-tests/run/shep.sock"),
                 local,
             ),
         )

--- a/crates/shep-cli/src/lookout/snapshots/shep__lookout__frames__tests__empty.snap
+++ b/crates/shep-cli/src/lookout/snapshots/shep__lookout__frames__tests__empty.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/shep-cli/src/lookout/frames.rs
+assertion_line: 1836
 expression: render_text(&buffer)
 ---
 shep lookout   /home/ada/.shep                                                        0 in the flock
@@ -29,4 +30,4 @@ bleats  no sheep is selected
                                                                                                     
                                                                                                     
                                                                                                     
-q quit   j/k select   g/G first/last   r refresh   / filter                                read-only
+q quit   j/k select   g/G first/last   r refresh   / filter   s settings                   read-only

--- a/crates/shep-cli/src/lookout/snapshots/shep__lookout__frames__tests__errored.snap
+++ b/crates/shep-cli/src/lookout/snapshots/shep__lookout__frames__tests__errored.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/shep-cli/src/lookout/frames.rs
+assertion_line: 1836
 expression: render_text(&buffer)
 ---
 shep lookout   /home/ada/.shep                                                                            6 in the flock
@@ -31,4 +32,4 @@ out  GET /v1/orders 200 44ms
 out  POST /v1/orders 201 88ms                                                                                           
 out  GET /v1/orders/8821 200 9ms                                                                                        
 out  connection pool: 14/50 in use                                                                                      
-q quit   j/k select   g/G first/last   r refresh   / filter                                                    read-only
+q quit   j/k select   g/G first/last   r refresh   / filter   s settings                                       read-only

--- a/crates/shep-cli/src/lookout/snapshots/shep__lookout__frames__tests__feed_gap.snap
+++ b/crates/shep-cli/src/lookout/snapshots/shep__lookout__frames__tests__feed_gap.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/shep-cli/src/lookout/frames.rs
+assertion_line: 1836
 expression: render_text(&buffer)
 ---
 shep lookout   /home/ada/.shep                                                                            6 in the flock
@@ -31,4 +32,4 @@ out  GET /v1/orders/26 200 34ms
 out  GET /v1/orders/27 200 35ms                                                                                         
 out  GET /v1/orders/28 200 36ms                                                                                         
 out  GET /v1/orders/29 200 37ms                                                                                         
-q quit   j/k select   g/G first/last   r refresh   / filter                                                    read-only
+q quit   j/k select   g/G first/last   r refresh   / filter   s settings                                       read-only

--- a/crates/shep-cli/src/lookout/snapshots/shep__lookout__frames__tests__feed_missing.snap
+++ b/crates/shep-cli/src/lookout/snapshots/shep__lookout__frames__tests__feed_missing.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/shep-cli/src/lookout/frames.rs
+assertion_line: 1836
 expression: render_text(&buffer)
 ---
 shep lookout   /home/ada/.shep                                                                            6 in the flock
@@ -31,4 +32,4 @@ this sheep has not written a log in this $SHEP_HOME
                                                                                                                         
                                                                                                                         
                                                                                                                         
-q quit   j/k select   g/G first/last   r refresh   / filter                                                    read-only
+q quit   j/k select   g/G first/last   r refresh   / filter   s settings                                       read-only

--- a/crates/shep-cli/src/lookout/snapshots/shep__lookout__frames__tests__frozen.snap
+++ b/crates/shep-cli/src/lookout/snapshots/shep__lookout__frames__tests__frozen.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/shep-cli/src/lookout/frames.rs
+assertion_line: 1836
 expression: render_text(&buffer)
 ---
 shep lookout   /home/ada/.shep                                                                            6 in the flock
@@ -31,4 +32,4 @@ out  GET /v1/orders 200 44ms
 out  POST /v1/orders 201 88ms                                                                                           
 out  GET /v1/orders/8821 200 9ms                                                                                        
 out  connection pool: 14/50 in use                                                                                      
-q quit   j/k select   g/G first/last   r refresh   / filter                                                    read-only
+q quit   j/k select   g/G first/last   r refresh   / filter   s settings                                       read-only

--- a/crates/shep-cli/src/lookout/snapshots/shep__lookout__frames__tests__grouped.snap
+++ b/crates/shep-cli/src/lookout/snapshots/shep__lookout__frames__tests__grouped.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/shep-cli/src/lookout/frames.rs
+assertion_line: 1836
 expression: render_text(&buffer)
 ---
 shep lookout   /home/ada/.shep                                                                            4 in the flock
@@ -31,4 +32,4 @@ bleats  web  follows one instance; select one to see its log
                                                                                                                         
                                                                                                                         
                                                                                                                         
-q quit   j/k select   g/G first/last   r refresh   / filter                                                    read-only
+q quit   j/k select   g/G first/last   r refresh   / filter   s settings                                       read-only

--- a/crates/shep-cli/src/lookout/snapshots/shep__lookout__frames__tests__healthy_wide.snap
+++ b/crates/shep-cli/src/lookout/snapshots/shep__lookout__frames__tests__healthy_wide.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/shep-cli/src/lookout/frames.rs
+assertion_line: 1836
 expression: render_text(&buffer)
 ---
 shep lookout   /home/ada/.shep                                                                            6 in the flock
@@ -31,4 +32,4 @@ out  GET /v1/orders 200 44ms
 out  POST /v1/orders 201 88ms                                                                                           
 out  GET /v1/orders/8821 200 9ms                                                                                        
 out  connection pool: 14/50 in use                                                                                      
-q quit   j/k select   g/G first/last   r refresh   / filter                                                    read-only
+q quit   j/k select   g/G first/last   r refresh   / filter   s settings                                       read-only

--- a/crates/shep-cli/src/lookout/snapshots/shep__lookout__frames__tests__host_unknown.snap
+++ b/crates/shep-cli/src/lookout/snapshots/shep__lookout__frames__tests__host_unknown.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/shep-cli/src/lookout/frames.rs
+assertion_line: 1836
 expression: render_text(&buffer)
 ---
 shep lookout   /home/ada/.shep                                                                            6 in the flock
@@ -31,4 +32,4 @@ out  GET /v1/orders 200 44ms
 out  POST /v1/orders 201 88ms                                                                                           
 out  GET /v1/orders/8821 200 9ms                                                                                        
 out  connection pool: 14/50 in use                                                                                      
-q quit   j/k select   g/G first/last   r refresh   / filter                                                    read-only
+q quit   j/k select   g/G first/last   r refresh   / filter   s settings                                       read-only

--- a/crates/shep-cli/src/lookout/snapshots/shep__lookout__frames__tests__lambs.snap
+++ b/crates/shep-cli/src/lookout/snapshots/shep__lookout__frames__tests__lambs.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/shep-cli/src/lookout/frames.rs
+assertion_line: 1836
 expression: render_text(&buffer)
 ---
 shep lookout   /home/ada/.shep                                                                            6 in the flock
@@ -31,4 +32,4 @@ out  GET /v1/orders 200 44ms
 out  POST /v1/orders 201 88ms                                                                                           
 out  GET /v1/orders/8821 200 9ms                                                                                        
 out  connection pool: 14/50 in use                                                                                      
-q quit   j/k select   / filter   x stop   R restart   L reload                                           control enabled
+q quit   j/k select   / filter   x stop   R restart   L reload   s settings                              control enabled

--- a/crates/shep-cli/src/lookout/snapshots/shep__lookout__frames__tests__lambs_unknown.snap
+++ b/crates/shep-cli/src/lookout/snapshots/shep__lookout__frames__tests__lambs_unknown.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/shep-cli/src/lookout/frames.rs
+assertion_line: 1836
 expression: render_text(&buffer)
 ---
 shep lookout   /home/ada/.shep                                                                            6 in the flock
@@ -31,4 +32,4 @@ out  GET /v1/orders 200 44ms
 out  POST /v1/orders 201 88ms                                                                                           
 out  GET /v1/orders/8821 200 9ms                                                                                        
 out  connection pool: 14/50 in use                                                                                      
-q quit   j/k select   g/G first/last   r refresh   / filter                                                    read-only
+q quit   j/k select   g/G first/last   r refresh   / filter   s settings                                       read-only

--- a/crates/shep-cli/src/lookout/snapshots/shep__lookout__frames__tests__no_detail.snap
+++ b/crates/shep-cli/src/lookout/snapshots/shep__lookout__frames__tests__no_detail.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/shep-cli/src/lookout/frames.rs
+assertion_line: 1836
 expression: render_text(&buffer)
 ---
 shep lookout   /home/ada/.shep                                                                            6 in the flock
@@ -21,4 +22,4 @@ out  GET /v1/orders 200 44ms
 out  POST /v1/orders 201 88ms                                                                                           
 out  GET /v1/orders/8821 200 9ms                                                                                        
 out  connection pool: 14/50 in use                                                                                      
-q quit   j/k select   g/G first/last   r refresh   / filter                                                    read-only
+q quit   j/k select   g/G first/last   r refresh   / filter   s settings                                       read-only

--- a/crates/shep-cli/src/lookout/snapshots/shep__lookout__frames__tests__retrying.snap
+++ b/crates/shep-cli/src/lookout/snapshots/shep__lookout__frames__tests__retrying.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/shep-cli/src/lookout/frames.rs
+assertion_line: 1836
 expression: render_text(&buffer)
 ---
 shep lookout   /home/ada/.shep                                                                            6 in the flock
@@ -31,4 +32,4 @@ out  GET /v1/orders 200 44ms
 out  POST /v1/orders 201 88ms                                                                                           
 out  GET /v1/orders/8821 200 9ms                                                                                        
 out  connection pool: 14/50 in use                                                                                      
-q quit   j/k select   g/G first/last   r refresh   / filter                                                    read-only
+q quit   j/k select   g/G first/last   r refresh   / filter   s settings                                       read-only

--- a/crates/shep-cli/src/lookout/snapshots/shep__lookout__frames__tests__settings_confirm.snap
+++ b/crates/shep-cli/src/lookout/snapshots/shep__lookout__frames__tests__settings_confirm.snap
@@ -1,0 +1,34 @@
+---
+source: crates/shep-cli/src/lookout/frames.rs
+expression: render_text(&buffer)
+---
+shep lookout   /home/ada/.shep                                                                                                                                        6 in the flock
+  [daemon]                                                                                                                                                                          
+> log_level        warn                            shep.toml    needs shep daemon reload                                                                                            
+  log_json         false                           the default  needs shep daemon reload                                                                                            
+  socket           /home/ada/.shep/run/shep.sock   shep.toml    needs the shepherd stopped and started                                                                              
+  max_cron_sleep   30s                             shep.toml    needs shep daemon reload                                                                                            
+                                                                                                                                                                                    
+  [whistle]                                                                                                                                                                         
+  allow_control    false                           the default  needs shep whistle restarted                                                                                        
+                                                                                                                                                                                    
+  [style]                                                                                                                                                                           
+  level            full                            shep.toml    the next command reads it                                                                                           
+                                                                                                                                                                                    
+  [dogs]                                                                                                                                                                            
+  space arms, Enter applies; a dog needs no reload                                                                                                                                  
+  NAME                                                                                                                              IN FILE  SOURCE                    RUNNING      
+  bark                                                                                                                              no       built-in                  not running  
+  metrics                                                                                                                           yes      built-in                  not running  
+                                                                                                                                                                                    
+  set log_level to info? needs shep daemon reload, and will not apply if the shepherd was booted with SHEP_LOG_LEVEL or --log-level  enter confirms, any other key cancels          
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+esc close   j/k select   g/G first/last   space cycle                                                                                                                control enabled

--- a/crates/shep-cli/src/lookout/snapshots/shep__lookout__frames__tests__settings_confirm.snap
+++ b/crates/shep-cli/src/lookout/snapshots/shep__lookout__frames__tests__settings_confirm.snap
@@ -31,4 +31,4 @@ shep lookout   /home/ada/.shep                                                  
                                                                                                                                                                                     
                                                                                                                                                                                     
                                                                                                                                                                                     
-esc close   j/k select   g/G first/last   space cycle                                                                                                                control enabled
+set log_level to info? needs shep daemon reload, and will not apply if the shepherd was booted with SHEP_LOG_LEVEL or --log-level  enter confirms, any other key ca… control enabled

--- a/crates/shep-cli/src/lookout/snapshots/shep__lookout__frames__tests__settings_confirm.snap
+++ b/crates/shep-cli/src/lookout/snapshots/shep__lookout__frames__tests__settings_confirm.snap
@@ -17,9 +17,9 @@ shep lookout   /home/ada/.shep                                                  
                                                                                                                                                                                     
   [dogs]                                                                                                                                                                            
   space arms, Enter applies; a dog needs no reload                                                                                                                                  
-  NAME                                                                                                                              IN FILE  SOURCE                    RUNNING      
-  bark                                                                                                                              no       built-in                  not running  
-  metrics                                                                                                                           yes      built-in                  not running  
+  NAME                                                                                                                            IN FILE  SOURCE                    RUNNING        
+  bark                                                                                                                            no       built-in                  not running    
+  metrics                                                                                                                         yes      built-in                  not running    
                                                                                                                                                                                     
   set log_level to info? needs shep daemon reload, and will not apply if the shepherd was booted with SHEP_LOG_LEVEL or --log-level  enter confirms, any other key cancels          
                                                                                                                                                                                     

--- a/crates/shep-cli/src/lookout/snapshots/shep__lookout__frames__tests__settings_dogs.snap
+++ b/crates/shep-cli/src/lookout/snapshots/shep__lookout__frames__tests__settings_dogs.snap
@@ -31,4 +31,4 @@ shep lookout   /home/ada/.shep                                                  
                                                                                                                         
                                                                                                                         
                                                                                                                         
-esc close   j/k select   g/G first/last   space cycle                                                          read-only
+esc/s close   j/k select   g/G first/last   r refresh                                                          read-only

--- a/crates/shep-cli/src/lookout/snapshots/shep__lookout__frames__tests__settings_dogs.snap
+++ b/crates/shep-cli/src/lookout/snapshots/shep__lookout__frames__tests__settings_dogs.snap
@@ -31,4 +31,4 @@ shep lookout   /home/ada/.shep                                                  
                                                                                                                         
                                                                                                                         
                                                                                                                         
-esc/s close   j/k select   g/G first/last   r refresh                                                          read-only
+esc/s close   j/k select   g/G first/last   r refresh   q quit                                                 read-only

--- a/crates/shep-cli/src/lookout/snapshots/shep__lookout__frames__tests__settings_dogs.snap
+++ b/crates/shep-cli/src/lookout/snapshots/shep__lookout__frames__tests__settings_dogs.snap
@@ -17,10 +17,10 @@ shep lookout   /home/ada/.shep                                                  
                                                                                                                         
   [dogs]                                                                                                                
   space arms, Enter applies; a dog needs no reload                                                                      
-  NAME                                                                  IN FILE  SOURCE                    RUNNING      
-  otel                                                                  no       built-in                  online       
-  ledger                                                                yes      built-in                  not running  
-  bark                                                                  yes      built-in                  silent       
+  NAME                                                                IN FILE  SOURCE                    RUNNING        
+  otel                                                                no       built-in                  online         
+  ledger                                                              yes      built-in                  not running    
+  bark                                                                yes      built-in                  silent         
                                                                                                                         
                                                                                                                         
                                                                                                                         

--- a/crates/shep-cli/src/lookout/snapshots/shep__lookout__frames__tests__settings_dogs.snap
+++ b/crates/shep-cli/src/lookout/snapshots/shep__lookout__frames__tests__settings_dogs.snap
@@ -1,0 +1,34 @@
+---
+source: crates/shep-cli/src/lookout/frames.rs
+expression: render_text(&buffer)
+---
+shep lookout   /home/ada/.shep                                                                            2 in the flock
+  [daemon]                                                                                                              
+> log_level        warn                            shep.toml    needs shep daemon reload                                
+  log_json         false                           the default  needs shep daemon reload                                
+  socket           /home/ada/.shep/run/shep.sock   shep.toml    needs the shepherd stopped and started                  
+  max_cron_sleep   30s                             shep.toml    needs shep daemon reload                                
+                                                                                                                        
+  [whistle]                                                                                                             
+  allow_control    false                           the default  needs shep whistle restarted                            
+                                                                                                                        
+  [style]                                                                                                               
+  level            full                            shep.toml    the next command reads it                               
+                                                                                                                        
+  [dogs]                                                                                                                
+  space arms, Enter applies; a dog needs no reload                                                                      
+  NAME                                                                  IN FILE  SOURCE                    RUNNING      
+  otel                                                                  no       built-in                  online       
+  ledger                                                                yes      built-in                  not running  
+  bark                                                                  yes      built-in                  silent       
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+esc close   j/k select   g/G first/last   space cycle                                                          read-only

--- a/crates/shep-cli/src/lookout/snapshots/shep__lookout__frames__tests__settings_dogs.snap
+++ b/crates/shep-cli/src/lookout/snapshots/shep__lookout__frames__tests__settings_dogs.snap
@@ -18,8 +18,8 @@ shep lookout   /home/ada/.shep                                                  
   [dogs]                                                                                                                
   space arms, Enter applies; a dog needs no reload                                                                      
   NAME                                                                IN FILE  SOURCE                    RUNNING        
-  otel                                                                no       built-in                  online         
-  ledger                                                              yes      built-in                  not running    
+  otel                                                                no       /usr/local/bin/shep-otel  online         
+  ledger                                                              yes      /opt/ledger/bin/dog       not running    
   bark                                                                yes      built-in                  silent         
                                                                                                                         
                                                                                                                         

--- a/crates/shep-cli/src/lookout/snapshots/shep__lookout__frames__tests__settings_fresh.snap
+++ b/crates/shep-cli/src/lookout/snapshots/shep__lookout__frames__tests__settings_fresh.snap
@@ -17,9 +17,9 @@ shep lookout   /home/ada/.shep                                                  
                                                                                                                         
   [dogs]                                                                                                                
   space arms, Enter applies; a dog needs no reload                                                                      
-  NAME                                                                  IN FILE  SOURCE                    RUNNING      
-  bark                                                                  no       built-in                  not running  
-  metrics                                                               no       built-in                  not running  
+  NAME                                                                IN FILE  SOURCE                    RUNNING        
+  bark                                                                no       built-in                  not running    
+  metrics                                                             no       built-in                  not running    
                                                                                                                         
                                                                                                                         
                                                                                                                         

--- a/crates/shep-cli/src/lookout/snapshots/shep__lookout__frames__tests__settings_fresh.snap
+++ b/crates/shep-cli/src/lookout/snapshots/shep__lookout__frames__tests__settings_fresh.snap
@@ -31,4 +31,4 @@ shep lookout   /home/ada/.shep                                                  
                                                                                                                         
                                                                                                                         
                                                                                                                         
-esc close   j/k select   g/G first/last   space cycle                                                          read-only
+esc/s close   j/k select   g/G first/last   r refresh                                                          read-only

--- a/crates/shep-cli/src/lookout/snapshots/shep__lookout__frames__tests__settings_fresh.snap
+++ b/crates/shep-cli/src/lookout/snapshots/shep__lookout__frames__tests__settings_fresh.snap
@@ -31,4 +31,4 @@ shep lookout   /home/ada/.shep                                                  
                                                                                                                         
                                                                                                                         
                                                                                                                         
-esc/s close   j/k select   g/G first/last   r refresh                                                          read-only
+esc/s close   j/k select   g/G first/last   r refresh   q quit                                                 read-only

--- a/crates/shep-cli/src/lookout/snapshots/shep__lookout__frames__tests__settings_fresh.snap
+++ b/crates/shep-cli/src/lookout/snapshots/shep__lookout__frames__tests__settings_fresh.snap
@@ -1,0 +1,34 @@
+---
+source: crates/shep-cli/src/lookout/frames.rs
+expression: render_text(&buffer)
+---
+shep lookout   /home/ada/.shep                                                                            6 in the flock
+  [daemon]                                                                                                              
+> log_level        warn                            the default  needs shep daemon reload                                
+  log_json         false                           the default  needs shep daemon reload                                
+  socket           /home/ada/.shep/run/shep.sock   the default  needs the shepherd stopped and started                  
+  max_cron_sleep   not set                         the default  needs shep daemon reload                                
+                                                                                                                        
+  [whistle]                                                                                                             
+  allow_control    false                           the default  needs shep whistle restarted                            
+                                                                                                                        
+  [style]                                                                                                               
+  level            full                            the default  the next command reads it                               
+                                                                                                                        
+  [dogs]                                                                                                                
+  space arms, Enter applies; a dog needs no reload                                                                      
+  NAME                                                                  IN FILE  SOURCE                    RUNNING      
+  bark                                                                  no       built-in                  not running  
+  metrics                                                               no       built-in                  not running  
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+esc close   j/k select   g/G first/last   space cycle                                                          read-only

--- a/crates/shep-cli/src/lookout/snapshots/shep__lookout__frames__tests__settings_narrow.snap
+++ b/crates/shep-cli/src/lookout/snapshots/shep__lookout__frames__tests__settings_narrow.snap
@@ -1,0 +1,28 @@
+---
+source: crates/shep-cli/src/lookout/frames.rs
+expression: render_text(&buffer)
+---
+shep lookout   /home/ada/.shep 2 in the flock
+  [daemon]                                   
+> log_level        warn           shep.toml  
+  log_json         false          the default
+  socket           /home/ada/.s…  shep.toml  
+  max_cron_sleep   30s            shep.toml  
+                                             
+  [whistle]                                  
+  allow_control    false          the default
+                                             
+  [style]                                    
+  level            full           shep.toml  
+                                             
+  [dogs]                                     
+  space arms, Enter applies; a dog needs no …
+  NAME               IN FILE  RUNNING        
+  otel               no       online         
+  ledger             yes      not running    
+  bark               yes      silent         
+                                             
+                                             
+                                             
+                                             
+esc close   j/k select   g/G first… read-only

--- a/crates/shep-cli/src/lookout/snapshots/shep__lookout__frames__tests__settings_narrow.snap
+++ b/crates/shep-cli/src/lookout/snapshots/shep__lookout__frames__tests__settings_narrow.snap
@@ -25,4 +25,4 @@ shep lookout   /home/ada/.shep 2 in the flock
                                              
                                              
                                              
-esc close   j/k select   g/G first… read-only
+esc/s close   j/k select   g/G fir… read-only

--- a/crates/shep-cli/src/lookout/snapshots/shep__lookout__frames__tests__settings_set.snap
+++ b/crates/shep-cli/src/lookout/snapshots/shep__lookout__frames__tests__settings_set.snap
@@ -31,4 +31,4 @@ shep lookout   /home/ada/.shep                                                  
                                                                                                                         
                                                                                                                         
                                                                                                                         
-esc close   j/k select   g/G first/last   space cycle                                                          read-only
+esc/s close   j/k select   g/G first/last   r refresh                                                          read-only

--- a/crates/shep-cli/src/lookout/snapshots/shep__lookout__frames__tests__settings_set.snap
+++ b/crates/shep-cli/src/lookout/snapshots/shep__lookout__frames__tests__settings_set.snap
@@ -31,4 +31,4 @@ shep lookout   /home/ada/.shep                                                  
                                                                                                                         
                                                                                                                         
                                                                                                                         
-esc/s close   j/k select   g/G first/last   r refresh                                                          read-only
+esc/s close   j/k select   g/G first/last   r refresh   q quit                                                 read-only

--- a/crates/shep-cli/src/lookout/snapshots/shep__lookout__frames__tests__settings_set.snap
+++ b/crates/shep-cli/src/lookout/snapshots/shep__lookout__frames__tests__settings_set.snap
@@ -1,0 +1,34 @@
+---
+source: crates/shep-cli/src/lookout/frames.rs
+expression: render_text(&buffer)
+---
+shep lookout   /home/ada/.shep                                                                            6 in the flock
+  [daemon]                                                                                                              
+> log_level        warn                            shep.toml    needs shep daemon reload                                
+  log_json         false                           the default  needs shep daemon reload                                
+  socket           /home/ada/.shep/run/shep.sock   shep.toml    needs the shepherd stopped and started                  
+  max_cron_sleep   30s                             shep.toml    needs shep daemon reload                                
+                                                                                                                        
+  [whistle]                                                                                                             
+  allow_control    false                           the default  needs shep whistle restarted                            
+                                                                                                                        
+  [style]                                                                                                               
+  level            full                            shep.toml    the next command reads it                               
+                                                                                                                        
+  [dogs]                                                                                                                
+  space arms, Enter applies; a dog needs no reload                                                                      
+  NAME                                                                  IN FILE  SOURCE                    RUNNING      
+  bark                                                                  no       built-in                  not running  
+  metrics                                                               yes      built-in                  not running  
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+esc close   j/k select   g/G first/last   space cycle                                                          read-only

--- a/crates/shep-cli/src/lookout/snapshots/shep__lookout__frames__tests__settings_set.snap
+++ b/crates/shep-cli/src/lookout/snapshots/shep__lookout__frames__tests__settings_set.snap
@@ -17,9 +17,9 @@ shep lookout   /home/ada/.shep                                                  
                                                                                                                         
   [dogs]                                                                                                                
   space arms, Enter applies; a dog needs no reload                                                                      
-  NAME                                                                  IN FILE  SOURCE                    RUNNING      
-  bark                                                                  no       built-in                  not running  
-  metrics                                                               yes      built-in                  not running  
+  NAME                                                                IN FILE  SOURCE                    RUNNING        
+  bark                                                                no       built-in                  not running    
+  metrics                                                             yes      built-in                  not running    
                                                                                                                         
                                                                                                                         
                                                                                                                         

--- a/crates/shep-cli/src/lookout/snapshots/shep__lookout__frames__tests__settings_typing.snap
+++ b/crates/shep-cli/src/lookout/snapshots/shep__lookout__frames__tests__settings_typing.snap
@@ -1,0 +1,34 @@
+---
+source: crates/shep-cli/src/lookout/frames.rs
+expression: render_text(&buffer)
+---
+shep lookout   /home/ada/.shep                                                                            6 in the flock
+  [daemon]                                                                                                              
+  log_level        warn                            shep.toml    needs shep daemon reload                                
+  log_json         false                           the default  needs shep daemon reload                                
+> socket           /home/ada/.shep/run/shep.sock   shep.toml    needs the shepherd stopped and started                  
+  max_cron_sleep   30s                             shep.toml    needs shep daemon reload                                
+                                                                                                                        
+  [whistle]                                                                                                             
+  allow_control    false                           the default  needs shep whistle restarted                            
+                                                                                                                        
+  [style]                                                                                                               
+  level            full                            shep.toml    the next command reads it                               
+                                                                                                                        
+  [dogs]                                                                                                                
+  space arms, Enter applies; a dog needs no reload                                                                      
+  NAME                                                                  IN FILE  SOURCE                    RUNNING      
+  bark                                                                  no       built-in                  not running  
+  metrics                                                               yes      built-in                  not running  
+                                                                                                                        
+  editing socket: /home/ada/.shep/run/s▏   enter applies   esc cancels                                                  
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+editing socket  /home/ada/.shep/run/s▏   enter applies   esc cancels                                     control enabled

--- a/crates/shep-cli/src/lookout/snapshots/shep__lookout__frames__tests__settings_typing.snap
+++ b/crates/shep-cli/src/lookout/snapshots/shep__lookout__frames__tests__settings_typing.snap
@@ -17,9 +17,9 @@ shep lookout   /home/ada/.shep                                                  
                                                                                                                         
   [dogs]                                                                                                                
   space arms, Enter applies; a dog needs no reload                                                                      
-  NAME                                                                  IN FILE  SOURCE                    RUNNING      
-  bark                                                                  no       built-in                  not running  
-  metrics                                                               yes      built-in                  not running  
+  NAME                                                                IN FILE  SOURCE                    RUNNING        
+  bark                                                                no       built-in                  not running    
+  metrics                                                             yes      built-in                  not running    
                                                                                                                         
   editing socket: /home/ada/.shep/run/s▏   enter applies   esc cancels                                                  
                                                                                                                         

--- a/crates/shep-cli/src/lookout/snapshots/shep__lookout__frames__tests__table_only.snap
+++ b/crates/shep-cli/src/lookout/snapshots/shep__lookout__frames__tests__table_only.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/shep-cli/src/lookout/frames.rs
+assertion_line: 1836
 expression: render_text(&buffer)
 ---
 shep lookout   /home/ada/.shep                                                                            6 in the flock
@@ -13,4 +14,4 @@ shep lookout   /home/ada/.shep                                                  
   1     web         online           48212    0         -          2.9%    178.0M    1h 26m    edge        -            
                                                                                                                         
                                                                                                                         
-q quit   j/k select   g/G first/last   r refresh   / filter                                                    read-only
+q quit   j/k select   g/G first/last   r refresh   / filter   s settings                                       read-only

--- a/crates/shep-cli/src/lookout/view/fixtures.rs
+++ b/crates/shep-cli/src/lookout/view/fixtures.rs
@@ -6,7 +6,7 @@ use std::time::Instant;
 
 use ratatui::text::Line;
 use shep_client::RequestError;
-use shep_core::protocol::{BusEvent, Lamb, ProcessInfo, Response};
+use shep_core::protocol::{BusEvent, DogSource, Lamb, ProcessInfo, Response};
 use shep_core::status::ProcStatus;
 
 use super::super::app::{
@@ -484,4 +484,120 @@ pub fn app_in_settings_with_control() -> App {
     let mut app = app_in_settings();
     app.set_control_for_tests(Control::Allowed);
     app
+}
+
+/// [`settings_snapshot`]'s own scalars, with `dogs` replaced -- for the
+/// dogs-table tests, which need particular names, `enabled` bits and (for
+/// the join) a matching or mismatching flock, none of which
+/// [`settings_snapshot`]'s own fixed two cover.
+fn settings_snapshot_with_dogs(dogs: Vec<DogView>) -> SettingsSnapshot {
+    SettingsSnapshot {
+        dogs,
+        ..settings_snapshot()
+    }
+}
+
+/// `otel` runs online while the file disables it -- what "a removed name
+/// keeps running" looks like from the outside. `ledger` is enabled in the
+/// file and absent from the flock -- a dog that failed to start. Exercises
+/// [`super::settings::dog_rows`]'s join, not the toggle.
+pub fn app_in_settings_with_dog_drift() -> App {
+    let flock = vec![
+        ProcessInfo::builder(90, "otel", ProcStatus::Online)
+            .pid(Some(90_000))
+            .dog(Some(DogSource::BuiltIn))
+            .build(),
+    ];
+    let mut app = app_with(flock, plain());
+    app.update(Msg::Key(KeyPress::Settings));
+    app.update(Msg::Settings {
+        result: Ok(settings_snapshot_with_dogs(vec![
+            DogView {
+                name: "otel".to_string(),
+                enabled: false,
+                adopted_path: None,
+            },
+            DogView {
+                name: "ledger".to_string(),
+                enabled: true,
+                adopted_path: None,
+            },
+        ])),
+    });
+    app
+}
+
+/// `bark` is up but has never completed a handshake -- Phase 3b's own
+/// `handshook: Some(false)` -- so [`super::settings::dog_rows`] must read it
+/// `silent`, not `online`, the same correction
+/// [`crate::vocabulary::Reported`] makes for the flock table.
+pub fn app_in_settings_with_silent_dog() -> App {
+    let flock = vec![
+        ProcessInfo::builder(91, "bark", ProcStatus::Online)
+            .pid(Some(91_000))
+            .dog(Some(DogSource::BuiltIn))
+            .handshook(Some(false))
+            .build(),
+    ];
+    let mut app = app_with(flock, plain());
+    app.update(Msg::Key(KeyPress::Settings));
+    app.update(Msg::Settings {
+        result: Ok(settings_snapshot_with_dogs(vec![DogView {
+            name: "bark".to_string(),
+            enabled: true,
+            adopted_path: None,
+        }])),
+    });
+    app
+}
+
+/// Two candidate dogs for the toggle tests: `metrics` disabled, `otel`
+/// enabled -- one of each starting bit, so a test can pick whichever
+/// direction (`enable`/`disable`) it means to arm.
+fn settings_snapshot_for_toggle_tests() -> SettingsSnapshot {
+    settings_snapshot_with_dogs(vec![
+        DogView {
+            name: "metrics".to_string(),
+            enabled: false,
+            adopted_path: None,
+        },
+        DogView {
+            name: "otel".to_string(),
+            enabled: true,
+            adopted_path: None,
+        },
+    ])
+}
+
+/// A dashboard with the settings screen open on
+/// [`settings_snapshot_for_toggle_tests`], the control gate open, and the
+/// cursor moved onto `name`'s dog row by real `SelectDown` keypresses --
+/// the same real-path rule [`app_in_settings_on`] follows for a scalar row.
+///
+/// The six scalar rows always sort first in `Settings::rows`, so the dog at
+/// index `i` of [`settings_snapshot_for_toggle_tests`]'s own list sits at
+/// row `6 + i`.
+pub fn app_in_settings_on_dog(name: &str) -> App {
+    let mut app = app_with(flock_of(3, 0), plain());
+    app.set_control_for_tests(Control::Allowed);
+    app.update(Msg::Key(KeyPress::Settings));
+    app.update(Msg::Settings {
+        result: Ok(settings_snapshot_for_toggle_tests()),
+    });
+    let dog_index = settings_snapshot_for_toggle_tests()
+        .dogs
+        .iter()
+        .position(|dog| dog.name == name)
+        .expect("name is one of settings_snapshot_for_toggle_tests's own dogs");
+    for _ in 0..(6 + dog_index) {
+        app.update(Msg::Key(KeyPress::SelectDown));
+    }
+    app
+}
+
+/// [`app_in_settings_on_dog`], named for the test that means to start on an
+/// already-enabled dog: same fixture, same mechanism, a name that reads
+/// what the test is asserting on without checking the dogs list.
+pub fn app_in_settings_on_enabled_dog(name: &str) -> App {
+    app_in_settings_on_dog(name)
 }

--- a/crates/shep-cli/src/lookout/view/fixtures.rs
+++ b/crates/shep-cli/src/lookout/view/fixtures.rs
@@ -2,6 +2,7 @@
 //! in one file rather than three.
 
 use std::ffi::OsStr;
+use std::path::PathBuf;
 use std::time::Instant;
 
 use ratatui::text::Line;
@@ -538,15 +539,20 @@ pub fn app_in_settings_with_dog_drift() -> App {
     app.update(Msg::Key(KeyPress::Settings));
     app.update(Msg::Settings {
         result: Ok(settings_snapshot_with_dogs(vec![
+            // Real paths, not `None`: `otel` and `ledger` are not in
+            // `BUILT_IN_DOGS`, so `dog_candidates` can only have built them
+            // from `[daemon] adopted_dogs`, and every value in that map is
+            // a path. A `None` here is a row the reader cannot produce
+            // from a document shep wrote.
             DogView {
                 name: "otel".to_string(),
                 enabled: false,
-                adopted_path: None,
+                adopted_path: Some(PathBuf::from("/usr/local/bin/shep-otel")),
             },
             DogView {
                 name: "ledger".to_string(),
                 enabled: true,
-                adopted_path: None,
+                adopted_path: Some(PathBuf::from("/opt/ledger/bin/dog")),
             },
         ])),
     });
@@ -590,7 +596,7 @@ fn settings_snapshot_for_toggle_tests() -> SettingsSnapshot {
         DogView {
             name: "otel".to_string(),
             enabled: true,
-            adopted_path: None,
+            adopted_path: Some(PathBuf::from("/usr/local/bin/shep-otel")),
         },
     ])
 }

--- a/crates/shep-cli/src/lookout/view/fixtures.rs
+++ b/crates/shep-cli/src/lookout/view/fixtures.rs
@@ -419,6 +419,9 @@ pub fn settings_snapshot() -> SettingsSnapshot {
         max_cron_sleep: config("30s"),
         allow_control: config("false"),
         style_level: config("full"),
+        // The document declares it, so the file and the resolved value
+        // agree -- see `SettingsSnapshot::style_level_in_file`.
+        style_level_in_file: Some("full".to_string()),
         dogs: vec![
             DogView {
                 name: "bark".to_string(),
@@ -475,6 +478,29 @@ pub fn app_in_settings_at() -> (App, Instant) {
         result: Ok(settings_snapshot()),
     });
     (app, t0)
+}
+
+/// The settings screen with `[style] level` SHADOWED: the document says
+/// `full`, `source` is the layer that outranked it, and the level in force
+/// is `bare`. The cursor sits on the style row, moved there by real
+/// keypresses the same way [`app_in_settings_on`] moves it.
+///
+/// The one state where a scalar's value in force and its value on disk
+/// disagree, which is the whole reason `[style]` carries two of them --
+/// every other field's layers belong to the shepherd's process, where
+/// lookout can see neither.
+pub fn app_in_settings_with_shadowed_style(source: StyleSource) -> App {
+    let mut app = app_in_settings_on(SettingField::StyleLevel);
+    let mut snapshot = settings_snapshot();
+    snapshot.style_level = ScalarView {
+        value: "bare".to_string(),
+        source,
+    };
+    snapshot.style_level_in_file = Some("full".to_string());
+    app.update(Msg::Settings {
+        result: Ok(snapshot),
+    });
+    app
 }
 
 /// [`app_in_settings`] with the control gate open, for the one test that

--- a/crates/shep-cli/src/lookout/view/fixtures.rs
+++ b/crates/shep-cli/src/lookout/view/fixtures.rs
@@ -310,21 +310,21 @@ pub fn filtered_app_of(flock: Vec<ProcessInfo>, query: &str) -> App {
     if !query.is_empty() {
         app.update(Msg::Key(KeyPress::FilterStart));
         for typed in query.chars() {
-            app.update(Msg::Key(KeyPress::FilterChar(typed)));
+            app.update(Msg::Key(KeyPress::TextChar(typed)));
         }
-        app.update(Msg::Key(KeyPress::FilterApply));
+        app.update(Msg::Key(KeyPress::TextApply));
     }
     app
 }
 
 /// The same four sheep with `query` half-typed and the box still OPEN: no
-/// `FilterApply`, which is the whole difference between this and
+/// `TextApply`, which is the whole difference between this and
 /// [`filtered_app`].
 pub fn editing_app(query: &str) -> App {
     let mut app = app_with(named_flock(), plain());
     app.update(Msg::Key(KeyPress::FilterStart));
     for typed in query.chars() {
-        app.update(Msg::Key(KeyPress::FilterChar(typed)));
+        app.update(Msg::Key(KeyPress::TextChar(typed)));
     }
     app
 }

--- a/crates/shep-cli/src/lookout/view/fixtures.rs
+++ b/crates/shep-cli/src/lookout/view/fixtures.rs
@@ -9,11 +9,13 @@ use shep_client::RequestError;
 use shep_core::protocol::{BusEvent, Lamb, ProcessInfo, Response};
 use shep_core::status::ProcStatus;
 
-use super::super::app::{ActionVerb, App, Control, KeyPress, LambWalk, Msg, RowKey, Sent};
+use super::super::app::{
+    ActionVerb, App, Control, KeyPress, LambWalk, Msg, RowKey, Sent, SettingsRow,
+};
 use super::super::source::HostSample;
 use super::super::tail::{Stream, Tail, TailLine};
 use super::super::theme::Palette;
-use crate::commands::settings::{DogView, ScalarView, SettingsSnapshot};
+use crate::commands::settings::{DogView, ScalarView, SettingField, SettingsSnapshot};
 use crate::style::StyleSource;
 
 /// No colour at all: the palette every fixture uses unless the test is about
@@ -446,6 +448,38 @@ pub fn app_in_settings() -> App {
 /// [`app_in_settings`] with the control gate open, for the one test that
 /// proves an action key stays unreachable even when actions would otherwise
 /// be permitted.
+/// [`app_in_settings_with_control`] with the cursor already moved onto
+/// `field`'s row, by real `SelectDown` keypresses -- not by poking the
+/// cursor index directly, so a test using this fixture is exercising the
+/// same path an operator would.
+pub fn app_in_settings_on(field: SettingField) -> App {
+    let mut app = app_in_settings_with_control();
+    let target = app
+        .settings()
+        .unwrap()
+        .rows()
+        .iter()
+        .position(|row| *row == SettingsRow::Scalar(field))
+        .expect("field is one of the six scalar rows Settings::rows always carries");
+    for _ in 0..target {
+        app.update(Msg::Key(KeyPress::SelectDown));
+    }
+    app
+}
+
+/// [`app_in_settings_with_control`], but built from a caller-visible `t0`
+/// rather than [`Instant::now`] read inside this function: an expiry test
+/// needs to hand `Msg::Tick` an instant it can do arithmetic against.
+pub fn app_in_settings_at() -> (App, Instant) {
+    let t0 = Instant::now();
+    let mut app = App::new(plain(), Control::Allowed, "/home/ada/.shep".to_string(), t0);
+    app.update(Msg::Key(KeyPress::Settings));
+    app.update(Msg::Settings {
+        result: Ok(settings_snapshot()),
+    });
+    (app, t0)
+}
+
 pub fn app_in_settings_with_control() -> App {
     let mut app = app_in_settings();
     app.set_control_for_tests(Control::Allowed);

--- a/crates/shep-cli/src/lookout/view/fixtures.rs
+++ b/crates/shep-cli/src/lookout/view/fixtures.rs
@@ -13,6 +13,8 @@ use super::super::app::{ActionVerb, App, Control, KeyPress, LambWalk, Msg, RowKe
 use super::super::source::HostSample;
 use super::super::tail::{Stream, Tail, TailLine};
 use super::super::theme::Palette;
+use crate::commands::settings::{DogView, ScalarView, SettingsSnapshot};
+use crate::style::StyleSource;
 
 /// No colour at all: the palette every fixture uses unless the test is about
 /// colour.
@@ -397,5 +399,55 @@ pub fn armed_app_with_a_filter_and_a_notice() -> App {
     app.set_control_for_tests(Control::Allowed);
     app.update(Msg::Key(KeyPress::Action(ActionVerb::Stop)));
     app.update(Msg::Event(BusEvent::Dropped { count: 3 }));
+    app
+}
+
+/// A plausible settings snapshot: every scalar rendered as if `shep.toml`
+/// declared it, and two candidate dogs, one enabled, for the tests that
+/// need a screen with real rows rather than a fresh home's all-default one.
+pub fn settings_snapshot() -> SettingsSnapshot {
+    let config = |value: &str| ScalarView {
+        value: value.to_string(),
+        source: StyleSource::Config,
+    };
+    SettingsSnapshot {
+        log_level: config("warn"),
+        log_json: config("false"),
+        socket: config("/home/ada/.shep/run/shep.sock"),
+        max_cron_sleep: config("30s"),
+        allow_control: config("false"),
+        style_level: config("full"),
+        dogs: vec![
+            DogView {
+                name: "bark".to_string(),
+                enabled: false,
+                adopted_path: None,
+            },
+            DogView {
+                name: "metrics".to_string(),
+                enabled: true,
+                adopted_path: None,
+            },
+        ],
+    }
+}
+
+/// A dashboard with the settings screen already open on
+/// [`settings_snapshot`], the gate closed ([`Control::ReadOnly`]).
+pub fn app_in_settings() -> App {
+    let mut app = app_with(flock_of(3, 0), plain());
+    app.update(Msg::Key(KeyPress::Settings));
+    app.update(Msg::Settings {
+        result: Ok(settings_snapshot()),
+    });
+    app
+}
+
+/// [`app_in_settings`] with the control gate open, for the one test that
+/// proves an action key stays unreachable even when actions would otherwise
+/// be permitted.
+pub fn app_in_settings_with_control() -> App {
+    let mut app = app_in_settings();
+    app.set_control_for_tests(Control::Allowed);
     app
 }

--- a/crates/shep-cli/src/lookout/view/fixtures.rs
+++ b/crates/shep-cli/src/lookout/view/fixtures.rs
@@ -445,9 +445,6 @@ pub fn app_in_settings() -> App {
     app
 }
 
-/// [`app_in_settings`] with the control gate open, for the one test that
-/// proves an action key stays unreachable even when actions would otherwise
-/// be permitted.
 /// [`app_in_settings_with_control`] with the cursor already moved onto
 /// `field`'s row, by real `SelectDown` keypresses -- not by poking the
 /// cursor index directly, so a test using this fixture is exercising the
@@ -480,6 +477,9 @@ pub fn app_in_settings_at() -> (App, Instant) {
     (app, t0)
 }
 
+/// [`app_in_settings`] with the control gate open, for the one test that
+/// proves an action key stays unreachable even when actions would otherwise
+/// be permitted.
 pub fn app_in_settings_with_control() -> App {
     let mut app = app_in_settings();
     app.set_control_for_tests(Control::Allowed);

--- a/crates/shep-cli/src/lookout/view/mod.rs
+++ b/crates/shep-cli/src/lookout/view/mod.rs
@@ -566,6 +566,44 @@ mod tests {
         }
     }
 
+    /// fails if an armed settings candidate ever draws with nothing on
+    /// screen to show it. `view::settings::content_lines`'s own pending
+    /// line used to be the ONLY place this showed, drawn last in the body
+    /// and cut by `draw_settings`'s `.take(area.height)` the moment the
+    /// body ran out of room -- an operator could arm an edit, see no
+    /// change anywhere, and press Enter into it blind. This is the
+    /// mutation that would catch a regression back to that state: at 200x10
+    /// the body alone has nowhere near the ~20 rows `settings_snapshot`'s
+    /// six scalars, two dogs and a two-line pending prompt need, so a body
+    /// with no independent floor would drop the confirm here exactly as it
+    /// used to. Width stays generous (200) so only HEIGHT is under test --
+    /// the confirm sentence itself runs long, and a narrow width would
+    /// truncate it in the status bar too and confound the two properties.
+    /// `status_line`'s own Slot 1 (`view::status`'s doc) is a fixed row
+    /// `draw` always reserves regardless of body height, which is the
+    /// property this pins: the confirm survives on the LAST line even
+    /// though the body above it has plainly been cut.
+    #[test]
+    fn an_armed_settings_candidate_survives_a_body_too_short_to_hold_it() {
+        let mut app = fixtures::app_in_settings_with_control();
+        let _ = app.update(Msg::Key(KeyPress::Cycle));
+        let text = app.settings().unwrap().pending().unwrap().text.to_string();
+
+        // 10 rows total, 8 of them body (title and status bar are the other
+        // two): nowhere near the ~20 rows `settings_snapshot`'s six scalars,
+        // two dogs and a two-line pending prompt need, so the body's OWN
+        // echo of this line is not on screen at this height -- confirmed by
+        // `settings_confirm`'s own gallery frame needing (180, 30) to show
+        // it at all. If the status bar slot below were ever removed, this
+        // assertion is what would catch the confirm vanishing again.
+        let rendered = draw_to(&app, 200, 10);
+        let last_line = rendered.lines().last().expect("at least one row");
+        assert!(
+            last_line.contains(text.trim()),
+            "the confirm must survive on the status bar's fixed row: {last_line:?}"
+        );
+    }
+
     /// fails if a tier can render taller than the terminal it was chosen for.
     /// The height twin of `every_tier_fits_the_width_it_claims`, and the check
     /// that makes the tier table a claim rather than a wish: every tier's

--- a/crates/shep-cli/src/lookout/view/mod.rs
+++ b/crates/shep-cli/src/lookout/view/mod.rs
@@ -10,6 +10,7 @@ pub mod bleats;
 pub mod detail;
 pub mod flock;
 pub mod host;
+pub mod settings;
 pub mod status;
 
 // `pub`, not private: Task 8's `a_heartbeat_puts_the_host_strip_on_the_frame`
@@ -21,6 +22,7 @@ pub mod status;
 pub mod fixtures;
 
 use ratatui::Frame;
+use ratatui::layout::Rect;
 use ratatui::text::{Line, Span};
 
 use self::flock::MIN_HEIGHT;
@@ -195,6 +197,27 @@ pub fn draw(app: &App, frame: &mut Frame<'_>) {
         width,
     );
     y += 1;
+
+    // The settings screen owns the whole body between the title and the
+    // status bar -- decision 1 of the design spec: "the title line and the
+    // status bar stay put". That is a swap, not an overlay: the banner,
+    // the host strip, the flock table and the two bottom panes all belong
+    // to the dashboard body this branch replaces, so none of them draw
+    // while the screen is open.
+    if let Some(settings) = app.settings() {
+        let body = Rect {
+            x: area.x,
+            y,
+            width,
+            // `bottom - y` never underflows: `y` is `area.y + 1` here and
+            // `bottom` is `area.y + height - 1`, and `height >= MIN_HEIGHT`
+            // (6) is already checked above, so `bottom > y` always holds.
+            height: bottom - y,
+        };
+        settings::draw_settings(app, settings, body, buffer);
+        buffer.set_line(area.x, bottom, &status::status_line(app, width), width);
+        return;
+    }
 
     if let Some(banner) = status::banner_line(app) {
         buffer.set_line(area.x, y, &banner, width);
@@ -527,6 +550,18 @@ mod tests {
             at: Instant::now(),
         });
         for (width, height) in [(1, 1), (20, 3), (31, 6), (80, 24), (250, 60), (400, 200)] {
+            let _ = draw_to(&app, width, height);
+        }
+    }
+
+    /// The settings screen's own twin of the sweep above. `Rect::height`
+    /// is `bottom - y`, computed once per frame rather than checked, so
+    /// this is what proves `MIN_HEIGHT` (6) actually keeps it from
+    /// underflowing at the floor the guard claims to cover.
+    #[test]
+    fn drawing_the_settings_screen_never_panics_across_the_size_sweep() {
+        let app = fixtures::app_in_settings();
+        for (width, height) in [(1, 1), (20, 3), (33, 6), (80, 24), (250, 60), (400, 200)] {
             let _ = draw_to(&app, width, height);
         }
     }

--- a/crates/shep-cli/src/lookout/view/settings.rs
+++ b/crates/shep-cli/src/lookout/view/settings.rs
@@ -621,7 +621,7 @@ fn content_lines(
             format!("{}  enter confirms, any other key cancels", prompt.text)
         };
         lines.push(Line::from(Span::styled(
-            format!("  {text}"),
+            format!("  {}", fit(&text, table_width)),
             palette.attention(),
         )));
     } else if let Some((field, buffer)) = settings.typing() {
@@ -636,8 +636,14 @@ fn content_lines(
         lines.push(Line::default());
         lines.push(Line::from(Span::styled(
             format!(
-                "  editing {}: {buffer}\u{258f}   enter applies   esc cancels",
-                field_label(*field)
+                "  {}",
+                fit(
+                    &format!(
+                        "editing {}: {buffer}\u{258f}   enter applies   esc cancels",
+                        field_label(*field)
+                    ),
+                    table_width,
+                )
             ),
             palette.attention(),
         )));

--- a/crates/shep-cli/src/lookout/view/settings.rs
+++ b/crates/shep-cli/src/lookout/view/settings.rs
@@ -1,16 +1,19 @@
 //! The settings screen: `[daemon]`, `[whistle]`, `[style]` then `[dogs]`,
 //! drawn straight into the buffer rather than composed as a `Vec<Line>` the
-//! way the dashboard's own panes are — this screen owns the whole body
+//! way the dashboard's own panes are (this screen owns the whole body
 //! between the title and the status bar, so there is no outer `draw` left to
-//! hand lines to.
+//! hand lines to).
 //!
 //! Every row goes through [`fit`], the same truncation `view::flock` uses:
 //! a value cut short says so with the same trailing `…`, rather than
 //! spilling into the column beside it.
 //!
-//! Reading is unconditional. Editing lands in later tasks (7 and 8), so
-//! every row here shows what `shep.toml` says today, never what an operator
-//! is mid-typing.
+//! Four of the six scalars (`log_level`, `log_json`, `allow_control`,
+//! `style level`) are editable, and their armed candidate is what one extra
+//! line under the dogs table shows, when there is one. `socket` and
+//! `max_cron_sleep` still only ever show what `shep.toml` says today: task
+//! 8's own free-text editor is what makes those two, and the dogs table's
+//! own enable/disable, editable as well.
 
 use ratatui::buffer::Buffer;
 use ratatui::layout::Rect;
@@ -280,47 +283,56 @@ fn scalar_line(
     Line::from(Span::raw(text))
 }
 
+/// Which `[section]` a scalar field's row lives under.
+const fn section_for(field: SettingField) -> &'static str {
+    match field {
+        SettingField::LogLevel
+        | SettingField::LogJson
+        | SettingField::Socket
+        | SettingField::MaxCronSleep => "[daemon]",
+        SettingField::AllowControl => "[whistle]",
+        SettingField::StyleLevel => "[style]",
+    }
+}
+
 /// Every line of the screen's body, top to bottom: `[daemon]`'s four rows,
 /// `[whistle]`'s one, `[style]`'s one, then `[dogs]`'s caption and table.
+///
+/// Walks [`Settings::rows`] itself rather than hand-listing the six scalars
+/// a second time in this function's own order: two lists that happen to
+/// agree today would silently desync the moment either one reordered, and
+/// the cursor -- which [`Settings::rows`] alone defines -- would then land
+/// on a row this function drew somewhere else.
 fn content_lines(settings: &Settings, palette: Palette, width: u16) -> Vec<Line<'static>> {
     let snapshot = settings.snapshot();
     let cursor = settings.cursor();
-    let is_selected = |field: SettingField| cursor == Some(SettingsRow::Scalar(field));
 
     let mut lines = Vec::new();
+    let mut current_section: Option<&'static str> = None;
 
-    lines.push(section_header("[daemon]", palette));
-    for field in [
-        SettingField::LogLevel,
-        SettingField::LogJson,
-        SettingField::Socket,
-        SettingField::MaxCronSleep,
-    ] {
+    // The six scalar rows always sort first in `Settings::rows`, ahead of
+    // every `SettingsRow::Dog` -- see its own doc -- so this loop's `break`
+    // on the first non-scalar row is exactly "stop once the scalars end",
+    // never "stop at the first dog that happens to come early".
+    for row in settings.rows() {
+        let SettingsRow::Scalar(field) = row else {
+            break;
+        };
+        let section = section_for(field);
+        if current_section != Some(section) {
+            if current_section.is_some() {
+                lines.push(Line::default());
+            }
+            lines.push(section_header(section, palette));
+            current_section = Some(section);
+        }
         lines.push(scalar_line(
             field,
             scalar_view(snapshot, field),
-            is_selected(field),
+            cursor == Some(row),
             width,
         ));
     }
-    lines.push(Line::default());
-
-    lines.push(section_header("[whistle]", palette));
-    lines.push(scalar_line(
-        SettingField::AllowControl,
-        &snapshot.allow_control,
-        is_selected(SettingField::AllowControl),
-        width,
-    ));
-    lines.push(Line::default());
-
-    lines.push(section_header("[style]", palette));
-    lines.push(scalar_line(
-        SettingField::StyleLevel,
-        &snapshot.style_level,
-        is_selected(SettingField::StyleLevel),
-        width,
-    ));
     lines.push(Line::default());
 
     lines.push(section_header("[dogs]", palette));
@@ -342,14 +354,33 @@ fn content_lines(settings: &Settings, palette: Palette, width: u16) -> Vec<Line<
         lines.push(dog_line(dog, &rendered_columns, width, selected));
     }
 
+    // One prompt line under the table, in the shape the status bar's own
+    // `confirm_prompt`/`in_flight_text` use for a sheep confirm: a question
+    // styled `attention` while it waits on `Enter`, an in-flight sentence
+    // once it has gone out. Drawn here rather than in the status bar itself
+    // -- the settings screen owns its own body between the title and that
+    // bar, and this prompt is about one row in the table above it, not
+    // about the whole dashboard.
+    if let Some(prompt) = settings.pending() {
+        lines.push(Line::default());
+        let text = if prompt.sent {
+            format!("{}  sent, waiting for the shepherd", prompt.text)
+        } else {
+            format!("{}  enter confirms, any other key cancels", prompt.text)
+        };
+        lines.push(Line::from(Span::styled(
+            format!("  {text}"),
+            palette.attention(),
+        )));
+    }
+
     lines
 }
 
 /// Draws the settings screen into `area`, straight into `buffer`.
 ///
-/// `app` supplies the palette; every other fact this screen shows comes off
-/// `settings` -- see this module's own doc for why reading is the whole of
-/// this task.
+/// `app` supplies the palette; every other fact this screen shows, including
+/// its one armed or in-flight prompt line, comes off `settings`.
 pub fn draw_settings(app: &App, settings: &Settings, area: Rect, buffer: &mut Buffer) {
     if area.width == 0 || area.height == 0 {
         return;
@@ -373,6 +404,7 @@ mod tests {
     use super::super::fixtures;
     use super::*;
     use crate::lookout::frames::render_text;
+    use crate::style::StyleSource;
 
     /// The whole screen at a comfortable width. The snapshot is the
     /// assertion: it pins the section order, every row's four columns and
@@ -445,6 +477,27 @@ mod tests {
         assert!(
             marked[0].contains("log_level"),
             "the cursor opens on the first row: {rendered:?}"
+        );
+    }
+
+    /// fails if `SCALAR_SOURCE_W` stops fitting the widest word this column
+    /// ever prints. `"the default"` is what a fresh `$SHEP_HOME` shows for
+    /// every scalar -- the state most operators open this screen in -- and
+    /// no fixture anywhere in this tree renders it: `settings_snapshot`
+    /// gives every scalar `StyleSource::Config`, which is one column
+    /// shorter (`"shep.toml"`) and would not catch the column shrinking out
+    /// from under the longer word.
+    #[test]
+    fn the_default_source_label_fits_the_column_it_was_sized_for() {
+        let rendered = fit(&StyleSource::Default.to_string(), SCALAR_SOURCE_W);
+        assert_eq!(
+            rendered.chars().count(),
+            usize::from(SCALAR_SOURCE_W),
+            "fit always pads or truncates to the exact column width"
+        );
+        assert!(
+            !rendered.contains('…'),
+            "SCALAR_SOURCE_W must fit \"the default\" whole: got {rendered:?}"
         );
     }
 }

--- a/crates/shep-cli/src/lookout/view/settings.rs
+++ b/crates/shep-cli/src/lookout/view/settings.rs
@@ -363,34 +363,161 @@ const fn apply_cost(field: SettingField, source: StyleSource) -> &'static str {
 /// NAME column width: fits `max_cron_sleep`, the longest field name, with a
 /// column of padding.
 const SCALAR_NAME_W: u16 = 15;
-/// VALUE column width: fits `/home/ada/.shep/run/shep.sock` (29 columns),
-/// an ordinary absolute socket path, whole -- a value already past this
-/// budget still truncates through [`fit`] rather than growing the column.
+/// VALUE column width where the terminal can afford it: fits
+/// `/home/ada/.shep/run/shep.sock` (29 columns), an ordinary absolute
+/// socket path, whole. A cap rather than a fixed width -- a narrow terminal
+/// gets [`SCALAR_VALUE_MIN`] instead, and a value past whatever budget it
+/// lands on truncates through [`fit`].
 const SCALAR_VALUE_W: u16 = 30;
+/// The floor on VALUE: enough for `not set`, `waiting`, a level name or the
+/// tail of a path, never a whole socket path. Below this the row stops
+/// saying anything and there is nothing left to trade.
+const SCALAR_VALUE_MIN: u16 = 10;
 /// SOURCE column width: `$SHEP_STYLE` and `the default` are both 11 columns,
 /// the widest two words [`crate::style::StyleSource::Display`] ever prints.
 const SCALAR_SOURCE_W: u16 = 11;
-/// The floor on the apply-cost column once `width` is too narrow to give it
-/// the remainder: enough for `needs`, never a whole sentence.
+/// The floor on the apply-cost column once the terminal is too narrow to
+/// give it the remainder: enough for `needs`, never a whole sentence.
 const SCALAR_COST_MIN: u16 = 8;
 
-/// One scalar row: name, value, source, apply cost.
+/// One column of a scalar row.
+///
+/// `Debug` is derived rather than redacted (IR-41): a bare variant name,
+/// nothing a `{:?}` could leak.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ScalarColumn {
+    /// The document's own key for this field.
+    Name,
+    /// What the file says, or the compiled fallback when it says nothing.
+    /// The flexible column, between [`SCALAR_VALUE_MIN`] and
+    /// [`SCALAR_VALUE_W`].
+    Value,
+    /// Which layer the value came from.
+    Source,
+    /// What applying an edit to this field costs. Takes whatever the other
+    /// three leave.
+    Cost,
+}
+
+const SCALAR_ALL: &[ScalarColumn] = &[
+    ScalarColumn::Name,
+    ScalarColumn::Value,
+    ScalarColumn::Source,
+    ScalarColumn::Cost,
+];
+const SCALAR_NO_COST: &[ScalarColumn] = &[
+    ScalarColumn::Name,
+    ScalarColumn::Value,
+    ScalarColumn::Source,
+];
+const SCALAR_FLOOR: &[ScalarColumn] = &[ScalarColumn::Name, ScalarColumn::Value];
+
+/// The narrowest the scalar rows will draw into, as a body width: NAME, a
+/// gap and VALUE at its floor. The terminal also pays [`GUTTER`], the same
+/// split [`DOG_MIN_WIDTH`] documents.
+const SCALAR_MIN_WIDTH: u16 = SCALAR_NAME_W + 2 + SCALAR_VALUE_MIN;
+
+/// Width thresholds for the scalar rows, widest first, the same shape
+/// [`DOG_TIERS`] and [`super::flock::TIERS`] both use.
+///
+/// The apply cost drops first, and SOURCE second, which is the reverse of
+/// the dogs table's order and is deliberate. The cost is the widest cell
+/// here (a whole sentence), and it is the one fact this screen says TWICE:
+/// arming a field puts it verbatim in the confirm, in the status bar, on a
+/// row the body pane's `.take(area.height)` cannot reach. SOURCE appears
+/// nowhere else at all, and it is the column decision 4 of the design spec
+/// exists for: it is what separates "the operator wrote this" from "nobody
+/// ever did", which is the state a fresh `$SHEP_HOME` opens in. NAME and
+/// VALUE are the floor for the reason ID/NAME/STATUS is the flock table's:
+/// those two are the pane.
+///
+/// This table did not exist until a whole-branch review found the rows
+/// drawn at fixed widths summing to 72 while the screen draws from
+/// [`super::MIN_TERM_WIDTH`] (33) up. At 40 columns SOURCE and the cost
+/// were gone with no marker; at 60 the cost cell clipped mid-word to
+/// `the defau`. The dogs table directly beneath had tiered properly the
+/// whole time.
+const SCALAR_TIERS: &[(u16, &[ScalarColumn])] = &[
+    (
+        SCALAR_NAME_W + 2 + SCALAR_VALUE_MIN + 2 + SCALAR_SOURCE_W + 2 + SCALAR_COST_MIN,
+        SCALAR_ALL,
+    ),
+    (
+        SCALAR_NAME_W + 2 + SCALAR_VALUE_MIN + 2 + SCALAR_SOURCE_W,
+        SCALAR_NO_COST,
+    ),
+    (SCALAR_MIN_WIDTH, SCALAR_FLOOR),
+];
+
+/// The widest scalar column set that fits `width`, a BODY width.
+fn scalar_columns_for(width: u16) -> &'static [ScalarColumn] {
+    SCALAR_TIERS
+        .iter()
+        .find(|(threshold, _)| width >= *threshold)
+        .map_or(SCALAR_FLOOR, |(_, columns)| *columns)
+}
+
+/// What VALUE and the apply cost get out of `width`, once NAME, SOURCE and
+/// the separators are paid for.
+///
+/// VALUE takes the remainder up to [`SCALAR_VALUE_W`] and never below
+/// [`SCALAR_VALUE_MIN`]; the cost takes what is left after that, so a wide
+/// terminal spends its extra columns on the sentence rather than on padding
+/// a value that has already been shown whole. The cost's number is zero
+/// when [`ScalarColumn::Cost`] is not in `columns`, and nothing reads it
+/// then.
+fn scalar_widths(width: u16, columns: &[ScalarColumn]) -> (u16, u16) {
+    let fixed = SCALAR_NAME_W
+        + if columns.contains(&ScalarColumn::Source) {
+            SCALAR_SOURCE_W
+        } else {
+            0
+        };
+    let gaps = u16::try_from(columns.len().saturating_sub(1)).unwrap_or(0) * 2;
+    let remainder = width.saturating_sub(fixed).saturating_sub(gaps);
+    if columns.contains(&ScalarColumn::Cost) {
+        let value = remainder
+            .saturating_sub(SCALAR_COST_MIN)
+            .clamp(SCALAR_VALUE_MIN, SCALAR_VALUE_W);
+        (value, remainder.saturating_sub(value).max(SCALAR_COST_MIN))
+    } else {
+        (remainder.clamp(SCALAR_VALUE_MIN, SCALAR_VALUE_W), 0)
+    }
+}
+
+/// One scalar cell's text.
+fn scalar_cell(field: SettingField, view: &ScalarView, column: ScalarColumn) -> String {
+    match column {
+        ScalarColumn::Name => field_label(field).to_string(),
+        ScalarColumn::Value => view.value.clone(),
+        ScalarColumn::Source => view.source.to_string(),
+        ScalarColumn::Cost => apply_cost(field, view.source).to_string(),
+    }
+}
+
+/// One scalar row: name, value, source, apply cost, as many of those as
+/// `width` (a BODY width) can pay for.
 fn scalar_line(
     field: SettingField,
     view: &ScalarView,
     selected: bool,
     width: u16,
 ) -> Line<'static> {
-    let fixed = 1 + 1 + SCALAR_NAME_W + 2 + SCALAR_VALUE_W + 2 + SCALAR_SOURCE_W + 2;
-    let cost_width = width.saturating_sub(fixed).max(SCALAR_COST_MIN);
-    let text = format!(
-        "{} {}  {}  {}  {}",
-        mark(selected),
-        fit(field_label(field), SCALAR_NAME_W),
-        fit(&view.value, SCALAR_VALUE_W),
-        fit(&view.source.to_string(), SCALAR_SOURCE_W),
-        fit(apply_cost(field, view.source), cost_width),
-    );
+    let columns = scalar_columns_for(width);
+    let (value_width, cost_width) = scalar_widths(width, columns);
+    let mut text = format!("{} ", mark(selected));
+    for (index, column) in columns.iter().enumerate() {
+        if index > 0 {
+            text.push_str("  ");
+        }
+        let cell_width = match column {
+            ScalarColumn::Name => SCALAR_NAME_W,
+            ScalarColumn::Value => value_width,
+            ScalarColumn::Source => SCALAR_SOURCE_W,
+            ScalarColumn::Cost => cost_width,
+        };
+        text.push_str(&fit(&scalar_cell(field, view, *column), cell_width));
+    }
     Line::from(Span::raw(text))
 }
 
@@ -450,7 +577,7 @@ fn content_lines(
             field,
             scalar_view(snapshot, field),
             cursor == Some(row),
-            width,
+            body_width(width),
         ));
     }
     lines.push(Line::default());
@@ -610,6 +737,57 @@ mod tests {
                     visible_width(line) <= usize::from(width),
                     "width {width} drew {} columns: {line:?}",
                     visible_width(line)
+                );
+            }
+        }
+    }
+
+    /// fails if the scalar rows stop tiering, or start dropping the wrong
+    /// column first.
+    ///
+    /// The cost sentence goes first because arming the field repeats it
+    /// verbatim in the status bar; SOURCE goes second because it appears
+    /// nowhere else on the screen at all. Widths are BODY widths, two
+    /// columns narrower than the terminal -- see `GUTTER`.
+    #[test]
+    fn the_scalar_apply_cost_drops_before_its_source() {
+        assert!(scalar_columns_for(118).contains(&ScalarColumn::Cost));
+        assert!(!scalar_columns_for(43).contains(&ScalarColumn::Cost));
+        assert!(
+            scalar_columns_for(43).contains(&ScalarColumn::Source),
+            "SOURCE is the screen's own subject and outlives the cost"
+        );
+        assert!(!scalar_columns_for(33).contains(&ScalarColumn::Source));
+        assert!(
+            scalar_columns_for(33).contains(&ScalarColumn::Value),
+            "NAME and VALUE are the floor"
+        );
+    }
+
+    /// fails if ANY line of the settings screen renders wider than the
+    /// terminal it was drawn for -- the scalar rows included, which is the
+    /// half `every_dogs_tier_fits_the_width_it_claims` above does not
+    /// reach.
+    ///
+    /// The scalar rows had no width adaptation at all: fixed widths of 15,
+    /// 30 and 11 with only the trailing cost column clamped, so the
+    /// narrowest row they could draw was 72 columns while the screen draws
+    /// from `MIN_TERM_WIDTH` (33) up. At 40 columns SOURCE and the cost
+    /// were gone with no marker, and at 60 the cost cell clipped mid-word
+    /// to `the defau`, both silently, because `Buffer::set_line` clips
+    /// without saying so.
+    #[test]
+    fn every_settings_line_fits_the_terminal_it_was_drawn_for() {
+        let app = fixtures::app_in_settings_with_dog_drift();
+        let settings = app.settings().unwrap();
+        let palette = app.palette();
+        for width in super::super::MIN_TERM_WIDTH..=200 {
+            for line in content_lines(&app, settings, palette, width) {
+                let rendered: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
+                assert!(
+                    visible_width(&rendered) <= usize::from(width),
+                    "width {width} drew {}: {rendered:?}",
+                    visible_width(&rendered)
                 );
             }
         }

--- a/crates/shep-cli/src/lookout/view/settings.rs
+++ b/crates/shep-cli/src/lookout/view/settings.rs
@@ -28,6 +28,7 @@ use super::super::app::{App, Settings, SettingsRow};
 use super::super::theme::Palette;
 use super::flock::{fit, mark};
 use crate::commands::settings::{ScalarView, SettingField, SettingsSnapshot};
+use crate::style::StyleSource;
 use crate::vocabulary::Reported;
 
 /// The dogs caption, verbatim. Not "space applies": this screen arms and
@@ -308,16 +309,26 @@ pub(super) const fn field_label(field: SettingField) -> &'static str {
 /// reload; `socket` needs a full stop and start, since a reload never moves
 /// the listening socket; `allow_control` needs whistle restarted rather
 /// than the daemon, because a dog toggle and a whistle setting are both
-/// read by a process the daemon itself never touches; `style level` costs
-/// nothing because lookout re-resolves it on its own next command.
-const fn apply_cost(field: SettingField) -> &'static str {
+/// read by a process the daemon itself never touches.
+///
+/// `style level` is the one cell that reads `source` as well as the field.
+/// It costs nothing when the file is what decides -- lookout re-resolves it
+/// on its own next command -- but `--style` and `$SHEP_STYLE` outrank the
+/// file, and under either of those "the next command reads it" is simply
+/// untrue. The SOURCE cell two columns left already names the layer, so
+/// this cell says what that layer does rather than repeating its name. The
+/// confirm says it at length; see `app::style_confirm_text`.
+const fn apply_cost(field: SettingField, source: StyleSource) -> &'static str {
     match field {
         SettingField::LogLevel | SettingField::LogJson | SettingField::MaxCronSleep => {
             "needs shep daemon reload"
         }
         SettingField::Socket => "needs the shepherd stopped and started",
         SettingField::AllowControl => "needs shep whistle restarted",
-        SettingField::StyleLevel => "the next command reads it",
+        SettingField::StyleLevel => match source {
+            StyleSource::Config | StyleSource::Default => "the next command reads it",
+            StyleSource::Env | StyleSource::Flag => "written, but outranked",
+        },
     }
 }
 
@@ -350,7 +361,7 @@ fn scalar_line(
         fit(field_label(field), SCALAR_NAME_W),
         fit(&view.value, SCALAR_VALUE_W),
         fit(&view.source.to_string(), SCALAR_SOURCE_W),
-        fit(apply_cost(field), cost_width),
+        fit(apply_cost(field, view.source), cost_width),
     );
     Line::from(Span::raw(text))
 }
@@ -595,6 +606,33 @@ mod tests {
             !rendered.contains('…'),
             "SCALAR_SOURCE_W must fit \"the default\" whole: got {rendered:?}"
         );
+    }
+
+    /// fails if the style row keeps claiming the next command reads it
+    /// while a layer above the file is set.
+    ///
+    /// The row's own SOURCE cell already says `$SHEP_STYLE`, so the cost
+    /// cell beside it saying "the next command reads it" is the same frame
+    /// contradicting itself: the next command reads `$SHEP_STYLE`.
+    #[test]
+    fn the_style_cost_cell_stops_promising_the_next_command_when_it_is_outranked() {
+        let app = fixtures::app_in_settings_with_shadowed_style(StyleSource::Env);
+        let settings = app.settings().unwrap();
+        let lines = content_lines(&app, settings, app.palette(), 120);
+        let rendered: Vec<String> = lines
+            .iter()
+            .map(|line| line.spans.iter().map(|s| s.content.as_ref()).collect())
+            .collect();
+        let row = rendered
+            .iter()
+            .find(|line| {
+                line.get(2..)
+                    .is_some_and(|cells| cells.starts_with("level "))
+            })
+            .unwrap_or_else(|| panic!("the style row is drawn: {rendered:?}"));
+        assert!(row.contains("$SHEP_STYLE"), "got: {row:?}");
+        assert!(row.contains("written, but outranked"), "got: {row:?}");
+        assert!(!row.contains("the next command reads it"), "got: {row:?}");
     }
 
     /// fails if the free-text editor stops showing what is being typed, or

--- a/crates/shep-cli/src/lookout/view/settings.rs
+++ b/crates/shep-cli/src/lookout/view/settings.rs
@@ -1,0 +1,450 @@
+//! The settings screen: `[daemon]`, `[whistle]`, `[style]` then `[dogs]`,
+//! drawn straight into the buffer rather than composed as a `Vec<Line>` the
+//! way the dashboard's own panes are — this screen owns the whole body
+//! between the title and the status bar, so there is no outer `draw` left to
+//! hand lines to.
+//!
+//! Every row goes through [`fit`], the same truncation `view::flock` uses:
+//! a value cut short says so with the same trailing `…`, rather than
+//! spilling into the column beside it.
+//!
+//! Reading is unconditional. Editing lands in later tasks (7 and 8), so
+//! every row here shows what `shep.toml` says today, never what an operator
+//! is mid-typing.
+
+use ratatui::buffer::Buffer;
+use ratatui::layout::Rect;
+use ratatui::text::{Line, Span};
+
+use super::super::app::{App, Settings, SettingsRow};
+use super::super::theme::Palette;
+use super::flock::{fit, mark};
+use crate::commands::settings::{DogView, ScalarView, SettingField, SettingsSnapshot};
+
+/// The dogs caption, verbatim. Not "space applies": this screen arms and
+/// confirms like every other action in lookout (`x`, `R`, `L`), and a
+/// caption claiming otherwise would be wrong on screen rather than merely
+/// wrong in a doc.
+const DOGS_CAPTION: &str = "space arms, Enter applies; a dog needs no reload";
+
+/// The floor on the dogs table's NAME column, matching
+/// [`super::flock::NAME_MIN`]'s own reasoning: whatever the fixed columns
+/// leave, NAME never shrinks below a name worth reading.
+const DOG_NAME_MIN: u16 = 8;
+
+/// One column of the dogs table.
+///
+/// `Debug` is derived rather than redacted (IR-41): a bare variant name,
+/// nothing a `{:?}` could leak.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DogColumn {
+    /// The dog's name. The flexible column.
+    Name,
+    /// Whether `[daemon] enabled_dogs` names it -- a fact about the file,
+    /// never about whether the shepherd has actually started it.
+    InFile,
+    /// `built-in`, or the adopted binary's path.
+    Source,
+    /// The join against the live flock: whether the dog is actually up.
+    /// This task never renders it -- task 9's `dog_rows` supplies the data
+    /// this cell needs, and until then drawing a RUNNING header over a
+    /// column with nothing under it would be a rendering bug wearing a
+    /// header. The variant and its place in [`DOG_TIERS`] exist now anyway, so
+    /// task 9 extends the drop order rather than re-arguing it.
+    Running,
+}
+
+impl DogColumn {
+    /// The header text.
+    #[must_use]
+    const fn header(self) -> &'static str {
+        match self {
+            Self::Name => "NAME",
+            Self::InFile => "IN FILE",
+            Self::Source => "SOURCE",
+            Self::Running => "RUNNING",
+        }
+    }
+
+    /// The fixed width of this column's cells. `Name` reports `0` -- see
+    /// [`super::flock::Column::width`]'s own doc for why.
+    #[must_use]
+    const fn width(self) -> u16 {
+        match self {
+            Self::Name => 0,
+            // 7: `IN FILE`, its own header -- `yes`/`no` cells are shorter.
+            Self::InFile => 7,
+            // 24: an adopted binary's path can run long, and this is the
+            // column that shows it whole up to that budget before `fit`
+            // truncates it.
+            Self::Source => 24,
+            // 15, matching `super::flock::Column::Status`'s own width and
+            // reasoning: task 9's join is expected to report the same kind
+            // of word (`online`, `silent`, `not running`) the flock table's
+            // STATUS column does.
+            Self::Running => 15,
+        }
+    }
+}
+
+const ALL_DOG_COLUMNS: &[DogColumn] = &[
+    DogColumn::Name,
+    DogColumn::InFile,
+    DogColumn::Source,
+    DogColumn::Running,
+];
+const NO_SOURCE: &[DogColumn] = &[DogColumn::Name, DogColumn::InFile, DogColumn::Running];
+const FLOOR_DOG_COLUMNS: &[DogColumn] = &[DogColumn::Name, DogColumn::Running];
+
+/// The narrowest terminal the dogs table's floor column set will draw into:
+/// [`DogColumn::Running`] plus [`DOG_NAME_MIN`] plus one gap.
+const DOG_MIN_WIDTH: u16 = DogColumn::Running.width() + DOG_NAME_MIN + 2;
+
+/// Width thresholds, widest first, mirroring [`super::flock::TIERS`]'s own
+/// shape and the reasoning it argues at length: least-diagnostic first.
+///
+/// SOURCE goes first because it is the widest column here and an adopted
+/// path can run long -- the same reasoning `flock::TIERS` gives for SMIT,
+/// its own widest column. IN FILE goes second: it says what the document
+/// declares, which RUNNING (once task 9 wires it) answers a sharper version
+/// of -- "is it up" rather than "is it named". NAME and RUNNING are the
+/// floor for the same reason ID/NAME/STATUS is the flock table's: those two
+/// are the pane.
+const DOG_TIERS: &[(u16, &[DogColumn])] = &[
+    (61, ALL_DOG_COLUMNS),
+    (34, NO_SOURCE),
+    (DOG_MIN_WIDTH, FLOOR_DOG_COLUMNS),
+];
+
+/// The widest dogs-table column set that fits `width`.
+///
+/// Includes [`DogColumn::Running`] in every tier, even though nothing in
+/// this task draws it -- see that variant's own doc. A caller that wants the
+/// columns this task actually renders filters it out; `draw_settings` does
+/// exactly that.
+#[must_use]
+pub fn columns_for(width: u16) -> &'static [DogColumn] {
+    DOG_TIERS
+        .iter()
+        .find(|(threshold, _)| width >= *threshold)
+        .map_or(FLOOR_DOG_COLUMNS, |(_, columns)| *columns)
+}
+
+/// What NAME gets once the fixed dogs-table columns and their separators
+/// are paid for. [`super::flock::name_width`]'s own twin.
+fn dog_name_width(width: u16, columns: &[DogColumn]) -> u16 {
+    let fixed: u16 = columns.iter().map(|column| column.width()).sum();
+    let gaps = u16::try_from(columns.len().saturating_sub(1)).unwrap_or(0) * 2;
+    width
+        .saturating_sub(fixed)
+        .saturating_sub(gaps)
+        .max(DOG_NAME_MIN)
+}
+
+/// One dog's cell text.
+///
+/// [`DogColumn::Running`] is never reached in this task: [`draw_settings`]
+/// filters it out of the rendered column set before calling this, per
+/// that variant's own doc. The arm stays here rather than being left
+/// unimplemented so the match is exhaustive and a future column cannot fall
+/// through it unnoticed.
+fn dog_cell(dog: &DogView, column: DogColumn) -> String {
+    match column {
+        DogColumn::Name => dog.name.clone(),
+        DogColumn::InFile => if dog.enabled { "yes" } else { "no" }.to_string(),
+        DogColumn::Source => dog
+            .adopted_path
+            .as_ref()
+            .map_or_else(|| "built-in".to_string(), |path| path.display().to_string()),
+        DogColumn::Running => String::new(),
+    }
+}
+
+/// The dogs table's header line, indented to match every row's own
+/// mark-and-gap prefix ([`super::flock::mark`]'s own two columns).
+fn dog_header_line(columns: &[DogColumn], width: u16, palette: Palette) -> Line<'static> {
+    let name_width = dog_name_width(width, columns);
+    let mut text = String::from("  ");
+    for (index, column) in columns.iter().enumerate() {
+        if index > 0 {
+            text.push_str("  ");
+        }
+        let cell_width = if *column == DogColumn::Name {
+            name_width
+        } else {
+            column.width()
+        };
+        text.push_str(&fit(column.header(), cell_width));
+    }
+    Line::from(Span::styled(text, palette.muted()))
+}
+
+/// One dog's row.
+fn dog_line(dog: &DogView, columns: &[DogColumn], width: u16, selected: bool) -> Line<'static> {
+    let name_width = dog_name_width(width, columns);
+    let mut text = format!("{} ", mark(selected));
+    for (index, column) in columns.iter().enumerate() {
+        if index > 0 {
+            text.push_str("  ");
+        }
+        let cell_width = if *column == DogColumn::Name {
+            name_width
+        } else {
+            column.width()
+        };
+        text.push_str(&fit(&dog_cell(dog, *column), cell_width));
+    }
+    Line::from(Span::raw(text))
+}
+
+/// A `[section]` header, indented to match every scalar row's own
+/// mark-and-gap prefix, same as [`dog_header_line`]'s own reasoning.
+fn section_header(label: &str, palette: Palette) -> Line<'static> {
+    Line::from(Span::styled(format!("  {label}"), palette.muted()))
+}
+
+/// Which of the six scalars a [`SettingField`] names.
+fn scalar_view(snapshot: &SettingsSnapshot, field: SettingField) -> &ScalarView {
+    match field {
+        SettingField::LogLevel => &snapshot.log_level,
+        SettingField::LogJson => &snapshot.log_json,
+        SettingField::Socket => &snapshot.socket,
+        SettingField::MaxCronSleep => &snapshot.max_cron_sleep,
+        SettingField::AllowControl => &snapshot.allow_control,
+        SettingField::StyleLevel => &snapshot.style_level,
+    }
+}
+
+/// The name printed in the NAME cell -- the document's own key, except
+/// `[style] level`, which drops the `style_` a section header already says.
+const fn field_label(field: SettingField) -> &'static str {
+    match field {
+        SettingField::LogLevel => "log_level",
+        SettingField::LogJson => "log_json",
+        SettingField::Socket => "socket",
+        SettingField::MaxCronSleep => "max_cron_sleep",
+        SettingField::AllowControl => "allow_control",
+        SettingField::StyleLevel => "level",
+    }
+}
+
+/// What applying this field costs, decision 6 of the design spec's own
+/// table. `log_level`, `log_json` and `max_cron_sleep` all need a daemon
+/// reload; `socket` needs a full stop and start, since a reload never moves
+/// the listening socket; `allow_control` needs whistle restarted rather
+/// than the daemon, because a dog toggle and a whistle setting are both
+/// read by a process the daemon itself never touches; `style level` costs
+/// nothing because lookout re-resolves it on its own next command.
+const fn apply_cost(field: SettingField) -> &'static str {
+    match field {
+        SettingField::LogLevel | SettingField::LogJson | SettingField::MaxCronSleep => {
+            "needs shep daemon reload"
+        }
+        SettingField::Socket => "needs the shepherd stopped and started",
+        SettingField::AllowControl => "needs shep whistle restarted",
+        SettingField::StyleLevel => "the next command reads it",
+    }
+}
+
+/// NAME column width: fits `max_cron_sleep`, the longest field name, with a
+/// column of padding.
+const SCALAR_NAME_W: u16 = 15;
+/// VALUE column width: fits `/home/ada/.shep/run/shep.sock` (29 columns),
+/// an ordinary absolute socket path, whole -- a value already past this
+/// budget still truncates through [`fit`] rather than growing the column.
+const SCALAR_VALUE_W: u16 = 30;
+/// SOURCE column width: `$SHEP_STYLE` and `the default` are both 11 columns,
+/// the widest two words [`crate::style::StyleSource::Display`] ever prints.
+const SCALAR_SOURCE_W: u16 = 11;
+/// The floor on the apply-cost column once `width` is too narrow to give it
+/// the remainder: enough for `needs`, never a whole sentence.
+const SCALAR_COST_MIN: u16 = 8;
+
+/// One scalar row: name, value, source, apply cost.
+fn scalar_line(
+    field: SettingField,
+    view: &ScalarView,
+    selected: bool,
+    width: u16,
+) -> Line<'static> {
+    let fixed = 1 + 1 + SCALAR_NAME_W + 2 + SCALAR_VALUE_W + 2 + SCALAR_SOURCE_W + 2;
+    let cost_width = width.saturating_sub(fixed).max(SCALAR_COST_MIN);
+    let text = format!(
+        "{} {}  {}  {}  {}",
+        mark(selected),
+        fit(field_label(field), SCALAR_NAME_W),
+        fit(&view.value, SCALAR_VALUE_W),
+        fit(&view.source.to_string(), SCALAR_SOURCE_W),
+        fit(apply_cost(field), cost_width),
+    );
+    Line::from(Span::raw(text))
+}
+
+/// Every line of the screen's body, top to bottom: `[daemon]`'s four rows,
+/// `[whistle]`'s one, `[style]`'s one, then `[dogs]`'s caption and table.
+fn content_lines(settings: &Settings, palette: Palette, width: u16) -> Vec<Line<'static>> {
+    let snapshot = settings.snapshot();
+    let cursor = settings.cursor();
+    let is_selected = |field: SettingField| cursor == Some(SettingsRow::Scalar(field));
+
+    let mut lines = Vec::new();
+
+    lines.push(section_header("[daemon]", palette));
+    for field in [
+        SettingField::LogLevel,
+        SettingField::LogJson,
+        SettingField::Socket,
+        SettingField::MaxCronSleep,
+    ] {
+        lines.push(scalar_line(
+            field,
+            scalar_view(snapshot, field),
+            is_selected(field),
+            width,
+        ));
+    }
+    lines.push(Line::default());
+
+    lines.push(section_header("[whistle]", palette));
+    lines.push(scalar_line(
+        SettingField::AllowControl,
+        &snapshot.allow_control,
+        is_selected(SettingField::AllowControl),
+        width,
+    ));
+    lines.push(Line::default());
+
+    lines.push(section_header("[style]", palette));
+    lines.push(scalar_line(
+        SettingField::StyleLevel,
+        &snapshot.style_level,
+        is_selected(SettingField::StyleLevel),
+        width,
+    ));
+    lines.push(Line::default());
+
+    lines.push(section_header("[dogs]", palette));
+    lines.push(Line::from(Span::styled(
+        format!("  {DOGS_CAPTION}"),
+        palette.muted(),
+    )));
+    // `Running` is dropped from what actually draws -- see its own doc --
+    // so NAME reclaims the columns it would have taken rather than leaving
+    // them blank.
+    let rendered_columns: Vec<DogColumn> = columns_for(width)
+        .iter()
+        .copied()
+        .filter(|column| *column != DogColumn::Running)
+        .collect();
+    lines.push(dog_header_line(&rendered_columns, width, palette));
+    for (index, dog) in snapshot.dogs.iter().enumerate() {
+        let selected = cursor == Some(SettingsRow::Dog(index));
+        lines.push(dog_line(dog, &rendered_columns, width, selected));
+    }
+
+    lines
+}
+
+/// Draws the settings screen into `area`, straight into `buffer`.
+///
+/// `app` supplies the palette; every other fact this screen shows comes off
+/// `settings` -- see this module's own doc for why reading is the whole of
+/// this task.
+pub fn draw_settings(app: &App, settings: &Settings, area: Rect, buffer: &mut Buffer) {
+    if area.width == 0 || area.height == 0 {
+        return;
+    }
+    let palette = app.palette();
+    for (offset, line) in content_lines(settings, palette, area.width)
+        .iter()
+        .enumerate()
+        .take(usize::from(area.height))
+    {
+        let offset = u16::try_from(offset).unwrap_or(0);
+        buffer.set_line(area.x, area.y + offset, line, area.width);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use ratatui::Terminal;
+    use ratatui::backend::TestBackend;
+
+    use super::super::fixtures;
+    use super::*;
+    use crate::lookout::frames::render_text;
+
+    /// The whole screen at a comfortable width. The snapshot is the
+    /// assertion: it pins the section order, every row's four columns and
+    /// the dogs table underneath them.
+    #[test]
+    fn settings_at_a_comfortable_width() {
+        let app = fixtures::app_in_settings();
+        let mut terminal = Terminal::new(TestBackend::new(120, 30)).unwrap();
+        terminal
+            .draw(|frame| super::super::draw(&app, frame))
+            .unwrap();
+        insta::assert_snapshot!(render_text(terminal.backend().buffer()));
+    }
+
+    /// SOURCE is the widest column and the first to go, the same reasoning
+    /// `flock::TIERS` gives for SMIT.
+    #[test]
+    fn the_dogs_source_column_drops_before_the_rest() {
+        assert!(columns_for(120).contains(&DogColumn::Source));
+        assert!(!columns_for(60).contains(&DogColumn::Source));
+        assert!(
+            columns_for(60).contains(&DogColumn::Running),
+            "RUNNING is the diagnostic half and outlives SOURCE"
+        );
+    }
+
+    /// fails if a dogs-table tier can render wider than the terminal it was
+    /// chosen for -- the same claim `flock`'s own
+    /// `every_tier_fits_the_width_it_claims` makes for the flock table.
+    #[test]
+    fn every_dogs_tier_fits_the_width_it_claims() {
+        for width in DOG_MIN_WIDTH..=200 {
+            let columns = columns_for(width);
+            let fixed: u16 = columns.iter().map(|c| c.width()).sum();
+            let gaps = u16::try_from(columns.len() - 1).unwrap() * 2;
+            assert!(
+                fixed + gaps + DOG_NAME_MIN <= width,
+                "width {width} chose {} columns needing {}",
+                columns.len(),
+                fixed + gaps + DOG_NAME_MIN
+            );
+        }
+    }
+
+    /// fails if the dogs caption starts claiming space applies rather than
+    /// arms. This screen arms and confirms like every other action in
+    /// lookout, and a caption that says otherwise is wrong on screen.
+    #[test]
+    fn the_dogs_caption_says_arms_not_applies() {
+        assert_eq!(
+            DOGS_CAPTION,
+            "space arms, Enter applies; a dog needs no reload"
+        );
+    }
+
+    /// fails if the cursor mark stops landing on the row `Settings::cursor`
+    /// actually points at, or lands on more than one.
+    #[test]
+    fn the_cursor_mark_sits_on_exactly_the_selected_row() {
+        let app = fixtures::app_in_settings();
+        let settings = app.settings().unwrap();
+        let palette = app.palette();
+        let lines = content_lines(settings, palette, 120);
+        let rendered: Vec<String> = lines
+            .iter()
+            .map(|line| line.spans.iter().map(|s| s.content.as_ref()).collect())
+            .collect();
+        let marked: Vec<&String> = rendered.iter().filter(|l| l.starts_with('>')).collect();
+        assert_eq!(marked.len(), 1, "exactly one row is marked: {rendered:?}");
+        assert!(
+            marked[0].contains("log_level"),
+            "the cursor opens on the first row: {rendered:?}"
+        );
+    }
+}

--- a/crates/shep-cli/src/lookout/view/settings.rs
+++ b/crates/shep-cli/src/lookout/view/settings.rs
@@ -8,12 +8,13 @@
 //! a value cut short says so with the same trailing `…`, rather than
 //! spilling into the column beside it.
 //!
-//! Four of the six scalars (`log_level`, `log_json`, `allow_control`,
-//! `style level`) are editable, and their armed candidate is what one extra
-//! line under the dogs table shows, when there is one. `socket` and
-//! `max_cron_sleep` still only ever show what `shep.toml` says today: task
-//! 8's own free-text editor is what makes those two, and the dogs table's
-//! own enable/disable, editable as well.
+//! All six scalars are editable. Four (`log_level`, `log_json`,
+//! `allow_control`, `style level`) cycle, and their armed candidate is what
+//! one extra line under the dogs table shows, when there is one. `socket`
+//! and `max_cron_sleep` are free text instead: `Enter` on either row opens
+//! an editor in that same slot ([`Settings::typing`]), and both are the
+//! only two fields an empty buffer can unset. The dogs table's own
+//! enable/disable is editable as well.
 
 use ratatui::buffer::Buffer;
 use ratatui::layout::Rect;
@@ -372,6 +373,23 @@ fn content_lines(settings: &Settings, palette: Palette, width: u16) -> Vec<Line<
             format!("  {text}"),
             palette.attention(),
         )));
+    } else if let Some((field, buffer)) = settings.typing() {
+        // The free-text editor's own line, in the same slot the prompt
+        // above uses -- the two never coexist ([`Settings::pending`]
+        // returns `None` for `Pending::Typing`), so this is an `else if`
+        // rather than a second, always-checked block. The cursor is a
+        // character rather than a style, the same call the status bar's
+        // own filter box already makes: the ANSI gallery renders
+        // foregrounds only, so a reversed cell would come out unstyled
+        // there.
+        lines.push(Line::default());
+        lines.push(Line::from(Span::styled(
+            format!(
+                "  editing {}: {buffer}\u{258f}   enter applies   esc cancels",
+                field_label(*field)
+            ),
+            palette.attention(),
+        )));
     }
 
     lines
@@ -403,6 +421,7 @@ mod tests {
 
     use super::super::fixtures;
     use super::*;
+    use crate::lookout::app::{KeyPress, Msg};
     use crate::lookout::frames::render_text;
     use crate::style::StyleSource;
 
@@ -498,6 +517,30 @@ mod tests {
         assert!(
             !rendered.contains('…'),
             "SCALAR_SOURCE_W must fit \"the default\" whole: got {rendered:?}"
+        );
+    }
+
+    /// fails if the free-text editor stops showing what is being typed, or
+    /// stops naming the field it belongs to -- the same claim
+    /// `the_cursor_mark_sits_on_exactly_the_selected_row` makes for the
+    /// cursor, aimed at task 8's own line instead.
+    #[test]
+    fn the_editor_line_names_its_field_and_shows_the_buffer() {
+        let mut app = fixtures::app_in_settings_on(SettingField::Socket);
+        let _ = app.update(Msg::Key(KeyPress::Confirm));
+        let settings = app.settings().unwrap();
+        let palette = app.palette();
+        let lines = content_lines(settings, palette, 120);
+        let rendered: Vec<String> = lines
+            .iter()
+            .map(|line| line.spans.iter().map(|s| s.content.as_ref()).collect())
+            .collect();
+        assert!(
+            rendered
+                .iter()
+                .any(|line| line.contains("editing socket:")
+                    && line.contains("/home/ada/.shep/run/shep.sock")),
+            "got: {rendered:?}"
         );
     }
 }

--- a/crates/shep-cli/src/lookout/view/settings.rs
+++ b/crates/shep-cli/src/lookout/view/settings.rs
@@ -428,13 +428,16 @@ fn content_lines(
         lines.push(dog_line(dog, rendered_columns, width, selected));
     }
 
-    // One prompt line under the table, in the shape the status bar's own
-    // `confirm_prompt`/`in_flight_text` use for a sheep confirm: a question
-    // styled `attention` while it waits on `Enter`, an in-flight sentence
-    // once it has gone out. Drawn here rather than in the status bar itself
-    // -- the settings screen owns its own body between the title and that
-    // bar, and this prompt is about one row in the table above it, not
-    // about the whole dashboard.
+    // One prompt line under the table, echoing the status bar's own Slot 1
+    // (`view::status::status_line`'s own doc): a question styled
+    // `attention` while it waits on `Enter`, an in-flight sentence once it
+    // has gone out. The status bar is the line of record now -- it is a
+    // fixed row `draw_settings`'s own `.take(area.height)` never reaches,
+    // where this body echo used to be the ONLY place an armed candidate
+    // showed at all, and the first thing a short terminal cut. Kept here
+    // too, for the same reason the free-text editor line below is kept in
+    // both places: when there is room, seeing the confirm sit right under
+    // the row it names is worth the redundancy.
     if let Some(prompt) = settings.pending() {
         lines.push(Line::default());
         let text = if prompt.sent {

--- a/crates/shep-cli/src/lookout/view/settings.rs
+++ b/crates/shep-cli/src/lookout/view/settings.rs
@@ -42,6 +42,27 @@ const DOGS_CAPTION: &str = "space arms, Enter applies; a dog needs no reload";
 /// leave, NAME never shrinks below a name worth reading.
 const DOG_NAME_MIN: u16 = 8;
 
+/// The columns every line on this screen spends on the selection mark and
+/// the space after it, before any cell is drawn.
+///
+/// [`super::flock::GUTTER`]'s twin, and it exists for the reason that one
+/// does: a budget that forgets it is a budget every line overruns. Both the
+/// dogs table and the scalar rows draw [`mark`] plus a space, so the width
+/// a tier is chosen for and the width its cells are fitted into is the
+/// terminal MINUS this, never the terminal itself. Leaving it out put every
+/// dogs line two columns over its budget at every width -- 122 columns
+/// drawn into a 120-column terminal -- with `Buffer::set_line` clipping the
+/// overflow in silence. RUNNING is last, so what got clipped was always the
+/// diagnostic half: `waiting-restart` is exactly 15 characters in a 15-wide
+/// column, so it drew as `waiting-resta` with no ellipsis to say so.
+const GUTTER: u16 = 2;
+
+/// The width the rows themselves are laid out in: the terminal minus
+/// [`GUTTER`].
+const fn body_width(width: u16) -> u16 {
+    width.saturating_sub(GUTTER)
+}
+
 /// One column of the dogs table.
 ///
 /// `Debug` is derived rather than redacted (IR-41): a bare variant name,
@@ -105,8 +126,15 @@ const ALL_DOG_COLUMNS: &[DogColumn] = &[
 const NO_SOURCE: &[DogColumn] = &[DogColumn::Name, DogColumn::InFile, DogColumn::Running];
 const FLOOR_DOG_COLUMNS: &[DogColumn] = &[DogColumn::Name, DogColumn::Running];
 
-/// The narrowest terminal the dogs table's floor column set will draw into:
-/// [`DogColumn::Running`] plus [`DOG_NAME_MIN`] plus one gap.
+/// The narrowest the dogs TABLE will draw into: [`DogColumn::Running`] plus
+/// [`DOG_NAME_MIN`] plus one gap.
+///
+/// The table's floor, not the terminal's, exactly as
+/// [`super::flock::MIN_WIDTH`] is: a terminal also has to pay [`GUTTER`]
+/// for the selection mark, so the narrowest TERMINAL this table fits is
+/// `DOG_MIN_WIDTH + GUTTER`. Every threshold in [`DOG_TIERS`] is a table
+/// width and is compared against [`body_width`], never against the raw
+/// terminal.
 const DOG_MIN_WIDTH: u16 = DogColumn::Running.width() + DOG_NAME_MIN + 2;
 
 /// Width thresholds, widest first, mirroring [`super::flock::TIERS`]'s own
@@ -428,15 +456,24 @@ fn content_lines(
     lines.push(Line::default());
 
     lines.push(section_header("[dogs]", palette));
+    // `body_width`, not `width`: every line below draws `mark`'s own two
+    // columns before its first cell, so the table is laid out in what is
+    // left after them. `view::mod`'s own `draw` does the same for the flock
+    // table, and this pane had not.
+    let table_width = body_width(width);
+    // Fitted rather than printed raw: the caption is 48 columns and the
+    // screen draws from `view::MIN_TERM_WIDTH` (33) up, so on a narrow
+    // terminal it was cut mid-word by `Buffer::set_line` with nothing
+    // saying it had been cut.
     lines.push(Line::from(Span::styled(
-        format!("  {DOGS_CAPTION}"),
+        format!("  {}", fit(DOGS_CAPTION, table_width)),
         palette.muted(),
     )));
-    let rendered_columns = columns_for(width);
-    lines.push(dog_header_line(rendered_columns, width, palette));
-    for (index, dog) in dog_rows(app, width).iter().enumerate() {
+    let rendered_columns = columns_for(table_width);
+    lines.push(dog_header_line(rendered_columns, table_width, palette));
+    for (index, dog) in dog_rows(app, table_width).iter().enumerate() {
         let selected = cursor == Some(SettingsRow::Dog(index));
-        lines.push(dog_line(dog, rendered_columns, width, selected));
+        lines.push(dog_line(dog, rendered_columns, table_width, selected));
     }
 
     // One prompt line under the table, echoing the status bar's own Slot 1
@@ -511,6 +548,7 @@ mod tests {
     use super::*;
     use crate::lookout::app::{KeyPress, Msg};
     use crate::lookout::frames::render_text;
+    use crate::output::width::visible_width;
     use crate::style::StyleSource;
 
     /// The whole screen at a comfortable width. The snapshot is the
@@ -541,18 +579,39 @@ mod tests {
     /// fails if a dogs-table tier can render wider than the terminal it was
     /// chosen for -- the same claim `flock`'s own
     /// `every_tier_fits_the_width_it_claims` makes for the flock table.
+    ///
+    /// Measures the RENDERED lines rather than summing the declared widths,
+    /// which is what the arithmetic version of this test did and why it
+    /// could not fail. Every row and the header carry `mark`'s own
+    /// two-column prefix, and the sum left it out exactly as the code did,
+    /// so the test agreed with the bug: every dogs line came out two
+    /// columns over its budget at every width, `Buffer::set_line` clipped
+    /// the overflow in silence, and RUNNING is the last column, so
+    /// `waiting-restart` (15 characters in a 15-wide column) always drew as
+    /// `waiting-resta` with no ellipsis to say it had been cut.
     #[test]
     fn every_dogs_tier_fits_the_width_it_claims() {
-        for width in DOG_MIN_WIDTH..=200 {
-            let columns = columns_for(width);
-            let fixed: u16 = columns.iter().map(|c| c.width()).sum();
-            let gaps = u16::try_from(columns.len() - 1).unwrap() * 2;
-            assert!(
-                fixed + gaps + DOG_NAME_MIN <= width,
-                "width {width} chose {} columns needing {}",
-                columns.len(),
-                fixed + gaps + DOG_NAME_MIN
-            );
+        let app = fixtures::app_in_settings_with_dog_drift();
+        let settings = app.settings().unwrap();
+        let palette = app.palette();
+        for width in (DOG_MIN_WIDTH + GUTTER)..=200 {
+            let rendered: Vec<String> = content_lines(&app, settings, palette, width)
+                .iter()
+                .map(|line| line.spans.iter().map(|s| s.content.as_ref()).collect())
+                .collect();
+            // Everything from the `[dogs]` header down: the caption, the
+            // column header and one line per dog.
+            let table = rendered
+                .iter()
+                .position(|line| line.contains("[dogs]"))
+                .expect("the dogs section is always drawn");
+            for line in &rendered[table..] {
+                assert!(
+                    visible_width(line) <= usize::from(width),
+                    "width {width} drew {} columns: {line:?}",
+                    visible_width(line)
+                );
+            }
         }
     }
 

--- a/crates/shep-cli/src/lookout/view/settings.rs
+++ b/crates/shep-cli/src/lookout/view/settings.rs
@@ -14,7 +14,11 @@
 //! and `max_cron_sleep` are free text instead: `Enter` on either row opens
 //! an editor in that same slot ([`Settings::typing`]), and both are the
 //! only two fields an empty buffer can unset. The dogs table's own
-//! enable/disable is editable as well.
+//! enable/disable is editable as well, and its RUNNING column
+//! ([`dog_rows`]) joins the file's own `enabled`/`SOURCE` pair against the
+//! live flock, which is the only one of the three that can drift from it.
+
+use std::path::PathBuf;
 
 use ratatui::buffer::Buffer;
 use ratatui::layout::Rect;
@@ -23,7 +27,8 @@ use ratatui::text::{Line, Span};
 use super::super::app::{App, Settings, SettingsRow};
 use super::super::theme::Palette;
 use super::flock::{fit, mark};
-use crate::commands::settings::{DogView, ScalarView, SettingField, SettingsSnapshot};
+use crate::commands::settings::{ScalarView, SettingField, SettingsSnapshot};
+use crate::vocabulary::Reported;
 
 /// The dogs caption, verbatim. Not "space applies": this screen arms and
 /// confirms like every other action in lookout (`x`, `R`, `L`), and a
@@ -50,11 +55,10 @@ pub enum DogColumn {
     /// `built-in`, or the adopted binary's path.
     Source,
     /// The join against the live flock: whether the dog is actually up.
-    /// This task never renders it -- task 9's `dog_rows` supplies the data
-    /// this cell needs, and until then drawing a RUNNING header over a
-    /// column with nothing under it would be a rendering bug wearing a
-    /// header. The variant and its place in [`DOG_TIERS`] exist now anyway, so
-    /// task 9 extends the drop order rather than re-arguing it.
+    /// [`dog_rows`] supplies the word this cell shows -- the same one
+    /// [`super::flock::Column::Status`] would print for a sheep of that
+    /// name, off [`crate::vocabulary::Reported`] -- or [`None`] when no
+    /// dog of this name is running, which reads `not running`.
     Running,
 }
 
@@ -122,10 +126,8 @@ const DOG_TIERS: &[(u16, &[DogColumn])] = &[
 
 /// The widest dogs-table column set that fits `width`.
 ///
-/// Includes [`DogColumn::Running`] in every tier, even though nothing in
-/// this task draws it -- see that variant's own doc. A caller that wants the
-/// columns this task actually renders filters it out; `draw_settings` does
-/// exactly that.
+/// Includes [`DogColumn::Running`] in every tier -- it is the floor,
+/// alongside NAME, and `draw_settings` renders every column this returns.
 #[must_use]
 pub fn columns_for(width: u16) -> &'static [DogColumn] {
     DOG_TIERS
@@ -145,14 +147,77 @@ fn dog_name_width(width: u16, columns: &[DogColumn]) -> u16 {
         .max(DOG_NAME_MIN)
 }
 
-/// One dog's cell text.
+/// One row of the dogs table, with the file and the live flock joined by
+/// name. Declared here rather than in the [`SettingsSnapshot`] task's own
+/// module because the join is this one's whole subject: that snapshot
+/// carries [`crate::commands::settings::DogView`]'s `enabled` and
+/// `adopted_path` alone, and [`Self::running`] is what [`dog_rows`] adds.
 ///
-/// [`DogColumn::Running`] is never reached in this task: [`draw_settings`]
-/// filters it out of the rendered column set before calling this, per
-/// that variant's own doc. The arm stays here rather than being left
-/// unimplemented so the match is exhaustive and a future column cannot fall
-/// through it unnoticed.
-fn dog_cell(dog: &DogView, column: DogColumn) -> String {
+/// `Debug` is derived rather than redacted (IR-41): a name, a bool, a
+/// rendered word and a path, none of which is a secret -- a dog's own
+/// config, which can be, lives in `dogs.toml` and neither this type nor the
+/// [`DogView`](crate::commands::settings::DogView) it is built from ever
+/// touches it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DogRow {
+    /// The dog's name.
+    pub name: String,
+    /// Whether `[daemon] enabled_dogs` names it -- a fact about the file,
+    /// never about whether the shepherd has actually started it.
+    pub enabled: bool,
+    /// The word the flock table would show for this dog's own row, or
+    /// `None` when no dog of this name is running.
+    pub running: Option<String>,
+    /// `None` for a built-in dog; the adopted binary's path otherwise.
+    pub adopted_path: Option<PathBuf>,
+}
+
+/// The dogs table's rows: `app`'s settings snapshot joined against its own
+/// live flock, by name.
+///
+/// `app` rather than `Settings` alone: the file half
+/// ([`SettingsSnapshot::dogs`]) and the join's other half
+/// (`App::all_rows`, the live flock) live on two different types, and this
+/// is the one function that reads both. Returns the empty vector when the
+/// settings screen is not open -- `draw_settings` never calls this while it
+/// is closed, but a caller that did gets no rows rather than a panic.
+#[must_use]
+pub fn dog_rows(app: &App, width: u16) -> Vec<DogRow> {
+    // Not read: every dogs-table tier keeps `DogColumn::Running`, so there
+    // is no width where the join this function does would go unrendered --
+    // see `columns_for`'s own doc. Kept in the signature to match every
+    // other view function in this file, which takes the render width it is
+    // about to be fit into.
+    let _ = width;
+    let Some(settings) = app.settings() else {
+        return Vec::new();
+    };
+    let running_by_name: std::collections::BTreeMap<&str, String> = app
+        .all_rows()
+        .into_iter()
+        .filter(|row| row.info.dog.is_some())
+        .map(|row| {
+            (
+                row.info.name.as_str(),
+                Reported::of(row.info.status, row.info.handshook).word(),
+            )
+        })
+        .collect();
+    settings
+        .snapshot()
+        .dogs
+        .iter()
+        .map(|dog| DogRow {
+            name: dog.name.clone(),
+            enabled: dog.enabled,
+            running: running_by_name.get(dog.name.as_str()).cloned(),
+            adopted_path: dog.adopted_path.clone(),
+        })
+        .collect()
+}
+
+/// One dog's cell text.
+fn dog_cell(dog: &DogRow, column: DogColumn) -> String {
     match column {
         DogColumn::Name => dog.name.clone(),
         DogColumn::InFile => if dog.enabled { "yes" } else { "no" }.to_string(),
@@ -160,7 +225,10 @@ fn dog_cell(dog: &DogView, column: DogColumn) -> String {
             .adopted_path
             .as_ref()
             .map_or_else(|| "built-in".to_string(), |path| path.display().to_string()),
-        DogColumn::Running => String::new(),
+        DogColumn::Running => dog
+            .running
+            .clone()
+            .unwrap_or_else(|| "not running".to_string()),
     }
 }
 
@@ -184,7 +252,7 @@ fn dog_header_line(columns: &[DogColumn], width: u16, palette: Palette) -> Line<
 }
 
 /// One dog's row.
-fn dog_line(dog: &DogView, columns: &[DogColumn], width: u16, selected: bool) -> Line<'static> {
+fn dog_line(dog: &DogRow, columns: &[DogColumn], width: u16, selected: bool) -> Line<'static> {
     let name_width = dog_name_width(width, columns);
     let mut text = format!("{} ", mark(selected));
     for (index, column) in columns.iter().enumerate() {
@@ -307,7 +375,16 @@ const fn section_for(field: SettingField) -> &'static str {
 /// agree today would silently desync the moment either one reordered, and
 /// the cursor -- which [`Settings::rows`] alone defines -- would then land
 /// on a row this function drew somewhere else.
-fn content_lines(settings: &Settings, palette: Palette, width: u16) -> Vec<Line<'static>> {
+///
+/// Takes `app` as well as `settings`, unlike every scalar row above it:
+/// [`dog_rows`] is the one read here that needs the live flock, which lives
+/// on `App` and not on `Settings` alone.
+fn content_lines(
+    app: &App,
+    settings: &Settings,
+    palette: Palette,
+    width: u16,
+) -> Vec<Line<'static>> {
     let snapshot = settings.snapshot();
     let cursor = settings.cursor();
 
@@ -344,18 +421,11 @@ fn content_lines(settings: &Settings, palette: Palette, width: u16) -> Vec<Line<
         format!("  {DOGS_CAPTION}"),
         palette.muted(),
     )));
-    // `Running` is dropped from what actually draws -- see its own doc --
-    // so NAME reclaims the columns it would have taken rather than leaving
-    // them blank.
-    let rendered_columns: Vec<DogColumn> = columns_for(width)
-        .iter()
-        .copied()
-        .filter(|column| *column != DogColumn::Running)
-        .collect();
-    lines.push(dog_header_line(&rendered_columns, width, palette));
-    for (index, dog) in snapshot.dogs.iter().enumerate() {
+    let rendered_columns = columns_for(width);
+    lines.push(dog_header_line(rendered_columns, width, palette));
+    for (index, dog) in dog_rows(app, width).iter().enumerate() {
         let selected = cursor == Some(SettingsRow::Dog(index));
-        lines.push(dog_line(dog, &rendered_columns, width, selected));
+        lines.push(dog_line(dog, rendered_columns, width, selected));
     }
 
     // One prompt line under the table, in the shape the status bar's own
@@ -400,14 +470,15 @@ fn content_lines(settings: &Settings, palette: Palette, width: u16) -> Vec<Line<
 
 /// Draws the settings screen into `area`, straight into `buffer`.
 ///
-/// `app` supplies the palette; every other fact this screen shows, including
-/// its one armed or in-flight prompt line, comes off `settings`.
+/// `app` supplies the palette and the live flock [`dog_rows`] joins against;
+/// every other fact this screen shows, including its one armed or in-flight
+/// prompt line, comes off `settings`.
 pub fn draw_settings(app: &App, settings: &Settings, area: Rect, buffer: &mut Buffer) {
     if area.width == 0 || area.height == 0 {
         return;
     }
     let palette = app.palette();
-    for (offset, line) in content_lines(settings, palette, area.width)
+    for (offset, line) in content_lines(app, settings, palette, area.width)
         .iter()
         .enumerate()
         .take(usize::from(area.height))
@@ -489,7 +560,7 @@ mod tests {
         let app = fixtures::app_in_settings();
         let settings = app.settings().unwrap();
         let palette = app.palette();
-        let lines = content_lines(settings, palette, 120);
+        let lines = content_lines(&app, settings, palette, 120);
         let rendered: Vec<String> = lines
             .iter()
             .map(|line| line.spans.iter().map(|s| s.content.as_ref()).collect())
@@ -533,7 +604,7 @@ mod tests {
         let _ = app.update(Msg::Key(KeyPress::Confirm));
         let settings = app.settings().unwrap();
         let palette = app.palette();
-        let lines = content_lines(settings, palette, 120);
+        let lines = content_lines(&app, settings, palette, 120);
         let rendered: Vec<String> = lines
             .iter()
             .map(|line| line.spans.iter().map(|s| s.content.as_ref()).collect())
@@ -543,5 +614,32 @@ mod tests {
                 && line.contains("/home/ada/.shep/run/shep.sock")),
             "got: {rendered:?}"
         );
+    }
+
+    /// `otel` runs while the file has it disabled, which is what "a removed
+    /// name keeps running" looks like. `ledger` is enabled and absent,
+    /// which is a dog that failed to start.
+    #[test]
+    fn the_dogs_table_joins_the_file_against_the_running_flock() {
+        let app = fixtures::app_in_settings_with_dog_drift();
+        let rows = dog_rows(&app, 120);
+
+        let otel = rows.iter().find(|r| r.name == "otel").unwrap();
+        assert!(!otel.enabled);
+        assert_eq!(otel.running.as_deref(), Some("online"));
+
+        let ledger = rows.iter().find(|r| r.name == "ledger").unwrap();
+        assert!(ledger.enabled);
+        assert_eq!(ledger.running, None);
+    }
+
+    /// Phase 3b: a dog that never completed a handshake reads `silent`, not
+    /// `online`, and this table must not undo that.
+    #[test]
+    fn a_dog_that_never_handshook_reads_silent_here_too() {
+        let app = fixtures::app_in_settings_with_silent_dog();
+        let rows = dog_rows(&app, 120);
+        let bark = rows.iter().find(|r| r.name == "bark").unwrap();
+        assert_eq!(bark.running.as_deref(), Some("silent"));
     }
 }

--- a/crates/shep-cli/src/lookout/view/settings.rs
+++ b/crates/shep-cli/src/lookout/view/settings.rs
@@ -221,7 +221,10 @@ fn scalar_view(snapshot: &SettingsSnapshot, field: SettingField) -> &ScalarView 
 
 /// The name printed in the NAME cell -- the document's own key, except
 /// `[style] level`, which drops the `style_` a section header already says.
-const fn field_label(field: SettingField) -> &'static str {
+/// `pub(super)`: `status::status_line`'s own editor-line branch names the
+/// field being typed with this same word, so the status bar and the body
+/// pane never disagree about what to call `socket` or `max_cron_sleep`.
+pub(super) const fn field_label(field: SettingField) -> &'static str {
     match field {
         SettingField::LogLevel => "log_level",
         SettingField::LogJson => "log_json",
@@ -536,10 +539,8 @@ mod tests {
             .map(|line| line.spans.iter().map(|s| s.content.as_ref()).collect())
             .collect();
         assert!(
-            rendered
-                .iter()
-                .any(|line| line.contains("editing socket:")
-                    && line.contains("/home/ada/.shep/run/shep.sock")),
+            rendered.iter().any(|line| line.contains("editing socket:")
+                && line.contains("/home/ada/.shep/run/shep.sock")),
             "got: {rendered:?}"
         );
     }

--- a/crates/shep-cli/src/lookout/view/snapshots/shep__lookout__view__settings__tests__settings_at_a_comfortable_width.snap
+++ b/crates/shep-cli/src/lookout/view/snapshots/shep__lookout__view__settings__tests__settings_at_a_comfortable_width.snap
@@ -17,9 +17,9 @@ shep lookout   /home/ada/.shep                                                  
                                                                                                                         
   [dogs]                                                                                                                
   space arms, Enter applies; a dog needs no reload                                                                      
-  NAME                                                                                   IN FILE  SOURCE                
-  bark                                                                                   no       built-in              
-  metrics                                                                                yes      built-in              
+  NAME                                                                  IN FILE  SOURCE                    RUNNING      
+  bark                                                                  no       built-in                  not running  
+  metrics                                                               yes      built-in                  not running  
                                                                                                                         
                                                                                                                         
                                                                                                                         

--- a/crates/shep-cli/src/lookout/view/snapshots/shep__lookout__view__settings__tests__settings_at_a_comfortable_width.snap
+++ b/crates/shep-cli/src/lookout/view/snapshots/shep__lookout__view__settings__tests__settings_at_a_comfortable_width.snap
@@ -31,4 +31,4 @@ shep lookout   /home/ada/.shep                                                  
                                                                                                                         
                                                                                                                         
                                                                                                                         
-esc close   j/k select   g/G first/last   space cycle                                                          read-only
+esc/s close   j/k select   g/G first/last   r refresh                                                          read-only

--- a/crates/shep-cli/src/lookout/view/snapshots/shep__lookout__view__settings__tests__settings_at_a_comfortable_width.snap
+++ b/crates/shep-cli/src/lookout/view/snapshots/shep__lookout__view__settings__tests__settings_at_a_comfortable_width.snap
@@ -31,4 +31,4 @@ shep lookout   /home/ada/.shep                                                  
                                                                                                                         
                                                                                                                         
                                                                                                                         
-esc/s close   j/k select   g/G first/last   r refresh                                                          read-only
+esc/s close   j/k select   g/G first/last   r refresh   q quit                                                 read-only

--- a/crates/shep-cli/src/lookout/view/snapshots/shep__lookout__view__settings__tests__settings_at_a_comfortable_width.snap
+++ b/crates/shep-cli/src/lookout/view/snapshots/shep__lookout__view__settings__tests__settings_at_a_comfortable_width.snap
@@ -1,0 +1,34 @@
+---
+source: crates/shep-cli/src/lookout/view/settings.rs
+expression: render_text(terminal.backend().buffer())
+---
+shep lookout   /home/ada/.shep                                                                            3 in the flock
+  [daemon]                                                                                                              
+> log_level        warn                            shep.toml    needs shep daemon reload                                
+  log_json         false                           shep.toml    needs shep daemon reload                                
+  socket           /home/ada/.shep/run/shep.sock   shep.toml    needs the shepherd stopped and started                  
+  max_cron_sleep   30s                             shep.toml    needs shep daemon reload                                
+                                                                                                                        
+  [whistle]                                                                                                             
+  allow_control    false                           shep.toml    needs shep whistle restarted                            
+                                                                                                                        
+  [style]                                                                                                               
+  level            full                            shep.toml    the next command reads it                               
+                                                                                                                        
+  [dogs]                                                                                                                
+  space arms, Enter applies; a dog needs no reload                                                                      
+  NAME                                                                                   IN FILE  SOURCE                
+  bark                                                                                   no       built-in              
+  metrics                                                                                yes      built-in              
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+esc close   j/k select   g/G first/last   space cycle                                                          read-only

--- a/crates/shep-cli/src/lookout/view/snapshots/shep__lookout__view__settings__tests__settings_at_a_comfortable_width.snap
+++ b/crates/shep-cli/src/lookout/view/snapshots/shep__lookout__view__settings__tests__settings_at_a_comfortable_width.snap
@@ -17,9 +17,9 @@ shep lookout   /home/ada/.shep                                                  
                                                                                                                         
   [dogs]                                                                                                                
   space arms, Enter applies; a dog needs no reload                                                                      
-  NAME                                                                  IN FILE  SOURCE                    RUNNING      
-  bark                                                                  no       built-in                  not running  
-  metrics                                                               yes      built-in                  not running  
+  NAME                                                                IN FILE  SOURCE                    RUNNING        
+  bark                                                                no       built-in                  not running    
+  metrics                                                             yes      built-in                  not running    
                                                                                                                         
                                                                                                                         
                                                                                                                         

--- a/crates/shep-cli/src/lookout/view/status.rs
+++ b/crates/shep-cli/src/lookout/view/status.rs
@@ -294,9 +294,9 @@ fn hint_for(control: Control, settings_open: bool) -> String {
         // `s` gets said here at all -- on this screen `s` is the close key,
         // not the open one. `r` and `Enter` were missing outright.
         return match control {
-            Control::ReadOnly => "esc/s close   j/k select   g/G first/last   r refresh",
+            Control::ReadOnly => "esc/s close   j/k select   g/G first/last   r refresh   q quit",
             Control::Allowed => {
-                "esc/s close   j/k select   g/G first/last   r refresh   space cycle   enter apply"
+                "esc/s close   j/k select   g/G first/last   r refresh   space cycle   enter apply   q quit"
             }
         }
         .to_string();
@@ -685,6 +685,18 @@ mod tests {
         for both in [&closed, &open] {
             assert!(both.contains("esc/s close"), "got {both:?}");
             assert!(both.contains("r refresh"), "got {both:?}");
+        }
+    }
+
+    /// fails if `q` stops being named on the settings screen's own status
+    /// bar -- `App` handles it there (`app.rs`'s settings key dispatch),
+    /// same as on the dashboard, but neither settings hint form said so.
+    #[test]
+    fn q_quit_is_named_on_the_settings_screen_in_both_control_states() {
+        let closed = rendered(&status_line(&app_in_settings(), 200));
+        let open = rendered(&status_line(&app_in_settings_with_control(), 200));
+        for hint in [&closed, &open] {
+            assert!(hint.contains("q quit"), "got {hint:?}");
         }
     }
 }

--- a/crates/shep-cli/src/lookout/view/status.rs
+++ b/crates/shep-cli/src/lookout/view/status.rs
@@ -127,13 +127,20 @@ pub fn status_line(app: &App, width: u16) -> Line<'static> {
         // overlay anywhere in this module, and one rule under the header
         // beats a full border for a pane somebody reads at 3am.
         (text, palette.attention())
-    } else if !app.filter().is_empty() {
+    } else if app.settings().is_none() && !app.filter().is_empty() {
+        // Gated on the screen being closed: the filter survives the swap
+        // into settings (`App::on_settings_key` never touches it), but `/`
+        // and `esc` mean something else entirely while the screen owns the
+        // keyboard, so this line would be false the moment it stayed up.
         (
             format!("filter \"{}\"   / edit   esc clear", app.filter()),
             palette.muted(),
         )
     } else {
-        (hint_for(app.control()), palette.muted())
+        (
+            hint_for(app.control(), app.settings().is_some()),
+            palette.muted(),
+        )
     };
     // Always rendered, in both states. An operator who does not know whether
     // their dashboard can act is one keystroke from finding out the wrong
@@ -201,23 +208,33 @@ fn in_flight_text(action: &ActionState<'_>) -> String {
 
 /// The key hint.
 ///
-/// Two forms now that the three action keys exist. This file's standing
-/// rule: a hint that needs a footnote to be true is an asterisk, not a hint,
-/// so `Control::Allowed`'s form is only ever handed to a dashboard where `x`,
-/// `R` and `L` really do arm a confirm.
+/// Three forms now: the settings screen's own, and the dashboard's two.
+/// `settings_open` picks between them, and wins outright, because the
+/// dashboard's `x`/`R`/`L`/`r`/`/` mean nothing while the screen owns the
+/// keyboard. This file's standing rule: a hint that needs a footnote to be
+/// true is an asterisk, not a hint, so `Control::Allowed`'s dashboard form
+/// is only ever handed to a dashboard where `x`, `R` and `L` really do arm a
+/// confirm, and the settings form is only ever handed to a dashboard where
+/// they do nothing at all.
 ///
-/// The read-only text is 59 characters, up from the 48 that shipped before
-/// this phase. It still truncates at the 39 columns the 49-column gap test
-/// leaves for it, and the first 40 characters are byte-identical to the old
-/// hint, so `a_truncated_hint_still_leaves_a_gap_before_the_control_label`
-/// measures exactly what it was written to measure and the `narrow` and
-/// `cramped` frames do not move.
-fn hint_for(control: Control) -> String {
+/// `s settings` is APPENDED to both dashboard forms, never inserted: the
+/// read-only text's first 40 characters have to stay byte-identical for
+/// `a_truncated_hint_still_leaves_a_gap_before_the_control_label` and the
+/// `narrow`/`cramped` gallery frames to keep measuring what they were
+/// written to measure, and appending is the one edit that cannot move them.
+fn hint_for(control: Control, settings_open: bool) -> String {
+    if settings_open {
+        return "esc close   j/k select   g/G first/last   space cycle".to_string();
+    }
     match control {
-        Control::ReadOnly => "q quit   j/k select   g/G first/last   r refresh   / filter",
+        Control::ReadOnly => {
+            "q quit   j/k select   g/G first/last   r refresh   / filter   s settings"
+        }
         // `g/G` and `r` drop out to make room. They are the two an operator
         // rediscovers by pressing them; an action key is not.
-        Control::Allowed => "q quit   j/k select   / filter   x stop   R restart   L reload",
+        Control::Allowed => {
+            "q quit   j/k select   / filter   x stop   R restart   L reload   s settings"
+        }
     }
     .to_string()
 }

--- a/crates/shep-cli/src/lookout/view/status.rs
+++ b/crates/shep-cli/src/lookout/view/status.rs
@@ -410,7 +410,7 @@ mod tests {
     fn closing_the_box_shows_the_notice_that_was_waiting() {
         let mut app = editing_app("we");
         app.update(Msg::Event(BusEvent::Dropped { count: 3 }));
-        app.update(Msg::Key(KeyPress::FilterApply));
+        app.update(Msg::Key(KeyPress::TextApply));
         let bar = rendered(&status_line(&app, 120));
         assert!(bar.contains("dropped 3 events"), "got {bar:?}");
     }

--- a/crates/shep-cli/src/lookout/view/status.rs
+++ b/crates/shep-cli/src/lookout/view/status.rs
@@ -63,23 +63,53 @@ pub fn banner_line(app: &App) -> Option<Line<'static>> {
     }
 }
 
-/// The bottom line: seven slots, highest priority first -- an armed
-/// confirm, the settings screen's own free-text editor, the filter box
-/// while editing, a notice, an in-flight action, the applied filter line,
-/// then the key hint -- with the control state always rendered on the
-/// right. See the phase plan's "Shapes the design named" #2 for why the
-/// box and the applied filter line are two slots and not one. The editor
-/// slot sits ahead of the filter box for the same reason the confirm sits
-/// ahead of both: `App::settings().and_then(Settings::typing)` is only
-/// ever `Some` while the settings screen owns `InputMode::Text`, and the
-/// filter box's own `App::filter` is untouched the whole time, so checking
-/// the editor first is what keeps the two from ever answering the same
-/// keystroke with the wrong sentence.
+/// The bottom line: eight slots, highest priority first -- the settings
+/// screen's own armed or in-flight edit, a dashboard armed confirm, the
+/// settings screen's own free-text editor, the filter box while editing, a
+/// notice, an in-flight action, the applied filter line, then the key hint
+/// -- with the control state always rendered on the right. See the phase
+/// plan's "Shapes the design named" #2 for why the box and the applied
+/// filter line are two slots and not one. The editor slot sits ahead of the
+/// filter box for the same reason the two confirms sit ahead of it:
+/// `App::settings().and_then(Settings::typing)` is only ever `Some` while
+/// the settings screen owns `InputMode::Text`, and the filter box's own
+/// `App::filter` is untouched the whole time, so checking the editor first
+/// is what keeps the two from ever answering the same keystroke with the
+/// wrong sentence.
+///
+/// **The settings confirm moved here from the body pane.** It used to be
+/// the last line `view::settings::content_lines` drew -- structurally the
+/// first thing a short terminal's `.take(area.height)` truncation dropped,
+/// which meant an operator could arm a candidate, see no change anywhere
+/// on screen, and press Enter into an edit nothing showed them was coming.
+/// This bar is a fixed row the layout never cuts, the same property the
+/// dashboard's own sheep confirm (the slot below this one) already relies
+/// on, so the fix is to give the settings screen's confirm the identical
+/// treatment rather than teach the body pane to tier. The body still
+/// echoes the same line beneath the table when there is room for it
+/// (`content_lines`'s own doc), the same redundancy the free-text editor
+/// slot below already has -- belt, not a second source of truth: both
+/// read `Settings::pending`/`Settings::typing` directly.
 #[must_use]
 pub fn status_line(app: &App, width: u16) -> Line<'static> {
     let palette = app.palette();
-    let (left, left_style) = if let Some(action) = app.action().filter(|a| !a.sent) {
-        // Slot 1. A18: a question awaiting an answer outranks everything,
+    let (left, left_style) = if let Some(prompt) = app.settings().and_then(Settings::pending) {
+        // Slot 1. The settings screen's own armed scalar or dog edit, or
+        // its in-flight sentence once sent. Outranks everything below,
+        // including the dashboard's own action confirm just underneath --
+        // moot in practice, since `Msg::Settings`'s own `opening` arm
+        // clears `self.action` the moment the screen opens and no
+        // dashboard action can arm while it stays open (`on_key`'s own
+        // settings short circuit), so the two can never actually compete
+        // for this slot on the same frame.
+        let text = if prompt.sent {
+            format!("{}  sent, waiting for the shepherd", prompt.text)
+        } else {
+            format!("{}  enter confirms, any other key cancels", prompt.text)
+        };
+        (text, palette.attention())
+    } else if let Some(action) = app.action().filter(|a| !a.sent) {
+        // Slot 2. A18: a question awaiting an answer outranks everything,
         // including the filter box, which it cannot coexist with anyway
         // because `/` cancels a confirm before it opens the box.
         (confirm_prompt(&action), palette.attention())
@@ -132,7 +162,7 @@ pub fn status_line(app: &App, width: u16) -> Line<'static> {
             },
         )
     } else if let Some(action) = app.action() {
-        // Slot 4. BELOW the notice, and that is load-bearing rather than a
+        // Slot 5. BELOW the notice, and that is load-bearing rather than a
         // concession. `arm`'s "one action is already in flight" IS a notice,
         // so a bar that put this line above notices would swallow the answer
         // to the operator's own keypress: they press `R` while a stop is out,

--- a/crates/shep-cli/src/lookout/view/status.rs
+++ b/crates/shep-cli/src/lookout/view/status.rs
@@ -278,9 +278,28 @@ fn in_flight_text(action: &ActionState<'_>) -> String {
 /// `a_truncated_hint_still_leaves_a_gap_before_the_control_label` and the
 /// `narrow`/`cramped` gallery frames to keep measuring what they were
 /// written to measure, and appending is the one edit that cannot move them.
+/// The settings forms below follow the same rule against each other: the
+/// read-only one is a prefix of the control one, and the two edit keys are
+/// appended rather than inserted.
+///
+/// The settings screen takes `control` for the same reason the dashboard
+/// does, which it did not until a whole-branch review caught it: the
+/// argument was taken and then thrown away on the `settings_open` branch,
+/// so a read-only lookout was told `space cycle` about a key that refuses.
+/// That is exactly the asterisk the rule above forbids, and the dashboard
+/// omits `x`, `R` and `L` for the same reason.
 fn hint_for(control: Control, settings_open: bool) -> String {
     if settings_open {
-        return "esc close   j/k select   g/G first/last   space cycle".to_string();
+        // `esc/s close` names both keys that close the screen, which is how
+        // `s` gets said here at all -- on this screen `s` is the close key,
+        // not the open one. `r` and `Enter` were missing outright.
+        return match control {
+            Control::ReadOnly => "esc/s close   j/k select   g/G first/last   r refresh",
+            Control::Allowed => {
+                "esc/s close   j/k select   g/G first/last   r refresh   space cycle   enter apply"
+            }
+        }
+        .to_string();
     }
     match control {
         Control::ReadOnly => {
@@ -314,8 +333,8 @@ mod tests {
     use shep_core::protocol::BusEvent;
 
     use super::super::fixtures::{
-        acting_app, allowed_app, app_in_settings_on, armed_app,
-        armed_app_with_a_filter_and_a_notice, editing_app, filtered_app, rendered,
+        acting_app, allowed_app, app_in_settings, app_in_settings_on, app_in_settings_with_control,
+        armed_app, armed_app_with_a_filter_and_a_notice, editing_app, filtered_app, rendered,
     };
     use super::*;
     use crate::commands::settings::SettingField;
@@ -632,5 +651,40 @@ mod tests {
             open.contains("/ filter"),
             "and the filter key survives both forms"
         );
+    }
+
+    /// fails if the settings screen advertises its edit keys behind a
+    /// closed gate, or stops naming the three keys it binds and never
+    /// mentioned.
+    ///
+    /// The same rule as the test above, on the screen that ignored it:
+    /// `hint_for` took `control` and discarded it whenever the settings
+    /// screen was open, so a read-only lookout read `space cycle` next to
+    /// the word `read-only` on the same line, about a key that refuses.
+    /// The published gallery pinned it.
+    ///
+    /// `Enter`, `r` and `s` are all bound on that screen and none of them
+    /// was named. `s` arrives as `esc/s close`, because on this screen `s`
+    /// is the key that closes rather than the one that opens.
+    #[test]
+    fn the_settings_edit_keys_are_advertised_only_when_the_gate_is_open() {
+        let closed = rendered(&status_line(&app_in_settings(), 200));
+        for key in ["space cycle", "enter apply"] {
+            assert!(
+                !closed.contains(key),
+                "{key} advertised read-only: {closed:?}"
+            );
+        }
+        let open = rendered(&status_line(&app_in_settings_with_control(), 200));
+        for key in ["space cycle", "enter apply"] {
+            assert!(
+                open.contains(key),
+                "{key} missing when the gate is open: {open:?}"
+            );
+        }
+        for both in [&closed, &open] {
+            assert!(both.contains("esc/s close"), "got {both:?}");
+            assert!(both.contains("r refresh"), "got {both:?}");
+        }
     }
 }

--- a/crates/shep-cli/src/lookout/view/status.rs
+++ b/crates/shep-cli/src/lookout/view/status.rs
@@ -8,8 +8,9 @@
 use ratatui::style::Style;
 use ratatui::text::{Line, Span};
 
-use super::super::app::{ActionState, App, Control, InputMode, Link, RowKey};
+use super::super::app::{ActionState, App, Control, InputMode, Link, RowKey, Settings};
 use super::flock::fit;
+use super::settings::field_label;
 
 /// The title: what this is, where it points, and how big the flock is.
 ///
@@ -62,11 +63,18 @@ pub fn banner_line(app: &App) -> Option<Line<'static>> {
     }
 }
 
-/// The bottom line: six slots, highest priority first — an armed confirm,
-/// the filter box while editing, a notice, an in-flight action, the applied
-/// filter line, then the key hint — with the control state always rendered
-/// on the right. See the phase plan's "Shapes the design named" #2 for why
-/// the box and the applied filter line are two slots and not one.
+/// The bottom line: seven slots, highest priority first -- an armed
+/// confirm, the settings screen's own free-text editor, the filter box
+/// while editing, a notice, an in-flight action, the applied filter line,
+/// then the key hint -- with the control state always rendered on the
+/// right. See the phase plan's "Shapes the design named" #2 for why the
+/// box and the applied filter line are two slots and not one. The editor
+/// slot sits ahead of the filter box for the same reason the confirm sits
+/// ahead of both: `App::settings().and_then(Settings::typing)` is only
+/// ever `Some` while the settings screen owns `InputMode::Text`, and the
+/// filter box's own `App::filter` is untouched the whole time, so checking
+/// the editor first is what keeps the two from ever answering the same
+/// keystroke with the wrong sentence.
 #[must_use]
 pub fn status_line(app: &App, width: u16) -> Line<'static> {
     let palette = app.palette();
@@ -75,6 +83,24 @@ pub fn status_line(app: &App, width: u16) -> Line<'static> {
         // including the filter box, which it cannot coexist with anyway
         // because `/` cancels a confirm before it opens the box.
         (confirm_prompt(&action), palette.attention())
+    } else if let Some((field, buffer)) = app.settings().and_then(Settings::typing) {
+        // The settings screen's own free-text editor, checked ahead of the
+        // dashboard's filter-box branch below: both share `InputMode::Text`
+        // (task 8's editor reuses the filter box's keymap), but this one is
+        // typing into `socket` or `max_cron_sleep`, not `App::filter`. A bar
+        // that fell through to the filter branch here would render the
+        // dashboard's own (untouched) query under the label "filter" while
+        // the body pane's own `editing socket: ...` line says something
+        // else entirely on the same frame -- the screen would contradict
+        // itself. `field_label` is shared with `view::settings` so the two
+        // panes can never disagree about what to call the field.
+        (
+            format!(
+                "editing {}  {buffer}\u{258f}   enter applies   esc cancels",
+                field_label(*field)
+            ),
+            palette.attention(),
+        )
     } else if app.mode() == InputMode::Text {
         // ABOVE the notice, not below it. `Msg::BusLagged`,
         // `BusEvent::Dropped` and `BusEvent::DaemonShutdown` all raise notices
@@ -258,10 +284,11 @@ mod tests {
     use shep_core::protocol::BusEvent;
 
     use super::super::fixtures::{
-        acting_app, allowed_app, armed_app, armed_app_with_a_filter_and_a_notice, editing_app,
-        filtered_app, rendered,
+        acting_app, allowed_app, app_in_settings_on, armed_app,
+        armed_app_with_a_filter_and_a_notice, editing_app, filtered_app, rendered,
     };
     use super::*;
+    use crate::commands::settings::SettingField;
     use crate::lookout::app::{ActionVerb, App, KeyPress, Msg};
     use crate::lookout::theme::Palette;
 
@@ -402,6 +429,31 @@ mod tests {
         assert!(bar.contains("enter applies"), "got {bar:?}");
         assert!(bar.contains("esc cancels"), "got {bar:?}");
         assert!(bar.contains("ctrl-c quits"), "got {bar:?}");
+    }
+
+    /// fails if the bar falls through to the dashboard's own filter box
+    /// while the settings screen's free-text editor owns `InputMode::Text`
+    /// instead -- the review finding this pins: before the fix, this state
+    /// rendered "filter  <the dashboard's untouched query>" under the
+    /// editor's own body line saying "editing socket: ...", contradicting
+    /// itself on one frame.
+    #[test]
+    fn the_bar_shows_the_settings_editor_rather_than_the_filter_box() {
+        let mut app = app_in_settings_on(SettingField::Socket);
+        let _ = app.update(Msg::Key(KeyPress::Confirm));
+        let bar = rendered(&status_line(&app, 120));
+        assert!(
+            bar.contains("editing socket  "),
+            "names the field being typed: {bar:?}"
+        );
+        assert!(
+            bar.contains("/home/ada/.shep/run/shep.sock\u{258f}"),
+            "shows the buffer and the cursor, not the dashboard's own filter: {bar:?}"
+        );
+        assert!(
+            !bar.contains("filter "),
+            "must not read as the filter box: {bar:?}"
+        );
     }
 
     /// fails if a notice covers the box. A `Dropped` event arrives with no

--- a/docs/brainstorming/specs/2026-09-04-lookout-settings-design.md
+++ b/docs/brainstorming/specs/2026-09-04-lookout-settings-design.md
@@ -1,0 +1,350 @@
+# Design: the lookout settings screen
+
+Status: designed 2026-09-04, not yet implemented. This builds decision 11 of
+[the config overrides design](2026-09-02-config-overrides-design.md), and only
+the `shep.toml` half of it. The overrides half of decision 11, and decision 12's
+write-only env, are a later slice.
+
+Two things in decision 11 are out of date, and one of its claims about dogs is
+wrong. All three are corrected below, with the code that settles them.
+
+## What this is
+
+`shep lookout` gains a settings screen, opened with `s`, that reads and writes
+`$SHEP_HOME/shep.toml`. Six scalars and a per-dog on and off toggle. Editing is
+behind the existing `--allow-control` gate; reading is not.
+
+The design work is in telling an operator what a change will and will not do.
+That differs per field, and decision 11's own table gets it wrong.
+
+## What already exists
+
+Established from the code, not assumed.
+
+- **`ShepToml` is the one writer this binary has for `shep.toml`**
+  (`crates/shep-cli/src/commands/shep_toml.rs`). `toml_edit`, so comments and
+  key order survive; an exclusive advisory lock on a sibling file held across
+  the read, modify and write; the new document staged at `0600`, `fsync`ed and
+  renamed. `shep style`, `shep enable`, `shep adopt` and `shep rehome` all go
+  through it.
+- **That lock blocks with no deadline.** `ConfigLock::acquire` uses
+  `FlockArg::LockExclusive` and says so at `shep_toml.rs:717`: *"`LockExclusive`
+  blocks; the non-blocking variant would need a retry loop and a deadline."*
+- **`try_edit`'s refusal leaves the file untouched down to its inode.** A
+  closure that returns `Err` skips `save` entirely, so no rename lands and no
+  fresh inode replaces the original.
+- **lookout's reducer is pure.** `App::update` returns an `Effect` and does no
+  I/O; `run_ui` performs it. The reducer holds no terminal types either, because
+  `input::map_key` does the crossterm translation at the edge.
+- **`--allow-control` is a fat-finger catch and the code says so**
+  (`lookout/app.rs:48`). Three keys arm a confirm rather than acting on the
+  press that armed them, and an armed confirm expires after ten seconds off
+  `Msg::Tick`.
+- **`StyleSource` already exists for exactly this class of bug**
+  (`crates/shep-cli/src/style.rs:223`). Its own doc: *"the failure this prevents
+  is an operator editing `shep.toml` and seeing nothing change, with
+  `$SHEP_STYLE` set in a shell profile they have forgotten about."* `shep style`
+  reports which layer decided.
+- **`s` and `space` are unbound.** `q`, `Esc`, `/`, `j`, `k`, `g`, `G`, `r`,
+  `x`, `R`, `L` and Enter are taken.
+- **`BUILT_IN_DOGS` is `["metrics", "bark"]`** (`crates/shep-cli/src/dog/mod.rs:46`).
+  Every other dog name is a key of `[daemon] adopted_dogs`.
+
+## Three corrections to decision 11
+
+### `[dog.<name>]` is not excluded, because it is not there
+
+Decision 11 excludes it as "a third-party dog's opaque schema". PR #112 moved
+every dog's config to `$SHEP_HOME/dogs.toml`, migrated once at boot.
+`RawDaemonConfig` keeps a `dog` field only so an un-migrated file still parses.
+There is nothing left to exclude.
+
+A dogs config pane is separate later work with its own spec
+([the dog config design](2026-09-03-dog-config-design.md), decision 9), and it
+depends on dogs publishing a schema, which is not built.
+
+### Decision 13 does not apply to this screen
+
+Decision 13 generates panes from `flockfile_schema_json()`. That describes the
+Flockfile. `shep.toml` is described by `DaemonConfig`, a struct shep owns, whose
+sections are three known shapes with six scalars between them. The screen is
+written against those fields by name.
+
+### A dog toggle costs nothing, and applies now
+
+Decision 11's table puts `[dog.*]` under "needs `shep daemon reload`". That is
+wrong for the toggle, and the reason is that `shep enable` is two steps rather
+than one. It writes the file, then sends `Request::EnableDog` to the shepherd,
+which starts the dog immediately (`commands/dogs.rs:193`). `shep disable`
+mirrors it with `Request::DisableDog` (`commands/dogs.rs:349`). Routed through
+that code, a toggle in lookout applies live and needs no reload.
+
+The handover asymmetry decision 11 describes is real, and it is about a
+different path: what a `daemon reload` does to an `enabled_dogs` list somebody
+edited by hand. All three of its claims verify:
+
+| Claim | Where |
+| --- | --- |
+| A successor computes the socket path and discards it | `boot.rs:1170` computes it; `boot.rs:1178`'s handover arm calls `rehydrate` and never `bind_socket` |
+| `do_start_dog` short-circuits on a name collision | `supervisor.rs:3355` returns the existing slot's `to_info` |
+| A name removed from `enabled_dogs` keeps running | `spawn_enabled_dogs` (`dogs.rs:280`) iterates the enabled list only, and nothing walks the inherited flock for de-enabled names |
+
+Because the toggle does not go through a handover, none of that reaches the
+screen. What does reach it is the RUNNING column, which shows the asymmetry as a
+fact when an operator has hit it by another route.
+
+## A fourth thing decision 11 does not cover
+
+The daemon boots `file < env < flags` (`commands/daemon.rs:318`, reading
+`std::env::var` and its own argv), and a handover successor inherits both
+through `execve`. So all four `[daemon]` scalars can be shadowed by
+`SHEP_LOG_JSON`, `SHEP_LOG_LEVEL`, `SHEP_SOCKET`, `SHEP_MAX_CRON_SLEEP` or the
+matching `shep daemon` flags. A `log_level` edit followed by a reload is inert
+if the shepherd was booted with `SHEP_LOG_LEVEL` set.
+
+`HelloAck` carries `daemon_version`, `protocol` and `pid`, so **lookout cannot
+see either layer.** It belongs to a different process.
+
+`[style]` is the exception, and it inverts: `$SHEP_STYLE` and `--style` are
+lookout's own env and argv, so lookout can name the layer in force exactly,
+reusing `StyleSource`.
+
+This is the same defect class as decision 11's own socket note, one layer up.
+
+## Decisions
+
+### 1. A screen, not a fourth stacked pane
+
+`s` swaps the dashboard body for the settings screen and `s` or `Esc` swaps back.
+The title line and the status bar stay put.
+
+At 24 rows the three existing panes claim 13 of them and settings needs about
+ten, so a fourth tier would sit above 34 rows and most terminals would never
+reach it. Settings is also a modal task rather than a monitoring surface: an
+operator opens it, changes something, and leaves.
+
+### 2. Per field, arm and confirm
+
+Editing a field arms a candidate and shows a prompt naming that field's own
+apply cost. Enter applies it. One field per write.
+
+This is the shape `x`, `R` and `L` already use, down to the ten-second expiry,
+so an operator who has learned one has learned the other. A staged set with one
+apply was considered and refused: a half-finished set is a state the reducer has
+no shape for, and the batching it buys matters only for dogs, which are the
+cheapest edits on the screen.
+
+`space` arms and re-arms. Each press advances the candidate and resets the
+clock, which is the only way to reach the fourth of six log levels without
+cancelling and re-arming.
+
+### 3. Both free-text fields are editable, validated under the lock
+
+Four of the six scalars are booleans or closed enums. `socket` and
+`max_cron_sleep` are free text, and both get an editor reusing the filter box's
+`InputMode::Text` keymap.
+
+Validation happens in one place, inside the `try_edit` closure: mutate the
+document, render it, run `DaemonConfig::load` over the result, and return `Err`
+on refusal. A refusal reopens the editor with the typed text intact and the
+loader's own message as a grave notice.
+
+Not at arm time, deliberately. `MIN_CRON_SLEEP` is private to `shep-core`, so an
+arm-time pre-check would re-derive the one-second floor locally, which is
+duplicating a rule to save a keystroke. Validating under the lock also catches a
+document another process made bad between the read and the write, which no
+pre-check can.
+
+### 4. The apply cost is per field, and the caveat lands in the confirm
+
+| Field | Edit | Cost |
+| --- | --- | --- |
+| `[style] level` | cycle | nothing, the next command reads it |
+| `[whistle] allow_control` | toggle | `shep whistle` restarted |
+| `[daemon] log_level` | cycle | `shep daemon reload` |
+| `[daemon] log_json` | toggle | `shep daemon reload` |
+| `[daemon] max_cron_sleep` | text | `shep daemon reload` |
+| `[daemon] socket` | text | the shepherd stopped and started |
+| a dog | toggle | nothing, it applies now |
+
+The shadowing caveat goes in the confirm rather than in an always-visible header,
+because it arrives where the operator is deciding and costs nothing on a screen
+that has other things to say. A `[daemon]` confirm names the variable and the
+flag by their own spellings.
+
+`[style]`'s row is the one that states its layer instead of hedging, because
+lookout can see it: `full   in force from $SHEP_STYLE`.
+
+`socket` says both halves. A reload will not move it, and an env or flag may
+shadow it anyway.
+
+### 5. lookout does not trigger the reload
+
+`shep daemon reload` is a config pre-flight, a dog migration, a `HandoverFitness`
+question and then `execve` signalling (`commands/daemon.rs:657`). It is not a
+wire request, and a handover severs lookout's own link mid-frame. Reproducing it
+inside the reducer would be a second implementation of the most dangerous command
+in the repository.
+
+lookout names the command. The operator runs it.
+
+### 6. The screen opens read-only when the gate is off
+
+Every value shows; the edit keys refuse by notice, the way `x`, `R` and `L`
+already do.
+
+Reading `shep.toml` is not a privileged act: anyone who can run lookout can read
+the file. The screen leaks nothing either, which is checked rather than assumed
+under decision 9. And a read-only screen is still diagnostic, since it names the
+style layer in force and shows which dogs are enabled against which are running.
+
+### 7. The dogs section shows three columns
+
+Name, what the file says, what the shepherd reports, and where the binary comes
+from. The middle two are joined by name from `App::flock`, which already carries
+every running dog: `ProcessInfo.dog` marks one, and Phase 3b's `handshook` is
+what makes a dog that never completed a handshake read `silent` rather than
+`online`.
+
+```
+  [dogs]   space toggles; enable and disable apply now, no reload
+
+  NAME       IN FILE     RUNNING     SOURCE
+> metrics    enabled     online      built in
+  bark       enabled     silent      built in
+  otel       -           online      /usr/local/bin/shep-otel
+  ledger     enabled     -           /opt/ledger/bin/dog
+```
+
+Two rows there are drift an operator cannot see anywhere else. `otel` is running
+while disabled in the file, which is what "a removed name keeps running" looks
+like. `ledger` is enabled and absent, which is a dog that failed to start.
+
+SOURCE is the widest column and the first to drop, mirroring `columns_for`'s own
+tier table in `view/flock.rs` and the reasoning in its doc.
+
+### 8. The toggle reuses `shep enable`'s decision, not its reporting
+
+`shep enable`'s file half is a `try_edit` closure holding a real decision: which
+`DogSource` this name resolves to, whether it names a dog at all, and the
+mutation. Its daemon half writes rows to stdout, which lookout does not have.
+
+So the cut is at that seam:
+
+```rust
+pub(crate) fn enable_in_config(path: &Path, name: &str) -> Result<DogSource, EnableRefusal>
+pub(crate) fn disable_in_config(path: &Path, name: &str) -> Result<DogSource, ShepTomlError>
+```
+
+`dogs::enable` and `dogs::disable` call those and keep their reporting; lookout
+calls the same two and reports through `Notice`. Nothing re-implements what a dog
+name means.
+
+### 9. Nothing on this screen is sensitive, and that is checked
+
+`StyleSection` and `WhistleSection` both carry an explicit note that their
+`Debug` is derived rather than redacted because neither holds a secret;
+`DaemonSection` derives `Debug` too. `DaemonConfig`'s own manual `Debug` redacts
+one field, `dog`, which this screen does not touch. So no redacted `Debug` is
+owed here (IR-41), and the call site says so rather than leaving it silent.
+
+## Data flow
+
+Three new effects, all performed in `run_ui` on `spawn_blocking`. The blocking
+matters: the config lock has no deadline, so a concurrent `shep adopt` would
+otherwise freeze the redraw, the tick and the bus drain together.
+
+```
+s              -> Effect::LoadSettings   -> Msg::Settings { fields, dogs }
+Enter, armed   -> Effect::WriteSetting   -> Msg::SettingWritten { edit, result }
+```
+
+A scalar write ends there, in a notice. A dog write chains one step further,
+because its file half and its daemon half are two acts:
+
+```
+Msg::SettingWritten { Ok(source) } -> Effect::Send(Sent::Dog { .. })
+                                   -> Msg::Replied -> notice
+```
+
+File first, then the daemon, which is `shep enable`'s own order. `Sent` gains a
+`Dog` variant carrying the name and the `DogSource` the write returned, so
+`Sent::request()` builds `EnableDog` and `DisableDog` the same way it already
+builds `Stop`, `Restart` and `Reload`.
+
+`PROTOCOL_VERSION` does not move. Both requests already exist.
+
+## Keys
+
+| Key | Does |
+| --- | --- |
+| `s` | opens from the dashboard, closes back to it |
+| `j` `k` `Up` `Down` `g` `G` | move the cursor across sections and into the dogs list |
+| `space` | arms a candidate, and advances it on each further press |
+| `Enter` | opens a text field's editor, or applies an armed confirm |
+| `Esc` | cancels the confirm, else the editor, else closes the screen |
+| `r` | re-reads `shep.toml`, so another process's write shows up |
+
+`Esc` never quits from this screen. That is the cascade `KeyPress::Escape`'s own
+doc already describes, with one arm swapped.
+
+`space` and `s` are unbound on the dashboard and stay that way: the keymap emits
+them and the reducer decides, because the keymap cannot see whether the screen is
+open. That is the same division the existing `Escape` arm is built on, so
+`InputMode` gains no third variant.
+
+The four `KeyPress::Filter*` variants are renamed `Text*`. The settings editor
+needs the identical keymap, and a variant named for the filter box would be
+naming a destination the keymap cannot see.
+
+## One divergence from the sheep confirm
+
+`Msg::Tick` stops advancing `self.now` once the link is `Lost`, so a sheep
+confirm never expires on a frozen dashboard, and `disarm_on_link_change` clears
+it. A settings edit is local file I/O over a file that is not stale, so it
+diverges:
+
+| On a lost link | A sheep action | Settings |
+| --- | --- | --- |
+| an armed confirm | disarmed | survives, and still expires, off the raw tick |
+| the six scalars | not applicable | still editable |
+| a dog toggle | not applicable | refuses with the existing `LINK_GONE` sentence |
+
+A dog toggle needs the link because its second step is a request. The scalars
+never leave the machine.
+
+## Testing
+
+No sleeps. Expiry rides synthesised `Instant`s through `Msg::Tick`, mirroring
+`a_confirm_expires_after_ten_seconds_of_ticks` (IR-46).
+
+| Tier | Proves |
+| --- | --- |
+| reducer, `lookout/app.rs` | arming, candidate cycling, expiry, the `Esc` cascade, the read-only refusals, the lost-link split above, and that `Msg::SettingWritten { Ok(..) }` yields `Effect::Send` |
+| render, `lookout/view/settings.rs` | the screen at several widths, for SOURCE's drop tiers |
+| `commands/dogs.rs` | `enable_in_config` and `disable_in_config` against the existing fixtures |
+| refusal | a `max_cron_sleep` under the floor is refused, and the file is byte-identical afterwards |
+
+Every new test is mutated to prove it is not vacuous, and the mutation is checked
+to have applied rather than trusted.
+
+## Docs
+
+`docs/lookout/frames.txt` gains settings frames through the existing
+`write_the_gallery` ignored test, in the shape the file already uses.
+`web/src/pages/docs/lookout.astro` gains the `s` key and the screen. Then
+`cargo build --release`, `./web/scripts/generate-cli-reference.sh`, and both
+`astro build` and `astro check`.
+
+## Out of scope
+
+- **`adopted_dogs` is not editable yet.** `shep adopt` vets a candidate by
+  spawning it and probing `--version`, refusing a protocol mismatch, and a raw
+  edit walks past that vetting. This is a later slice rather than a closed door:
+  the dogs table already renders the path in its SOURCE column, so making that
+  column writable is an addition, and what it has to route through is the probe.
+- **`[interpreters]`**, a free-form extension map with no field list to render
+  (decision 11).
+- **The overrides half of decision 11**, and decision 12's write-only env. Both
+  are a later slice.
+- **Triggering the reload**, per decision 5 above.

--- a/docs/brainstorming/specs/2026-09-04-lookout-settings-design.md
+++ b/docs/brainstorming/specs/2026-09-04-lookout-settings-design.md
@@ -2,8 +2,12 @@
 
 Status: designed 2026-09-04, not yet implemented. This builds decision 11 of
 [the config overrides design](2026-09-02-config-overrides-design.md), and only
-the `shep.toml` half of it. The overrides half of decision 11, and decision 12's
-write-only env, are a later slice.
+the `shep.toml` half of it. That decision's other half, the overrides store,
+and decision 12's write-only env are a later slice.
+
+A bare "decision 11" here means that spec's, which is the authority. This
+spec's own numbered decisions are always written "decision 4 above" or
+"decision 7 below".
 
 Two things in decision 11 are out of date, and one of its claims about dogs is
 wrong. All three are corrected below, with the code that settles them.
@@ -45,6 +49,17 @@ Established from the code, not assumed.
   is an operator editing `shep.toml` and seeing nothing change, with
   `$SHEP_STYLE` set in a shell profile they have forgotten about."* `shep style`
   reports which layer decided.
+- **A fresh `shep.toml` contains only `[interpreters]`.**
+  `scaffold_first_run_interpreters` (`lib.rs:776`) runs at every `home_is_new`
+  site and writes the starter interpreter mapping; nothing scaffolds `[daemon]`,
+  `[style]` or `[whistle]`. `ShepToml::open` treats a missing file as an empty
+  document, so on a fresh box every field this screen shows is absent.
+- **There is a lock-free read path already.** `adopted_dog_path_readonly`
+  argues it: `save`'s rename is atomic, so a concurrent writer can only be
+  observed before or after it, never torn.
+- **`shep style` cannot clear `[style] level`.** `set_style_level` only writes,
+  and the verb with no argument reports the level in force instead of changing
+  it (`cli.rs:1177`).
 - **`s` and `space` are unbound.** `q`, `Esc`, `/`, `j`, `k`, `g`, `G`, `r`,
   `x`, `R`, `L` and Enter are taken.
 - **`BUILT_IN_DOGS` is `["metrics", "bark"]`** (`crates/shep-cli/src/dog/mod.rs:46`).
@@ -93,7 +108,9 @@ Because the toggle does not go through a handover, none of that reaches the
 screen. What does reach it is the RUNNING column, which shows the asymmetry as a
 fact when an operator has hit it by another route.
 
-## A fourth thing decision 11 does not cover
+## Two things decision 11 does not cover
+
+### The shepherd's own env and flags
 
 The daemon boots `file < env < flags` (`commands/daemon.rs:318`, reading
 `std::env::var` and its own argv), and a handover successor inherits both
@@ -110,6 +127,19 @@ lookout's own env and argv, so lookout can name the layer in force exactly,
 reusing `StyleSource`.
 
 This is the same defect class as decision 11's own socket note, one layer up.
+
+### An absent field, which is the common case
+
+`DaemonSection`, `WhistleSection` and `StyleSection` are all
+`#[serde(default)]`, so `DaemonConfig::load` returns a fully populated struct
+whether the file declared a key or not. `log_level` reads `warn` for a file that
+says `warn` and for a file that says nothing, and by then the difference is
+gone.
+
+On a fresh `$SHEP_HOME` that is every field on the screen, so it is the state
+most operators open it in rather than an edge case. And it is the same defect as
+the section above: a layer the screen cannot see. That one was caught by
+reading the boot path. This one hides inside a struct that looks like an answer.
 
 ## Decisions
 
@@ -155,7 +185,56 @@ duplicating a rule to save a keystroke. Validating under the lock also catches a
 document another process made bad between the read and the write, which no
 pre-check can.
 
-### 4. The apply cost is per field, and the caveat lands in the confirm
+### 4. The screen reads the document, and every scalar carries a source
+
+The screen reads presence out of the `toml_edit` document, key by key, because
+that is the fact `DaemonConfig::load` destroys. `DaemonConfig` keeps two jobs
+and loses one: it supplies the effective value when a key is absent, and it
+validates inside `try_edit`, but it is not what the screen reads a value from.
+
+That gives every scalar a SOURCE, and the vocabulary already exists.
+`StyleSource`'s own `Display` renders `--style`, `$SHEP_STYLE`, `shep.toml` and
+`the default`. Only `[style]` ever reaches the first two, because only those
+layers are lookout's own process.
+
+```
+  [daemon]
+> log_level        warn                       the default    needs: shep daemon reload
+  log_json         false                      the default    needs: shep daemon reload
+  socket           ~/.shep/run/shep.sock      the default    needs: full stop and start
+  max_cron_sleep   30s                        shep.toml      needs: shep daemon reload
+
+  [whistle]
+  allow_control    false                      the default    needs: shep whistle restart
+
+  [style]
+  level            full                       $SHEP_STYLE
+```
+
+The column is headed SOURCE and not IN FORCE, and the difference carries weight.
+`shep.toml` is a true statement about where lookout read the value. It is never
+a claim that the shepherd is using it, which the confirm handles separately for
+the two layers lookout cannot see.
+
+`socket` shows `paths.socket` rather than an empty cell, because that is the
+socket this lookout is connected over, so it is the live answer by construction.
+
+### 5. Unsetting exists where the field is optional and no verb owns it
+
+`socket` and `max_cron_sleep` can be unset from an empty text editor, which
+deletes the key and returns the row to `the default`.
+
+`style.level` is `Option<String>` too, so the types alone would give it an unset.
+It does not get one: `shep style` owns that key, `set_style_level` only ever
+writes, and the verb with no argument reports rather than clears. lookout does
+not grow a capability the verb that owns the field lacks.
+
+`log_level`, `log_json` and `allow_control` are not optional and always write a
+key. So the screen can move those three from `the default` to `shep.toml` and
+not back, which is a real limitation and is stated on the docs page rather than
+left for an operator to discover.
+
+### 6. The apply cost is per field, and the caveat lands in the confirm
 
 | Field | Edit | Cost |
 | --- | --- | --- |
@@ -178,7 +257,7 @@ lookout can see it: `full   in force from $SHEP_STYLE`.
 `socket` says both halves. A reload will not move it, and an env or flag may
 shadow it anyway.
 
-### 5. lookout does not trigger the reload
+### 7. lookout does not trigger the reload
 
 `shep daemon reload` is a config pre-flight, a dog migration, a `HandoverFitness`
 question and then `execve` signalling (`commands/daemon.rs:657`). It is not a
@@ -188,17 +267,18 @@ in the repository.
 
 lookout names the command. The operator runs it.
 
-### 6. The screen opens read-only when the gate is off
+### 8. The screen opens read-only when the gate is off
 
 Every value shows; the edit keys refuse by notice, the way `x`, `R` and `L`
 already do.
 
 Reading `shep.toml` is not a privileged act: anyone who can run lookout can read
 the file. The screen leaks nothing either, which is checked rather than assumed
-under decision 9. And a read-only screen is still diagnostic, since it names the
-style layer in force and shows which dogs are enabled against which are running.
+under decision 11 below. And a read-only screen is still diagnostic, since it
+names the style layer in force and shows which dogs are enabled against which
+are running.
 
-### 7. The dogs section shows three columns
+### 9. The dogs section shows three columns
 
 Name, what the file says, what the shepherd reports, and where the binary comes
 from. The middle two are joined by name from `App::flock`, which already carries
@@ -207,7 +287,7 @@ what makes a dog that never completed a handshake read `silent` rather than
 `online`.
 
 ```
-  [dogs]   space toggles; enable and disable apply now, no reload
+  [dogs]   space arms, Enter applies; a dog needs no reload
 
   NAME       IN FILE     RUNNING     SOURCE
 > metrics    enabled     online      built in
@@ -223,7 +303,7 @@ like. `ledger` is enabled and absent, which is a dog that failed to start.
 SOURCE is the widest column and the first to drop, mirroring `columns_for`'s own
 tier table in `view/flock.rs` and the reasoning in its doc.
 
-### 8. The toggle reuses `shep enable`'s decision, not its reporting
+### 10. The toggle reuses `shep enable`'s decision, not its reporting
 
 `shep enable`'s file half is a `try_edit` closure holding a real decision: which
 `DogSource` this name resolves to, whether it names a dog at all, and the
@@ -240,7 +320,7 @@ pub(crate) fn disable_in_config(path: &Path, name: &str) -> Result<DogSource, Sh
 calls the same two and reports through `Notice`. Nothing re-implements what a dog
 name means.
 
-### 9. Nothing on this screen is sensitive, and that is checked
+### 11. Nothing on this screen is sensitive, and that is checked
 
 `StyleSection` and `WhistleSection` both carry an explicit note that their
 `Debug` is derived rather than redacted because neither holds a secret;
@@ -250,9 +330,13 @@ owed here (IR-41), and the call site says so rather than leaving it silent.
 
 ## Data flow
 
-Three new effects, all performed in `run_ui` on `spawn_blocking`. The blocking
-matters: the config lock has no deadline, so a concurrent `shep adopt` would
-otherwise freeze the redraw, the tick and the bus drain together.
+Two new effects, both performed in `run_ui` on `spawn_blocking`. The blocking
+matters for the write: the config lock has no deadline, so a concurrent
+`shep adopt` would otherwise freeze the redraw, the tick and the bus drain
+together. The read takes no lock at all, following
+`adopted_dog_path_readonly`'s argument, and rides `spawn_blocking` anyway so
+that the rule is "no file I/O on the redraw task" rather than a judgement call
+per site.
 
 ```
 s              -> Effect::LoadSettings   -> Msg::Settings { fields, dogs }
@@ -295,7 +379,15 @@ open. That is the same division the existing `Escape` arm is built on, so
 
 The four `KeyPress::Filter*` variants are renamed `Text*`. The settings editor
 needs the identical keymap, and a variant named for the filter box would be
-naming a destination the keymap cannot see.
+naming a destination the keymap cannot see. This touches shipped code and the
+keymap's own test, so it lands first, on its own, before any of this screen
+exists.
+
+`App.selected` is untouched by opening or closing the screen, so the flock
+cursor and the filter both survive the swap by construction. A test pins it
+rather than leaving it to inspection. The settings cursor itself resets to the
+first field on every open, because the open re-reads and the dogs list can
+change length underneath a remembered position.
 
 ## One divergence from the sheep confirm
 
@@ -324,6 +416,8 @@ No sleeps. Expiry rides synthesised `Instant`s through `Msg::Tick`, mirroring
 | render, `lookout/view/settings.rs` | the screen at several widths, for SOURCE's drop tiers |
 | `commands/dogs.rs` | `enable_in_config` and `disable_in_config` against the existing fixtures |
 | refusal | a `max_cron_sleep` under the floor is refused, and the file is byte-identical afterwards |
+| absence | a `shep.toml` holding only `[interpreters]`, which is what a fresh home has, renders every scalar as `the default`, and a file that declares `log_level = "warn"` renders the same value as `shep.toml` |
+| selection | the flock cursor and the filter survive a swap out to settings and back |
 
 Every new test is mutated to prove it is not vacuous, and the mutation is checked
 to have applied rather than trusted.
@@ -345,6 +439,6 @@ to have applied rather than trusted.
   column writable is an addition, and what it has to route through is the probe.
 - **`[interpreters]`**, a free-form extension map with no field list to render
   (decision 11).
-- **The overrides half of decision 11**, and decision 12's write-only env. Both
-  are a later slice.
-- **Triggering the reload**, per decision 5 above.
+- **Decision 11's overrides half**, and decision 12's write-only env. Both are
+  a later slice.
+- **Triggering the reload**, per decision 7 above.

--- a/docs/brainstorming/specs/2026-09-04-lookout-settings-design.md
+++ b/docs/brainstorming/specs/2026-09-04-lookout-settings-design.md
@@ -1,6 +1,6 @@
 # Design: the lookout settings screen
 
-Status: designed 2026-09-04, not yet implemented. This builds decision 11 of
+Status: designed 2026-09-04, implemented. This builds decision 11 of
 [the config overrides design](2026-09-02-config-overrides-design.md), and only
 the `shep.toml` half of it. That decision's other half, the overrides store,
 and decision 12's write-only env are a later slice.

--- a/docs/brainstorming/specs/2026-09-04-lookout-settings-design.md
+++ b/docs/brainstorming/specs/2026-09-04-lookout-settings-design.md
@@ -75,8 +75,8 @@ every dog's config to `$SHEP_HOME/dogs.toml`, migrated once at boot.
 There is nothing left to exclude.
 
 A dogs config pane is separate later work with its own spec
-([the dog config design](2026-09-03-dog-config-design.md), decision 9), and it
-depends on dogs publishing a schema, which is not built.
+([the dog config design](2026-09-03-dog-config-design.md), decision 9). Dogs
+now publish a config schema, but the pane itself is not built.
 
 ### Decision 13 does not apply to this screen
 

--- a/docs/brainstorming/specs/2026-09-04-lookout-settings-design.md
+++ b/docs/brainstorming/specs/2026-09-04-lookout-settings-design.md
@@ -330,25 +330,40 @@ owed here (IR-41), and the call site says so rather than leaving it silent.
 
 ## Data flow
 
-Two new effects, both performed in `run_ui` on `spawn_blocking`. The blocking
-matters for the write: the config lock has no deadline, so a concurrent
-`shep adopt` would otherwise freeze the redraw, the tick and the bus drain
-together. The read takes no lock at all, following
+Three effects, each performed in `run_ui` on `spawn_blocking`, and none of
+them awaited in its own arm: the `JoinHandle` is wrapped in a future that
+resolves to the `Msg` its result belongs in, pushed into a `FuturesUnordered`
+the `select!` drains as a fifth arm, and the loop is back at the `select!`
+before the I/O has started. Both halves matter for a write, and
+`spawn_blocking` alone only buys the first. It keeps the blocking off a
+runtime worker thread; awaiting the handle inline would still park the UI task
+until the write landed, which freezes the redraw, the tick and the bus drain
+for exactly as long as doing the write on this task would have. The config
+lock has no deadline, so a concurrent `shep adopt` is enough to make that
+unbounded. The read takes no lock at all, following
 `adopted_dog_path_readonly`'s argument, and rides `spawn_blocking` anyway so
 that the rule is "no file I/O on the redraw task" rather than a judgement call
 per site.
 
 ```
-s              -> Effect::LoadSettings   -> Msg::Settings { fields, dogs }
+s              -> Effect::LoadSettings   -> Msg::Settings { result }
 Enter, armed   -> Effect::WriteSetting   -> Msg::SettingWritten { edit, result }
+Enter, dog     -> Effect::WriteDog       -> Msg::DogWritten { edit, result }
 ```
 
-A scalar write ends there, in a notice. A dog write chains one step further,
-because its file half and its daemon half are two acts:
+A dog toggle is its own effect rather than a third shape of `WriteSetting`,
+because its file half and its daemon half are two acts and only the dog has a
+second one.
+
+A scalar write ends there: `Msg::SettingWritten` carries `Result<(), String>`,
+and its `Ok` arm raises a fresh `Effect::LoadSettings` so the row redraws from
+the document rather than from what was just typed into it. A dog write chains
+one step further, and `Msg::DogWritten` carries `Result<DogSource, String>`
+because the daemon half needs the source the file half resolved:
 
 ```
-Msg::SettingWritten { Ok(source) } -> Effect::Send(Sent::Dog { .. })
-                                   -> Msg::Replied -> notice
+Msg::DogWritten { Ok(source) } -> Effect::Send(Sent::Dog { .. })
+                               -> Msg::Replied -> notice
 ```
 
 File first, then the daemon, which is `shep enable`'s own order. `Sent` gains a

--- a/docs/lookout/frames.ansi
+++ b/docs/lookout/frames.ansi
@@ -738,7 +738,7 @@ shep lookout   /home/ada/.shep                                                  
                                                                                                                         [0m
                                                                                                                         [0m
                                                                                                                         [0m
-[0m[38;5;245mesc close   j/k select   g/G first/last   space cycle                                                          read-only[0m
+[0m[38;5;245mesc/s close   j/k select   g/G first/last   r refresh                                                          read-only[0m
 
 
 === settings_set  (120x30) ===
@@ -773,7 +773,7 @@ shep lookout   /home/ada/.shep                                                  
                                                                                                                         [0m
                                                                                                                         [0m
                                                                                                                         [0m
-[0m[38;5;245mesc close   j/k select   g/G first/last   space cycle                                                          read-only[0m
+[0m[38;5;245mesc/s close   j/k select   g/G first/last   r refresh                                                          read-only[0m
 
 
 === settings_confirm  (180x30) ===
@@ -878,7 +878,7 @@ shep lookout   /home/ada/.shep                                                  
                                                                                                                         [0m
                                                                                                                         [0m
                                                                                                                         [0m
-[0m[38;5;245mesc close   j/k select   g/G first/last   space cycle                                                          read-only[0m
+[0m[38;5;245mesc/s close   j/k select   g/G first/last   r refresh                                                          read-only[0m
 
 
 === settings_narrow  (45x24) ===
@@ -907,4 +907,4 @@ shep lookout   /home/ada/.shep[0m[38;5;245m 2 in the flock[0m
                                              [0m
                                              [0m
                                              [0m
-[0m[38;5;245mesc close   j/k select   g/G first… read-only[0m
+[0m[38;5;245mesc/s close   j/k select   g/G fir… read-only[0m

--- a/docs/lookout/frames.ansi
+++ b/docs/lookout/frames.ansi
@@ -738,7 +738,7 @@ shep lookout   /home/ada/.shep                                                  
                                                                                                                         [0m
                                                                                                                         [0m
                                                                                                                         [0m
-[0m[38;5;245mesc/s close   j/k select   g/G first/last   r refresh                                                          read-only[0m
+[0m[38;5;245mesc/s close   j/k select   g/G first/last   r refresh   q quit                                                 read-only[0m
 
 
 === settings_set  (120x30) ===
@@ -773,7 +773,7 @@ shep lookout   /home/ada/.shep                                                  
                                                                                                                         [0m
                                                                                                                         [0m
                                                                                                                         [0m
-[0m[38;5;245mesc/s close   j/k select   g/G first/last   r refresh                                                          read-only[0m
+[0m[38;5;245mesc/s close   j/k select   g/G first/last   r refresh   q quit                                                 read-only[0m
 
 
 === settings_confirm  (180x30) ===
@@ -798,7 +798,7 @@ shep lookout   /home/ada/.shep                                                  
   bark                                                                                                                            no       built-in                  not running    [0m
   metrics                                                                                                                         yes      built-in                  not running    [0m
                                                                                                                                                                                     [0m
-[0m[38;5;221m  set log_level to info? needs shep daemon reload, and will not apply if the shepherd was booted with SHEP_LOG_LEVEL or --log-level  enter confirms, any other key cancels[0m          [0m
+[0m[38;5;221m  set log_level to info? needs shep daemon reload, and will not apply if the shepherd was booted with SHEP_LOG_LEVEL or --log-level  enter confirms, any other key cancels          [0m
                                                                                                                                                                                     [0m
                                                                                                                                                                                     [0m
                                                                                                                                                                                     [0m
@@ -833,7 +833,7 @@ shep lookout   /home/ada/.shep                                                  
   bark                                                                no       built-in                  not running    [0m
   metrics                                                             yes      built-in                  not running    [0m
                                                                                                                         [0m
-[0m[38;5;221m  editing socket: /home/ada/.shep/run/s▏   enter applies   esc cancels[0m                                                  [0m
+[0m[38;5;221m  editing socket: /home/ada/.shep/run/s▏   enter applies   esc cancels                                                  [0m
                                                                                                                         [0m
                                                                                                                         [0m
                                                                                                                         [0m
@@ -878,7 +878,7 @@ shep lookout   /home/ada/.shep                                                  
                                                                                                                         [0m
                                                                                                                         [0m
                                                                                                                         [0m
-[0m[38;5;245mesc/s close   j/k select   g/G first/last   r refresh                                                          read-only[0m
+[0m[38;5;245mesc/s close   j/k select   g/G first/last   r refresh   q quit                                                 read-only[0m
 
 
 === settings_narrow  (45x24) ===

--- a/docs/lookout/frames.ansi
+++ b/docs/lookout/frames.ansi
@@ -865,8 +865,8 @@ shep lookout   /home/ada/.shep                                                  
 [0m[38;5;245m  [dogs][0m                                                                                                                [0m
 [0m[38;5;245m  space arms, Enter applies; a dog needs no reload                                                                      [0m
 [0m[38;5;245m  NAME                                                                IN FILE  SOURCE                    RUNNING        [0m
-  otel                                                                no       built-in                  online         [0m
-  ledger                                                              yes      built-in                  not running    [0m
+  otel                                                                no       /usr/local/bin/shep-otel  online         [0m
+  ledger                                                              yes      /opt/ledger/bin/dog       not running    [0m
   bark                                                                yes      built-in                  silent         [0m
                                                                                                                         [0m
                                                                                                                         [0m

--- a/docs/lookout/frames.ansi
+++ b/docs/lookout/frames.ansi
@@ -7,7 +7,7 @@ These are real frames, rendered headlessly through ratatui's TestBackend by
 
 Nothing here is a mockup.
 
-frames.ansi is the same thirty frames with colour; read it with `less -R`.
+frames.ansi is the same thirty-one frames with colour; read it with `less -R`.
 
 All four panes are here: the flock table (the spine), the host-usage strip,
 the sheep detail pane and the bleats feed. `>` marks the selected sheep, and
@@ -24,11 +24,11 @@ it read and dropped are counted exactly; bytes below its 64 KiB window were
 never read at all, so those are reported in bytes, because nothing counted the
 lines in them and guessing would be worse than saying so.
 
-The last five frames are the settings screen, `s` from the dashboard. It owns
+The last six frames are the settings screen, `s` from the dashboard. It owns
 the whole body between the title and the status bar rather than sharing it
 with the flock table, so a fresh $SHEP_HOME, some scalars declared, an armed
-confirm, the socket editor mid-type and the dogs table's own drift each get a
-frame of their own.
+confirm, the socket editor mid-type, the dogs table's own drift and the same
+screen at 45 columns each get a frame of their own.
 
 
 === healthy_wide  (120x30) ===
@@ -879,3 +879,32 @@ shep lookout   /home/ada/.shep                                                  
                                                                                                                         [0m
                                                                                                                         [0m
 [0m[38;5;245mesc close   j/k select   g/G first/last   space cycle                                                          read-only[0m
+
+
+=== settings_narrow  (45x24) ===
+The same screen at 45 columns. Both of its tables have dropped a column rather than clipping: the scalar rows have lost the apply cost and kept SOURCE, and the dogs table has lost SOURCE and kept RUNNING. Each keeps whichever half is not said anywhere else.
+
+shep lookout   /home/ada/.shep[0m[38;5;245m 2 in the flock[0m
+[0m[38;5;245m  [daemon][0m                                   [0m
+> log_level        warn           shep.toml  [0m
+  log_json         false          the default[0m
+  socket           /home/ada/.s…  shep.toml  [0m
+  max_cron_sleep   30s            shep.toml  [0m
+                                             [0m
+[0m[38;5;245m  [whistle][0m                                  [0m
+  allow_control    false          the default[0m
+                                             [0m
+[0m[38;5;245m  [style][0m                                    [0m
+  level            full           shep.toml  [0m
+                                             [0m
+[0m[38;5;245m  [dogs][0m                                     [0m
+[0m[38;5;245m  space arms, Enter applies; a dog needs no …[0m
+[0m[38;5;245m  NAME               IN FILE  RUNNING        [0m
+  otel               no       online         [0m
+  ledger             yes      not running    [0m
+  bark               yes      silent         [0m
+                                             [0m
+                                             [0m
+                                             [0m
+                                             [0m
+[0m[38;5;245mesc close   j/k select   g/G first… read-only[0m

--- a/docs/lookout/frames.ansi
+++ b/docs/lookout/frames.ansi
@@ -723,10 +723,10 @@ shep lookout   /home/ada/.shep                                                  
   level            full                            the default  the next command reads it                               [0m
                                                                                                                         [0m
 [0m[38;5;245m  [dogs][0m                                                                                                                [0m
-[0m[38;5;245m  space arms, Enter applies; a dog needs no reload[0m                                                                      [0m
-[0m[38;5;245m  NAME                                                                  IN FILE  SOURCE                    RUNNING      [0m
-  bark                                                                  no       built-in                  not running  [0m
-  metrics                                                               no       built-in                  not running  [0m
+[0m[38;5;245m  space arms, Enter applies; a dog needs no reload                                                                      [0m
+[0m[38;5;245m  NAME                                                                IN FILE  SOURCE                    RUNNING        [0m
+  bark                                                                no       built-in                  not running    [0m
+  metrics                                                             no       built-in                  not running    [0m
                                                                                                                         [0m
                                                                                                                         [0m
                                                                                                                         [0m
@@ -758,10 +758,10 @@ shep lookout   /home/ada/.shep                                                  
   level            full                            shep.toml    the next command reads it                               [0m
                                                                                                                         [0m
 [0m[38;5;245m  [dogs][0m                                                                                                                [0m
-[0m[38;5;245m  space arms, Enter applies; a dog needs no reload[0m                                                                      [0m
-[0m[38;5;245m  NAME                                                                  IN FILE  SOURCE                    RUNNING      [0m
-  bark                                                                  no       built-in                  not running  [0m
-  metrics                                                               yes      built-in                  not running  [0m
+[0m[38;5;245m  space arms, Enter applies; a dog needs no reload                                                                      [0m
+[0m[38;5;245m  NAME                                                                IN FILE  SOURCE                    RUNNING        [0m
+  bark                                                                no       built-in                  not running    [0m
+  metrics                                                             yes      built-in                  not running    [0m
                                                                                                                         [0m
                                                                                                                         [0m
                                                                                                                         [0m
@@ -793,10 +793,10 @@ shep lookout   /home/ada/.shep                                                  
   level            full                            shep.toml    the next command reads it                                                                                           [0m
                                                                                                                                                                                     [0m
 [0m[38;5;245m  [dogs][0m                                                                                                                                                                            [0m
-[0m[38;5;245m  space arms, Enter applies; a dog needs no reload[0m                                                                                                                                  [0m
-[0m[38;5;245m  NAME                                                                                                                              IN FILE  SOURCE                    RUNNING      [0m
-  bark                                                                                                                              no       built-in                  not running  [0m
-  metrics                                                                                                                           yes      built-in                  not running  [0m
+[0m[38;5;245m  space arms, Enter applies; a dog needs no reload                                                                                                                                  [0m
+[0m[38;5;245m  NAME                                                                                                                            IN FILE  SOURCE                    RUNNING        [0m
+  bark                                                                                                                            no       built-in                  not running    [0m
+  metrics                                                                                                                         yes      built-in                  not running    [0m
                                                                                                                                                                                     [0m
 [0m[38;5;221m  set log_level to info? needs shep daemon reload, and will not apply if the shepherd was booted with SHEP_LOG_LEVEL or --log-level  enter confirms, any other key cancels[0m          [0m
                                                                                                                                                                                     [0m
@@ -828,10 +828,10 @@ shep lookout   /home/ada/.shep                                                  
   level            full                            shep.toml    the next command reads it                               [0m
                                                                                                                         [0m
 [0m[38;5;245m  [dogs][0m                                                                                                                [0m
-[0m[38;5;245m  space arms, Enter applies; a dog needs no reload[0m                                                                      [0m
-[0m[38;5;245m  NAME                                                                  IN FILE  SOURCE                    RUNNING      [0m
-  bark                                                                  no       built-in                  not running  [0m
-  metrics                                                               yes      built-in                  not running  [0m
+[0m[38;5;245m  space arms, Enter applies; a dog needs no reload                                                                      [0m
+[0m[38;5;245m  NAME                                                                IN FILE  SOURCE                    RUNNING        [0m
+  bark                                                                no       built-in                  not running    [0m
+  metrics                                                             yes      built-in                  not running    [0m
                                                                                                                         [0m
 [0m[38;5;221m  editing socket: /home/ada/.shep/run/s▏   enter applies   esc cancels[0m                                                  [0m
                                                                                                                         [0m
@@ -863,11 +863,11 @@ shep lookout   /home/ada/.shep                                                  
   level            full                            shep.toml    the next command reads it                               [0m
                                                                                                                         [0m
 [0m[38;5;245m  [dogs][0m                                                                                                                [0m
-[0m[38;5;245m  space arms, Enter applies; a dog needs no reload[0m                                                                      [0m
-[0m[38;5;245m  NAME                                                                  IN FILE  SOURCE                    RUNNING      [0m
-  otel                                                                  no       built-in                  online       [0m
-  ledger                                                                yes      built-in                  not running  [0m
-  bark                                                                  yes      built-in                  silent       [0m
+[0m[38;5;245m  space arms, Enter applies; a dog needs no reload                                                                      [0m
+[0m[38;5;245m  NAME                                                                IN FILE  SOURCE                    RUNNING        [0m
+  otel                                                                no       built-in                  online         [0m
+  ledger                                                              yes      built-in                  not running    [0m
+  bark                                                                yes      built-in                  silent         [0m
                                                                                                                         [0m
                                                                                                                         [0m
                                                                                                                         [0m

--- a/docs/lookout/frames.ansi
+++ b/docs/lookout/frames.ansi
@@ -808,7 +808,7 @@ shep lookout   /home/ada/.shep                                                  
                                                                                                                                                                                     [0m
                                                                                                                                                                                     [0m
                                                                                                                                                                                     [0m
-[0m[38;5;245mesc close   j/k select   g/G first/last   space cycle                                                                                                                control enabled[0m
+[0m[38;5;221mset log_level to info? needs shep daemon reload, and will not apply if the shepherd was booted with SHEP_LOG_LEVEL or --log-level  enter confirms, any other key ca…[0m[38;5;245m control enabled[0m
 
 
 === settings_typing  (120x30) ===

--- a/docs/lookout/frames.ansi
+++ b/docs/lookout/frames.ansi
@@ -7,7 +7,7 @@ These are real frames, rendered headlessly through ratatui's TestBackend by
 
 Nothing here is a mockup.
 
-frames.ansi is the same twenty-five frames with colour; read it with `less -R`.
+frames.ansi is the same thirty frames with colour; read it with `less -R`.
 
 All four panes are here: the flock table (the spine), the host-usage strip,
 the sheep detail pane and the bleats feed. `>` marks the selected sheep, and
@@ -23,6 +23,12 @@ When the pane cannot show everything, the header says what went instead. Lines
 it read and dropped are counted exactly; bytes below its 64 KiB window were
 never read at all, so those are reported in bytes, because nothing counted the
 lines in them and guessing would be worse than saying so.
+
+The last five frames are the settings screen, `s` from the dashboard. It owns
+the whole body between the title and the status bar rather than sharing it
+with the flock table, so a fresh $SHEP_HOME, some scalars declared, an armed
+confirm, the socket editor mid-type and the dogs table's own drift each get a
+frame of their own.
 
 
 === healthy_wide  (120x30) ===
@@ -57,7 +63,7 @@ sheep 2  api   [0m[38;5;29monline[0m   pid 48219   restarts 1   uptime 1h 28m
 [0m[38;5;245mout  [0mPOST /v1/orders 201 88ms                                                                                           [0m
 [0m[38;5;245mout  [0mGET /v1/orders/8821 200 9ms                                                                                        [0m
 [0m[38;5;245mout  [0mconnection pool: 14/50 in use                                                                                      [0m
-[0m[38;5;245mq quit   j/k select   g/G first/last   r refresh   / filter                                                    read-only[0m
+[0m[38;5;245mq quit   j/k select   g/G first/last   r refresh   / filter   s settings                                       read-only[0m
 
 
 === errored  (120x30) ===
@@ -92,7 +98,7 @@ sheep 2  api   [0m[38;5;166merrored[0m   pid -   restarts 14   uptime 1h 18m 
 [0m[38;5;245mout  [0mPOST /v1/orders 201 88ms                                                                                           [0m
 [0m[38;5;245mout  [0mGET /v1/orders/8821 200 9ms                                                                                        [0m
 [0m[38;5;245mout  [0mconnection pool: 14/50 in use                                                                                      [0m
-[0m[38;5;245mq quit   j/k select   g/G first/last   r refresh   / filter                                                    read-only[0m
+[0m[38;5;245mq quit   j/k select   g/G first/last   r refresh   / filter   s settings                                       read-only[0m
 
 
 === grouped  (120x30) ===
@@ -127,7 +133,7 @@ app web ×3  [0m[38;5;29monline[0m   restarts 3   uptime 15m   cpu 9.4%   mem
                                                                                                                         [0m
                                                                                                                         [0m
                                                                                                                         [0m
-[0m[38;5;245mq quit   j/k select   g/G first/last   r refresh   / filter                                                    read-only[0m
+[0m[38;5;245mq quit   j/k select   g/G first/last   r refresh   / filter   s settings                                       read-only[0m
 
 
 === empty  (100x28) ===
@@ -160,7 +166,7 @@ shep lookout   /home/ada/.shep                                                  
                                                                                                     [0m
                                                                                                     [0m
                                                                                                     [0m
-[0m[38;5;245mq quit   j/k select   g/G first/last   r refresh   / filter                                read-only[0m
+[0m[38;5;245mq quit   j/k select   g/G first/last   r refresh   / filter   s settings                   read-only[0m
 
 
 === narrow  (51x14) ===
@@ -227,7 +233,7 @@ sheep 2  api   [0m[38;5;29monline[0m   pid 48219   restarts 1   uptime 1h 28m
 [0m[38;5;245mout  [0mPOST /v1/orders 201 88ms                                                                                           [0m
 [0m[38;5;245mout  [0mGET /v1/orders/8821 200 9ms                                                                                        [0m
 [0m[38;5;245mout  [0mconnection pool: 14/50 in use                                                                                      [0m
-[0m[38;5;245mq quit   j/k select   g/G first/last   r refresh   / filter                                                    read-only[0m
+[0m[38;5;245mq quit   j/k select   g/G first/last   r refresh   / filter   s settings                                       read-only[0m
 
 
 === frozen  (120x30) ===
@@ -262,7 +268,7 @@ sheep 2  api   [0m[38;5;166merrored[0m   pid -   restarts 14   uptime 1h 18m 
 [0m[38;5;245mout  [0mPOST /v1/orders 201 88ms                                                                                           [0m
 [0m[38;5;245mout  [0mGET /v1/orders/8821 200 9ms                                                                                        [0m
 [0m[38;5;245mout  [0mconnection pool: 14/50 in use                                                                                      [0m
-[0m[38;5;245mq quit   j/k select   g/G first/last   r refresh   / filter                                                    read-only[0m
+[0m[38;5;245mq quit   j/k select   g/G first/last   r refresh   / filter   s settings                                       read-only[0m
 
 
 === refused  (120x30) ===
@@ -379,7 +385,7 @@ shep lookout   /home/ada/.shep                                                  
 [0m[38;5;245mout  [0mPOST /v1/orders 201 88ms                                                                                           [0m
 [0m[38;5;245mout  [0mGET /v1/orders/8821 200 9ms                                                                                        [0m
 [0m[38;5;245mout  [0mconnection pool: 14/50 in use                                                                                      [0m
-[0m[38;5;245mq quit   j/k select   g/G first/last   r refresh   / filter                                                    read-only[0m
+[0m[38;5;245mq quit   j/k select   g/G first/last   r refresh   / filter   s settings                                       read-only[0m
 
 
 === table_only  (120x12) ===
@@ -396,7 +402,7 @@ shep lookout   /home/ada/.shep                                                  
   1     web         [0m[38;5;29monline         [0m  48212    0         -          2.9%    178.0M    1h 26m    edge        -            [0m
                                                                                                                         [0m
                                                                                                                         [0m
-[0m[38;5;245mq quit   j/k select   g/G first/last   r refresh   / filter                                                    read-only[0m
+[0m[38;5;245mq quit   j/k select   g/G first/last   r refresh   / filter   s settings                                       read-only[0m
 
 
 === feed_gap  (120x30) ===
@@ -431,7 +437,7 @@ sheep 2  api   [0m[38;5;29monline[0m   pid 48219   restarts 1   uptime 1h 28m
 [0m[38;5;245mout  [0mGET /v1/orders/27 200 35ms                                                                                         [0m
 [0m[38;5;245mout  [0mGET /v1/orders/28 200 36ms                                                                                         [0m
 [0m[38;5;245mout  [0mGET /v1/orders/29 200 37ms                                                                                         [0m
-[0m[38;5;245mq quit   j/k select   g/G first/last   r refresh   / filter                                                    read-only[0m
+[0m[38;5;245mq quit   j/k select   g/G first/last   r refresh   / filter   s settings                                       read-only[0m
 
 
 === feed_missing  (120x30) ===
@@ -466,7 +472,7 @@ sheep 2  api   [0m[38;5;29monline[0m   pid 48219   restarts 1   uptime 1h 28m
                                                                                                                         [0m
                                                                                                                         [0m
                                                                                                                         [0m
-[0m[38;5;245mq quit   j/k select   g/G first/last   r refresh   / filter                                                    read-only[0m
+[0m[38;5;245mq quit   j/k select   g/G first/last   r refresh   / filter   s settings                                       read-only[0m
 
 
 === cramped  (33x26) ===
@@ -532,7 +538,7 @@ sheep 2  api   [0m[38;5;29monline[0m   pid 48219   restarts 1   uptime 1h 28m
 [0m[38;5;245mout  [0mPOST /v1/orders 201 88ms                                                                                           [0m
 [0m[38;5;245mout  [0mGET /v1/orders/8821 200 9ms                                                                                        [0m
 [0m[38;5;245mout  [0mconnection pool: 14/50 in use                                                                                      [0m
-[0m[38;5;245mq quit   j/k select   g/G first/last   r refresh   / filter                                                    read-only[0m
+[0m[38;5;245mq quit   j/k select   g/G first/last   r refresh   / filter   s settings                                       read-only[0m
 
 
 === lambs  (120x30) ===
@@ -567,7 +573,7 @@ sheep 2  api   [0m[38;5;29monline[0m   pid 48219   restarts 1   uptime 1h 28m
 [0m[38;5;245mout  [0mPOST /v1/orders 201 88ms                                                                                           [0m
 [0m[38;5;245mout  [0mGET /v1/orders/8821 200 9ms                                                                                        [0m
 [0m[38;5;245mout  [0mconnection pool: 14/50 in use                                                                                      [0m
-[0m[38;5;245mq quit   j/k select   / filter   x stop   R restart   L reload                                           control enabled[0m
+[0m[38;5;245mq quit   j/k select   / filter   x stop   R restart   L reload   s settings                              control enabled[0m
 
 
 === lambs_unknown  (120x30) ===
@@ -602,7 +608,7 @@ sheep 4  cron   [0m[38;5;245mstopped[0m   pid -   restarts 0   uptime 1h 21m 
 [0m[38;5;245mout  [0mPOST /v1/orders 201 88ms                                                                                           [0m
 [0m[38;5;245mout  [0mGET /v1/orders/8821 200 9ms                                                                                        [0m
 [0m[38;5;245mout  [0mconnection pool: 14/50 in use                                                                                      [0m
-[0m[38;5;245mq quit   j/k select   g/G first/last   r refresh   / filter                                                    read-only[0m
+[0m[38;5;245mq quit   j/k select   g/G first/last   r refresh   / filter   s settings                                       read-only[0m
 
 
 === confirm  (100x14) ===
@@ -698,3 +704,178 @@ shep lookout   /home/ada/.shep                                                  
                                                                                                     [0m
                                                                                                     [0m
 [0m[38;5;166mthe shepherd stopped answering — reconnecting (attempt 3)                           [0m[38;5;245m control enabled[0m
+
+
+=== settings_fresh  (120x30) ===
+The settings screen on a fresh $SHEP_HOME: shep.toml holds only [interpreters], so every scalar's SOURCE column reads `the default` and its VALUE is the compiled fallback. The state most operators open this screen in.
+
+shep lookout   /home/ada/.shep                                                                           [0m[38;5;245m 6 in the flock[0m
+[0m[38;5;245m  [daemon][0m                                                                                                              [0m
+> log_level        warn                            the default  needs shep daemon reload                                [0m
+  log_json         false                           the default  needs shep daemon reload                                [0m
+  socket           /home/ada/.shep/run/shep.sock   the default  needs the shepherd stopped and started                  [0m
+  max_cron_sleep   not set                         the default  needs shep daemon reload                                [0m
+                                                                                                                        [0m
+[0m[38;5;245m  [whistle][0m                                                                                                             [0m
+  allow_control    false                           the default  needs shep whistle restarted                            [0m
+                                                                                                                        [0m
+[0m[38;5;245m  [style][0m                                                                                                               [0m
+  level            full                            the default  the next command reads it                               [0m
+                                                                                                                        [0m
+[0m[38;5;245m  [dogs][0m                                                                                                                [0m
+[0m[38;5;245m  space arms, Enter applies; a dog needs no reload[0m                                                                      [0m
+[0m[38;5;245m  NAME                                                                  IN FILE  SOURCE                    RUNNING      [0m
+  bark                                                                  no       built-in                  not running  [0m
+  metrics                                                               no       built-in                  not running  [0m
+                                                                                                                        [0m
+                                                                                                                        [0m
+                                                                                                                        [0m
+                                                                                                                        [0m
+                                                                                                                        [0m
+                                                                                                                        [0m
+                                                                                                                        [0m
+                                                                                                                        [0m
+                                                                                                                        [0m
+                                                                                                                        [0m
+                                                                                                                        [0m
+[0m[38;5;245mesc close   j/k select   g/G first/last   space cycle                                                          read-only[0m
+
+
+=== settings_set  (120x30) ===
+The settings screen with some scalars declared. `shep.toml` and `the default` sit side by side in the SOURCE column, so what the operator wrote and what shep assumes are both visible at once.
+
+shep lookout   /home/ada/.shep                                                                           [0m[38;5;245m 6 in the flock[0m
+[0m[38;5;245m  [daemon][0m                                                                                                              [0m
+> log_level        warn                            shep.toml    needs shep daemon reload                                [0m
+  log_json         false                           the default  needs shep daemon reload                                [0m
+  socket           /home/ada/.shep/run/shep.sock   shep.toml    needs the shepherd stopped and started                  [0m
+  max_cron_sleep   30s                             shep.toml    needs shep daemon reload                                [0m
+                                                                                                                        [0m
+[0m[38;5;245m  [whistle][0m                                                                                                             [0m
+  allow_control    false                           the default  needs shep whistle restarted                            [0m
+                                                                                                                        [0m
+[0m[38;5;245m  [style][0m                                                                                                               [0m
+  level            full                            shep.toml    the next command reads it                               [0m
+                                                                                                                        [0m
+[0m[38;5;245m  [dogs][0m                                                                                                                [0m
+[0m[38;5;245m  space arms, Enter applies; a dog needs no reload[0m                                                                      [0m
+[0m[38;5;245m  NAME                                                                  IN FILE  SOURCE                    RUNNING      [0m
+  bark                                                                  no       built-in                  not running  [0m
+  metrics                                                               yes      built-in                  not running  [0m
+                                                                                                                        [0m
+                                                                                                                        [0m
+                                                                                                                        [0m
+                                                                                                                        [0m
+                                                                                                                        [0m
+                                                                                                                        [0m
+                                                                                                                        [0m
+                                                                                                                        [0m
+                                                                                                                        [0m
+                                                                                                                        [0m
+                                                                                                                        [0m
+[0m[38;5;245mesc close   j/k select   g/G first/last   space cycle                                                          read-only[0m
+
+
+=== settings_confirm  (180x30) ===
+A [daemon] confirm armed on log_level, naming the variable and the flag it cannot see: SHEP_LOG_LEVEL and --log-level, and the shep daemon reload the edit needs.
+
+shep lookout   /home/ada/.shep                                                                                                                                       [0m[38;5;245m 6 in the flock[0m
+[0m[38;5;245m  [daemon][0m                                                                                                                                                                          [0m
+> log_level        warn                            shep.toml    needs shep daemon reload                                                                                            [0m
+  log_json         false                           the default  needs shep daemon reload                                                                                            [0m
+  socket           /home/ada/.shep/run/shep.sock   shep.toml    needs the shepherd stopped and started                                                                              [0m
+  max_cron_sleep   30s                             shep.toml    needs shep daemon reload                                                                                            [0m
+                                                                                                                                                                                    [0m
+[0m[38;5;245m  [whistle][0m                                                                                                                                                                         [0m
+  allow_control    false                           the default  needs shep whistle restarted                                                                                        [0m
+                                                                                                                                                                                    [0m
+[0m[38;5;245m  [style][0m                                                                                                                                                                           [0m
+  level            full                            shep.toml    the next command reads it                                                                                           [0m
+                                                                                                                                                                                    [0m
+[0m[38;5;245m  [dogs][0m                                                                                                                                                                            [0m
+[0m[38;5;245m  space arms, Enter applies; a dog needs no reload[0m                                                                                                                                  [0m
+[0m[38;5;245m  NAME                                                                                                                              IN FILE  SOURCE                    RUNNING      [0m
+  bark                                                                                                                              no       built-in                  not running  [0m
+  metrics                                                                                                                           yes      built-in                  not running  [0m
+                                                                                                                                                                                    [0m
+[0m[38;5;221m  set log_level to info? needs shep daemon reload, and will not apply if the shepherd was booted with SHEP_LOG_LEVEL or --log-level  enter confirms, any other key cancels[0m          [0m
+                                                                                                                                                                                    [0m
+                                                                                                                                                                                    [0m
+                                                                                                                                                                                    [0m
+                                                                                                                                                                                    [0m
+                                                                                                                                                                                    [0m
+                                                                                                                                                                                    [0m
+                                                                                                                                                                                    [0m
+                                                                                                                                                                                    [0m
+                                                                                                                                                                                    [0m
+[0m[38;5;245mesc close   j/k select   g/G first/last   space cycle                                                                                                                control enabled[0m
+
+
+=== settings_typing  (120x30) ===
+The socket editor open mid-path. The status bar names the field being typed, not the dashboard's own filter box, which is what it showed here before the fix this frame now pins.
+
+shep lookout   /home/ada/.shep                                                                           [0m[38;5;245m 6 in the flock[0m
+[0m[38;5;245m  [daemon][0m                                                                                                              [0m
+  log_level        warn                            shep.toml    needs shep daemon reload                                [0m
+  log_json         false                           the default  needs shep daemon reload                                [0m
+> socket           /home/ada/.shep/run/shep.sock   shep.toml    needs the shepherd stopped and started                  [0m
+  max_cron_sleep   30s                             shep.toml    needs shep daemon reload                                [0m
+                                                                                                                        [0m
+[0m[38;5;245m  [whistle][0m                                                                                                             [0m
+  allow_control    false                           the default  needs shep whistle restarted                            [0m
+                                                                                                                        [0m
+[0m[38;5;245m  [style][0m                                                                                                               [0m
+  level            full                            shep.toml    the next command reads it                               [0m
+                                                                                                                        [0m
+[0m[38;5;245m  [dogs][0m                                                                                                                [0m
+[0m[38;5;245m  space arms, Enter applies; a dog needs no reload[0m                                                                      [0m
+[0m[38;5;245m  NAME                                                                  IN FILE  SOURCE                    RUNNING      [0m
+  bark                                                                  no       built-in                  not running  [0m
+  metrics                                                               yes      built-in                  not running  [0m
+                                                                                                                        [0m
+[0m[38;5;221m  editing socket: /home/ada/.shep/run/s▏   enter applies   esc cancels[0m                                                  [0m
+                                                                                                                        [0m
+                                                                                                                        [0m
+                                                                                                                        [0m
+                                                                                                                        [0m
+                                                                                                                        [0m
+                                                                                                                        [0m
+                                                                                                                        [0m
+                                                                                                                        [0m
+                                                                                                                        [0m
+[0m[38;5;221mediting socket  /home/ada/.shep/run/s▏   enter applies   esc cancels                                    [0m[38;5;245m control enabled[0m
+
+
+=== settings_dogs  (120x30) ===
+The dogs table showing the drift it exists to reveal: otel running while disabled in the file, ledger enabled and absent, and bark enabled, running, and silent.
+
+shep lookout   /home/ada/.shep                                                                           [0m[38;5;245m 2 in the flock[0m
+[0m[38;5;245m  [daemon][0m                                                                                                              [0m
+> log_level        warn                            shep.toml    needs shep daemon reload                                [0m
+  log_json         false                           the default  needs shep daemon reload                                [0m
+  socket           /home/ada/.shep/run/shep.sock   shep.toml    needs the shepherd stopped and started                  [0m
+  max_cron_sleep   30s                             shep.toml    needs shep daemon reload                                [0m
+                                                                                                                        [0m
+[0m[38;5;245m  [whistle][0m                                                                                                             [0m
+  allow_control    false                           the default  needs shep whistle restarted                            [0m
+                                                                                                                        [0m
+[0m[38;5;245m  [style][0m                                                                                                               [0m
+  level            full                            shep.toml    the next command reads it                               [0m
+                                                                                                                        [0m
+[0m[38;5;245m  [dogs][0m                                                                                                                [0m
+[0m[38;5;245m  space arms, Enter applies; a dog needs no reload[0m                                                                      [0m
+[0m[38;5;245m  NAME                                                                  IN FILE  SOURCE                    RUNNING      [0m
+  otel                                                                  no       built-in                  online       [0m
+  ledger                                                                yes      built-in                  not running  [0m
+  bark                                                                  yes      built-in                  silent       [0m
+                                                                                                                        [0m
+                                                                                                                        [0m
+                                                                                                                        [0m
+                                                                                                                        [0m
+                                                                                                                        [0m
+                                                                                                                        [0m
+                                                                                                                        [0m
+                                                                                                                        [0m
+                                                                                                                        [0m
+                                                                                                                        [0m
+[0m[38;5;245mesc close   j/k select   g/G first/last   space cycle                                                          read-only[0m

--- a/docs/lookout/frames.txt
+++ b/docs/lookout/frames.txt
@@ -7,7 +7,7 @@ These are real frames, rendered headlessly through ratatui's TestBackend by
 
 Nothing here is a mockup.
 
-frames.ansi is the same twenty-five frames with colour; read it with `less -R`.
+frames.ansi is the same thirty frames with colour; read it with `less -R`.
 
 All four panes are here: the flock table (the spine), the host-usage strip,
 the sheep detail pane and the bleats feed. `>` marks the selected sheep, and
@@ -23,6 +23,12 @@ When the pane cannot show everything, the header says what went instead. Lines
 it read and dropped are counted exactly; bytes below its 64 KiB window were
 never read at all, so those are reported in bytes, because nothing counted the
 lines in them and guessing would be worse than saying so.
+
+The last five frames are the settings screen, `s` from the dashboard. It owns
+the whole body between the title and the status bar rather than sharing it
+with the flock table, so a fresh $SHEP_HOME, some scalars declared, an armed
+confirm, the socket editor mid-type and the dogs table's own drift each get a
+frame of their own.
 
 
 === healthy_wide  (120x30) ===
@@ -57,7 +63,7 @@ out  GET /v1/orders 200 44ms
 out  POST /v1/orders 201 88ms                                                                                           
 out  GET /v1/orders/8821 200 9ms                                                                                        
 out  connection pool: 14/50 in use                                                                                      
-q quit   j/k select   g/G first/last   r refresh   / filter                                                    read-only
+q quit   j/k select   g/G first/last   r refresh   / filter   s settings                                       read-only
 
 === errored  (120x30) ===
 One errored, one waiting to restart, one stopped, with the selection parked on the errored sheep. Each row's own STATUS cell is the only coloured cell in that row, and EXIT carries why each of the three stopped: a code for the two that crashed, a signal name for the one shep stopped itself.
@@ -91,7 +97,7 @@ out  GET /v1/orders 200 44ms
 out  POST /v1/orders 201 88ms                                                                                           
 out  GET /v1/orders/8821 200 9ms                                                                                        
 out  connection pool: 14/50 in use                                                                                      
-q quit   j/k select   g/G first/last   r refresh   / filter                                                    read-only
+q quit   j/k select   g/G first/last   r refresh   / filter   s settings                                       read-only
 
 === grouped  (120x30) ===
 Three instances of one app under a group header, with the cursor parked on the header. The header sums their restarts, CPU and memory and takes the SHORTEST of their uptimes, so a group reads as time since the app was last disturbed rather than as the age of its luckiest instance. The detail pane repeats that rollup and says lambs are per-instance; the feed will not guess which instance to tail.
@@ -125,7 +131,7 @@ bleats  web  follows one instance; select one to see its log
                                                                                                                         
                                                                                                                         
                                                                                                                         
-q quit   j/k select   g/G first/last   r refresh   / filter                                                    read-only
+q quit   j/k select   g/G first/last   r refresh   / filter   s settings                                       read-only
 
 === empty  (100x28) ===
 No sheep registered. Each of the three panes says why it is empty, and the three sentences are different because the three reasons are.
@@ -157,7 +163,7 @@ bleats  no sheep is selected
                                                                                                     
                                                                                                     
                                                                                                     
-q quit   j/k select   g/G first/last   r refresh   / filter                                read-only
+q quit   j/k select   g/G first/last   r refresh   / filter   s settings                   read-only
 
 === narrow  (51x14) ===
 51 columns: FOLD, EXIT, RESTARTS, PID and MEM are gone, in that order. CPU and UPTIME survive because they explain WHY a RUNNING sheep is behaving badly, a question EXIT cannot even ask. The host strip fits; the detail pane and the feed do not, at 14 rows.
@@ -221,7 +227,7 @@ out  GET /v1/orders 200 44ms
 out  POST /v1/orders 201 88ms                                                                                           
 out  GET /v1/orders/8821 200 9ms                                                                                        
 out  connection pool: 14/50 in use                                                                                      
-q quit   j/k select   g/G first/last   r refresh   / filter                                                    read-only
+q quit   j/k select   g/G first/last   r refresh   / filter   s settings                                       read-only
 
 === frozen  (120x30) ===
 The ladder ran out. Last known values stay, the uptime clock has stopped, and so has the host strip — one line ticking over on a frozen screen is a contradiction on the same frame.
@@ -255,7 +261,7 @@ out  GET /v1/orders 200 44ms
 out  POST /v1/orders 201 88ms                                                                                           
 out  GET /v1/orders/8821 200 9ms                                                                                        
 out  connection pool: 14/50 in use                                                                                      
-q quit   j/k select   g/G first/last   r refresh   / filter                                                    read-only
+q quit   j/k select   g/G first/last   r refresh   / filter   s settings                                       read-only
 
 === refused  (120x30) ===
 `x` with actions gated off. The refusal is literal, nothing about damage gets charming, and the panes below carry on.
@@ -367,7 +373,7 @@ out  GET /v1/orders 200 44ms
 out  POST /v1/orders 201 88ms                                                                                           
 out  GET /v1/orders/8821 200 9ms                                                                                        
 out  connection pool: 14/50 in use                                                                                      
-q quit   j/k select   g/G first/last   r refresh   / filter                                                    read-only
+q quit   j/k select   g/G first/last   r refresh   / filter   s settings                                       read-only
 
 === table_only  (120x12) ===
 12 rows: no optional panes at all. This is 12a's frame, and the only thing that changed is the two-column gutter the marker sits in.
@@ -383,7 +389,7 @@ shep lookout   /home/ada/.shep                                                  
   1     web         online           48212    0         -          2.9%    178.0M    1h 26m    edge        -            
                                                                                                                         
                                                                                                                         
-q quit   j/k select   g/G first/last   r refresh   / filter                                                    read-only
+q quit   j/k select   g/G first/last   r refresh   / filter   s settings                                       read-only
 
 === feed_gap  (120x30) ===
 The feed under a burst: 3.8 megabytes were never read and some hundreds of lines were read and dropped. The pane counts both, and counts them separately, because it knows the second exactly and cannot know how many lines are in the first.
@@ -417,7 +423,7 @@ out  GET /v1/orders/26 200 34ms
 out  GET /v1/orders/27 200 35ms                                                                                         
 out  GET /v1/orders/28 200 36ms                                                                                         
 out  GET /v1/orders/29 200 37ms                                                                                         
-q quit   j/k select   g/G first/last   r refresh   / filter                                                    read-only
+q quit   j/k select   g/G first/last   r refresh   / filter   s settings                                       read-only
 
 === feed_missing  (120x30) ===
 The selected sheep has never written a log in this $SHEP_HOME. The feed names that cause rather than sitting blank.
@@ -451,7 +457,7 @@ this sheep has not written a log in this $SHEP_HOME
                                                                                                                         
                                                                                                                         
                                                                                                                         
-q quit   j/k select   g/G first/last   r refresh   / filter                                                    read-only
+q quit   j/k select   g/G first/last   r refresh   / filter   s settings                                       read-only
 
 === cramped  (33x26) ===
 33 columns: the narrowest terminal that draws. 26 rows — a couple more than the 24-row floor for all three panes being up, so this frame has a little breathing room rather than sitting exactly on the edge. Everything truncates with an ellipsis; nothing overlaps.
@@ -515,7 +521,7 @@ out  GET /v1/orders 200 44ms
 out  POST /v1/orders 201 88ms                                                                                           
 out  GET /v1/orders/8821 200 9ms                                                                                        
 out  connection pool: 14/50 in use                                                                                      
-q quit   j/k select   g/G first/last   r refresh   / filter                                                    read-only
+q quit   j/k select   g/G first/last   r refresh   / filter   s settings                                       read-only
 
 === lambs  (120x30) ===
 The detail pane with a lamb list: how many descendants the shepherd's walk found, how old that reading is, and each lamb's pid and executable name. The stamp sits before the list so a narrow terminal truncates lambs rather than the caveat.
@@ -549,7 +555,7 @@ out  GET /v1/orders 200 44ms
 out  POST /v1/orders 201 88ms                                                                                           
 out  GET /v1/orders/8821 200 9ms                                                                                        
 out  connection pool: 14/50 in use                                                                                      
-q quit   j/k select   / filter   x stop   R restart   L reload                                           control enabled
+q quit   j/k select   / filter   x stop   R restart   L reload   s settings                              control enabled
 
 === lambs_unknown  (120x30) ===
 The same pane on a stopped sheep. The shepherd had no pid to walk from and left the field unset rather than empty, and the line says which of the two it is looking at rather than reporting none found.
@@ -583,7 +589,7 @@ out  GET /v1/orders 200 44ms
 out  POST /v1/orders 201 88ms                                                                                           
 out  GET /v1/orders/8821 200 9ms                                                                                        
 out  connection pool: 14/50 in use                                                                                      
-q quit   j/k select   g/G first/last   r refresh   / filter                                                    read-only
+q quit   j/k select   g/G first/last   r refresh   / filter   s settings                                       read-only
 
 === confirm  (100x14) ===
 `R` pressed with the gate open. Nothing has been sent: the bar asks a question naming the verb and the exact sheep, and `api` is still online in the table behind it.
@@ -674,3 +680,173 @@ host  load 2.31 4.10 3.88 / 10 cores   host mem 12.4G / 32.0G   flock cpu 14.7% 
                                                                                                     
                                                                                                     
 the shepherd stopped answering — reconnecting (attempt 3)                            control enabled
+
+=== settings_fresh  (120x30) ===
+The settings screen on a fresh $SHEP_HOME: shep.toml holds only [interpreters], so every scalar's SOURCE column reads `the default` and its VALUE is the compiled fallback. The state most operators open this screen in.
+
+shep lookout   /home/ada/.shep                                                                            6 in the flock
+  [daemon]                                                                                                              
+> log_level        warn                            the default  needs shep daemon reload                                
+  log_json         false                           the default  needs shep daemon reload                                
+  socket           /home/ada/.shep/run/shep.sock   the default  needs the shepherd stopped and started                  
+  max_cron_sleep   not set                         the default  needs shep daemon reload                                
+                                                                                                                        
+  [whistle]                                                                                                             
+  allow_control    false                           the default  needs shep whistle restarted                            
+                                                                                                                        
+  [style]                                                                                                               
+  level            full                            the default  the next command reads it                               
+                                                                                                                        
+  [dogs]                                                                                                                
+  space arms, Enter applies; a dog needs no reload                                                                      
+  NAME                                                                  IN FILE  SOURCE                    RUNNING      
+  bark                                                                  no       built-in                  not running  
+  metrics                                                               no       built-in                  not running  
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+esc close   j/k select   g/G first/last   space cycle                                                          read-only
+
+=== settings_set  (120x30) ===
+The settings screen with some scalars declared. `shep.toml` and `the default` sit side by side in the SOURCE column, so what the operator wrote and what shep assumes are both visible at once.
+
+shep lookout   /home/ada/.shep                                                                            6 in the flock
+  [daemon]                                                                                                              
+> log_level        warn                            shep.toml    needs shep daemon reload                                
+  log_json         false                           the default  needs shep daemon reload                                
+  socket           /home/ada/.shep/run/shep.sock   shep.toml    needs the shepherd stopped and started                  
+  max_cron_sleep   30s                             shep.toml    needs shep daemon reload                                
+                                                                                                                        
+  [whistle]                                                                                                             
+  allow_control    false                           the default  needs shep whistle restarted                            
+                                                                                                                        
+  [style]                                                                                                               
+  level            full                            shep.toml    the next command reads it                               
+                                                                                                                        
+  [dogs]                                                                                                                
+  space arms, Enter applies; a dog needs no reload                                                                      
+  NAME                                                                  IN FILE  SOURCE                    RUNNING      
+  bark                                                                  no       built-in                  not running  
+  metrics                                                               yes      built-in                  not running  
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+esc close   j/k select   g/G first/last   space cycle                                                          read-only
+
+=== settings_confirm  (180x30) ===
+A [daemon] confirm armed on log_level, naming the variable and the flag it cannot see: SHEP_LOG_LEVEL and --log-level, and the shep daemon reload the edit needs.
+
+shep lookout   /home/ada/.shep                                                                                                                                        6 in the flock
+  [daemon]                                                                                                                                                                          
+> log_level        warn                            shep.toml    needs shep daemon reload                                                                                            
+  log_json         false                           the default  needs shep daemon reload                                                                                            
+  socket           /home/ada/.shep/run/shep.sock   shep.toml    needs the shepherd stopped and started                                                                              
+  max_cron_sleep   30s                             shep.toml    needs shep daemon reload                                                                                            
+                                                                                                                                                                                    
+  [whistle]                                                                                                                                                                         
+  allow_control    false                           the default  needs shep whistle restarted                                                                                        
+                                                                                                                                                                                    
+  [style]                                                                                                                                                                           
+  level            full                            shep.toml    the next command reads it                                                                                           
+                                                                                                                                                                                    
+  [dogs]                                                                                                                                                                            
+  space arms, Enter applies; a dog needs no reload                                                                                                                                  
+  NAME                                                                                                                              IN FILE  SOURCE                    RUNNING      
+  bark                                                                                                                              no       built-in                  not running  
+  metrics                                                                                                                           yes      built-in                  not running  
+                                                                                                                                                                                    
+  set log_level to info? needs shep daemon reload, and will not apply if the shepherd was booted with SHEP_LOG_LEVEL or --log-level  enter confirms, any other key cancels          
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+esc close   j/k select   g/G first/last   space cycle                                                                                                                control enabled
+
+=== settings_typing  (120x30) ===
+The socket editor open mid-path. The status bar names the field being typed, not the dashboard's own filter box, which is what it showed here before the fix this frame now pins.
+
+shep lookout   /home/ada/.shep                                                                            6 in the flock
+  [daemon]                                                                                                              
+  log_level        warn                            shep.toml    needs shep daemon reload                                
+  log_json         false                           the default  needs shep daemon reload                                
+> socket           /home/ada/.shep/run/shep.sock   shep.toml    needs the shepherd stopped and started                  
+  max_cron_sleep   30s                             shep.toml    needs shep daemon reload                                
+                                                                                                                        
+  [whistle]                                                                                                             
+  allow_control    false                           the default  needs shep whistle restarted                            
+                                                                                                                        
+  [style]                                                                                                               
+  level            full                            shep.toml    the next command reads it                               
+                                                                                                                        
+  [dogs]                                                                                                                
+  space arms, Enter applies; a dog needs no reload                                                                      
+  NAME                                                                  IN FILE  SOURCE                    RUNNING      
+  bark                                                                  no       built-in                  not running  
+  metrics                                                               yes      built-in                  not running  
+                                                                                                                        
+  editing socket: /home/ada/.shep/run/s▏   enter applies   esc cancels                                                  
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+editing socket  /home/ada/.shep/run/s▏   enter applies   esc cancels                                     control enabled
+
+=== settings_dogs  (120x30) ===
+The dogs table showing the drift it exists to reveal: otel running while disabled in the file, ledger enabled and absent, and bark enabled, running, and silent.
+
+shep lookout   /home/ada/.shep                                                                            2 in the flock
+  [daemon]                                                                                                              
+> log_level        warn                            shep.toml    needs shep daemon reload                                
+  log_json         false                           the default  needs shep daemon reload                                
+  socket           /home/ada/.shep/run/shep.sock   shep.toml    needs the shepherd stopped and started                  
+  max_cron_sleep   30s                             shep.toml    needs shep daemon reload                                
+                                                                                                                        
+  [whistle]                                                                                                             
+  allow_control    false                           the default  needs shep whistle restarted                            
+                                                                                                                        
+  [style]                                                                                                               
+  level            full                            shep.toml    the next command reads it                               
+                                                                                                                        
+  [dogs]                                                                                                                
+  space arms, Enter applies; a dog needs no reload                                                                      
+  NAME                                                                  IN FILE  SOURCE                    RUNNING      
+  otel                                                                  no       built-in                  online       
+  ledger                                                                yes      built-in                  not running  
+  bark                                                                  yes      built-in                  silent       
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+esc close   j/k select   g/G first/last   space cycle                                                          read-only

--- a/docs/lookout/frames.txt
+++ b/docs/lookout/frames.txt
@@ -713,7 +713,7 @@ shep lookout   /home/ada/.shep                                                  
                                                                                                                         
                                                                                                                         
                                                                                                                         
-esc/s close   j/k select   g/G first/last   r refresh                                                          read-only
+esc/s close   j/k select   g/G first/last   r refresh   q quit                                                 read-only
 
 === settings_set  (120x30) ===
 The settings screen with some scalars declared. `shep.toml` and `the default` sit side by side in the SOURCE column, so what the operator wrote and what shep assumes are both visible at once.
@@ -747,7 +747,7 @@ shep lookout   /home/ada/.shep                                                  
                                                                                                                         
                                                                                                                         
                                                                                                                         
-esc/s close   j/k select   g/G first/last   r refresh                                                          read-only
+esc/s close   j/k select   g/G first/last   r refresh   q quit                                                 read-only
 
 === settings_confirm  (180x30) ===
 A [daemon] confirm armed on log_level, naming the variable and the flag it cannot see: SHEP_LOG_LEVEL and --log-level, and the shep daemon reload the edit needs.
@@ -849,7 +849,7 @@ shep lookout   /home/ada/.shep                                                  
                                                                                                                         
                                                                                                                         
                                                                                                                         
-esc/s close   j/k select   g/G first/last   r refresh                                                          read-only
+esc/s close   j/k select   g/G first/last   r refresh   q quit                                                 read-only
 
 === settings_narrow  (45x24) ===
 The same screen at 45 columns. Both of its tables have dropped a column rather than clipping: the scalar rows have lost the apply cost and kept SOURCE, and the dogs table has lost SOURCE and kept RUNNING. Each keeps whichever half is not said anywhere else.

--- a/docs/lookout/frames.txt
+++ b/docs/lookout/frames.txt
@@ -836,8 +836,8 @@ shep lookout   /home/ada/.shep                                                  
   [dogs]                                                                                                                
   space arms, Enter applies; a dog needs no reload                                                                      
   NAME                                                                IN FILE  SOURCE                    RUNNING        
-  otel                                                                no       built-in                  online         
-  ledger                                                              yes      built-in                  not running    
+  otel                                                                no       /usr/local/bin/shep-otel  online         
+  ledger                                                              yes      /opt/ledger/bin/dog       not running    
   bark                                                                yes      built-in                  silent         
                                                                                                                         
                                                                                                                         

--- a/docs/lookout/frames.txt
+++ b/docs/lookout/frames.txt
@@ -7,7 +7,7 @@ These are real frames, rendered headlessly through ratatui's TestBackend by
 
 Nothing here is a mockup.
 
-frames.ansi is the same thirty frames with colour; read it with `less -R`.
+frames.ansi is the same thirty-one frames with colour; read it with `less -R`.
 
 All four panes are here: the flock table (the spine), the host-usage strip,
 the sheep detail pane and the bleats feed. `>` marks the selected sheep, and
@@ -24,11 +24,11 @@ it read and dropped are counted exactly; bytes below its 64 KiB window were
 never read at all, so those are reported in bytes, because nothing counted the
 lines in them and guessing would be worse than saying so.
 
-The last five frames are the settings screen, `s` from the dashboard. It owns
+The last six frames are the settings screen, `s` from the dashboard. It owns
 the whole body between the title and the status bar rather than sharing it
 with the flock table, so a fresh $SHEP_HOME, some scalars declared, an armed
-confirm, the socket editor mid-type and the dogs table's own drift each get a
-frame of their own.
+confirm, the socket editor mid-type, the dogs table's own drift and the same
+screen at 45 columns each get a frame of their own.
 
 
 === healthy_wide  (120x30) ===
@@ -850,3 +850,31 @@ shep lookout   /home/ada/.shep                                                  
                                                                                                                         
                                                                                                                         
 esc close   j/k select   g/G first/last   space cycle                                                          read-only
+
+=== settings_narrow  (45x24) ===
+The same screen at 45 columns. Both of its tables have dropped a column rather than clipping: the scalar rows have lost the apply cost and kept SOURCE, and the dogs table has lost SOURCE and kept RUNNING. Each keeps whichever half is not said anywhere else.
+
+shep lookout   /home/ada/.shep 2 in the flock
+  [daemon]                                   
+> log_level        warn           shep.toml  
+  log_json         false          the default
+  socket           /home/ada/.s…  shep.toml  
+  max_cron_sleep   30s            shep.toml  
+                                             
+  [whistle]                                  
+  allow_control    false          the default
+                                             
+  [style]                                    
+  level            full           shep.toml  
+                                             
+  [dogs]                                     
+  space arms, Enter applies; a dog needs no …
+  NAME               IN FILE  RUNNING        
+  otel               no       online         
+  ledger             yes      not running    
+  bark               yes      silent         
+                                             
+                                             
+                                             
+                                             
+esc close   j/k select   g/G first… read-only

--- a/docs/lookout/frames.txt
+++ b/docs/lookout/frames.txt
@@ -699,9 +699,9 @@ shep lookout   /home/ada/.shep                                                  
                                                                                                                         
   [dogs]                                                                                                                
   space arms, Enter applies; a dog needs no reload                                                                      
-  NAME                                                                  IN FILE  SOURCE                    RUNNING      
-  bark                                                                  no       built-in                  not running  
-  metrics                                                               no       built-in                  not running  
+  NAME                                                                IN FILE  SOURCE                    RUNNING        
+  bark                                                                no       built-in                  not running    
+  metrics                                                             no       built-in                  not running    
                                                                                                                         
                                                                                                                         
                                                                                                                         
@@ -733,9 +733,9 @@ shep lookout   /home/ada/.shep                                                  
                                                                                                                         
   [dogs]                                                                                                                
   space arms, Enter applies; a dog needs no reload                                                                      
-  NAME                                                                  IN FILE  SOURCE                    RUNNING      
-  bark                                                                  no       built-in                  not running  
-  metrics                                                               yes      built-in                  not running  
+  NAME                                                                IN FILE  SOURCE                    RUNNING        
+  bark                                                                no       built-in                  not running    
+  metrics                                                             yes      built-in                  not running    
                                                                                                                         
                                                                                                                         
                                                                                                                         
@@ -767,9 +767,9 @@ shep lookout   /home/ada/.shep                                                  
                                                                                                                                                                                     
   [dogs]                                                                                                                                                                            
   space arms, Enter applies; a dog needs no reload                                                                                                                                  
-  NAME                                                                                                                              IN FILE  SOURCE                    RUNNING      
-  bark                                                                                                                              no       built-in                  not running  
-  metrics                                                                                                                           yes      built-in                  not running  
+  NAME                                                                                                                            IN FILE  SOURCE                    RUNNING        
+  bark                                                                                                                            no       built-in                  not running    
+  metrics                                                                                                                         yes      built-in                  not running    
                                                                                                                                                                                     
   set log_level to info? needs shep daemon reload, and will not apply if the shepherd was booted with SHEP_LOG_LEVEL or --log-level  enter confirms, any other key cancels          
                                                                                                                                                                                     
@@ -801,9 +801,9 @@ shep lookout   /home/ada/.shep                                                  
                                                                                                                         
   [dogs]                                                                                                                
   space arms, Enter applies; a dog needs no reload                                                                      
-  NAME                                                                  IN FILE  SOURCE                    RUNNING      
-  bark                                                                  no       built-in                  not running  
-  metrics                                                               yes      built-in                  not running  
+  NAME                                                                IN FILE  SOURCE                    RUNNING        
+  bark                                                                no       built-in                  not running    
+  metrics                                                             yes      built-in                  not running    
                                                                                                                         
   editing socket: /home/ada/.shep/run/s▏   enter applies   esc cancels                                                  
                                                                                                                         
@@ -835,10 +835,10 @@ shep lookout   /home/ada/.shep                                                  
                                                                                                                         
   [dogs]                                                                                                                
   space arms, Enter applies; a dog needs no reload                                                                      
-  NAME                                                                  IN FILE  SOURCE                    RUNNING      
-  otel                                                                  no       built-in                  online       
-  ledger                                                                yes      built-in                  not running  
-  bark                                                                  yes      built-in                  silent       
+  NAME                                                                IN FILE  SOURCE                    RUNNING        
+  otel                                                                no       built-in                  online         
+  ledger                                                              yes      built-in                  not running    
+  bark                                                                yes      built-in                  silent         
                                                                                                                         
                                                                                                                         
                                                                                                                         

--- a/docs/lookout/frames.txt
+++ b/docs/lookout/frames.txt
@@ -781,7 +781,7 @@ shep lookout   /home/ada/.shep                                                  
                                                                                                                                                                                     
                                                                                                                                                                                     
                                                                                                                                                                                     
-esc close   j/k select   g/G first/last   space cycle                                                                                                                control enabled
+set log_level to info? needs shep daemon reload, and will not apply if the shepherd was booted with SHEP_LOG_LEVEL or --log-level  enter confirms, any other key ca… control enabled
 
 === settings_typing  (120x30) ===
 The socket editor open mid-path. The status bar names the field being typed, not the dashboard's own filter box, which is what it showed here before the fix this frame now pins.

--- a/docs/lookout/frames.txt
+++ b/docs/lookout/frames.txt
@@ -713,7 +713,7 @@ shep lookout   /home/ada/.shep                                                  
                                                                                                                         
                                                                                                                         
                                                                                                                         
-esc close   j/k select   g/G first/last   space cycle                                                          read-only
+esc/s close   j/k select   g/G first/last   r refresh                                                          read-only
 
 === settings_set  (120x30) ===
 The settings screen with some scalars declared. `shep.toml` and `the default` sit side by side in the SOURCE column, so what the operator wrote and what shep assumes are both visible at once.
@@ -747,7 +747,7 @@ shep lookout   /home/ada/.shep                                                  
                                                                                                                         
                                                                                                                         
                                                                                                                         
-esc close   j/k select   g/G first/last   space cycle                                                          read-only
+esc/s close   j/k select   g/G first/last   r refresh                                                          read-only
 
 === settings_confirm  (180x30) ===
 A [daemon] confirm armed on log_level, naming the variable and the flag it cannot see: SHEP_LOG_LEVEL and --log-level, and the shep daemon reload the edit needs.
@@ -849,7 +849,7 @@ shep lookout   /home/ada/.shep                                                  
                                                                                                                         
                                                                                                                         
                                                                                                                         
-esc close   j/k select   g/G first/last   space cycle                                                          read-only
+esc/s close   j/k select   g/G first/last   r refresh                                                          read-only
 
 === settings_narrow  (45x24) ===
 The same screen at 45 columns. Both of its tables have dropped a column rather than clipping: the scalar rows have lost the apply cost and kept SOURCE, and the dogs table has lost SOURCE and kept RUNNING. Each keeps whichever half is not said anywhere else.
@@ -877,4 +877,4 @@ shep lookout   /home/ada/.shep 2 in the flock
                                              
                                              
                                              
-esc close   j/k select   g/G first… read-only
+esc/s close   j/k select   g/G fir… read-only

--- a/docs/writing-plans/plans/2026-09-04-lookout-settings.md
+++ b/docs/writing-plans/plans/2026-09-04-lookout-settings.md
@@ -818,9 +818,10 @@ Cursor movement clamps rather than wrapping, matching the flock table. Store the
 ```rust
 Effect::LoadSettings => {
     let path = paths.daemon_config.clone();
+    let socket_default = paths.socket.clone();
     let style = /* the resolved style this lookout already holds */;
     let result = tokio::task::spawn_blocking(move || {
-        commands::settings::load_settings(&path, &style)
+        commands::settings::load_settings(&path, &socket_default, style)
     })
     .await
     .map_err(|err| err.to_string())
@@ -830,7 +831,11 @@ Effect::LoadSettings => {
 }
 ```
 
+`load_settings` takes three arguments, not two: the config path, the socket path a document that declares none falls back to, and the already-resolved style. The style goes by value, since it is a `(StyleLevel, StyleSource)` pair of two `Copy` fields.
+
 `spawn_blocking` even though the read takes no lock: the rule is "no file I/O on the redraw task", which is cheaper to hold than a judgement per call site. Say so in a comment.
+
+What shipped does not `.await` the handle in the arm, as the sample above does. Awaiting it there parks the UI task until the I/O lands, which is the freeze `spawn_blocking` was reached for in the first place; the handle goes into a `FuturesUnordered` the `select!` drains instead. See the commit that fixed it for the full argument.
 
 Add the fixtures `settings_snapshot()`, `app_in_settings()` and `app_in_settings_with_control()` to `view/fixtures.rs`, in the shape the ones already there use.
 
@@ -1607,4 +1612,4 @@ Run against the spec before dispatching task 1.
 - **Spec coverage.** Decision 1 is task 6 (`draw` branches rather than adding a pane tier). Decision 2 is task 7. Decision 3 is tasks 3 and 8. Decision 4 is tasks 2, 3 and 6. Decision 5 is tasks 2, 3 and 8. Decision 6 is tasks 7, 8 and 9's confirm strings. Decision 7 is task 11's docs, since lookout only names the command. Decision 8 is task 5's read-only test. Decision 9 is tasks 6 and 9. Decision 10 is task 4. Decision 11 is a note at the call sites, checked in review rather than by a test, because there is nothing to redact.
 - **Types.** `SettingField`, `SettingEdit`, `SettingsSnapshot`, `ScalarView`, `DogView` and `SettingError` are defined in task 3 and used unchanged in 5 through 9. `SettingsRow` and `Settings` are task 5's. `Pending` is task 7's, extended by task 8. `Effect::WriteDog`, `Msg::DogWritten` and `Sent::Dog` are task 9's.
 - **Loose ends, all closed before dispatch.** `resolve_style` returns `(StyleLevel, StyleSource)` at `lib.rs:533`; `SettingSource` is not declared at all; `StyleSource` already has the four variants; `DogSource` is `BuiltIn | Adopted { path: String }` at `request.rs:587`; the read-only refusal is `"read-only: actions need --allow-control"` at `app.rs:1033`; and `silent` comes from `Reported::of(..).word()` at `vocabulary.rs:117`. Nothing in this plan is left for an implementer to guess at.
-- **`ino()` needs `std::os::unix::fs::MetadataExt`** in task 3's test module. `commands` is already `cfg(unix)` wholesale, so no gate is needed around it.
+- **`ino()` needs `std::os::unix::fs::MetadataExt`** in task 3's test module, and the import needs its own `#[cfg(unix)]`. `mod commands;` carries no gate at all: each site that reaches for a unix API gates itself. Assuming otherwise is what broke the Windows leg of CI on this branch.

--- a/docs/writing-plans/plans/2026-09-04-lookout-settings.md
+++ b/docs/writing-plans/plans/2026-09-04-lookout-settings.md
@@ -17,7 +17,7 @@ Every task's requirements implicitly include all of these.
 - **Clean-room rule, non-negotiable.** Never open, read, or port source from `~/GitHub/pm2`. Nothing in this feature has a pm2 ancestor.
 - **Invoke the `shep-idiomatic-rust` skill before writing or reviewing any Rust in this repository.** Cite rules as `IR-<n>` in review.
 - **No em dashes and no en dashes anywhere.** Not in code, comments, docs, commit messages, operator-facing strings or the PR body. Existing strings that carry one are out of scope and stay as they are.
-- **Operator-facing prose goes through `humanizer` then `rin-voice` before it lands.** That covers every string this feature prints, the docs page, and the PR body. Not commit messages, which stay long and detailed.
+- **Operator-facing prose goes through the project's voice review before it lands.** That covers every string this feature prints, the docs page, and the PR body. Not commit messages, which stay long and detailed.
 - **Never write the maintainer's real name, personal email, or any absolute home-directory path** into a committed file, a commit message, or a PR body. Repo-relative paths only.
 - **Any snippet in this plan that quotes existing code is a guess.** Grep the real file and follow what is there, not what is written here. Signatures for code this plan introduces are binding; quotations of code that already exists are not.
 - **Every new test must be proved non-vacuous.** Mutate the thing it protects, watch that test go red, and **verify the mutation actually applied** before trusting the red. `cargo fmt` has rewrapped a line a patch was matching, leaving the patch a silent no-op and three green runs looking like evidence.
@@ -963,7 +963,7 @@ git commit -m "feat(lookout): the settings screen renders, with a source per sca
   }
   ```
 
-**Confirm strings, verbatim.** These have already been through `humanizer` and `rin-voice`; use them as written and do not paraphrase.
+**Confirm strings, verbatim.** These have already been through the project's voice review; use them as written and do not paraphrase.
 
 | Field | Prompt |
 | --- | --- |
@@ -1550,7 +1550,7 @@ git commit -m "docs(lookout): gallery frames for the settings screen"
 3. That a `[daemon]` edit can be shadowed by the shepherd's own `SHEP_*` env or boot flags, which lookout cannot see, and that `[style]` is the exception because those layers are lookout's own.
 4. That `log_level`, `log_json` and `allow_control` can move from `the default` to `shep.toml` and not back from this screen, because `socket` and `max_cron_sleep` are the only optional ones (spec decision 5).
 
-Run `humanizer` then `rin-voice` over the prose before committing it. Match the page's existing register rather than inventing one.
+Run the project's voice review over the prose before committing it. Match the page's existing register rather than inventing one.
 
 - [ ] **Step 2: Regenerate the CLI reference and check the diff**
 

--- a/docs/writing-plans/plans/2026-09-04-lookout-settings.md
+++ b/docs/writing-plans/plans/2026-09-04-lookout-settings.md
@@ -379,12 +379,12 @@ fn a_fresh_home_reads_every_scalar_as_the_default() {
     let path = dir.path().join("shep.toml");
     ShepToml::edit(&path, ShepToml::write_starter_interpreters).unwrap();
 
-    let snap = load_settings(&path, &style_fixture()).unwrap();
-    assert_eq!(snap.log_level.source, SettingSource::Default);
+    let snap = load_settings(&path, &socket_fixture(), style_fixture()).unwrap();
+    assert_eq!(snap.log_level.source, StyleSource::Default);
     assert_eq!(snap.log_level.value, "warn");
-    assert_eq!(snap.log_json.source, SettingSource::Default);
-    assert_eq!(snap.allow_control.source, SettingSource::Default);
-    assert_eq!(snap.max_cron_sleep.source, SettingSource::Default);
+    assert_eq!(snap.log_json.source, StyleSource::Default);
+    assert_eq!(snap.allow_control.source, StyleSource::Default);
+    assert_eq!(snap.max_cron_sleep.source, StyleSource::Default);
 }
 
 #[test]
@@ -393,11 +393,11 @@ fn a_declared_scalar_reads_as_config_even_at_its_default_value() {
     let path = dir.path().join("shep.toml");
     std::fs::write(&path, "[daemon]\nlog_level = \"warn\"\n").unwrap();
 
-    let snap = load_settings(&path, &style_fixture()).unwrap();
+    let snap = load_settings(&path, &socket_fixture(), style_fixture()).unwrap();
     assert_eq!(snap.log_level.value, "warn");
     assert_eq!(
         snap.log_level.source,
-        SettingSource::Config,
+        StyleSource::Config,
         "a key written to its own default is still a key someone wrote"
     );
 }
@@ -456,8 +456,8 @@ fn unsetting_an_optional_field_returns_it_to_the_default() {
 
     apply_setting(&path, &SettingEdit::Unset { field: SettingField::MaxCronSleep }).unwrap();
 
-    let snap = load_settings(&path, &style_fixture()).unwrap();
-    assert_eq!(snap.max_cron_sleep.source, SettingSource::Default);
+    let snap = load_settings(&path, &socket_fixture(), style_fixture()).unwrap();
+    assert_eq!(snap.max_cron_sleep.source, StyleSource::Default);
 }
 
 #[test]
@@ -466,7 +466,7 @@ fn every_built_in_dog_is_a_candidate_even_when_nothing_is_enabled() {
     let path = dir.path().join("shep.toml");
     std::fs::write(&path, "").unwrap();
 
-    let snap = load_settings(&path, &style_fixture()).unwrap();
+    let snap = load_settings(&path, &socket_fixture(), style_fixture()).unwrap();
     let names: Vec<&str> = snap.dogs.iter().map(|d| d.name.as_str()).collect();
     assert_eq!(names, vec!["bark", "metrics"]);
     assert!(snap.dogs.iter().all(|d| !d.enabled));
@@ -482,7 +482,7 @@ fn an_adopted_dog_joins_the_candidates_and_carries_its_path() {
     )
     .unwrap();
 
-    let snap = load_settings(&path, &style_fixture()).unwrap();
+    let snap = load_settings(&path, &socket_fixture(), style_fixture()).unwrap();
     let otel = snap.dogs.iter().find(|d| d.name == "otel").unwrap();
     assert!(otel.enabled);
     assert_eq!(otel.adopted_path.as_deref(), Some(Path::new("/usr/local/bin/shep-otel")));
@@ -491,7 +491,7 @@ fn an_adopted_dog_joins_the_candidates_and_carries_its_path() {
 }
 ```
 
-`style_fixture()` is a local helper returning whatever `load_settings`'s second parameter turns out to be, with the level resolved from the config layer. Write it once at the top of the test module.
+`style_fixture()` returns a `(StyleLevel, StyleSource)` pair with the level resolved from the config layer; `socket_fixture()` returns a `&Path` standing in for `paths.socket`. Write both once at the top of the test module.
 
 - [ ] **Step 2: Run them and watch them fail**
 
@@ -503,7 +503,7 @@ Expected: FAIL, module not found.
 
 - [ ] **Step 3: Implement**
 
-`load_settings` opens through `ShepToml::read_only`, asks each task-2 reader for its `Option`, and pairs `Some` with `SettingSource::Config` and `None` with `SettingSource::Default` plus the compiled default rendered as a string. Take the defaults from `DaemonSection::default()` and `WhistleSection::default()` rather than typing literals, so a changed default cannot leave this module lying.
+`load_settings` opens through `ShepToml::read_only`, asks each task-2 reader for its `Option`, and pairs `Some` with `StyleSource::Config` and `None` with `StyleSource::Default` plus the compiled default rendered as a string. Take the defaults from `DaemonSection::default()` and `WhistleSection::default()` rather than typing literals, so a changed default cannot leave this module lying.
 
 `socket`'s default is the resolved socket path, not an empty cell: pass it in from `ShepPaths` and render that. It is the socket this lookout is connected over, so it is the live answer by construction.
 
@@ -1049,7 +1049,7 @@ fn a_written_edit_updates_the_row_and_its_source() {
     };
     let _ = app.update(Msg::SettingWritten { edit, result: Ok(()) });
 
-    assert_eq!(app.settings().unwrap().snapshot().log_level.source, SettingSource::Config);
+    assert_eq!(app.settings().unwrap().snapshot().log_level.source, StyleSource::Config);
     assert!(app.settings().unwrap().pending().is_none());
 }
 
@@ -1123,7 +1123,7 @@ enum Pending {
 }
 ```
 
-`Cycle` on a scalar row builds the next candidate and stores `Armed`, resetting `at` each press. `Confirm` on `Armed` moves to `Sent` and returns `Effect::WriteSetting`. `Msg::SettingWritten` clears `Pending` and, on `Ok`, updates that field's `ScalarView` in place to the written value with `SettingSource::Config`; on `Err` it leaves the view alone and raises a grave `Notice`.
+`Cycle` on a scalar row builds the next candidate and stores `Armed`, resetting `at` each press. `Confirm` on `Armed` moves to `Sent` and returns `Effect::WriteSetting`. `Msg::SettingWritten` clears `Pending` and, on `Ok`, updates that field's `ScalarView` in place to the written value with `StyleSource::Config`; on `Err` it leaves the view alone and raises a grave `Notice`.
 
 Expiry: extend the `Msg::Tick` arm. The existing sheep-action expiry sits inside `if !matches!(self.link, Link::Lost { .. })`. The settings expiry goes **outside** that guard and compares against the tick's own `now`, not `self.now`. Comment why: the sheep confirm freezes because everything it describes is stale, and a settings edit describes a file that is not.
 
@@ -1605,6 +1605,6 @@ git commit -m "docs(web): the lookout settings screen, and what a change there c
 Run against the spec before dispatching task 1.
 
 - **Spec coverage.** Decision 1 is task 6 (`draw` branches rather than adding a pane tier). Decision 2 is task 7. Decision 3 is tasks 3 and 8. Decision 4 is tasks 2, 3 and 6. Decision 5 is tasks 2, 3 and 8. Decision 6 is tasks 7, 8 and 9's confirm strings. Decision 7 is task 11's docs, since lookout only names the command. Decision 8 is task 5's read-only test. Decision 9 is tasks 6 and 9. Decision 10 is task 4. Decision 11 is a note at the call sites, checked in review rather than by a test, because there is nothing to redact.
-- **Types.** `SettingField`, `SettingEdit`, `SettingsSnapshot`, `ScalarView`, `SettingSource`, `DogView` and `SettingError` are defined in task 3 and used unchanged in 5 through 9. `SettingsRow` and `Settings` are task 5's. `Pending` is task 7's, extended by task 8. `Effect::WriteDog`, `Msg::DogWritten` and `Sent::Dog` are task 9's.
-- **Loose ends, all closed before dispatch.** `resolve_style` returns `(StyleLevel, StyleSource)` at `lib.rs:533`; `SettingSource` collapses into `StyleSource`, which already has the four variants; `DogSource` is `BuiltIn | Adopted { path: String }` at `request.rs:587`; the read-only refusal is `"read-only: actions need --allow-control"` at `app.rs:1033`; and `silent` comes from `Reported::of(..).word()` at `vocabulary.rs:117`. Nothing in this plan is left for an implementer to guess at.
+- **Types.** `SettingField`, `SettingEdit`, `SettingsSnapshot`, `ScalarView`, `DogView` and `SettingError` are defined in task 3 and used unchanged in 5 through 9. `SettingsRow` and `Settings` are task 5's. `Pending` is task 7's, extended by task 8. `Effect::WriteDog`, `Msg::DogWritten` and `Sent::Dog` are task 9's.
+- **Loose ends, all closed before dispatch.** `resolve_style` returns `(StyleLevel, StyleSource)` at `lib.rs:533`; `SettingSource` is not declared at all; `StyleSource` already has the four variants; `DogSource` is `BuiltIn | Adopted { path: String }` at `request.rs:587`; the read-only refusal is `"read-only: actions need --allow-control"` at `app.rs:1033`; and `silent` comes from `Reported::of(..).word()` at `vocabulary.rs:117`. Nothing in this plan is left for an implementer to guess at.
 - **`ino()` needs `std::os::unix::fs::MetadataExt`** in task 3's test module. `commands` is already `cfg(unix)` wholesale, so no gate is needed around it.

--- a/docs/writing-plans/plans/2026-09-04-lookout-settings.md
+++ b/docs/writing-plans/plans/2026-09-04-lookout-settings.md
@@ -49,12 +49,12 @@ Every task's requirements implicitly include all of these.
 
 ## Dependency graph
 
-Tasks 1, 2 and 4 are independent and can be dispatched together. Everything else is a chain.
+Tasks 1 and 2 are independent and dispatch together. Task 4 reads back through task 2's `read_only` and `enabled_dog_names`, so it is not independent of it, and 3 and 4 form the second parallel leg.
 
 ```
-1 (rename) ─┐
-2 (ShepToml)─┼─> 3 (settings module) ─> 5 (open/close) ─> 6 (render) ─┬─> 7 (scalars) ─> 8 (text editor) ─┬─> 10 (frames) ─> 11 (docs)
-4 (dogs)  ───┘                                                        └─> 9 (dogs section) ──────────────┘
+1 (rename) ──────────────────────┐
+2 (ShepToml) ─┬─> 3 (settings) ──┴─> 5 (open/close) ─> 6 (render) ─┬─> 7 (scalars) ─> 8 (editor) ─┬─> 10 (frames) ─> 11 (docs)
+              └─> 4 (dogs) ──────────────────────────────────────────────────────────────────────┘
 ```
 
 ---
@@ -737,14 +737,16 @@ fn the_flock_cursor_and_the_filter_survive_the_swap() {
         let _ = app.update(Msg::Key(KeyPress::TextChar(c)));
     }
     let _ = app.update(Msg::Key(KeyPress::TextApply));
-    let selected = app.selected().cloned();
+    // `selected()` hands back an owned `Option<RowKey>` (app.rs:1434), so
+    // there is nothing to clone.
+    let selected = app.selected();
     let filter = app.filter().to_string();
 
     let _ = app.update(Msg::Key(KeyPress::Settings));
     let _ = app.update(Msg::Settings { result: Ok(fixtures::settings_snapshot()) });
     let _ = app.update(Msg::Key(KeyPress::Settings));
 
-    assert_eq!(app.selected().cloned(), selected);
+    assert_eq!(app.selected(), selected);
     assert_eq!(app.filter(), filter);
 }
 
@@ -779,7 +781,8 @@ fn an_action_key_from_the_dashboard_is_unreachable_while_the_screen_is_up() {
     let mut app = fixtures::app_in_settings_with_control();
     // `x` is the stop key on the dashboard. In here it is not an action at all.
     let _ = app.update(Msg::Key(KeyPress::Action(ActionVerb::Stop)));
-    assert!(app.action_state().is_none(), "no sheep confirm can arm from here");
+    // The accessor is `App::action()` (app.rs:1662).
+    assert!(app.action().is_none(), "no sheep confirm can arm from here");
 }
 
 #[test]
@@ -904,6 +907,8 @@ Expected: FAIL, module not found. The snapshot test will want `cargo insta accep
 `settings.rs` renders, in order: `[daemon]` with its four rows, `[whistle]` with one, `[style]` with one, then `[dogs]` with its caption and table. Each scalar row is name, value, source, and the apply cost. Section headers use the palette's muted style; the cursor row is marked `>` exactly as the flock table marks its selection.
 
 The dogs caption is `space arms, Enter applies; a dog needs no reload`. Do not write a caption that says space applies: this screen arms and confirms like every other action in lookout.
+
+This task renders the dogs table from `SettingsSnapshot` alone: NAME, IN FILE and SOURCE. The RUNNING column is the join against the live flock and belongs to task 9, which declares `dog_rows` for it. Leave the column out here rather than rendering an empty one.
 
 Model the drop tiers on `view/flock.rs`'s `TIERS` and `columns_for`, including the doc explaining the drop order. SOURCE goes first because it is the widest and an adopted path can be long; then IN FILE, because RUNNING is the half that answers "is it up".
 
@@ -1323,6 +1328,24 @@ The file half and the daemon half are two acts. File first, then the request, wh
   }
   ```
   `Sent::request()` gains its two arms: `EnableDog { name, source }` and `DisableDog { name }`. `PROTOCOL_VERSION` does not move; both requests already exist.
+
+  Also produced, in `view/settings.rs`:
+  ```rust
+  /// One row of the dogs table, with the file and the live flock joined by
+  /// name. Declared here rather than in task 6 because the join is this
+  /// task's whole subject: task 6 renders IN FILE and SOURCE from the
+  /// snapshot alone, and RUNNING is what this adds.
+  pub struct DogRow {
+      pub name: String,
+      pub enabled: bool,
+      /// The word the flock table would show, or `None` when no dog of this
+      /// name is running.
+      pub running: Option<String>,
+      pub adopted_path: Option<PathBuf>,
+  }
+
+  pub fn dog_rows(app: &App, width: u16) -> Vec<DogRow>;
+  ```
 
 **Confirm strings, verbatim:**
 

--- a/docs/writing-plans/plans/2026-09-04-lookout-settings.md
+++ b/docs/writing-plans/plans/2026-09-04-lookout-settings.md
@@ -1,0 +1,1587 @@
+# lookout settings screen implementation plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `shep lookout` gains a settings screen, opened with `s`, that reads and writes `$SHEP_HOME/shep.toml`: six scalars and a per-dog toggle, editing behind the existing `--allow-control` gate and reading outside it.
+
+**Architecture:** The reducer stays pure. Two new effects (`LoadSettings`, `WriteSetting`) are performed in `run_ui` on `spawn_blocking`, and a dog toggle chains a third step through the existing `Effect::Send`. The screen reads presence out of the `toml_edit` document rather than through `DaemonConfig`, because `DaemonConfig::load` destroys the difference between an absent key and one written to its default. `DaemonConfig` keeps two jobs: the effective value when a key is absent, and validation inside `try_edit`.
+
+**Tech Stack:** Rust 2024, MSRV 1.88. `ratatui` for the screen, `toml_edit` through the existing `ShepToml`, `insta` for frame snapshots, `tokio` for `spawn_blocking`.
+
+**Spec:** [docs/brainstorming/specs/2026-09-04-lookout-settings-design.md](../../brainstorming/specs/2026-09-04-lookout-settings-design.md). Read it before task 1. It carries the reasoning this plan only summarises, and its eleven decisions are cited by number throughout.
+
+## Global constraints
+
+Every task's requirements implicitly include all of these.
+
+- **Clean-room rule, non-negotiable.** Never open, read, or port source from `~/GitHub/pm2`. Nothing in this feature has a pm2 ancestor.
+- **Invoke the `shep-idiomatic-rust` skill before writing or reviewing any Rust in this repository.** Cite rules as `IR-<n>` in review.
+- **No em dashes and no en dashes anywhere.** Not in code, comments, docs, commit messages, operator-facing strings or the PR body. Existing strings that carry one are out of scope and stay as they are.
+- **Operator-facing prose goes through `humanizer` then `rin-voice` before it lands.** That covers every string this feature prints, the docs page, and the PR body. Not commit messages, which stay long and detailed.
+- **Never write the maintainer's real name, personal email, or any absolute home-directory path** into a committed file, a commit message, or a PR body. Repo-relative paths only.
+- **Any snippet in this plan that quotes existing code is a guess.** Grep the real file and follow what is there, not what is written here. Signatures for code this plan introduces are binding; quotations of code that already exists are not.
+- **Every new test must be proved non-vacuous.** Mutate the thing it protects, watch that test go red, and **verify the mutation actually applied** before trusting the red. `cargo fmt` has rewrapped a line a patch was matching, leaving the patch a silent no-op and three green runs looking like evidence.
+- **No sleeps in tests (IR-46).** Every wait has a forcing mechanism. Expiry rides synthesised `Instant`s through `Msg::Tick`, the way `a_confirm_expires_after_ten_seconds_of_ticks` already does.
+- **One cargo shape for the whole task, while iterating:**
+  ```
+  cargo test --workspace --lib --bins --all-features -- --skip ::slow::
+  ```
+  Do not alternate with `-p`. Each switch invalidates feature resolution and rebuilds the world.
+- **Every new public item needs docs and a deliberate `Debug` decision.** Decision 11 of the spec establishes that nothing on this screen is sensitive, so no redacted `Debug` is owed. Say so at the call site rather than leaving it silent.
+- **Commit at the end of every task.** One commit per task, conventional-commit subject.
+
+---
+
+## File structure
+
+| File | Responsibility |
+| --- | --- |
+| `crates/shep-cli/src/lookout/input.rs` | keymap only. Gains `s` and `space`; the four `Filter*` presses become `Text*`. |
+| `crates/shep-cli/src/commands/shep_toml.rs` | the document. Gains typed readers, setters and two unsetters for the six scalars, plus a lock-free `read_only` constructor. Knows nothing about validity. |
+| `crates/shep-cli/src/commands/settings.rs` | **new.** Owns `SettingsSnapshot`, `SettingField`, `SettingEdit`, `load_settings` and `apply_setting`. The one place that pairs the document with `DaemonConfig`'s validation. |
+| `crates/shep-cli/src/commands/dogs.rs` | gains `enable_in_config` and `disable_in_config`, extracted from `enable` and `disable`. Reporting stays where it is. |
+| `crates/shep-cli/src/lookout/app.rs` | reducer state and transitions: `App.settings`, the new `Msg`, `Effect` and `Sent` variants. |
+| `crates/shep-cli/src/lookout/view/settings.rs` | **new.** Renders the screen. Holds no state. |
+| `crates/shep-cli/src/lookout/view/mod.rs` | dispatches `draw` to the screen or the dashboard. |
+| `crates/shep-cli/src/lookout/mod.rs` | performs the two new effects on `spawn_blocking`. |
+| `crates/shep-cli/src/lookout/frames.rs` | gallery scenes for the screen. |
+| `web/src/pages/docs/lookout.astro` | the `s` key and the screen, for operators. |
+
+## Dependency graph
+
+Tasks 1, 2 and 4 are independent and can be dispatched together. Everything else is a chain.
+
+```
+1 (rename) ─┐
+2 (ShepToml)─┼─> 3 (settings module) ─> 5 (open/close) ─> 6 (render) ─┬─> 7 (scalars) ─> 8 (text editor) ─┬─> 10 (frames) ─> 11 (docs)
+4 (dogs)  ───┘                                                        └─> 9 (dogs section) ──────────────┘
+```
+
+---
+
+### Task 1: Rename `KeyPress::Filter*` to `Text*`
+
+The settings editor needs the identical text keymap, and a variant named for the filter box would name a destination the keymap cannot see. Mechanical, no behaviour change, and it lands first because it touches shipped code and the keymap's own test.
+
+**Files:**
+- Modify: `crates/shep-cli/src/lookout/input.rs`
+- Modify: `crates/shep-cli/src/lookout/app.rs`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `KeyPress::TextChar(char)`, `KeyPress::TextBackspace`, `KeyPress::TextApply`, `KeyPress::TextAbandon`. `KeyPress::FilterStart` keeps its name: it opens the filter box specifically and is not shared with the settings editor.
+
+- [ ] **Step 1: Rename the four variants and every use**
+
+In `input.rs`, the `InputMode::Text` arm returns the new names. In `app.rs`, the enum declaration, the doc comments on each variant, and every `match` arm follow.
+
+Rewrite each variant's doc so it describes the keymap rather than the filter. For example, `TextChar`'s becomes "One printable character typed into whichever text field is open." The reducer, not the keymap, decides which that is, which is the same division `KeyPress::Escape`'s own doc already argues for.
+
+- [ ] **Step 2: Run the suite and confirm it is green**
+
+```bash
+cargo test --workspace --lib --bins --all-features -- --skip ::slow::
+```
+
+Expected: PASS, with no test count change. This task adds no test because it adds no behaviour; `every_bound_key_resolves_to_its_press` in `input.rs` already covers the mapping and now covers it under the new names.
+
+- [ ] **Step 3: Prove the existing test still binds**
+
+Change `KeyCode::Backspace` in `input.rs`'s text arm to return `KeyPress::TextApply`. Confirm the patch applied by re-reading the line. Run the suite and confirm `every_bound_key_resolves_to_its_press` fails. Revert.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/shep-cli/src/lookout/input.rs crates/shep-cli/src/lookout/app.rs
+git commit -m "refactor(lookout): the text keymap is named for text, not for the filter"
+```
+
+---
+
+### Task 2: `ShepToml` gains typed access to the six scalars
+
+The document layer only. Nothing here knows whether a value is legal; that is task 3's job and `DaemonConfig`'s.
+
+**Files:**
+- Modify: `crates/shep-cli/src/commands/shep_toml.rs`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces, all on `ShepToml`:
+  ```rust
+  pub fn read_only(path: &Path) -> Result<Self, ShepTomlError>
+
+  pub fn daemon_log_json(&self) -> Option<bool>
+  pub fn daemon_log_level(&self) -> Option<String>
+  pub fn daemon_socket(&self) -> Option<PathBuf>
+  pub fn daemon_max_cron_sleep(&self) -> Option<String>
+  pub fn whistle_allow_control(&self) -> Option<bool>
+  pub fn style_level(&self) -> Option<String>
+
+  pub fn set_daemon_log_json(&mut self, value: bool) -> Result<(), ShepTomlError>
+  pub fn set_daemon_log_level(&mut self, value: &str) -> Result<(), ShepTomlError>
+  pub fn set_daemon_socket(&mut self, value: &Path) -> Result<(), ShepTomlError>
+  pub fn set_daemon_max_cron_sleep(&mut self, value: &str) -> Result<(), ShepTomlError>
+  pub fn set_whistle_allow_control(&mut self, value: bool) -> Result<(), ShepTomlError>
+
+  pub fn unset_daemon_socket(&mut self)
+  pub fn unset_daemon_max_cron_sleep(&mut self)
+
+  pub fn enabled_dog_names(&self) -> Vec<String>
+  ```
+  Every reader returns `None` for an absent key, which is the distinction the whole screen rests on. `set_style_level` and `adopted_dog_names` already exist and are not re-declared.
+
+  The setters return `Result` for the reason `set_style_level` already does: an operator's hand-written `daemon = "loud"` is a key of the wrong shape, and `ShepTomlError::WrongShape` is what says so instead of clobbering it. The two unsetters cannot meet that case, because removing a key from a table that is not a table is already a no-op, so they return nothing.
+
+- [ ] **Step 1: Write the failing tests**
+
+```rust
+#[test]
+fn a_document_with_no_daemon_section_reads_every_scalar_as_absent() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("shep.toml");
+    std::fs::write(&path, "[interpreters]\njs = \"node\"\n").unwrap();
+
+    let cfg = ShepToml::read_only(&path).unwrap();
+    assert_eq!(cfg.daemon_log_json(), None);
+    assert_eq!(cfg.daemon_log_level(), None);
+    assert_eq!(cfg.daemon_socket(), None);
+    assert_eq!(cfg.daemon_max_cron_sleep(), None);
+    assert_eq!(cfg.whistle_allow_control(), None);
+    assert_eq!(cfg.style_level(), None);
+}
+
+/// The distinction the screen rests on: a key written to its own default is
+/// not the same fact as a key nobody wrote, and `DaemonConfig::load` cannot
+/// tell them apart because every section is `serde(default)`.
+#[test]
+fn a_scalar_written_to_its_default_still_reads_as_present() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("shep.toml");
+    std::fs::write(&path, "[daemon]\nlog_level = \"warn\"\nlog_json = false\n").unwrap();
+
+    let cfg = ShepToml::read_only(&path).unwrap();
+    assert_eq!(cfg.daemon_log_level().as_deref(), Some("warn"));
+    assert_eq!(cfg.daemon_log_json(), Some(false));
+}
+
+#[test]
+fn a_missing_file_reads_as_an_empty_document_and_creates_nothing() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("shep.toml");
+
+    let cfg = ShepToml::read_only(&path).unwrap();
+    assert_eq!(cfg.daemon_log_level(), None);
+    assert!(!path.exists(), "a read must never create the file");
+}
+
+#[test]
+fn setting_a_scalar_keeps_the_comments_and_the_keys_around_it() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("shep.toml");
+    std::fs::write(
+        &path,
+        "# keep me\n[daemon]\nenabled_dogs = [\"metrics\"]\n\n[style]\nlevel = \"full\"\n",
+    )
+    .unwrap();
+
+    ShepToml::try_edit(&path, |cfg| cfg.set_daemon_log_level("debug")).unwrap();
+
+    let text = std::fs::read_to_string(&path).unwrap();
+    assert!(text.starts_with("# keep me\n"), "got: {text}");
+    assert!(text.contains("enabled_dogs = [\"metrics\"]"), "got: {text}");
+    assert!(text.contains("level = \"full\""), "got: {text}");
+    assert!(text.contains("log_level = \"debug\""), "got: {text}");
+}
+
+#[test]
+fn unsetting_removes_the_key_and_leaves_its_neighbours() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("shep.toml");
+    std::fs::write(
+        &path,
+        "[daemon]\nlog_level = \"debug\"\nmax_cron_sleep = \"30s\"\n",
+    )
+    .unwrap();
+
+    ShepToml::edit(&path, ShepToml::unset_daemon_max_cron_sleep).unwrap();
+
+    let cfg = ShepToml::read_only(&path).unwrap();
+    assert_eq!(cfg.daemon_max_cron_sleep(), None);
+    assert_eq!(cfg.daemon_log_level().as_deref(), Some("debug"));
+}
+
+#[test]
+fn a_daemon_key_of_the_wrong_shape_is_refused_rather_than_clobbered() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("shep.toml");
+    std::fs::write(&path, "daemon = \"loud\"\n").unwrap();
+
+    // `try_edit`, not `edit`. `edit` runs `save` whatever the closure
+    // returned, so a refusal through it would still stage and rename a
+    // byte-identical copy, landing a fresh inode on a file the refusal never
+    // touched. That is the failure `try_edit` exists for, and it is why
+    // every setter on this screen goes through it.
+    let refusal: Result<(), ShepTomlError> =
+        ShepToml::try_edit(&path, |cfg| cfg.set_daemon_log_json(true));
+
+    assert!(matches!(
+        refusal,
+        Err(ShepTomlError::WrongShape { key: "daemon", .. })
+    ));
+    assert_eq!(std::fs::read_to_string(&path).unwrap(), "daemon = \"loud\"\n");
+}
+```
+
+- [ ] **Step 2: Run them and watch them fail**
+
+```bash
+cargo test --workspace --lib --bins --all-features -- --skip ::slow:: shep_toml
+```
+
+Expected: FAIL, on unresolved methods.
+
+- [ ] **Step 3: Implement**
+
+Model the readers on `adopted_dog_names`, which already walks `doc.get("daemon").and_then(Item::as_table)`. Model `read_only` on `adopted_dog_path_readonly`: `Ok(Self::open(path)?)`, taking no lock, and carry that function's own argument in the doc comment, that `save`'s rename is atomic so a concurrent writer is observed before or after it and never torn.
+
+Model the setters on `set_style_level`, which is already the shape: `entry(section).or_insert_with(Table)`, refuse with `WrongShape` if it is not a table, then `insert`. Factor the section lookup rather than writing it five times.
+
+The two unsetters call `remove` on the section table if it is one, and do nothing if it is not.
+
+`daemon_max_cron_sleep` returns the raw string as written, not a parsed `UpDuration`. The screen shows what the file says, and parsing it here would put a second opinion about the grammar next to `DaemonConfig`'s.
+
+- [ ] **Step 4: Run them and watch them pass**
+
+```bash
+cargo test --workspace --lib --bins --all-features -- --skip ::slow::
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Prove each test binds**
+
+One mutation per test, each reverted before the next. Make `daemon_log_json` return `Some(false)` for an absent key and confirm the absence test reddens. Make a setter write into `[style]` instead of `[daemon]` and confirm the comment-preservation test reddens. Make `unset_daemon_max_cron_sleep` a no-op and confirm the unset test reddens. Re-read each patched line before running, to confirm the patch applied.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/shep-cli/src/commands/shep_toml.rs
+git commit -m "feat(cli): ShepToml can read and write shep.toml's six scalars"
+```
+
+---
+
+### Task 3: `commands/settings.rs`, the one place that pairs the document with validation
+
+`shep_toml.rs`'s own module doc says `DaemonConfig::load` is "the one place the SHAPE of the file is decided" and that `shep_toml` "only ever adds or removes the handful of keys each verb owns". So validation does not go there. This module is where the two meet.
+
+**Files:**
+- Create: `crates/shep-cli/src/commands/settings.rs`
+- Modify: `crates/shep-cli/src/commands/mod.rs` (declare the module)
+
+**Interfaces:**
+- Consumes: task 2's `ShepToml` readers, setters and unsetters.
+- Produces:
+  ```rust
+  // No new source enum. `crate::style::StyleSource` already has exactly
+  // `Flag`, `Env`, `Config`, `Default`, and "which layer decided" is one
+  // concept, so this reuses it rather than declaring a twin. Its `Display`
+  // spells `Flag` and `Env` as `--style` and `$SHEP_STYLE`, which are
+  // style-specific, and that is correct here because only `style_level`
+  // ever produces those two variants: the shepherd's own env and flags are
+  // invisible to this process, so a `[daemon]` field is only ever `Config`
+  // or `Default`.
+  //
+  // `Config` is not a claim that the shepherd is using the value. It says
+  // the key is in the file. See the spec, "Two things decision 11 does not
+  // cover".
+  use crate::style::StyleSource;
+
+  /// One scalar as the screen shows it.
+  #[derive(Debug, Clone, PartialEq, Eq)]
+  pub struct ScalarView {
+      /// Already rendered for display, defaults resolved.
+      pub value: String,
+      pub source: StyleSource,
+  }
+
+  /// Which scalar an edit names.
+  #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+  pub enum SettingField {
+      LogLevel, LogJson, Socket, MaxCronSleep, AllowControl, StyleLevel,
+  }
+
+  /// One edit, ready to apply.
+  #[derive(Debug, Clone, PartialEq, Eq)]
+  pub enum SettingEdit {
+      Set { field: SettingField, value: String },
+      /// Only `Socket` and `MaxCronSleep` reach this: `style_level` is owned
+      /// by `shep style`, which cannot clear it, and the other three are not
+      /// optional (spec decision 5).
+      Unset { field: SettingField },
+  }
+
+  /// Everything the screen reads off disk in one go.
+  #[derive(Debug, Clone, PartialEq, Eq)]
+  pub struct SettingsSnapshot {
+      pub log_level: ScalarView,
+      pub log_json: ScalarView,
+      pub socket: ScalarView,
+      pub max_cron_sleep: ScalarView,
+      pub allow_control: ScalarView,
+      pub style_level: ScalarView,
+      /// Every candidate dog: `BUILT_IN_DOGS` plus every `adopted_dogs` key,
+      /// sorted, deduplicated.
+      pub dogs: Vec<DogView>,
+  }
+
+  #[derive(Debug, Clone, PartialEq, Eq)]
+  pub struct DogView {
+      pub name: String,
+      pub enabled: bool,
+      /// `None` for a built-in dog; the adopted binary's path otherwise.
+      pub adopted_path: Option<PathBuf>,
+  }
+
+  #[derive(Debug)]
+  pub enum SettingError {
+      Config(ShepTomlError),
+      /// `DaemonConfig::load` refused the document this edit would have
+      /// written. Carries the loader's own message.
+      Invalid(String),
+  }
+
+  /// Reads the snapshot. Takes no lock.
+  pub fn load_settings(
+      path: &Path,
+      socket_default: &Path,
+      style: (StyleLevel, StyleSource),
+  ) -> Result<SettingsSnapshot, ShepTomlError>
+
+  /// Applies one edit under the config lock, validating before it saves.
+  pub fn apply_setting(path: &Path, edit: &SettingEdit) -> Result<(), SettingError>
+  ```
+  `load_settings` takes the already-resolved style pair, which is exactly what `lib.rs`'s `resolve_style` returns (`fn resolve_style(global: &GlobalArgs) -> (style::StyleLevel, style::StyleSource)`, `lib.rs:533`). `Streams.style` is a `Presentation` and carries the level without the source, so it is not enough on its own.
+
+  Plumbing, decided rather than left open: `lookout()` gains a `style: (StyleLevel, StyleSource)` parameter, passed from the dispatch site that already computes it, and `App` holds the pair beside `palette`. One parameter and one field, with no second call to `style::resolve` that could disagree with the first.
+
+  `socket_default` is `paths.socket`, the socket this lookout is connected over, so `socket`'s default row is the live answer by construction rather than a recomputed guess.
+
+- [ ] **Step 1: Write the failing tests**
+
+```rust
+#[test]
+fn a_fresh_home_reads_every_scalar_as_the_default() {
+    // What `scaffold_first_run_interpreters` actually leaves behind, and the
+    // state most operators open this screen in.
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("shep.toml");
+    ShepToml::edit(&path, ShepToml::write_starter_interpreters).unwrap();
+
+    let snap = load_settings(&path, &style_fixture()).unwrap();
+    assert_eq!(snap.log_level.source, SettingSource::Default);
+    assert_eq!(snap.log_level.value, "warn");
+    assert_eq!(snap.log_json.source, SettingSource::Default);
+    assert_eq!(snap.allow_control.source, SettingSource::Default);
+    assert_eq!(snap.max_cron_sleep.source, SettingSource::Default);
+}
+
+#[test]
+fn a_declared_scalar_reads_as_config_even_at_its_default_value() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("shep.toml");
+    std::fs::write(&path, "[daemon]\nlog_level = \"warn\"\n").unwrap();
+
+    let snap = load_settings(&path, &style_fixture()).unwrap();
+    assert_eq!(snap.log_level.value, "warn");
+    assert_eq!(
+        snap.log_level.source,
+        SettingSource::Config,
+        "a key written to its own default is still a key someone wrote"
+    );
+}
+
+#[test]
+fn a_value_the_loader_refuses_leaves_the_file_byte_identical() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("shep.toml");
+    let before = "# mine\n[daemon]\nlog_level = \"debug\"\n";
+    std::fs::write(&path, before).unwrap();
+    let inode_before = std::fs::metadata(&path).unwrap().ino();
+
+    let refusal = apply_setting(
+        &path,
+        &SettingEdit::Set {
+            field: SettingField::MaxCronSleep,
+            value: "500ms".into(),
+        },
+    );
+
+    assert!(matches!(refusal, Err(SettingError::Invalid(_))));
+    assert_eq!(std::fs::read_to_string(&path).unwrap(), before);
+    assert_eq!(
+        std::fs::metadata(&path).unwrap().ino(),
+        inode_before,
+        "a refusal must not stage and rename, which is what try_edit buys"
+    );
+}
+
+#[test]
+fn the_refusal_carries_the_loaders_own_message() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("shep.toml");
+    std::fs::write(&path, "").unwrap();
+
+    let Err(SettingError::Invalid(message)) = apply_setting(
+        &path,
+        &SettingEdit::Set {
+            field: SettingField::MaxCronSleep,
+            value: "500ms".into(),
+        },
+    ) else {
+        panic!("a value under the floor must be refused");
+    };
+    assert!(
+        message.contains("max_cron_sleep"),
+        "the operator has to be told which key: {message}"
+    );
+}
+
+#[test]
+fn unsetting_an_optional_field_returns_it_to_the_default() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("shep.toml");
+    std::fs::write(&path, "[daemon]\nmax_cron_sleep = \"30s\"\n").unwrap();
+
+    apply_setting(&path, &SettingEdit::Unset { field: SettingField::MaxCronSleep }).unwrap();
+
+    let snap = load_settings(&path, &style_fixture()).unwrap();
+    assert_eq!(snap.max_cron_sleep.source, SettingSource::Default);
+}
+
+#[test]
+fn every_built_in_dog_is_a_candidate_even_when_nothing_is_enabled() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("shep.toml");
+    std::fs::write(&path, "").unwrap();
+
+    let snap = load_settings(&path, &style_fixture()).unwrap();
+    let names: Vec<&str> = snap.dogs.iter().map(|d| d.name.as_str()).collect();
+    assert_eq!(names, vec!["bark", "metrics"]);
+    assert!(snap.dogs.iter().all(|d| !d.enabled));
+}
+
+#[test]
+fn an_adopted_dog_joins_the_candidates_and_carries_its_path() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("shep.toml");
+    std::fs::write(
+        &path,
+        "[daemon]\nenabled_dogs = [\"otel\"]\n\n[daemon.adopted_dogs]\notel = \"/usr/local/bin/shep-otel\"\n",
+    )
+    .unwrap();
+
+    let snap = load_settings(&path, &style_fixture()).unwrap();
+    let otel = snap.dogs.iter().find(|d| d.name == "otel").unwrap();
+    assert!(otel.enabled);
+    assert_eq!(otel.adopted_path.as_deref(), Some(Path::new("/usr/local/bin/shep-otel")));
+    let metrics = snap.dogs.iter().find(|d| d.name == "metrics").unwrap();
+    assert_eq!(metrics.adopted_path, None, "a built-in dog has no path");
+}
+```
+
+`style_fixture()` is a local helper returning whatever `load_settings`'s second parameter turns out to be, with the level resolved from the config layer. Write it once at the top of the test module.
+
+- [ ] **Step 2: Run them and watch them fail**
+
+```bash
+cargo test --workspace --lib --bins --all-features -- --skip ::slow:: settings
+```
+
+Expected: FAIL, module not found.
+
+- [ ] **Step 3: Implement**
+
+`load_settings` opens through `ShepToml::read_only`, asks each task-2 reader for its `Option`, and pairs `Some` with `SettingSource::Config` and `None` with `SettingSource::Default` plus the compiled default rendered as a string. Take the defaults from `DaemonSection::default()` and `WhistleSection::default()` rather than typing literals, so a changed default cannot leave this module lying.
+
+`socket`'s default is the resolved socket path, not an empty cell: pass it in from `ShepPaths` and render that. It is the socket this lookout is connected over, so it is the live answer by construction.
+
+`style_level`'s source comes straight from the pair that was passed in. Every `[daemon]` and `[whistle]` field is `Config` or `Default` and nothing else, because this process cannot see the layers that would make it `Env` or `Flag`.
+
+`apply_setting` goes through `ShepToml::try_edit`. Inside the closure: call the task-2 setter or unsetter, then render the document with `to_string()`, then `DaemonConfig::load(Some(&rendered), &|_| None)`. A loader `Err` becomes `SettingError::Invalid(err.to_string())` and returns from the closure, which is what leaves the file untouched. The env layer is `&|_| None` for the reason `reload_with_wait` already gives at its own pre-flight: this process's env is not the shepherd's, so layering it would refuse a file the shepherd would have survived and pass one it would not.
+
+- [ ] **Step 4: Run them and watch them pass**
+
+```bash
+cargo test --workspace --lib --bins --all-features -- --skip ::slow::
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Prove each test binds**
+
+Make `load_settings` report `Config` unconditionally and confirm the fresh-home test reddens. Drop the `DaemonConfig::load` call from `apply_setting` and confirm both refusal tests redden. Make the dog list skip `BUILT_IN_DOGS` and confirm the candidates test reddens. Re-read each patched line before running.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/shep-cli/src/commands/settings.rs crates/shep-cli/src/commands/mod.rs
+git commit -m "feat(cli): a settings snapshot that keeps absent apart from defaulted"
+```
+
+---
+
+### Task 4: Extract the dog toggle's decision from its reporting
+
+`shep enable`'s file half holds a real decision: which `DogSource` a name resolves to, whether it names a dog at all, and the mutation. Its daemon half writes rows to stdout, which lookout does not have. Cut at that seam so lookout reuses the decision and brings its own reporting.
+
+**Files:**
+- Modify: `crates/shep-cli/src/commands/dogs.rs`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces:
+  ```rust
+  pub(crate) fn enable_in_config(path: &Path, name: &str) -> Result<DogSource, EnableRefusal>
+  pub(crate) fn disable_in_config(path: &Path, name: &str) -> Result<DogSource, ShepTomlError>
+  ```
+  `EnableRefusal` already exists in this module and keeps both variants.
+
+- [ ] **Step 1: Write the failing tests**
+
+```rust
+#[test]
+fn enable_in_config_writes_the_name_and_reports_a_built_in_source() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("shep.toml");
+
+    let source = enable_in_config(&path, "metrics").unwrap();
+
+    assert!(matches!(source, DogSource::BuiltIn));
+    assert!(ShepToml::read_only(&path).unwrap().enabled_dog_names().contains(&"metrics".to_string()));
+}
+
+#[test]
+fn enable_in_config_refuses_a_name_that_is_no_dog_and_writes_nothing() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("shep.toml");
+    std::fs::write(&path, "").unwrap();
+
+    let refusal = enable_in_config(&path, "nonsense");
+
+    assert!(matches!(refusal, Err(EnableRefusal::UnknownDog { .. })));
+    assert_eq!(
+        std::fs::read_to_string(&path).unwrap(),
+        "",
+        "a refused enable leaves shep.toml untouched"
+    );
+}
+
+#[test]
+fn disable_in_config_removes_the_name_and_keeps_the_adoption() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("shep.toml");
+    std::fs::write(
+        &path,
+        "[daemon]\nenabled_dogs = [\"otel\"]\n\n[daemon.adopted_dogs]\notel = \"/usr/local/bin/shep-otel\"\n",
+    )
+    .unwrap();
+
+    let source = disable_in_config(&path, "otel").unwrap();
+
+    assert!(matches!(source, DogSource::Adopted { .. }));
+    let cfg = ShepToml::read_only(&path).unwrap();
+    assert!(cfg.enabled_dog_names().is_empty());
+    assert_eq!(
+        cfg.adopted_dog_names(),
+        vec!["otel".to_string()],
+        "disable is not rehome, so the adoption survives"
+    );
+}
+```
+
+`DogSource` is `BuiltIn` or `Adopted { path: String }` (`shep-core/src/protocol/request.rs:587`). Note `path` is a `String` there, while `ShepToml::adopted_dog_path` hands back a `PathBuf`; `DogView.adopted_path` follows `ShepToml`, since that is where it is read.
+
+- [ ] **Step 2: Run them and watch them fail**
+
+```bash
+cargo test --workspace --lib --bins --all-features -- --skip ::slow:: dogs
+```
+
+Expected: FAIL, on unresolved functions.
+
+- [ ] **Step 3: Extract**
+
+Move the body of `enable`'s `ShepToml::try_edit` call into `enable_in_config`, unchanged, and have `enable` call it. Same for `disable` and its `ShepToml::edit` call. No behaviour changes: the closure, the refusal, the lock and the order are all as they were. Carry over the comment explaining why the check lives inside the closure rather than before the call, because that reasoning belongs to the extracted function now.
+
+- [ ] **Step 4: Run the suite**
+
+```bash
+cargo test --workspace --lib --bins --all-features -- --skip ::slow::
+```
+
+Expected: PASS, including every existing `dogs.rs` test unchanged. If any existing test needed editing, the extraction changed behaviour and is wrong.
+
+- [ ] **Step 5: Prove the new tests bind**
+
+Make `enable_in_config` skip the `BUILT_IN_DOGS` check and confirm the refusal test reddens. Make `disable_in_config` call `rehome_dog` instead and confirm the adoption test reddens. Re-read each patched line before running.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/shep-cli/src/commands/dogs.rs
+git commit -m "refactor(cli): a dog toggle's config decision, apart from its reporting"
+```
+
+---
+
+### Task 5: The screen opens and closes, read-only
+
+State and transitions only. Nothing renders yet and nothing writes yet.
+
+**Files:**
+- Modify: `crates/shep-cli/src/lookout/app.rs`
+- Modify: `crates/shep-cli/src/lookout/input.rs`
+- Modify: `crates/shep-cli/src/lookout/mod.rs`
+
+**Interfaces:**
+- Consumes: task 3's `SettingsSnapshot`, `SettingField`; task 1's `KeyPress::Text*`.
+- Produces:
+  ```rust
+  // input.rs, normal-mode arms
+  KeyPress::Settings   // `s`
+  KeyPress::Cycle      // `space`
+
+  // app.rs
+  pub enum Msg { /* ... */ Settings { result: Result<SettingsSnapshot, String> } }
+  pub enum Effect { /* ... */ LoadSettings }
+
+  /// The settings screen's own state. `None` on `App` is the dashboard.
+  #[derive(Debug, Clone)]
+  pub struct Settings { /* private */ }
+
+  /// One row the cursor can sit on.
+  #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+  pub enum SettingsRow {
+      Scalar(SettingField),
+      /// Index into the snapshot's own dog list.
+      Dog(usize),
+  }
+
+  impl Settings {
+      pub fn snapshot(&self) -> &SettingsSnapshot;
+      pub fn rows(&self) -> Vec<SettingsRow>;
+      pub fn cursor(&self) -> Option<SettingsRow>;
+  }
+
+  impl App {
+      pub fn settings(&self) -> Option<&Settings>;
+  }
+  ```
+  `Msg::Settings` carries `Result<_, String>` rather than the error type, because the reducer holds no error types from `commands` and a notice needs a rendered sentence anyway. `run_ui` does the `to_string()`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```rust
+/// `s` asks for the read rather than opening on stale or empty state: the
+/// file can have changed since the last look, and an empty screen while the
+/// read is in flight is a screen that lies for one frame.
+#[test]
+fn s_asks_for_the_file_before_the_screen_opens() {
+    let mut app = fixtures::full_app();
+    assert_eq!(app.update(Msg::Key(KeyPress::Settings)), Effect::LoadSettings);
+    assert!(app.settings().is_none(), "nothing opens until the read lands");
+}
+
+#[test]
+fn the_screen_opens_when_the_read_lands() {
+    let mut app = fixtures::full_app();
+    let _ = app.update(Msg::Key(KeyPress::Settings));
+    let _ = app.update(Msg::Settings { result: Ok(fixtures::settings_snapshot()) });
+    assert!(app.settings().is_some());
+}
+
+#[test]
+fn a_read_that_failed_says_so_and_leaves_the_dashboard_up() {
+    let mut app = fixtures::full_app();
+    let _ = app.update(Msg::Key(KeyPress::Settings));
+    let _ = app.update(Msg::Settings { result: Err("no such file".into()) });
+    assert!(app.settings().is_none());
+    let notice = app.notice().expect("a failed read has to say so");
+    assert!(notice.is_grave());
+    assert!(notice.to_string().contains("no such file"));
+}
+
+#[test]
+fn s_closes_the_screen_again() {
+    let mut app = fixtures::app_in_settings();
+    let _ = app.update(Msg::Key(KeyPress::Settings));
+    assert!(app.settings().is_none());
+}
+
+/// The one arm of the `Escape` cascade this screen swaps. From the dashboard
+/// with no filter, `Esc` quits; from here it must not.
+#[test]
+fn escape_closes_the_screen_and_never_quits() {
+    let mut app = fixtures::app_in_settings();
+    assert_eq!(app.update(Msg::Key(KeyPress::Escape)), Effect::None);
+    assert!(app.settings().is_none());
+}
+
+#[test]
+fn the_flock_cursor_and_the_filter_survive_the_swap() {
+    let mut app = fixtures::full_app();
+    let _ = app.update(Msg::Key(KeyPress::FilterStart));
+    for c in "web".chars() {
+        let _ = app.update(Msg::Key(KeyPress::TextChar(c)));
+    }
+    let _ = app.update(Msg::Key(KeyPress::TextApply));
+    let selected = app.selected().cloned();
+    let filter = app.filter().to_string();
+
+    let _ = app.update(Msg::Key(KeyPress::Settings));
+    let _ = app.update(Msg::Settings { result: Ok(fixtures::settings_snapshot()) });
+    let _ = app.update(Msg::Key(KeyPress::Settings));
+
+    assert_eq!(app.selected().cloned(), selected);
+    assert_eq!(app.filter(), filter);
+}
+
+#[test]
+fn the_settings_cursor_starts_at_the_first_row_on_every_open() {
+    let mut app = fixtures::app_in_settings();
+    let _ = app.update(Msg::Key(KeyPress::SelectDown));
+    let _ = app.update(Msg::Key(KeyPress::SelectDown));
+    let _ = app.update(Msg::Key(KeyPress::Settings));
+    let _ = app.update(Msg::Key(KeyPress::Settings));
+    let _ = app.update(Msg::Settings { result: Ok(fixtures::settings_snapshot()) });
+
+    let first = app.settings().unwrap().rows()[0];
+    assert_eq!(app.settings().unwrap().cursor(), Some(first));
+}
+
+#[test]
+fn the_cursor_moves_through_the_scalars_and_into_the_dogs() {
+    let mut app = fixtures::app_in_settings();
+    let rows = app.settings().unwrap().rows();
+    for _ in 0..rows.len() - 1 {
+        let _ = app.update(Msg::Key(KeyPress::SelectDown));
+    }
+    assert_eq!(app.settings().unwrap().cursor(), Some(*rows.last().unwrap()));
+    // and it stops rather than wrapping, the way the flock table does
+    let _ = app.update(Msg::Key(KeyPress::SelectDown));
+    assert_eq!(app.settings().unwrap().cursor(), Some(*rows.last().unwrap()));
+}
+
+#[test]
+fn an_action_key_from_the_dashboard_is_unreachable_while_the_screen_is_up() {
+    let mut app = fixtures::app_in_settings_with_control();
+    // `x` is the stop key on the dashboard. In here it is not an action at all.
+    let _ = app.update(Msg::Key(KeyPress::Action(ActionVerb::Stop)));
+    assert!(app.action_state().is_none(), "no sheep confirm can arm from here");
+}
+
+#[test]
+fn a_read_only_lookout_opens_the_screen_and_refuses_the_edit_key() {
+    let mut app = fixtures::app_in_settings(); // Control::ReadOnly
+    assert!(app.settings().is_some(), "reading shep.toml is not gated");
+    let _ = app.update(Msg::Key(KeyPress::Cycle));
+    let notice = app.notice().expect("the refusal has to say why");
+    assert!(notice.is_grave());
+}
+```
+
+The existing refusal is `"read-only: actions need --allow-control"` (`app.rs:1033`). Reuse it verbatim rather than writing a second sentence for the same fact.
+
+- [ ] **Step 2: Run them and watch them fail**
+
+```bash
+cargo test --workspace --lib --bins --all-features -- --skip ::slow:: lookout
+```
+
+Expected: FAIL, on missing variants and missing fixtures.
+
+- [ ] **Step 3: Implement**
+
+`input.rs` gains two normal-mode arms: `KeyCode::Char('s') => Some(KeyPress::Settings)` and `KeyCode::Char(' ') => Some(KeyPress::Cycle)`. No third `InputMode`: the keymap emits both unconditionally and the reducer decides, which is the division `KeyPress::Escape`'s own doc already argues for. Extend `every_bound_key_resolves_to_its_press` to cover both.
+
+`app.rs` gains `settings: Option<Settings>` on `App`, initialised `None` in `new`. `on_key` grows a branch ahead of the ordinary dispatch, after the text-mode branch: when `self.settings.is_some()`, route to `on_settings_key`, which owns `Settings`, `Escape`, `SelectUp`/`SelectDown`/`SelectFirst`/`SelectLast`, `Cycle`, `Confirm` and `Refresh`, and ignores everything else. `Quit` still falls through, for the reason the armed-confirm branch already carves it out.
+
+Cursor movement clamps rather than wrapping, matching the flock table. Store the cursor as a `usize` index into `rows()` and resolve it through `cursor()`, so a shorter dog list after a refresh cannot point past the end; clamp on every read.
+
+`mod.rs`'s effect loop gains an arm:
+
+```rust
+Effect::LoadSettings => {
+    let path = paths.daemon_config.clone();
+    let style = /* the resolved style this lookout already holds */;
+    let result = tokio::task::spawn_blocking(move || {
+        commands::settings::load_settings(&path, &style)
+    })
+    .await
+    .map_err(|err| err.to_string())
+    .and_then(|inner| inner.map_err(|err| err.to_string()));
+    let _ = app.update(Msg::Settings { result });
+    dirty = true;
+}
+```
+
+`spawn_blocking` even though the read takes no lock: the rule is "no file I/O on the redraw task", which is cheaper to hold than a judgement per call site. Say so in a comment.
+
+Add the fixtures `settings_snapshot()`, `app_in_settings()` and `app_in_settings_with_control()` to `view/fixtures.rs`, in the shape the ones already there use.
+
+- [ ] **Step 4: Run them and watch them pass**
+
+```bash
+cargo test --workspace --lib --bins --all-features -- --skip ::slow::
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Prove each test binds**
+
+Make `Escape` in the settings branch return `Effect::Quit` and confirm that test reddens. Have the open path keep the previous cursor and confirm the reset test reddens. Clear `self.filter` when the screen opens and confirm the survival test reddens. Re-read each patched line before running.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/shep-cli/src/lookout/
+git commit -m "feat(lookout): s opens a settings screen, read-only for now"
+```
+
+---
+
+### Task 6: The screen renders
+
+**Files:**
+- Create: `crates/shep-cli/src/lookout/view/settings.rs`
+- Modify: `crates/shep-cli/src/lookout/view/mod.rs`
+
+**Interfaces:**
+- Consumes: task 5's `App::settings`, `Settings::rows`, `Settings::cursor`.
+- Produces: `pub fn draw_settings(app: &App, settings: &Settings, area: Rect, buffer: &mut Buffer)`, plus `pub fn columns_for(width: u16) -> &'static [DogColumn]` for the dogs table's drop tiers.
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+/// The whole screen at a comfortable width. The snapshot is the assertion:
+/// it pins the section order, the SOURCE column's wording and the fact that
+/// a fresh home reads `the default` all the way down.
+#[test]
+fn settings_at_a_comfortable_width() {
+    let app = fixtures::app_in_settings();
+    let mut terminal = Terminal::new(TestBackend::new(120, 30)).unwrap();
+    terminal.draw(|frame| super::draw(&app, frame)).unwrap();
+    insta::assert_snapshot!(render_text(terminal.backend().buffer()));
+}
+
+/// SOURCE is the widest column and the first to go, the same reasoning
+/// `flock::TIERS` gives for SMIT.
+#[test]
+fn the_dogs_source_column_drops_before_the_rest() {
+    assert!(columns_for(120).contains(&DogColumn::Source));
+    assert!(!columns_for(60).contains(&DogColumn::Source));
+    assert!(
+        columns_for(60).contains(&DogColumn::Running),
+        "RUNNING is the diagnostic half and outlives SOURCE"
+    );
+}
+```
+
+- [ ] **Step 2: Run and watch it fail**
+
+```bash
+cargo test --workspace --lib --bins --all-features -- --skip ::slow:: settings
+```
+
+Expected: FAIL, module not found. The snapshot test will want `cargo insta accept` once the render is right; read the frame before accepting it.
+
+- [ ] **Step 3: Implement**
+
+`view/mod.rs`'s `draw` keeps the title line and the status bar and branches on `app.settings()`: `Some` draws the screen into the body, `None` draws today's dashboard. The `MIN_TERM_WIDTH`/`MIN_HEIGHT` refusal stays ahead of the branch and covers both.
+
+`settings.rs` renders, in order: `[daemon]` with its four rows, `[whistle]` with one, `[style]` with one, then `[dogs]` with its caption and table. Each scalar row is name, value, source, and the apply cost. Section headers use the palette's muted style; the cursor row is marked `>` exactly as the flock table marks its selection.
+
+The dogs caption is `space arms, Enter applies; a dog needs no reload`. Do not write a caption that says space applies: this screen arms and confirms like every other action in lookout.
+
+Model the drop tiers on `view/flock.rs`'s `TIERS` and `columns_for`, including the doc explaining the drop order. SOURCE goes first because it is the widest and an adopted path can be long; then IN FILE, because RUNNING is the half that answers "is it up".
+
+Values render defaults resolved, never blank. `socket` shows the resolved path.
+
+- [ ] **Step 4: Run and watch it pass**
+
+```bash
+cargo test --workspace --lib --bins --all-features -- --skip ::slow::
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Prove the test binds**
+
+Make `load_settings`'s fixture report `Config` for every field and confirm the snapshot reddens with `the default` replaced. Swap two tiers in `columns_for` and confirm the tier test reddens. Re-read each patched line before running.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/shep-cli/src/lookout/view/
+git commit -m "feat(lookout): the settings screen renders, with a source per scalar"
+```
+
+---
+
+### Task 7: Editing the four closed scalars
+
+`space` arms a candidate and re-arms on each press; `Enter` applies. The confirm names the field's own apply cost, and for `[daemon]` it names the two layers lookout cannot see.
+
+**Files:**
+- Modify: `crates/shep-cli/src/lookout/app.rs`
+- Modify: `crates/shep-cli/src/lookout/view/settings.rs`
+- Modify: `crates/shep-cli/src/lookout/mod.rs`
+
+**Interfaces:**
+- Consumes: task 3's `SettingEdit`, `apply_setting`; task 5's `Settings`.
+- Produces:
+  ```rust
+  pub enum Msg { /* ... */ SettingWritten { edit: SettingEdit, result: Result<(), String> } }
+  pub enum Effect { /* ... */ WriteSetting(SettingEdit) }
+
+  impl Settings {
+      /// The armed candidate and its prompt, or `None`.
+      pub fn pending(&self) -> Option<SettingsPrompt<'_>>;
+  }
+
+  pub struct SettingsPrompt<'a> {
+      pub text: &'a str,
+      /// False while it is a question, true once it has gone out.
+      pub sent: bool,
+  }
+  ```
+
+**Confirm strings, verbatim.** These have already been through `humanizer` and `rin-voice`; use them as written and do not paraphrase.
+
+| Field | Prompt |
+| --- | --- |
+| `log_level` | `set log_level to debug? needs shep daemon reload, and will not apply if the shepherd was booted with SHEP_LOG_LEVEL or --log-level` |
+| `log_json` | `set log_json to true? needs shep daemon reload, and will not apply if the shepherd was booted with SHEP_LOG_JSON or --log-json` |
+| `allow_control` | `turn whistle control tools on? needs shep whistle restarted` |
+| `style level` | `set style level to plain? the next command reads it` |
+
+The value in each is the candidate, so `debug`, `true` and `plain` above are examples rather than constants.
+
+- [ ] **Step 1: Write the failing tests**
+
+```rust
+#[test]
+fn space_arms_a_candidate_without_changing_the_row() {
+    let mut app = fixtures::app_in_settings_with_control();
+    let before = app.settings().unwrap().snapshot().log_level.value.clone();
+
+    assert_eq!(app.update(Msg::Key(KeyPress::Cycle)), Effect::None);
+
+    assert_eq!(
+        app.settings().unwrap().snapshot().log_level.value,
+        before,
+        "arming is a question, so the row still shows what the file says"
+    );
+    assert!(app.settings().unwrap().pending().is_some());
+}
+
+/// Six log levels and one cycle key. Without re-arming, the fourth is
+/// unreachable without cancelling in between.
+#[test]
+fn space_advances_the_candidate_rather_than_needing_a_cancel() {
+    let mut app = fixtures::app_in_settings_with_control();
+    let _ = app.update(Msg::Key(KeyPress::Cycle));
+    let first = app.settings().unwrap().pending().unwrap().text.to_string();
+    let _ = app.update(Msg::Key(KeyPress::Cycle));
+    let second = app.settings().unwrap().pending().unwrap().text.to_string();
+    assert_ne!(first, second);
+}
+
+#[test]
+fn the_daemon_confirm_names_both_layers_lookout_cannot_see() {
+    let mut app = fixtures::app_in_settings_with_control();
+    let _ = app.update(Msg::Key(KeyPress::Cycle));
+    let text = app.settings().unwrap().pending().unwrap().text.to_string();
+    assert!(text.contains("shep daemon reload"), "got: {text}");
+    assert!(text.contains("SHEP_LOG_LEVEL"), "got: {text}");
+    assert!(text.contains("--log-level"), "got: {text}");
+}
+
+#[test]
+fn the_whistle_confirm_names_a_whistle_restart_and_not_a_reload() {
+    let mut app = fixtures::app_in_settings_on(SettingField::AllowControl);
+    let _ = app.update(Msg::Key(KeyPress::Cycle));
+    let text = app.settings().unwrap().pending().unwrap().text.to_string();
+    assert!(text.contains("shep whistle restarted"), "got: {text}");
+    assert!(!text.contains("daemon reload"), "a whistle key needs no reload: {text}");
+}
+
+#[test]
+fn the_style_confirm_promises_nothing_beyond_the_next_command() {
+    let mut app = fixtures::app_in_settings_on(SettingField::StyleLevel);
+    let _ = app.update(Msg::Key(KeyPress::Cycle));
+    let text = app.settings().unwrap().pending().unwrap().text.to_string();
+    assert!(text.contains("the next command reads it"), "got: {text}");
+}
+
+#[test]
+fn enter_sends_the_armed_edit() {
+    let mut app = fixtures::app_in_settings_with_control();
+    let _ = app.update(Msg::Key(KeyPress::Cycle));
+    let effect = app.update(Msg::Key(KeyPress::Confirm));
+    assert!(matches!(effect, Effect::WriteSetting(SettingEdit::Set { field: SettingField::LogLevel, .. })));
+    assert!(app.settings().unwrap().pending().unwrap().sent);
+}
+
+#[test]
+fn a_written_edit_updates_the_row_and_its_source() {
+    let mut app = fixtures::app_in_settings_with_control();
+    let _ = app.update(Msg::Key(KeyPress::Cycle));
+    let Effect::WriteSetting(edit) = app.update(Msg::Key(KeyPress::Confirm)) else {
+        panic!("Enter must send");
+    };
+    let _ = app.update(Msg::SettingWritten { edit, result: Ok(()) });
+
+    assert_eq!(app.settings().unwrap().snapshot().log_level.source, SettingSource::Config);
+    assert!(app.settings().unwrap().pending().is_none());
+}
+
+#[test]
+fn a_refused_write_says_why_and_leaves_the_row_alone() {
+    let mut app = fixtures::app_in_settings_with_control();
+    let before = app.settings().unwrap().snapshot().log_level.clone();
+    let _ = app.update(Msg::Key(KeyPress::Cycle));
+    let Effect::WriteSetting(edit) = app.update(Msg::Key(KeyPress::Confirm)) else {
+        panic!("Enter must send");
+    };
+    let _ = app.update(Msg::SettingWritten {
+        edit,
+        result: Err("max_cron_sleep is 500ms, below the 1s floor".into()),
+    });
+
+    assert_eq!(app.settings().unwrap().snapshot().log_level, before);
+    let notice = app.notice().unwrap();
+    assert!(notice.is_grave());
+    assert!(notice.to_string().contains("below the 1s floor"));
+}
+
+/// The divergence from the sheep confirm, which `disarm_on_link_change`
+/// clears. A settings edit is local file I/O over a file that is not stale.
+#[test]
+fn a_lost_link_leaves_a_scalar_confirm_armed() {
+    let mut app = fixtures::app_in_settings_with_control();
+    let _ = app.update(Msg::Key(KeyPress::Cycle));
+    let _ = app.update(Msg::Frozen { at_local: "12:00:00".into() });
+    assert!(
+        app.settings().unwrap().pending().is_some(),
+        "a scalar never leaves the machine, so a dead shepherd is irrelevant to it"
+    );
+}
+
+/// And it still expires, off the raw tick rather than `self.now`, which
+/// stops advancing once the link is lost.
+#[test]
+fn a_settings_confirm_expires_on_a_frozen_dashboard() {
+    let (mut app, start) = fixtures::app_in_settings_at();
+    let _ = app.update(Msg::Key(KeyPress::Cycle));
+    let _ = app.update(Msg::Frozen { at_local: "12:00:00".into() });
+    let _ = app.update(Msg::Tick { now: start + CONFIRM_EXPIRY });
+    assert!(app.settings().unwrap().pending().is_none());
+}
+
+#[test]
+fn escape_cancels_the_confirm_before_it_closes_the_screen() {
+    let mut app = fixtures::app_in_settings_with_control();
+    let _ = app.update(Msg::Key(KeyPress::Cycle));
+    let _ = app.update(Msg::Key(KeyPress::Escape));
+    assert!(app.settings().unwrap().pending().is_none());
+    assert!(app.settings().is_some(), "the first Esc cancels, it does not close");
+    let _ = app.update(Msg::Key(KeyPress::Escape));
+    assert!(app.settings().is_none());
+}
+```
+
+- [ ] **Step 2: Run them and watch them fail**
+
+- [ ] **Step 3: Implement**
+
+Add `Pending` inside `Settings`, as one field rather than several `Option`s so that typing, armed and sent cannot overlap:
+
+```rust
+enum Pending {
+    /// Only `Socket` and `MaxCronSleep` reach this. Task 8.
+    Typing { field: SettingField, buffer: String },
+    Armed { edit: SettingEdit, at: Instant },
+    Sent { edit: SettingEdit },
+}
+```
+
+`Cycle` on a scalar row builds the next candidate and stores `Armed`, resetting `at` each press. `Confirm` on `Armed` moves to `Sent` and returns `Effect::WriteSetting`. `Msg::SettingWritten` clears `Pending` and, on `Ok`, updates that field's `ScalarView` in place to the written value with `SettingSource::Config`; on `Err` it leaves the view alone and raises a grave `Notice`.
+
+Expiry: extend the `Msg::Tick` arm. The existing sheep-action expiry sits inside `if !matches!(self.link, Link::Lost { .. })`. The settings expiry goes **outside** that guard and compares against the tick's own `now`, not `self.now`. Comment why: the sheep confirm freezes because everything it describes is stale, and a settings edit describes a file that is not.
+
+`mod.rs` gains the write arm, mirroring task 5's:
+
+```rust
+Effect::WriteSetting(edit) => {
+    let path = paths.daemon_config.clone();
+    let for_msg = edit.clone();
+    let result = tokio::task::spawn_blocking(move || {
+        commands::settings::apply_setting(&path, &edit)
+    })
+    .await
+    .map_err(|err| err.to_string())
+    .and_then(|inner| inner.map_err(|err| err.to_string()));
+    let _ = app.update(Msg::SettingWritten { edit: for_msg, result });
+    dirty = true;
+}
+```
+
+`spawn_blocking` is load-bearing here rather than a convention: `ConfigLock::acquire` blocks with no deadline, so a concurrent `shep adopt` on the UI task would freeze the redraw, the tick and the bus drain together. Say that in the comment.
+
+The view grows a prompt line under the table, in the shape the status bar already uses for a sheep confirm.
+
+- [ ] **Step 4: Run them and watch them pass**
+
+- [ ] **Step 5: Prove each test binds**
+
+Move the settings expiry inside the link guard and confirm the frozen-expiry test reddens. Have `Cycle` mutate the row rather than arm and confirm the first test reddens. Drop `SHEP_LOG_LEVEL` from the daemon prompt and confirm that test reddens. Re-read each patched line before running.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/shep-cli/src/lookout/
+git commit -m "feat(lookout): the four closed scalars arm, confirm and write"
+```
+
+---
+
+### Task 8: The text editor, and unsetting the two optional fields
+
+**Files:**
+- Modify: `crates/shep-cli/src/lookout/app.rs`
+- Modify: `crates/shep-cli/src/lookout/view/settings.rs`
+
+**Interfaces:**
+- Consumes: task 7's `Pending`, task 1's `KeyPress::Text*`.
+- Produces: `Settings::typing() -> Option<(&SettingField, &str)>` for the view.
+
+**Confirm strings, verbatim:**
+
+| Edit | Prompt |
+| --- | --- |
+| set `socket` | `set socket to /run/shep/shep.sock? needs the shepherd stopped and started; a reload will not move it, and it will not apply if the shepherd was booted with SHEP_SOCKET or --socket` |
+| set `max_cron_sleep` | `set max_cron_sleep to 30s? needs shep daemon reload, and will not apply if the shepherd was booted with SHEP_MAX_CRON_SLEEP or --max-cron-sleep` |
+| unset `socket` | `unset socket? it goes back to the default under $SHEP_HOME, and needs the shepherd stopped and started` |
+| unset `max_cron_sleep` | `unset max_cron_sleep? it goes back to the daemon's own default, and needs shep daemon reload` |
+
+- [ ] **Step 1: Write the failing tests**
+
+```rust
+#[test]
+fn enter_on_a_text_row_opens_the_editor_seeded_with_the_current_value() {
+    let mut app = fixtures::app_in_settings_on(SettingField::MaxCronSleep);
+    let _ = app.update(Msg::Key(KeyPress::Confirm));
+    let (field, buffer) = app.settings().unwrap().typing().expect("the editor opens");
+    assert_eq!(*field, SettingField::MaxCronSleep);
+    assert_eq!(buffer, "30s");
+}
+
+#[test]
+fn typing_then_enter_arms_rather_than_writing() {
+    let mut app = fixtures::app_in_settings_on(SettingField::MaxCronSleep);
+    let _ = app.update(Msg::Key(KeyPress::Confirm));
+    for _ in 0..3 {
+        let _ = app.update(Msg::Key(KeyPress::TextBackspace));
+    }
+    for c in "45s".chars() {
+        let _ = app.update(Msg::Key(KeyPress::TextChar(c)));
+    }
+    assert_eq!(app.update(Msg::Key(KeyPress::TextApply)), Effect::None);
+    let prompt = app.settings().unwrap().pending().unwrap();
+    assert!(!prompt.sent, "the editor arms; a second Enter is what sends");
+    assert!(prompt.text.contains("45s"), "got: {}", prompt.text);
+    assert!(prompt.text.contains("SHEP_MAX_CRON_SLEEP"), "got: {}", prompt.text);
+}
+
+#[test]
+fn an_empty_editor_arms_an_unset() {
+    let mut app = fixtures::app_in_settings_on(SettingField::MaxCronSleep);
+    let _ = app.update(Msg::Key(KeyPress::Confirm));
+    for _ in 0..8 {
+        let _ = app.update(Msg::Key(KeyPress::TextBackspace));
+    }
+    let _ = app.update(Msg::Key(KeyPress::TextApply));
+    let text = app.settings().unwrap().pending().unwrap().text.to_string();
+    assert!(text.starts_with("unset max_cron_sleep?"), "got: {text}");
+}
+
+#[test]
+fn the_socket_confirm_rules_out_the_reload_it_would_otherwise_imply() {
+    let mut app = fixtures::app_in_settings_on(SettingField::Socket);
+    let _ = app.update(Msg::Key(KeyPress::Confirm));
+    let _ = app.update(Msg::Key(KeyPress::TextApply));
+    let text = app.settings().unwrap().pending().unwrap().text.to_string();
+    assert!(text.contains("stopped and started"), "got: {text}");
+    assert!(text.contains("a reload will not move it"), "got: {text}");
+}
+
+/// A refusal is discovered under the lock, so it lands after the confirm.
+/// The typed text has to survive it, or the operator retypes a path to fix
+/// one character.
+#[test]
+fn a_refused_write_reopens_the_editor_with_the_text_intact() {
+    let mut app = fixtures::app_in_settings_on(SettingField::MaxCronSleep);
+    let _ = app.update(Msg::Key(KeyPress::Confirm));
+    for _ in 0..3 {
+        let _ = app.update(Msg::Key(KeyPress::TextBackspace));
+    }
+    for c in "500ms".chars() {
+        let _ = app.update(Msg::Key(KeyPress::TextChar(c)));
+    }
+    let _ = app.update(Msg::Key(KeyPress::TextApply));
+    let Effect::WriteSetting(edit) = app.update(Msg::Key(KeyPress::Confirm)) else {
+        panic!("Enter must send");
+    };
+    let _ = app.update(Msg::SettingWritten {
+        edit,
+        result: Err("max_cron_sleep is 500ms, below the 1s floor".into()),
+    });
+
+    let (_, buffer) = app.settings().unwrap().typing().expect("the editor reopens");
+    assert_eq!(buffer, "500ms");
+    assert!(app.notice().unwrap().to_string().contains("below the 1s floor"));
+}
+
+#[test]
+fn escape_abandons_the_editor_and_keeps_the_screen_open() {
+    let mut app = fixtures::app_in_settings_on(SettingField::Socket);
+    let _ = app.update(Msg::Key(KeyPress::Confirm));
+    let _ = app.update(Msg::Key(KeyPress::TextAbandon));
+    assert!(app.settings().unwrap().typing().is_none());
+    assert!(app.settings().is_some());
+}
+
+#[test]
+fn a_closed_scalar_has_no_editor() {
+    let mut app = fixtures::app_in_settings_with_control(); // on log_level
+    let _ = app.update(Msg::Key(KeyPress::Confirm));
+    assert!(
+        app.settings().unwrap().typing().is_none(),
+        "log_level is a cycle, not a text field"
+    );
+}
+```
+
+- [ ] **Step 2: Run them and watch them fail**
+
+- [ ] **Step 3: Implement**
+
+`Confirm` on a `Socket` or `MaxCronSleep` row with no `Pending` sets `Pending::Typing` seeded with the row's current value and sets `self.mode = InputMode::Text`. The text keys route through the existing text branch in `on_key`, which now has two destinations: the filter box when `settings` is `None`, the editor when it is `Some`. That is the reducer deciding, which is why task 1 renamed the variants.
+
+`TextApply` on an empty buffer builds `SettingEdit::Unset`; on a non-empty one, `SettingEdit::Set`. Either way it moves `Pending` to `Armed` and leaves `InputMode::Normal`.
+
+`Msg::SettingWritten` with an `Err` whose edit named a text field returns `Pending` to `Typing` with the buffer the edit carried, and sets `InputMode::Text` again.
+
+Do not trim the buffer. This repository does not widen an accepted input grammar without a basis in the spec, and the filter box already carries that rule explicitly.
+
+- [ ] **Step 4: Run them and watch them pass**
+
+- [ ] **Step 5: Prove each test binds**
+
+Have the refusal clear the buffer and confirm the reopen test reddens. Make `TextApply` on an empty buffer arm a `Set` with an empty string and confirm the unset test reddens. Re-read each patched line before running.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/shep-cli/src/lookout/
+git commit -m "feat(lookout): socket and max_cron_sleep get an editor, and can be unset"
+```
+
+---
+
+### Task 9: The dogs section, and the two-step toggle
+
+The file half and the daemon half are two acts. File first, then the request, which is `shep enable`'s own order.
+
+**Files:**
+- Modify: `crates/shep-cli/src/lookout/app.rs`
+- Modify: `crates/shep-cli/src/lookout/view/settings.rs`
+- Modify: `crates/shep-cli/src/lookout/mod.rs`
+
+**Interfaces:**
+- Consumes: task 4's `enable_in_config`/`disable_in_config`; task 6's `DogColumn`.
+- Produces:
+  ```rust
+  pub enum Sent {
+      /* ... */
+      /// One dog's daemon half, after its file half landed. `source` is what
+      /// the write returned, so the request cannot disagree with the file.
+      Dog { name: String, enable: bool, source: DogSource },
+  }
+  ```
+  `Sent::request()` gains its two arms: `EnableDog { name, source }` and `DisableDog { name }`. `PROTOCOL_VERSION` does not move; both requests already exist.
+
+**Confirm strings, verbatim:**
+
+| Edit | Prompt |
+| --- | --- |
+| enable | `enable metrics? it starts now, no reload` |
+| disable | `disable otel? it stops now and is deregistered` |
+
+`DisableDog`'s own doc is "Stop and deregister one dog", answering `Response::Deleted`. The prompt says deregister out loud rather than letting an operator find out afterwards.
+
+- [ ] **Step 1: Write the failing tests**
+
+```rust
+#[test]
+fn the_dogs_table_joins_the_file_against_the_running_flock() {
+    // `otel` runs while the file has it disabled, which is what "a removed
+    // name keeps running" looks like from the outside. `ledger` is enabled
+    // and absent, which is a dog that failed to start.
+    let app = fixtures::app_in_settings_with_dog_drift();
+    let rows = view::settings::dog_rows(&app, 120);
+
+    let otel = rows.iter().find(|r| r.name == "otel").unwrap();
+    assert!(!otel.enabled);
+    assert_eq!(otel.running.as_deref(), Some("online"));
+
+    let ledger = rows.iter().find(|r| r.name == "ledger").unwrap();
+    assert!(ledger.enabled);
+    assert_eq!(ledger.running, None);
+}
+
+/// Phase 3b: a dog that never completed a handshake reads `silent`, not
+/// `online`, and this table must not undo that.
+#[test]
+fn a_dog_that_never_handshook_reads_silent_here_too() {
+    let app = fixtures::app_in_settings_with_silent_dog();
+    let rows = view::settings::dog_rows(&app, 120);
+    let bark = rows.iter().find(|r| r.name == "bark").unwrap();
+    assert_eq!(bark.running.as_deref(), Some("silent"));
+}
+
+#[test]
+fn arming_a_dog_names_the_live_apply_and_not_a_reload() {
+    let mut app = fixtures::app_in_settings_on_dog("metrics");
+    let _ = app.update(Msg::Key(KeyPress::Cycle));
+    let text = app.settings().unwrap().pending().unwrap().text.to_string();
+    assert!(text.contains("it starts now, no reload"), "got: {text}");
+}
+
+#[test]
+fn disabling_says_it_deregisters() {
+    let mut app = fixtures::app_in_settings_on_enabled_dog("otel");
+    let _ = app.update(Msg::Key(KeyPress::Cycle));
+    let text = app.settings().unwrap().pending().unwrap().text.to_string();
+    assert!(text.contains("deregistered"), "got: {text}");
+}
+
+/// The chain: the write lands, and the reducer raises the daemon half. One
+/// message still yields one effect.
+#[test]
+fn a_written_dog_toggle_raises_the_daemon_half() {
+    let mut app = fixtures::app_in_settings_on_dog("metrics");
+    let _ = app.update(Msg::Key(KeyPress::Cycle));
+    let Effect::WriteDog(edit) = app.update(Msg::Key(KeyPress::Confirm)) else {
+        panic!("Enter must send the file half first");
+    };
+    let effect = app.update(Msg::DogWritten {
+        edit,
+        result: Ok(DogSource::BuiltIn),
+    });
+    assert!(matches!(
+        effect,
+        Effect::Send(Sent::Dog { enable: true, .. })
+    ));
+}
+
+#[test]
+fn a_refused_file_half_never_reaches_the_shepherd() {
+    let mut app = fixtures::app_in_settings_on_dog("metrics");
+    let _ = app.update(Msg::Key(KeyPress::Cycle));
+    let Effect::WriteDog(edit) = app.update(Msg::Key(KeyPress::Confirm)) else {
+        panic!("Enter must send the file half first");
+    };
+    let effect = app.update(Msg::DogWritten {
+        edit,
+        result: Err("permission denied".into()),
+    });
+    assert_eq!(effect, Effect::None, "a failed write must not ask the shepherd");
+    assert!(app.notice().unwrap().is_grave());
+}
+
+/// The scalars never leave the machine; a dog's second half does.
+#[test]
+fn a_dog_toggle_refuses_while_the_link_is_gone() {
+    let mut app = fixtures::app_in_settings_on_dog("metrics");
+    let _ = app.update(Msg::Frozen { at_local: "12:00:00".into() });
+    let effect = app.update(Msg::Key(KeyPress::Cycle));
+    assert_eq!(effect, Effect::None);
+    assert!(app.settings().unwrap().pending().is_none(), "nothing arms");
+    assert!(app.notice().unwrap().is_grave());
+}
+
+#[test]
+fn a_scalar_still_edits_while_the_link_is_gone() {
+    let mut app = fixtures::app_in_settings_with_control(); // on log_level
+    let _ = app.update(Msg::Frozen { at_local: "12:00:00".into() });
+    let _ = app.update(Msg::Key(KeyPress::Cycle));
+    assert!(
+        app.settings().unwrap().pending().is_some(),
+        "a scalar is local file I/O and needs no shepherd"
+    );
+}
+```
+
+The dog toggle gets its own `Effect::WriteDog` and `Msg::DogWritten` rather than reusing task 7's `WriteSetting`, because the two carry different payloads and different next steps: a scalar write ends in a notice, a dog write ends in a request. Grep `Sent` and `DogSource` for their real shapes before writing the chain.
+
+- [ ] **Step 2: Run them and watch them fail**
+
+- [ ] **Step 3: Implement**
+
+The join: `App::all_rows` already carries every running dog, and `ProcessInfo.dog` is `Some` for one. The word comes from `Reported::of(status, handshook).word()` (`vocabulary.rs:117`), which is the one place that turns an `Online` status with `handshook: Some(false)` into `silent`. Call it. Writing a second mapping here would be a second opinion about the wire contract's own vocabulary.
+
+`Cycle` on a dog row checks the link first and refuses with the existing `LINK_GONE` sentence when it is `Lost`, then arms. `Confirm` returns `Effect::WriteDog`. `Msg::DogWritten` with `Ok(source)` returns `Effect::Send(Sent::Dog { .. })`; with `Err` it raises a grave notice and returns `Effect::None`.
+
+`mod.rs` gains the `WriteDog` arm, on `spawn_blocking`, calling `dogs::enable_in_config` or `dogs::disable_in_config`. The `Effect::Send` arm needs no change: `Sent::Dog` rides the existing request channel.
+
+The RUNNING column repairs itself: the next `ListFlock` two seconds later carries the new state, so nothing here has to poke the snapshot.
+
+- [ ] **Step 4: Run them and watch them pass**
+
+- [ ] **Step 5: Prove each test binds**
+
+Have `Msg::DogWritten`'s `Err` arm still return `Effect::Send` and confirm that test reddens. Drop the link check from the dog arm and confirm the refusal test reddens. Map a non-handshook dog to `online` and confirm the silent test reddens. Re-read each patched line before running.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/shep-cli/src/lookout/
+git commit -m "feat(lookout): per-dog toggles, applying live through the shepherd"
+```
+
+---
+
+### Task 10: Gallery frames
+
+**Files:**
+- Modify: `crates/shep-cli/src/lookout/frames.rs`
+- Modify: `docs/lookout/frames.txt` (regenerated, not hand-edited)
+- Modify: `docs/lookout/frames.ansi` (same)
+
+- [ ] **Step 1: Add the scenes**
+
+Five, appended to `Scene`, to `Scene::ALL`, and to `label`, `caption` and `size`:
+
+| Scene | Shows |
+| --- | --- |
+| `SettingsFresh` | a `shep.toml` holding only `[interpreters]`, so every scalar reads `the default`. The state most operators open the screen in. |
+| `SettingsSet` | some scalars declared, so `shep.toml` and `the default` sit side by side and the difference is visible. |
+| `SettingsConfirm` | a `[daemon]` confirm armed, naming the variable and the flag it cannot see. |
+| `SettingsTyping` | the `socket` editor open mid-path. |
+| `SettingsDogs` | the dogs table with the drift: one running while disabled, one enabled and absent, one silent. |
+
+`SettingsReadOnly` is deliberately not a sixth: `Refused` already covers the read-only refusal for the dashboard, and the settings screen's own read-only state is one caption line different. Add it only if the caption turns out to carry something the others do not.
+
+- [ ] **Step 2: Run the suite and read every new snapshot before accepting it**
+
+```bash
+cargo test --workspace --lib --bins --all-features -- --skip ::slow::
+```
+
+Then `cargo insta accept` only after reading each pending snapshot. A snapshot accepted unread is a test that pins whatever the bug was.
+
+- [ ] **Step 3: Regenerate the gallery**
+
+```bash
+cargo test -p shep --lib --all-features -- --ignored write_the_gallery
+```
+
+Then read the diff on `docs/lookout/frames.txt`. Extend its header prose to mention the settings screen, in the register the file already uses.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/shep-cli/src/lookout/frames.rs crates/shep-cli/src/lookout/snapshots/ docs/lookout/
+git commit -m "docs(lookout): gallery frames for the settings screen"
+```
+
+---
+
+### Task 11: Docs, and the gate
+
+**Files:**
+- Modify: `web/src/pages/docs/lookout.astro`
+- Modify: `docs/specs/deferred.md` if it carries a line this closes
+- Possibly modify: `web/src/pages/docs/cli/*` (generated, never hand-edited)
+
+- [ ] **Step 1: Write the docs**
+
+`lookout.astro` gains the `s` key in its key table and a section on the screen. It must state four things an operator cannot infer:
+
+1. Reading is not gated; editing is.
+2. `the default` against `shep.toml` in the SOURCE column, and what the difference means.
+3. That a `[daemon]` edit can be shadowed by the shepherd's own `SHEP_*` env or boot flags, which lookout cannot see, and that `[style]` is the exception because those layers are lookout's own.
+4. That `log_level`, `log_json` and `allow_control` can move from `the default` to `shep.toml` and not back from this screen, because `socket` and `max_cron_sleep` are the only optional ones (spec decision 5).
+
+Run `humanizer` then `rin-voice` over the prose before committing it. Match the page's existing register rather than inventing one.
+
+- [ ] **Step 2: Regenerate the CLI reference and check the diff**
+
+```bash
+cargo build --release
+```
+```bash
+./web/scripts/generate-cli-reference.sh
+```
+
+`git diff` afterwards is the check. This feature adds no flag and no verb, so an empty diff here is the expected result rather than a failure. A non-empty one means something drifted earlier and should be committed with a note saying so.
+
+- [ ] **Step 3: Build and check the site**
+
+```bash
+cd web && npx astro build
+```
+```bash
+cd web && npx astro check
+```
+
+Both. `check` is the one CI does not run and the one that catches a component given a prop it does not have.
+
+- [ ] **Step 4: The task gate**
+
+Each from its own command, with `$?` captured directly and never through a pipe: in zsh a pipeline's `$?` belongs to the last command and `${PIPESTATUS[0]}` is empty.
+
+```bash
+cargo fmt --all --check
+```
+```bash
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+```
+```bash
+cargo test --workspace --all-features
+```
+```bash
+RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/ docs/
+git commit -m "docs(web): the lookout settings screen, and what a change there costs"
+```
+
+---
+
+## Self-review
+
+Run against the spec before dispatching task 1.
+
+- **Spec coverage.** Decision 1 is task 6 (`draw` branches rather than adding a pane tier). Decision 2 is task 7. Decision 3 is tasks 3 and 8. Decision 4 is tasks 2, 3 and 6. Decision 5 is tasks 2, 3 and 8. Decision 6 is tasks 7, 8 and 9's confirm strings. Decision 7 is task 11's docs, since lookout only names the command. Decision 8 is task 5's read-only test. Decision 9 is tasks 6 and 9. Decision 10 is task 4. Decision 11 is a note at the call sites, checked in review rather than by a test, because there is nothing to redact.
+- **Types.** `SettingField`, `SettingEdit`, `SettingsSnapshot`, `ScalarView`, `SettingSource`, `DogView` and `SettingError` are defined in task 3 and used unchanged in 5 through 9. `SettingsRow` and `Settings` are task 5's. `Pending` is task 7's, extended by task 8. `Effect::WriteDog`, `Msg::DogWritten` and `Sent::Dog` are task 9's.
+- **Loose ends, all closed before dispatch.** `resolve_style` returns `(StyleLevel, StyleSource)` at `lib.rs:533`; `SettingSource` collapses into `StyleSource`, which already has the four variants; `DogSource` is `BuiltIn | Adopted { path: String }` at `request.rs:587`; the read-only refusal is `"read-only: actions need --allow-control"` at `app.rs:1033`; and `silent` comes from `Reported::of(..).word()` at `vocabulary.rs:117`. Nothing in this plan is left for an implementer to guess at.
+- **`ino()` needs `std::os::unix::fs::MetadataExt`** in task 3's test module. `commands` is already `cfg(unix)` wholesale, so no gate is needed around it.

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -16,7 +16,7 @@
         "typescript": "^6.0.3"
       },
       "engines": {
-        "node": ">=22.12.0"
+        "node": ">=22.18.0"
       }
     },
     "node_modules/@astrojs/check": {

--- a/web/src/pages/docs/lookout.astro
+++ b/web/src/pages/docs/lookout.astro
@@ -180,9 +180,9 @@ const settingsFresh = `shep lookout   /home/ada/.shep                           
 
   [dogs]
   space arms, Enter applies; a dog needs no reload
-  NAME                                                                  IN FILE  SOURCE                    RUNNING
-  bark                                                                  no       built-in                  not running
-  metrics                                                               no       built-in                  not running
+  NAME                                                                IN FILE  SOURCE                    RUNNING
+  bark                                                                no       built-in                  not running
+  metrics                                                             no       built-in                  not running
 
 esc close   j/k select   g/G first/last   space cycle                                                          read-only`;
 
@@ -201,9 +201,9 @@ const settingsConfirm = `shep lookout   /home/ada/.shep                         
 
   [dogs]
   space arms, Enter applies; a dog needs no reload
-  NAME                                                                                                                              IN FILE  SOURCE                    RUNNING
-  bark                                                                                                                              no       built-in                  not running
-  metrics                                                                                                                           yes      built-in                  not running
+  NAME                                                                                                                            IN FILE  SOURCE                    RUNNING
+  bark                                                                                                                            no       built-in                  not running
+  metrics                                                                                                                         yes      built-in                  not running
 
   set log_level to info? needs shep daemon reload, and will not apply if the shepherd was booted with SHEP_LOG_LEVEL or --log-level  enter confirms, any other key cancels
 set log_level to info? needs shep daemon reload, and will not apply if the shepherd was booted with SHEP_LOG_LEVEL or --log-level  enter confirms, any other key ca… control enabled`;
@@ -223,10 +223,10 @@ const settingsDogs = `shep lookout   /home/ada/.shep                            
 
   [dogs]
   space arms, Enter applies; a dog needs no reload
-  NAME                                                                  IN FILE  SOURCE                    RUNNING
-  otel                                                                  no       built-in                  online
-  ledger                                                                yes      built-in                  not running
-  bark                                                                  yes      built-in                  silent
+  NAME                                                                IN FILE  SOURCE                    RUNNING
+  otel                                                                no       built-in                  online
+  ledger                                                              yes      built-in                  not running
+  bark                                                                yes      built-in                  silent
 
 esc close   j/k select   g/G first/last   space cycle                                                          read-only`;
 ---

--- a/web/src/pages/docs/lookout.astro
+++ b/web/src/pages/docs/lookout.astro
@@ -184,7 +184,7 @@ const settingsFresh = `shep lookout   /home/ada/.shep                           
   bark                                                                no       built-in                  not running
   metrics                                                             no       built-in                  not running
 
-esc close   j/k select   g/G first/last   space cycle                                                          read-only`;
+esc/s close   j/k select   g/G first/last   r refresh                                                          read-only`;
 
 const settingsConfirm = `shep lookout   /home/ada/.shep                                                                                                                                        6 in the flock
   [daemon]
@@ -228,7 +228,7 @@ const settingsDogs = `shep lookout   /home/ada/.shep                            
   ledger                                                              yes      built-in                  not running
   bark                                                                yes      built-in                  silent
 
-esc close   j/k select   g/G first/last   space cycle                                                          read-only`;
+esc/s close   j/k select   g/G first/last   r refresh                                                          read-only`;
 ---
 
 <DocsLayout

--- a/web/src/pages/docs/lookout.astro
+++ b/web/src/pages/docs/lookout.astro
@@ -224,8 +224,8 @@ const settingsDogs = `shep lookout   /home/ada/.shep                            
   [dogs]
   space arms, Enter applies; a dog needs no reload
   NAME                                                                IN FILE  SOURCE                    RUNNING
-  otel                                                                no       built-in                  online
-  ledger                                                              yes      built-in                  not running
+  otel                                                                no       /usr/local/bin/shep-otel  online
+  ledger                                                              yes      /opt/ledger/bin/dog       not running
   bark                                                                yes      built-in                  silent
 
 esc/s close   j/k select   g/G first/last   r refresh                                                          read-only`;

--- a/web/src/pages/docs/lookout.astro
+++ b/web/src/pages/docs/lookout.astro
@@ -36,7 +36,7 @@ out  GET /v1/orders 200 44ms
 out  POST /v1/orders 201 88ms
 out  GET /v1/orders/8821 200 9ms
 out  connection pool: 14/50 in use
-q quit   j/k select   g/G first/last   r refresh   / filter                                                    read-only`;
+q quit   j/k select   g/G first/last   r refresh   / filter   s settings                                       read-only`;
 
 const narrow = `shep lookout   /home/ada/.shep       6 in the flock
 host  load 2.31 4.10 3.88 / 10 cores   host mem 12…
@@ -76,7 +76,7 @@ out  GET /v1/orders 200 44ms
 out  POST /v1/orders 201 88ms
 out  GET /v1/orders/8821 200 9ms
 out  connection pool: 14/50 in use
-q quit   j/k select   g/G first/last   r refresh   / filter                                                    read-only`;
+q quit   j/k select   g/G first/last   r refresh   / filter   s settings                                       read-only`;
 
 const refused = `shep lookout   /home/ada/.shep                                                                            6 in the flock
 host  load 2.31 4.10 3.88 / 10 cores   host mem 12.4G / 32.0G   flock cpu 14.7%   flock mem 716.0M   up 6d 3h
@@ -131,7 +131,7 @@ out  GET /v1/orders 200 44ms
 out  POST /v1/orders 201 88ms
 out  GET /v1/orders/8821 200 9ms
 out  connection pool: 14/50 in use
-q quit   j/k select   / filter   x stop   R restart   L reload                                           control enabled`;
+q quit   j/k select   / filter   x stop   R restart   L reload   s settings                              control enabled`;
 
 const filterActive = `shep lookout   /home/ada/.shep                                                   2 of 6 in the flock
 host  load 2.31 4.10 3.88 / 10 cores   host mem 12.4G / 32.0G   flock cpu 14.7%   flock mem 716.0M …
@@ -164,6 +164,71 @@ host  load 2.31 4.10 3.88 / 10 cores   host mem 12.4G / 32.0G   flock cpu 14.7% 
   0     web                online           48211    0         -          3.4%    182.0M    1h 25m
   1     web                online           48212    0         -          2.9%    178.0M    1h 26m
 restart api (id 2): the shepherd restarted it                                        control enabled`;
+
+const settingsFresh = `shep lookout   /home/ada/.shep                                                                            6 in the flock
+  [daemon]
+> log_level        warn                            the default  needs shep daemon reload
+  log_json         false                           the default  needs shep daemon reload
+  socket           /home/ada/.shep/run/shep.sock   the default  needs the shepherd stopped and started
+  max_cron_sleep   not set                         the default  needs shep daemon reload
+
+  [whistle]
+  allow_control    false                           the default  needs shep whistle restarted
+
+  [style]
+  level            full                            the default  the next command reads it
+
+  [dogs]
+  space arms, Enter applies; a dog needs no reload
+  NAME                                                                  IN FILE  SOURCE                    RUNNING
+  bark                                                                  no       built-in                  not running
+  metrics                                                               no       built-in                  not running
+
+esc close   j/k select   g/G first/last   space cycle                                                          read-only`;
+
+const settingsConfirm = `shep lookout   /home/ada/.shep                                                                                                                                        6 in the flock
+  [daemon]
+> log_level        warn                            shep.toml    needs shep daemon reload
+  log_json         false                           the default  needs shep daemon reload
+  socket           /home/ada/.shep/run/shep.sock   shep.toml    needs the shepherd stopped and started
+  max_cron_sleep   30s                             shep.toml    needs shep daemon reload
+
+  [whistle]
+  allow_control    false                           the default  needs shep whistle restarted
+
+  [style]
+  level            full                            shep.toml    the next command reads it
+
+  [dogs]
+  space arms, Enter applies; a dog needs no reload
+  NAME                                                                                                                              IN FILE  SOURCE                    RUNNING
+  bark                                                                                                                              no       built-in                  not running
+  metrics                                                                                                                           yes      built-in                  not running
+
+  set log_level to info? needs shep daemon reload, and will not apply if the shepherd was booted with SHEP_LOG_LEVEL or --log-level  enter confirms, any other key cancels
+set log_level to info? needs shep daemon reload, and will not apply if the shepherd was booted with SHEP_LOG_LEVEL or --log-level  enter confirms, any other key ca… control enabled`;
+
+const settingsDogs = `shep lookout   /home/ada/.shep                                                                            2 in the flock
+  [daemon]
+> log_level        warn                            shep.toml    needs shep daemon reload
+  log_json         false                           the default  needs shep daemon reload
+  socket           /home/ada/.shep/run/shep.sock   shep.toml    needs the shepherd stopped and started
+  max_cron_sleep   30s                             shep.toml    needs shep daemon reload
+
+  [whistle]
+  allow_control    false                           the default  needs shep whistle restarted
+
+  [style]
+  level            full                            shep.toml    the next command reads it
+
+  [dogs]
+  space arms, Enter applies; a dog needs no reload
+  NAME                                                                  IN FILE  SOURCE                    RUNNING
+  otel                                                                  no       built-in                  online
+  ledger                                                                yes      built-in                  not running
+  bark                                                                  yes      built-in                  silent
+
+esc close   j/k select   g/G first/last   space cycle                                                          read-only`;
 ---
 
 <DocsLayout
@@ -362,6 +427,107 @@ restart api (id 2): the shepherd restarted it                                   
       <code>shep stop</code> yourself. Every color on screen is also
       redundant with text, so <code>NO_COLOR</code> and a 16-color terminal
       lose decoration, never information.
+    </p>
+    <h2>Settings</h2>
+    <p>
+      <code>s</code> opens a full-screen settings view over
+      <code>shep.toml</code>: the four daemon fields, the whistle gate, the
+      style level, and the dogs table's own enable/disable, each with a
+      SOURCE column and a note on what it takes to apply. <code>s</code>
+      or <code>Esc</code> closes it again, back to the flock table.
+    </p>
+    <p>
+      Reading this screen needs nothing. It opens under a plain
+      <code>shep lookout</code>, with no <code>--allow-control</code>, the
+      same as everything else on the dashboard. Changing a value is a
+      different story: every edit and the dog toggle need the same gate the
+      action keys do, and refuse the same way if it's closed.
+    </p>
+    <CodeBlock label="120×30, a fresh $SHEP_HOME">{settingsFresh}</CodeBlock>
+    <p>
+      SOURCE reads <code>the default</code> when <code>shep.toml</code>
+      doesn't mention the field at all, and the VALUE column shows the
+      compiled fallback instead of anything from disk. A fresh
+      <code>$SHEP_HOME</code> ships a <code>shep.toml</code> holding only
+      <code>[interpreters]</code>, so this is the state you land in the
+      first time you open the screen: every field on it is a guess about
+      what the daemon assumes, not a record of what anyone wrote. Once a
+      field is set, SOURCE switches to <code>shep.toml</code> and VALUE
+      shows what's actually there.
+    </p>
+    <CodeBlock label="120×30, some fields set">{settingsDogs}</CodeBlock>
+    <p>
+      The <code>[dogs]</code> table is the one place SOURCE isn't the whole
+      story: IN FILE says whether <code>[daemon] enabled_dogs</code> names
+      the dog, SOURCE says whether it's built in or adopted from a path, and
+      RUNNING joins both against the live flock. The three can disagree, and
+      when they do that's the point of showing all three: <code>otel</code>
+      above is running with nothing enabling it, <code>ledger</code> is
+      enabled and not running, and <code>bark</code> is enabled, running,
+      and still <code>silent</code> because it never finished a handshake.
+      <code>space</code> arms a toggle on the selected dog and <code>Enter</code>
+      sends it; unlike a scalar edit, this reaches the shepherd directly and
+      needs no reload.
+    </p>
+    <Callout variant="careful">
+      A <code>[daemon]</code> edit only ever changes <code>shep.toml</code>.
+      The shepherd itself can be started with <code>SHEP_LOG_LEVEL</code>,
+      <code>SHEP_SOCKET</code>, or the matching <code>--log-level</code> /
+      <code>--socket</code> flags, and shep's own precedence puts those above
+      the file. Lookout has no way to see what the shepherd was booted with,
+      so setting <code>log_level</code> here and running
+      <code>shep daemon reload</code> can do nothing at all if the process
+      was started with <code>SHEP_LOG_LEVEL</code> set, and nothing on
+      screen will say so. <code>[style]</code> is the one exception: those
+      layers belong to lookout's own process, not the shepherd's, so a style
+      edit always takes.
+    </Callout>
+    <p>
+      The confirm names exactly this risk when it's <code>[daemon]</code>
+      that's armed:
+    </p>
+    <CodeBlock label="180×30, armed">{settingsConfirm}</CodeBlock>
+    <p>
+      <code>log_level</code>, <code>log_json</code>, and
+      <code>allow_control</code> cycle through a fixed set of values, and the
+      cycle only ever moves a field from <code>the default</code> to
+      <code>shep.toml</code>, never back: <code>space</code> proposes the
+      next value, it's never "unset". <code>socket</code> and
+      <code>max_cron_sleep</code> are the only two fields this screen can put
+      back to the default, because they're free text, and clearing the
+      editor back to an empty line is what unsets them. <code>style level</code>
+      is optional too, but <code>shep style</code> is what owns it and can't
+      clear it either, so this screen doesn't offer to.
+    </p>
+    <p>
+      Keys, all of them local to this screen while it's open:
+    </p>
+    <ul>
+      <li><code>s</code> opens the screen, and closes it again</li>
+      <li><code>j</code>/<code>k</code>, arrows move the cursor one row</li>
+      <li><code>g</code>/<code>G</code> jump to the first or last row</li>
+      <li>
+        <code>space</code> arms the cursor's row; pressing it again on the
+        same field re-arms with the next candidate
+      </li>
+      <li>
+        <code>Enter</code> opens the text editor on <code>socket</code>/
+        <code>max_cron_sleep</code>, or sends an armed confirm
+      </li>
+      <li>
+        <code>Esc</code> cancels an armed confirm, else abandons the text
+        editor, else closes the screen; it never quits lookout
+      </li>
+      <li><code>r</code> re-reads <code>shep.toml</code> from disk</li>
+    </ul>
+    <p class="fine">
+      An armed candidate is cancelled, not acted on, by any movement key, by
+      <code>r</code>, or by <code>s</code>: the same rule the dashboard's own
+      action keys follow, where a stray keystroke right after arming backs
+      out of the question instead of both dismissing it and doing something
+      else. The confirm itself renders in the status bar, the same fixed row
+      the dashboard's <code>x</code>/<code>R</code>/<code>L</code> confirm
+      uses.
     </p>
     <h2>Where to go next</h2>
 

--- a/web/src/pages/docs/lookout.astro
+++ b/web/src/pages/docs/lookout.astro
@@ -229,6 +229,28 @@ const settingsDogs = `shep lookout   /home/ada/.shep                            
   bark                                                                yes      built-in                  silent
 
 esc/s close   j/k select   g/G first/last   r refresh                                                          read-only`;
+
+const settingsNarrow = `shep lookout   /home/ada/.shep 2 in the flock
+  [daemon]
+> log_level        warn           shep.toml
+  log_json         false          the default
+  socket           /home/ada/.s…  shep.toml
+  max_cron_sleep   30s            shep.toml
+
+  [whistle]
+  allow_control    false          the default
+
+  [style]
+  level            full           shep.toml
+
+  [dogs]
+  space arms, Enter applies; a dog needs no …
+  NAME               IN FILE  RUNNING
+  otel               no       online
+  ledger             yes      not running
+  bark               yes      silent
+
+esc/s close   j/k select   g/G fir… read-only`;
 ---
 
 <DocsLayout
@@ -369,6 +391,20 @@ esc/s close   j/k select   g/G first/last   r refresh                           
       existed; you see <code>CFG</code> past 122.
     </p>
     <CodeBlock label="51×14">{narrow}</CodeBlock>
+    <p>
+      The settings screen has its own drop order, and its two tables
+      disagree about which column goes first. The scalar rows drop the
+      apply cost and keep SOURCE; the dogs table drops SOURCE and keeps
+      RUNNING. Each keeps whichever fact is not said anywhere else on the
+      screen. The apply cost already appears twice more, in the confirm and
+      in the status bar the moment a candidate arms, so it can go first.
+      SOURCE on a scalar row is the only place that says whether an
+      operator wrote the value or shep assumed it, so it stays until the
+      last column falls. The dogs table has no such backup for SOURCE, so
+      it goes, and RUNNING, the one fact nothing else on the pane answers,
+      stays.
+    </p>
+    <CodeBlock label="45×24">{settingsNarrow}</CodeBlock>
     <p>
       Below 33 columns or 6 rows, lookout refuses to draw rather than risk
       overlapping garbage. The refusal message is short enough to survive

--- a/web/src/pages/docs/lookout.astro
+++ b/web/src/pages/docs/lookout.astro
@@ -478,9 +478,13 @@ esc close   j/k select   g/G first/last   space cycle                           
       so setting <code>log_level</code> here and running
       <code>shep daemon reload</code> can do nothing at all if the process
       was started with <code>SHEP_LOG_LEVEL</code> set, and nothing on
-      screen will say so. <code>[style]</code> is the one exception: those
-      layers belong to lookout's own process, not the shepherd's, so a style
-      edit always takes.
+      screen will say so. <code>[style]</code> is not an exception:
+      <code>--style</code> and <code>$SHEP_STYLE</code> outrank the file
+      there too. The difference is that those layers belong to lookout's own
+      process, so lookout can see them. SOURCE names the one in force, the
+      last column reads <code>written, but outranked</code> instead of
+      promising anything, and the confirm names the layer that will keep
+      winning.
     </Callout>
     <p>
       The confirm names exactly this risk when it's <code>[daemon]</code>


### PR DESCRIPTION
Adds a settings screen to `shep lookout`, opened with `s`. Editing is behind the existing `--allow-control` gate, reading is not.

- `[daemon]` `log_level`, `log_json`, `socket`, `max_cron_sleep`, plus `[whistle]` `allow_control` and `[style]` `level`
- Per-dog enable and disable, routed through the code `shep enable` and `shep disable` already use, so they apply live rather than waiting on a reload
- A SOURCE column per scalar, `the default` against `shep.toml`. A key nobody wrote and a key written to its own default are different facts, and `DaemonConfig::load` cannot tell them apart
- Confirms name what a change costs per field, including what it will not do. A `[daemon]` edit says it may be shadowed by the shepherd's own `SHEP_*` env or boot flags, which lookout cannot see. `socket` says a reload will not move it
- Five gallery frames in `docs/lookout/frames.txt`, and a settings section on the lookout docs page

`PROTOCOL_VERSION` does not move. `EnableDog` and `DisableDog` already existed.

Spec: `docs/brainstorming/specs/2026-09-04-lookout-settings-design.md`
Plan: `docs/writing-plans/plans/2026-09-04-lookout-settings.md`

Three things worth knowing before review:

- A reply landing after the screen closes reopens it. Nothing writes, and `Esc` closes it again.
- Dropping a stale `#[cfg(unix)]` makes `completions_never_resolves_paths` run on Windows for the first time. Only the `windows-latest` legs can confirm it passes.
- One `package-lock.json` node-engine line rides in the docs commit. Pre-existing drift that `npm install` surfaced.

The whole-branch review found `--allow-control` was bypassable. The gate guarded `space`, and the text editor added a second door with no check, so a read-only lookout could write `shep.toml`. Fixed as a property every write path passes rather than as a second guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a Lookout settings screen, opened with `s`, for viewing daemon, whistle, style, and dog configuration.
  - Added editing for supported settings and dog enablement when control access is allowed.
  - Added confirmations, validation, responsive layouts, text editing, configuration-source indicators, and live dog status.
  - Added Space to cycle through settings and updated keyboard hints.

- **Bug Fixes**
  - Unknown dogs and invalid setting changes no longer modify configuration files.

- **Documentation**
  - Added guidance for settings navigation, editing, permissions, layouts, and keyboard controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->