### PR TITLE
ci: reject a commit subject release-plz cannot read

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -17,13 +17,36 @@
 msg_file="$1"
 subject=$(sed -n '1p' "$msg_file")
 
-# A merge, revert, fixup or squash subject is git's own wording, not ours.
+# A merge subject is git's own wording. So are the autosquash markers, and
+# those are legitimate HERE because they are created locally and consumed by
+# `git rebase --autosquash` before the branch is pushed. The CI gate rejects
+# them, since one surviving to a pull request head was never squashed.
+#
+# `Revert "..."`, which `git revert` writes for you, is NOT exempt. It parses
+# as nothing and release-plz drops it, so a reverted breaking change would go
+# unrecorded. Retitle it `revert: ...` and see the note below about giving
+# `revert` a parser.
 case "$subject" in
-    "Merge "*|"Revert "*|"fixup!"*|"squash!"*|"amend!"*) exit 0 ;;
+    "Merge "*|"fixup!"*|"squash!"*|"amend!"*) exit 0 ;;
 esac
 
+# The nine types below are not the conventional-commits list, they are what
+# release-plz-changelog.toml actually handles. Measured with git-cliff 2.14.1
+# against that exact config:
+#
+#   feat fix perf refactor   produce a changelog entry
+#   docs test ci chore style  match `skip = true`, dropped on purpose
+#   revert build              match NO parser, so `filter_commits = true`
+#                             drops them with no entry and no warning
+#
+# `revert` and `build` are the trap. They are real conventional types, they
+# look correct, and they contribute nothing. They are rejected here rather
+# than accepted, because a gate that passes a commit release-plz discards is
+# the bug this file exists to prevent. To use one, give it a parser in
+# release-plz-changelog.toml first, then add it here.
+
 # type(optional scope)optional !: space, then something.
-if printf '%s' "$subject" | grep -qE '^(feat|fix|perf|refactor|docs|test|ci|chore|style|build|revert)(\([a-z0-9 ._/-]+\))?!?: .+'; then
+if printf '%s' "$subject" | grep -qE '^(feat|fix|perf|refactor|docs|test|ci|chore|style)(\([a-z0-9 ._/-]+\))?!?: .+'; then
     exit 0
 fi
 
@@ -40,8 +63,13 @@ changed public signature.
 Write it as: type(optional-scope): lowercase summary
 
   feat: a new surface        fix: a bug            perf: faster
-  refactor: no behaviour change                    revert: undo
-  docs / style / test / ci / chore / build: no release
+  refactor: no behaviour change
+  docs / style / test / ci / chore: no changelog entry, which is fine
+
+Not accepted: revert and build. Both are real conventional types and both
+match no parser in release-plz-changelog.toml, so release-plz drops them
+exactly as it drops an unreadable subject. Give one a parser there before
+using it here.
 
 Add ! after the type or scope for a BREAKING change, and put it on the
 commit that actually breaks something, in the crate that breaks:

--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,56 @@
+#!/bin/sh
+# Rejects a commit subject release-plz cannot read.
+#
+# release-plz walks the INDIVIDUAL commits on a branch, not the merge
+# commit's subject, and `filter_unconventional = true` in
+# release-plz-changelog.toml silently drops anything that does not parse.
+# A dropped commit contributes nothing to the changelog and nothing to the
+# version bump, so a breaking change in one ships inside a compatible
+# version with an empty changelog entry and no error anywhere.
+#
+# That is not hypothetical. shep-core 0.2.1 went to crates.io carrying a
+# changed public signature because the commit that made it was called
+# "Tell a running dog its config changed".
+#
+# Install once per clone: git config core.hooksPath .githooks
+
+msg_file="$1"
+subject=$(sed -n '1p' "$msg_file")
+
+# A merge, revert, fixup or squash subject is git's own wording, not ours.
+case "$subject" in
+    "Merge "*|"Revert "*|"fixup!"*|"squash!"*|"amend!"*) exit 0 ;;
+esac
+
+# type(optional scope)optional !: space, then something.
+if printf '%s' "$subject" | grep -qE '^(feat|fix|perf|refactor|docs|test|ci|chore|style|build|revert)(\([a-z0-9 ._/-]+\))?!?: .+'; then
+    exit 0
+fi
+
+cat >&2 <<MSG
+This commit subject is not a conventional commit, so release-plz will drop it:
+
+  $subject
+
+Nothing will fail. The commit merges, the changelog section for its crate
+comes out empty, and if the change was breaking it ships inside a
+semver-compatible version. That is how shep-core 0.2.1 was published with a
+changed public signature.
+
+Write it as: type(optional-scope): lowercase summary
+
+  feat: a new surface        fix: a bug            perf: faster
+  refactor: no behaviour change                    revert: undo
+  docs / style / test / ci / chore / build: no release
+
+Add ! after the type or scope for a BREAKING change, and put it on the
+commit that actually breaks something, in the crate that breaks:
+
+  feat(core)!: BusEvent::topic returns Cow rather than a static str
+
+The ! on a pull request title does nothing. release-plz never reads it.
+
+To bypass once, and only for a commit nobody needs in a changelog:
+  git commit --no-verify
+MSG
+exit 1

--- a/.github/workflows/commits.yml
+++ b/.github/workflows/commits.yml
@@ -1,0 +1,81 @@
+name: commits
+# Rejects a pull request carrying a commit subject release-plz cannot read.
+#
+# This is a release-correctness gate wearing a lint's clothes. release-plz
+# walks the INDIVIDUAL commits on a branch and `filter_unconventional = true`
+# in release-plz-changelog.toml drops anything that does not parse, so an
+# unreadable subject contributes nothing to its crate's changelog and nothing
+# to the version bump. A breaking change in such a commit ships inside a
+# semver-compatible version, with an empty changelog section, and no step
+# anywhere fails.
+#
+# Measured before this existed: of the 31 commits on the branch that became
+# shep-core 0.2.1, 19 were unreadable. One of those 19 changed a public
+# signature. 0.2.1 went to crates.io as a patch, with an empty changelog
+# section for that crate. `semver_check = true` did not catch it either; run
+# by hand against origin/main it reported 196 passing checks and no update
+# required, because it has no lint for a changed inherent-method return type.
+#
+# `.githooks/commit-msg` runs the same rule locally, but core.hooksPath is
+# per-clone and a fresh clone or worktree has it unset, so that hook is a
+# convenience and this job is the gate.
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  conventional:
+    name: conventional subjects
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      # The full range, because a subject is only checkable if it is fetched.
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Check every commit subject on this branch
+        env:
+          BASE: ${{ github.event.pull_request.base.sha }}
+          HEAD: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -eu
+          # --no-merges: a merge subject is git's own wording, and release-plz
+          # ignores merge commits anyway, which is the whole reason a `!` in a
+          # pull request title buys nothing.
+          bad=0
+          while IFS= read -r subject; do
+            [ -z "$subject" ] && continue
+            case "$subject" in
+              "Revert "*|"fixup!"*|"squash!"*|"amend!"*) continue ;;
+            esac
+            if printf '%s' "$subject" | grep -qE '^(feat|fix|perf|refactor|docs|test|ci|chore|style|build|revert)(\([a-z0-9 ._/-]+\))?!?: .+'; then
+              printf '  ok      %s\n' "$subject"
+            else
+              printf '  DROPPED %s\n' "$subject"
+              bad=$((bad + 1))
+            fi
+          done <<EOF
+          $(git log --no-merges --format='%s' "$BASE..$HEAD")
+          EOF
+
+          if [ "$bad" -gt 0 ]; then
+            cat >&2 <<MSG
+
+          $bad commit subject(s) above will be dropped by release-plz.
+
+          Each one contributes nothing to its crate's changelog and nothing to
+          the version bump. If any of them changes a public API, that change
+          ships inside a semver-compatible version and nothing reports it.
+
+          Rewrite them as: type(optional-scope): lowercase summary
+
+          Put a ! after the type or scope on the commit that actually breaks
+          something, in the crate that breaks. A ! on this pull request's
+          title does nothing, because release-plz never reads the merge commit.
+          MSG
+            exit 1
+          fi
+          echo "All $(git log --no-merges --oneline "$BASE..$HEAD" | wc -l | tr -d ' ') commit subject(s) are readable."

--- a/.github/workflows/commits.yml
+++ b/.github/workflows/commits.yml
@@ -45,13 +45,27 @@ jobs:
           # --no-merges: a merge subject is git's own wording, and release-plz
           # ignores merge commits anyway, which is the whole reason a `!` in a
           # pull request title buys nothing.
+          #
+          # Nothing is exempt here, unlike the local hook. `fixup!`, `squash!`
+          # and `amend!` are fine to create locally and are consumed by
+          # `git rebase --autosquash`; one reaching a pull request head was
+          # never squashed and would be dropped like any other unreadable
+          # subject. `Revert "..."`, which `git revert` writes, parses as
+          # nothing and is dropped too.
+          #
+          # The nine accepted types are what release-plz-changelog.toml
+          # actually handles, not the conventional-commits list. Measured with
+          # git-cliff 2.14.1 against that config: feat, fix, perf and refactor
+          # produce entries; docs, test, ci, chore and style are `skip = true`
+          # and dropped on purpose; revert and build match NO parser, so
+          # `filter_commits = true` discards them silently. Those last two are
+          # the trap, since they are real conventional types that look correct
+          # and contribute nothing. Give one a parser in that config before
+          # adding it here.
           bad=0
           while IFS= read -r subject; do
             [ -z "$subject" ] && continue
-            case "$subject" in
-              "Revert "*|"fixup!"*|"squash!"*|"amend!"*) continue ;;
-            esac
-            if printf '%s' "$subject" | grep -qE '^(feat|fix|perf|refactor|docs|test|ci|chore|style|build|revert)(\([a-z0-9 ._/-]+\))?!?: .+'; then
+            if printf '%s' "$subject" | grep -qE '^(feat|fix|perf|refactor|docs|test|ci|chore|style)(\([a-z0-9 ._/-]+\))?!?: .+'; then
               printf '  ok      %s\n' "$subject"
             else
               printf '  DROPPED %s\n' "$subject"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -219,6 +219,14 @@ re-running that suite in isolation with the mutation still applied.
   changelog section. Nothing failed. `semver_check = true` did not catch it
   either, having no lint for a changed inherent-method return type.
 
+  Nine types are accepted, and they are what `release-plz-changelog.toml`
+  handles rather than the conventional-commits list. `feat`, `fix`, `perf`
+  and `refactor` produce entries; `docs`, `test`, `ci`, `chore` and `style`
+  are `skip = true` and drop on purpose. `revert` and `build` are refused,
+  because they match no parser there and `filter_commits = true` discards
+  them as silently as it discards a sentence. Measured with git-cliff 2.14.1
+  against the real config.
+
   `.github/workflows/commits.yml` gates it now and `.githooks/commit-msg`
   catches it earlier, so this bullet is the explanation rather than the
   enforcement. It still belongs here, because a brief that omits the rule

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -200,6 +200,30 @@ re-running that suite in isolation with the mutation still applied.
   plan spends its cost later, in review loops.
 - **Implementing a written plan:** Sonnet, high thinking. The design decisions
   are already made.
+- **Every brief says to use conventional commit subjects, and says it in the
+  brief rather than trusting it to be known.** `type(scope): summary`, with a
+  `!` on the commit that actually breaks something, in the crate that breaks.
+
+  This is a release-correctness rule, not a style one. release-plz walks the
+  INDIVIDUAL commits and `filter_unconventional = true` drops whatever does
+  not parse, so an unreadable subject contributes nothing to its crate's
+  changelog and nothing to the version bump. The `!` on a pull request title
+  is read by nobody: release-plz ignores merge commits, which is the opposite
+  of what a `merge_commit_title = PR_TITLE` setting suggests.
+
+  Measured 2026-09-04, and it is the reason this bullet exists. Of the 31
+  commits behind `shep-core` 0.2.1, 19 were unreadable, and the split was
+  exact: every readable one was written in the main thread, every unreadable
+  one by an implementer subagent. One of the 19 changed `BusEvent::topic`'s
+  signature, so a source break went to crates.io as a patch with an empty
+  changelog section. Nothing failed. `semver_check = true` did not catch it
+  either, having no lint for a changed inherent-method return type.
+
+  `.github/workflows/commits.yml` gates it now and `.githooks/commit-msg`
+  catches it earlier, so this bullet is the explanation rather than the
+  enforcement. It still belongs here, because a brief that omits the rule
+  produces a branch that fails CI at the end instead of a subagent that gets
+  it right at the start.
 
 ## Architecture
 


### PR DESCRIPTION
`shep-core` 0.2.1 is on crates.io as a patch, carrying a changed public signature, with an empty changelog section. Nothing failed anywhere. This closes the hole.

- `.github/workflows/commits.yml` fails a pull request whose commits release-plz would drop. Verified against the range that caused this: it flags exactly the 19
- `.githooks/commit-msg` runs the same rule locally. Enable with `git config core.hooksPath .githooks`
- `CLAUDE.md` gains the rule under Subagent dispatch, where briefs get written

The config was not the problem, which is worth saying because it was the obvious suspect. Diffed against zendriver-rs: `release-plz-changelog.toml` is identical bar header prose, and `release-plz.toml` differs only in this workspace's package list and version groups. What differs is what feeds it. zendriver-rs's last 40 commits are 40 conventional subjects; this repository's are 21.

release-plz walks the individual commits and `filter_unconventional = true` drops whatever does not parse, so a dropped commit contributes nothing to its crate's changelog and nothing to the version bump. `BusEvent::topic` went from `&'static str` to `Cow<'static, str>` in a commit called "Tell a running dog its config changed", so the break was invisible and the version went 0.2.0 to 0.2.1.

Three things that look like they should have caught it:

- the pull request title was `feat(dogs)!: ...`, conventional and marked breaking. release-plz ignores merge commits, so it was never read. That is the opposite of what `merge_commit_title = PR_TITLE` suggests, which is exactly why it was believed
- `semver_check = true` is on. Against `origin/main` as baseline it reports 196 checks passing, 58 skipped, no update required. It has no lint for a changed inherent-method return type
- 0.2.0 recorded its own breaking change correctly, which is what made the pipeline look healthy. That came from `2f58721b refactor(core)!: ResetDepth gains File and Env`, a branch commit that was conventional, carried the `!`, and touched the crate it broke. All three are needed and 0.2.1 had none

The split on the branch behind 0.2.1 says where the bad subjects come from. 19 of 31 unreadable, and the division is exact: every readable subject was written in the main thread, every unreadable one by an implementer subagent working from a brief that never mentioned the convention. That is why the CI job is the gate and the hook is only a convenience: `core.hooksPath` is per-clone and unset in every fresh worktree, which describes every subagent.

Still open, not fixed here: 0.2.1 is published and `^0.2` is a live range that currently lies. Three reverse deps, all this workspace's own crates, so nobody outside is broken yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Added commit-message validation for supported Conventional Commits formats, including clear guidance for rejected messages.
  - Added pull request checks to identify invalid commit subjects before merging.
  - Merge and autosquash commit subjects remain supported; revert and build commit types are rejected when they cannot be processed for release tracking.

- **Documentation**
  - Documented commit formatting requirements, breaking-change notation, and automated enforcement through local hooks and continuous integration checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->