### PR TITLE
chore: release v0.2.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2058,7 +2058,7 @@ dependencies = [
 
 [[package]]
 name = "shep"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anstyle",
  "assert_cmd",
@@ -2096,11 +2096,11 @@ dependencies = [
 
 [[package]]
 name = "shep-cli"
-version = "0.2.1"
+version = "0.2.2"
 
 [[package]]
 name = "shep-client"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "futures-util",
  "nix 0.29.0",
@@ -2116,7 +2116,7 @@ dependencies = [
 
 [[package]]
 name = "shep-core"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "annotate-snippets",
  "anstyle",
@@ -2146,7 +2146,7 @@ dependencies = [
 
 [[package]]
 name = "shep-daemon"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "bytes",
  "chrono",
@@ -2175,14 +2175,14 @@ dependencies = [
 
 [[package]]
 name = "shep-examples"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "nix 0.29.0",
 ]
 
 [[package]]
 name = "shep-macros"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "proc-macro2",
  "quote 1.0.47",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.1"
+version = "0.2.2"
 edition = "2024"
 # 1.88 forced by serde-saphyr (let-chains, stabilized 1.88) — a current dep,
 # not a future one. Also the floor for ratatui/sysinfo/rmcp in later phases.
@@ -32,10 +32,10 @@ license = "MIT OR Apache-2.0"
 # the `[package]` table. This literal is not sourced from
 # `workspace.package.version` above and a release bump has to touch both
 # places by hand. If that drifts, `cargo-release` is the mechanical fix.
-shep-core = { path = "crates/shep-core", version = "0.2.1" }
-shep-daemon = { path = "crates/shep-daemon", version = "0.2.1" }
-shep-client = { path = "crates/shep-client", version = "0.2.1" }
-shep-macros = { path = "crates/shep-macros", version = "0.2.1" }
+shep-core = { path = "crates/shep-core", version = "0.2.2" }
+shep-daemon = { path = "crates/shep-daemon", version = "0.2.2" }
+shep-client = { path = "crates/shep-client", version = "0.2.2" }
+shep-macros = { path = "crates/shep-macros", version = "0.2.2" }
 serde = { version = "1", default-features = false, features = ["derive"] }
 serde_json = { version = "1", default-features = false, features = ["std"] }
 toml = { version = "0.8", default-features = false, features = ["parse", "display"] }

--- a/crates/shep-cli/CHANGELOG.md
+++ b/crates/shep-cli/CHANGELOG.md
@@ -13,6 +13,46 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.2] - 2026-09-04
+
+### Added
+
+- ShepToml can read and write shep.toml's six scalars
+- A settings snapshot that keeps absent apart from defaulted
+- S opens a settings screen, read-only for now
+- The settings screen renders, with a source per scalar
+- The four closed scalars arm, confirm and write
+- Socket and max_cron_sleep get an editor, and can be unset
+- Per-dog toggles, applying live through the shepherd
+
+### Changed
+
+- One name reaches both the topic and the re-read request
+- The text keymap is named for text, not for the filter
+- A dog toggle's config decision, apart from its reporting
+
+### Fixed
+
+- Silence ShepToml's dead-code lint and close two test gaps
+- Unix-only settings test, closed boolean grammar, dead reader
+- Close the settings/action race, thread the resolved style
+- Close the settings/filter race the same way as the confirm one
+- Reload the row after a landed write, and un-contradict the status bar
+- Name what the shepherd did on a landed dog reply, cover on_dog_reply
+- Move the settings confirm to the status bar
+- Make the control gate a property of every settings write
+- Re-read the file after a landed dog toggle
+- The style row says what the layer above the file will do
+- Pay the selection gutter in the dogs table's own budget
+- The scalar rows adapt to width instead of clipping
+- The settings key hint answers to the control gate
+- An adopted dog carries a path in the fixtures and the gallery
+- Fit the settings confirm and editor lines like every other row
+- WriteAuthority::granted reads the app's own gate, not a bare Control
+- Name q quit on the settings screen's status bar
+- A settings write no longer parks the loop it was moved off
+
+
 ## [0.2.1] - 2026-09-04
 
 ### Changed

--- a/crates/shep-client/CHANGELOG.md
+++ b/crates/shep-client/CHANGELOG.md
@@ -10,6 +10,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.2] - 2026-09-04
+
+### Fixed
+
+- Keep a secret mark on the type shep asked about
+- Gate the schema tests on the feature that supplies them
+
+
 ## [0.2.1] - 2026-09-04
 
 ### Fixed

--- a/crates/shep-core/CHANGELOG.md
+++ b/crates/shep-core/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.2] - 2026-09-04
+
+
 ## [0.2.1] - 2026-09-04
 
 

--- a/crates/shep-daemon/CHANGELOG.md
+++ b/crates/shep-daemon/CHANGELOG.md
@@ -10,6 +10,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.2] - 2026-09-04
+
+### Fixed
+
+- A stop no longer discards the child's last line
+- Drain on every exit from the pump loop, not just one
+- Gate fill_pipe on unix, which is where its argument type exists
+- Put FINAL_DRAIN back to 100ms, and name what actually bounds it
+
+
 ## [0.2.1] - 2026-09-04
 
 

--- a/crates/shep-macros/CHANGELOG.md
+++ b/crates/shep-macros/CHANGELOG.md
@@ -7,5 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.2] - 2026-09-04
+
+
 ## [0.2.1] - 2026-09-04
 


### PR DESCRIPTION



## 🤖 New release

* `shep-core`: 0.2.1 -> 0.2.2
* `shep-daemon`: 0.2.1 -> 0.2.2 (✓ API compatible changes)
* `shep-macros`: 0.2.0 -> 0.2.2
* `shep-client`: 0.2.0 -> 0.2.2
* `shep`: 0.2.0 -> 0.2.2

<details><summary><i><b>Changelog</b></i></summary><p>


## `shep-daemon`

<blockquote>

## [0.2.2] - 2026-09-04

### Fixed

- A stop no longer discards the child's last line
- Drain on every exit from the pump loop, not just one
- Gate fill_pipe on unix, which is where its argument type exists
- Put FINAL_DRAIN back to 100ms, and name what actually bounds it
</blockquote>


## `shep-client`

<blockquote>

## [0.2.2] - 2026-09-04

### Fixed

- Keep a secret mark on the type shep asked about
- Gate the schema tests on the feature that supplies them
</blockquote>

## `shep`

<blockquote>

## [0.2.2] - 2026-09-04

### Added

- ShepToml can read and write shep.toml's six scalars
- A settings snapshot that keeps absent apart from defaulted
- S opens a settings screen, read-only for now
- The settings screen renders, with a source per scalar
- The four closed scalars arm, confirm and write
- Socket and max_cron_sleep get an editor, and can be unset
- Per-dog toggles, applying live through the shepherd

### Changed

- One name reaches both the topic and the re-read request
- The text keymap is named for text, not for the filter
- A dog toggle's config decision, apart from its reporting

### Fixed

- Silence ShepToml's dead-code lint and close two test gaps
- Unix-only settings test, closed boolean grammar, dead reader
- Close the settings/action race, thread the resolved style
- Close the settings/filter race the same way as the confirm one
- Reload the row after a landed write, and un-contradict the status bar
- Name what the shepherd did on a landed dog reply, cover on_dog_reply
- Move the settings confirm to the status bar
- Make the control gate a property of every settings write
- Re-read the file after a landed dog toggle
- The style row says what the layer above the file will do
- Pay the selection gutter in the dogs table's own budget
- The scalar rows adapt to width instead of clipping
- The settings key hint answers to the control gate
- An adopted dog carries a path in the fixtures and the gallery
- Fit the settings confirm and editor lines like every other row
- WriteAuthority::granted reads the app's own gate, not a bare Control
- Name q quit on the settings screen's status bar
- A settings write no longer parks the loop it was moved off
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).