### PR TITLE
ci: run the test legs under nextest, and retry the integration tier

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,41 @@
+# nextest profiles for CI. `cargo test` still works and is still what the
+# task gate in CLAUDE.md runs locally; this file only shapes the CI legs.
+#
+# Why nextest is here at all: `cli_e2e` spawns a real shepherd and real sheep
+# per case, and a contended runner cannot always schedule them promptly. Two
+# such failures on 2026-09-04 turned out to be real defects and were fixed
+# (see docs/decisions.md), but the residual class is genuine and will not go
+# away: the musl leg already caps its thread count for exactly this reason,
+# and its comment records that the triage cost more than the fix, twice.
+#
+# What retries DO NOT excuse. A retry hides a defect as readily as a flake,
+# and both of the 2026-09-04 failures would have been hidden by one: a
+# missing precondition in a test, and the log pump dropping a child's last
+# line 39 times in 64 at the seam. Read a retried failure before shrugging at
+# it. `--junit` is on so the retries are countable rather than invisible.
+
+[profile.ci]
+# Report every failure in one run. A matrix leg is expensive to re-trigger
+# and one pass should name the whole picture.
+fail-fast = false
+
+# Retries on the integration tier ONLY, which is `kind(test)`: 165 tests as
+# of 2026-09-04, against 2376 `kind(lib)` unit tests that get none. Measured
+# with `cargo nextest list -E 'kind(test)'` rather than assumed, and the two
+# sum to the whole suite. The unit tiers are deterministic, so a retry there
+# would buy nothing and mask a real race.
+[[profile.ci.overrides]]
+filter = 'kind(test)'
+retries = 2
+
+[profile.ci-slow]
+# The `slow` job's tier: real FSEvents, real inotify, real elapsed time, and
+# two thread races. Serial, because the only load should be its own.
+fail-fast = false
+test-threads = 1
+
+# Deliberately NO retries here, unlike `ci` above. This tier exists because
+# these tests assert a duration, a batch or a count that a contended runner
+# cannot hold still, and a quiet serial job is already the answer to that. A
+# retry would instead let a real debouncer regression through, which is the
+# one thing the tier was carved out to protect.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -253,7 +253,13 @@ jobs:
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
         if: ${{ needs.changes.outputs.rust == 'true' || needs.changes.result != 'success' || github.event_name == 'workflow_dispatch' }}
       # `--all-features` mirrors the task gate, as in `lint` above.
-      - run: 'cargo +${{ matrix.toolchain }} test --workspace --locked --all-features -- --skip ::slow:: --skip two_concurrent_boots --skip signal_ignored_then_kill_tree_reaps --skip a_reload_costs_a'
+      - uses: taiki-e/install-action@nextest
+        if: ${{ needs.changes.outputs.rust == 'true' || needs.changes.result != 'success' || github.event_name == 'workflow_dispatch' }}
+      - run: "cargo +${{ matrix.toolchain }} nextest run --profile ci --workspace --locked --all-features -E 'not (test(::slow::) or test(two_concurrent_boots) or test(signal_ignored_then_kill_tree_reaps) or test(a_reload_costs_a))'"
+        if: ${{ needs.changes.outputs.rust == 'true' || needs.changes.result != 'success' || github.event_name == 'workflow_dispatch' }}
+      # nextest does not run doctests at all, so they need their own line
+      # or they stop running on this platform. 14 of them, 6.8s warm.
+      - run: 'cargo +${{ matrix.toolchain }} test --workspace --locked --all-features --doc'
         if: ${{ needs.changes.outputs.rust == 'true' || needs.changes.result != 'success' || github.event_name == 'workflow_dispatch' }}
   minimal-versions:
     needs: changes
@@ -267,7 +273,9 @@ jobs:
       - run: rustup toolchain install nightly stable --profile minimal
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
       - run: cargo +nightly generate-lockfile -Z minimal-versions
-      - run: 'cargo +stable test --workspace -- --skip ::slow:: --skip two_concurrent_boots --skip signal_ignored_then_kill_tree_reaps --skip a_reload_costs_a'
+      - uses: taiki-e/install-action@nextest
+      - run: "cargo +stable nextest run --profile ci --workspace -E 'not (test(::slow::) or test(two_concurrent_boots) or test(signal_ignored_then_kill_tree_reaps) or test(a_reload_costs_a))'"
+      - run: 'cargo +stable test --workspace --doc'
   musl:
     needs: changes
     if: ${{ !cancelled() && (needs.changes.outputs.rust == 'true' || needs.changes.result != 'success' || github.event_name == 'workflow_dispatch') }}
@@ -298,7 +306,9 @@ jobs:
       # serialising. The number is a judgement call and the headroom is
       # large, since this job has been running 132 to 185 seconds against a
       # twenty-minute timeout. If it flakes here again, one is affordable.
-      - run: 'cargo test --workspace --locked --target x86_64-unknown-linux-musl -- --test-threads=2 --skip ::slow:: --skip two_concurrent_boots --skip signal_ignored_then_kill_tree_reaps --skip a_reload_costs_a'
+      - uses: taiki-e/install-action@nextest
+      - run: "cargo nextest run --profile ci --workspace --locked --target x86_64-unknown-linux-musl --test-threads 2 -E 'not (test(::slow::) or test(two_concurrent_boots) or test(signal_ignored_then_kill_tree_reaps) or test(a_reload_costs_a))'"
+      - run: 'cargo test --workspace --locked --target x86_64-unknown-linux-musl --doc'
   # CLAUDE.md's phase-gate cross-check
   # (`cargo check --workspace --all-targets --all-features --target
   # x86_64-pc-windows-gnu`) had no workflow behind it, so it only ran when a
@@ -360,7 +370,11 @@ jobs:
         if: ${{ needs.changes.outputs.rust == 'true' || needs.changes.result != 'success' || github.event_name == 'workflow_dispatch' }}
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
         if: ${{ needs.changes.outputs.rust == 'true' || needs.changes.result != 'success' || github.event_name == 'workflow_dispatch' }}
-      - run: 'cargo test -p shep-daemon --locked --no-default-features -- --skip ::slow:: --skip two_concurrent_boots --skip signal_ignored_then_kill_tree_reaps --skip a_reload_costs_a'
+      - uses: taiki-e/install-action@nextest
+        if: ${{ needs.changes.outputs.rust == 'true' || needs.changes.result != 'success' || github.event_name == 'workflow_dispatch' }}
+      - run: "cargo nextest run --profile ci -p shep-daemon --locked --no-default-features -E 'not (test(::slow::) or test(two_concurrent_boots) or test(signal_ignored_then_kill_tree_reaps) or test(a_reload_costs_a))'"
+        if: ${{ needs.changes.outputs.rust == 'true' || needs.changes.result != 'success' || github.event_name == 'workflow_dispatch' }}
+      - run: 'cargo test -p shep-daemon --locked --no-default-features --doc'
         if: ${{ needs.changes.outputs.rust == 'true' || needs.changes.result != 'success' || github.event_name == 'workflow_dispatch' }}
       # shep-client's `schema` feature is ON by default and a dog is
       # allowed to turn it off, so the opt-out needs a leg of its own: the
@@ -372,7 +386,9 @@ jobs:
       # way and only a doctest run reads it.
       - run: cargo test -p shep-client --locked --no-default-features
         if: ${{ needs.changes.outputs.rust == 'true' || needs.changes.result != 'success' || github.event_name == 'workflow_dispatch' }}
-      - run: 'cargo test --workspace --locked --all-features -- --skip ::slow:: --skip two_concurrent_boots --skip signal_ignored_then_kill_tree_reaps --skip a_reload_costs_a'
+      - run: "cargo nextest run --profile ci --workspace --locked --all-features -E 'not (test(::slow::) or test(two_concurrent_boots) or test(signal_ignored_then_kill_tree_reaps) or test(a_reload_costs_a))'"
+        if: ${{ needs.changes.outputs.rust == 'true' || needs.changes.result != 'success' || github.event_name == 'workflow_dispatch' }}
+      - run: 'cargo test --workspace --locked --all-features --doc'
         if: ${{ needs.changes.outputs.rust == 'true' || needs.changes.result != 'success' || github.event_name == 'workflow_dispatch' }}
   # Tests that need a quiet machine, run serially in a job of their own.
   #
@@ -443,7 +459,8 @@ jobs:
       - uses: actions/checkout@v4
       - run: rustup toolchain install stable --profile minimal
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
-      - run: 'cargo test --workspace --locked --all-features -- --test-threads=1 ::slow:: two_concurrent_boots signal_ignored_then_kill_tree_reaps a_reload_costs_a'
+      - uses: taiki-e/install-action@nextest
+      - run: "cargo nextest run --profile ci-slow --workspace --locked --all-features -E 'test(::slow::) or test(two_concurrent_boots) or test(signal_ignored_then_kill_tree_reaps) or test(a_reload_costs_a)'"
   # `cargo llvm-cov` on its own runs `cargo test --tests`, and `--tests` does
   # not build a package's examples. Four of `daemon_e2e`'s reload tests exec
   # `examples/reuse_port_sheep`, the SO_REUSEPORT fixture the whole reload
@@ -473,10 +490,11 @@ jobs:
       - run: rustup toolchain install stable --profile minimal --component llvm-tools
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
       - uses: taiki-e/install-action@cargo-llvm-cov
+      - uses: taiki-e/install-action@nextest
       - run: |
           source <(cargo llvm-cov show-env --sh)
           cargo llvm-cov clean --workspace
-          cargo test --workspace --locked -- --skip ::slow:: --skip two_concurrent_boots --skip signal_ignored_then_kill_tree_reaps --skip a_reload_costs_a
+          cargo nextest run --profile ci --workspace --locked -E 'not (test(::slow::) or test(two_concurrent_boots) or test(signal_ignored_then_kill_tree_reaps) or test(a_reload_costs_a))'
           cargo llvm-cov report --lcov --output-path lcov.info
       - uses: actions/upload-artifact@v4
         with: { name: coverage, path: lcov.info }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -196,6 +196,23 @@ on a project where doctests dominated. It does not transfer: this workspace's
 cost is the integration tier (`cli_e2e` ~47s, `daemon_e2e` ~22s), which
 `--lib --bins` would skip entirely rather than speed up. Keep the bare form.
 
+**This holds for the LOCAL gate. CI splits them, because nextest cannot run
+them at all.** As of 2026-09-04 every CI leg that used to run `cargo test`
+runs `cargo nextest run` plus a separate `cargo test --doc`, so a flaky
+integration test can be retried without retrying anything else. That split is
+forced by the tool rather than chosen, and it is cheap: measured the same day
+on this machine, warm, doctests alone are **6.8s**, not the 30.9s above, which
+was a colder tree. `cargo nextest run` over the same skip set is **26.1s**
+against `cargo test`'s **45.2s**, so a leg is faster even paying for the
+second command.
+
+Two numbers to keep straight when a count looks wrong. `cargo test --workspace
+--all-features` over the skip set reports **2525**; nextest reports **2511**,
+and the missing **14** are exactly the doctests it does not run. The two
+filtersets in the workflow partition the suite with nothing dropped: 2511 in
+the ordinary legs plus 30 in `slow` is 2541, which is every non-doctest test.
+Nothing here changes the local gate: keep running bare `cargo test`.
+
 ### The phase gate — run at a merge, not per task
 
 The four above, plus `cargo test --workspace --all-features -- --test-threads=1`


### PR DESCRIPTION
Follow-up to #125, which fixed two CI-only failures that turned out to be real defects. The residual flake class is genuine and will not be fixed away: `cli_e2e` spawns a real shepherd and real sheep per case, and the musl leg already caps its thread count for that reason.

- every leg that ran `cargo test` now runs `cargo nextest run --profile ci`
- retries, 2, on the integration tier only (`kind(test)`, 165 tests), never on the unit tiers (`kind(lib)`, 2376)
- `slow` gets its own `ci-slow` profile: serial, and deliberately no retries
- each converted leg gains a `cargo test --doc` line, since nextest does not run doctests
- `cargo test -p shep-client --no-default-features` stays on cargo, per its own comment

### Why the slow tier gets no retries

That tier exists because its tests assert a duration, a batch or a count that a contended runner cannot hold still, and a quiet serial job is already the answer. A retry there would let a debouncer regression through, which is the one thing the tier was carved out to protect.

### The filter translation is exact

libtest's `--skip` is a substring match and nextest's `test()` is too, so the four skips become one `not (...)` expression and the `slow` job's positional filters become the same expression without the `not`. Verified by counting rather than by reading docs: the two filtersets select 2511 and 30, summing to 2541, the whole non-doctest suite, no overlap and no gap.

### Doctests

`CLAUDE.md` argues against splitting doctests out and that still holds for the local gate. This is CI, the split is forced by the tool, and it is cheap. Measured warm on this machine today:

| | tests | wall clock |
|---|---|---|
| `cargo test` over the skip set | 2525 incl. doctests | 45.2s |
| `cargo nextest run` + `cargo test --doc` | 2511 + 14 | 26.1s + 6.8s |

So a leg is faster even paying for the second command. The 6.8s corrects `CLAUDE.md`'s 30.9s, which came off a colder tree.

### Verified locally

- `--profile ci` over the skip set: 2511 passed, 26.1s
- `--profile ci-slow` over the slow set: 30 passed, 39.4s
- doctests: 14 passed, 6.8s
- coverage end to end, `llvm-cov show-env` then nextest then `llvm-cov report`: 2511 passed, `lcov.info` written, both exit 0

musl keeps `--test-threads 2`. Process-per-test may make it unnecessary, but that is a separate measurement and this swaps the tool without changing what runs.

Not verified locally: the Windows and Linux legs, and whether `taiki-e/install-action@nextest` behaves on the musl job. CI is the check for those.

One thing nextest reports that `cargo test` never did: two tests pass while leaking a handle, `lookout::view::tests::drawing_never_panics_across_the_size_sweep` and its settings-screen sibling, both from #124. Not touched here, and not a failure.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated CI test runs to use `cargo-nextest` across standard, minimal-version, musl, feature, slow, and coverage workflows.
  * Added retry handling for selected integration tests and serial execution for slow test runs.
  * Doctests continue to run separately through `cargo test`.

* **Documentation**
  * Clarified local and CI test commands, doctest handling, timing differences, and test-count variations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->