### PR TITLE
fix: break the dev-dependency cycle that deadlocked the 0.2.2 release

### DIFF
--- a/.github/workflows/manifests.yml
+++ b/.github/workflows/manifests.yml
@@ -1,0 +1,51 @@
+name: manifests
+# Rejects a pull request that would deadlock the release.
+#
+# Another release-correctness gate wearing a lint's clothes, and a sibling to
+# commits.yml. That one guards what release-plz can READ; this one guards what
+# cargo can PUBLISH.
+#
+# `cargo publish` treats the two dependency kinds oppositely. A normal
+# dependency has its `path` stripped and needs a `version` to put in its place,
+# which is why every entry in the root `[workspace.dependencies]` table carries
+# one. A dev-dependency WITH a version is kept in the published manifest and has
+# to resolve; one without is dropped outright. So a version on an
+# intra-workspace dev-dependency is a publish-order constraint, not a
+# formality, and `workspace = true` inherits one without looking like it does.
+#
+# Measured, because this is what it cost: shep-macros dev-depended on
+# shep-client that way, shep-client depends on shep-macros normally, and
+# neither could publish first. The 0.2.2 release died partway through with
+#
+#   failed to select a version for the requirement `shep-client = "^0.2.2"`
+#   candidate versions found which didn't match: 0.2.0, 0.1.34, 0.1.33, ...
+#
+# after shep-core and shep-daemon had already gone out, leaving the workspace
+# split across two versions on crates.io until someone noticed.
+#
+# Nothing off the shelf catches this. cargo-deny covers bans, licences,
+# advisories and sources; cargo-semver-checks covers the API. release-plz does
+# catch it, at publish time, which is the outage rather than a warning about it.
+#
+# The script runs locally too, and takes about a second:
+#
+#   python3 scripts/check-dev-deps.py
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  dev-dependencies:
+    name: intra-workspace dev-dependencies
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      # No toolchain and no cargo. The check reads the manifests with tomllib
+      # and never resolves anything, so it wants a Python and nothing else.
+      # ubuntu-latest ships 3.12; tomllib landed in 3.11.
+      - name: Check every intra-workspace dev-dependency is path-only
+        run: python3 scripts/check-dev-deps.py

--- a/crates/shep-cli/Cargo.toml
+++ b/crates/shep-cli/Cargo.toml
@@ -255,7 +255,13 @@ tokio = { workspace = true, features = ["test-util", "rt-multi-thread"] }
 # the hand-rolled daemon fakes this crate's command tests drive. A
 # dev-dependency, so the feature is on for the test targets and off for the
 # shipped binary.
-shep-client = { workspace = true, features = ["test-support"] }
+# Path-only, with no `version`, for the reason `crates/shep-macros/Cargo.toml`
+# spells out: `cargo publish` keeps a dev-dependency that carries a version and
+# drops one that does not, so a version here would make packaging this crate
+# require a shep-client release that may not exist yet. That is not a deadlock
+# from this side, since shep publishes last, but it is the same publish-order
+# constraint and it buys nothing. `scripts/check-dev-deps.py` enforces the rule.
+shep-client = { path = "../shep-client", features = ["test-support"] }
 # Snapshot coverage for `--format json` payloads.
 insta.workspace = true
 # The real-binary e2e tier (`tests/cli_e2e.rs`).

--- a/crates/shep-macros/Cargo.toml
+++ b/crates/shep-macros/Cargo.toml
@@ -27,7 +27,14 @@ proc-macro2.workspace = true
 # means publishing a snippet nothing compiles for the one crate whose whole
 # job is to turn a typo into a compile error.
 [dev-dependencies]
-shep-client.workspace = true
+# Path-only, with no `version`, DELIBERATELY. `cargo publish` strips `path`
+# and keeps whatever `version` a dependency carries, so the workspace entry's
+# `version = "0.2.x"` would make packaging this crate require a shep-client
+# release that cannot exist yet: shep-client depends on this crate normally, so
+# it publishes AFTER it. A dev-dependency with no version is dropped from the
+# published manifest outright, which is what breaks the cycle. Keep it inline —
+# `workspace = true` pulls the version back in.
+shep-client = { path = "../shep-client" }
 schemars.workspace = true
 serde.workspace = true
 

--- a/scripts/check-dev-deps.py
+++ b/scripts/check-dev-deps.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""Refuse an intra-workspace dev-dependency that carries a version.
+
+`cargo publish` treats the two dependency kinds oppositely. A normal
+dependency has its `path` stripped and NEEDS a `version` to put in its place,
+which is why every entry in the root `[workspace.dependencies]` table carries
+one. A dev-dependency with a version is kept in the published manifest and has
+to resolve; a dev-dependency without one is dropped outright.
+
+So a version on an intra-workspace dev-dependency is never a formality. It is
+a publish-order constraint: packaging crate A now requires crate B to already
+be on crates.io at that exact version. When B depends on A normally, B
+publishes after A and cannot exist yet, and neither crate can go first:
+
+    error: failed to prepare local package for uploading
+    Caused by:
+      failed to select a version for the requirement `shep-client = "^0.2.2"`
+      candidate versions found which didn't match: 0.2.0, 0.1.34, 0.1.33, ...
+      required by package `shep-macros v0.2.2`
+
+That is not hypothetical. It stopped the 0.2.2 release after shep-core and
+shep-daemon had already published, stranding shep-macros, shep-client and shep
+at 0.2.0 while the two halves of the workspace sat at different versions.
+
+The trap is `workspace = true`, which reads as inheriting a path and silently
+inherits the version alongside it. Write such an entry inline instead, with a
+path and no version:
+
+    shep-client = { path = "../shep-client" }
+
+Exits 0 when every intra-workspace dev-dependency is path-only, 1 otherwise.
+"""
+
+from __future__ import annotations
+
+import sys
+import tomllib
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+def dev_dep_tables(manifest: dict) -> list[tuple[str, dict]]:
+    """Every dev-dependency table in a manifest, including per-target ones.
+
+    `[target.'cfg(unix)'.dev-dependencies]` is as much a publish-order
+    constraint as the plain table, and shep-client already has one.
+    """
+    tables = []
+    if isinstance(plain := manifest.get("dev-dependencies"), dict):
+        tables.append(("dev-dependencies", plain))
+    for cfg, table in (manifest.get("target") or {}).items():
+        if isinstance(scoped := (table or {}).get("dev-dependencies"), dict):
+            tables.append((f"target.{cfg}.dev-dependencies", scoped))
+    return tables
+
+
+def carries_a_version(entry, name: str, workspace_deps: dict) -> str | None:
+    """The version this entry would publish with, or None if it publishes clean.
+
+    A bare string IS a version. `workspace = true` inherits whatever the root
+    table declares, which for an intra-workspace crate is always a version.
+    """
+    if isinstance(entry, str):
+        return entry
+    if not isinstance(entry, dict):
+        return None
+    if entry.get("workspace") is True:
+        inherited = workspace_deps.get(name)
+        if isinstance(inherited, str):
+            return inherited
+        if isinstance(inherited, dict):
+            return inherited.get("version")
+        return None
+    return entry.get("version")
+
+
+def main() -> int:
+    root = tomllib.loads((ROOT / "Cargo.toml").read_text())
+    workspace = root["workspace"]
+    workspace_deps = workspace.get("dependencies", {})
+
+    # `publish = false` members are skipped deliberately. Nothing packages them,
+    # so a version on one of their dev-dependencies constrains no release, and
+    # refusing it would be a false rejection. A gate that blocks correct work is
+    # worse than one that misses: `examples` is the member this covers.
+    members = {}
+    for member in workspace["members"]:
+        path = ROOT / member / "Cargo.toml"
+        manifest = tomllib.loads(path.read_text())
+        if manifest["package"].get("publish") is False:
+            continue
+        members[manifest["package"]["name"]] = (member, manifest)
+
+    offenders = []
+    for name, (member, manifest) in sorted(members.items()):
+        for table_name, table in dev_dep_tables(manifest):
+            for dep, entry in table.items():
+                if dep not in members:
+                    continue
+                version = carries_a_version(entry, dep, workspace_deps)
+                if version is not None:
+                    offenders.append((member, table_name, name, dep, version))
+
+    # To stderr, like the explanation below it: stdout is block-buffered when a
+    # CI runner captures it and stderr is not, so splitting the two reorders the
+    # offender list after the paragraph explaining it.
+    for member, table, name, dep, version in offenders:
+        print(
+            f"  {member}  [{table}]  {name} dev-depends on {dep} = \"{version}\"",
+            file=sys.stderr,
+        )
+
+    if offenders:
+        print(
+            f"\n{len(offenders)} intra-workspace dev-dependency(ies) above carry a version.\n"
+            "\n"
+            "cargo publish keeps a dev-dependency that has a version and drops one\n"
+            "that does not, so each of these makes packaging its crate require a\n"
+            "release of the other that may not exist yet. Where the other crate\n"
+            "depends back on this one normally, neither can publish first and the\n"
+            "release deadlocks partway through, leaving the workspace split across\n"
+            "two versions on crates.io.\n"
+            "\n"
+            "Write the entry inline with a path and no version:\n"
+            "\n"
+            "    shep-client = { path = \"../shep-client\" }\n"
+            "\n"
+            "workspace = true is the trap: it inherits the version too.",
+            file=sys.stderr,
+        )
+        return 1
+
+    checked = sum(len(dev_dep_tables(m)) for _, m in members.values())
+    print(
+        f"Every intra-workspace dev-dependency is path-only "
+        f"({len(members)} members, {checked} dev-dependency table(s))."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
The 0.2.2 release deadlocked halfway through: shep-core and shep-daemon published, shep-macros/shep-client/shep are still at 0.2.0 on crates.io.

shep-macros dev-depended on shep-client through `workspace = true`, which inherits a version alongside the path. `cargo publish` keeps a versioned dev-dependency and makes it resolve, but shep-client depends on shep-macros normally and publishes after it, so neither could go first.

- Make the shep-macros dev-dependency path-only, which drops it from the published manifest
- Same for shep-cli, which had the pattern without the cycle
- Add `scripts/check-dev-deps.py` and a `manifests` workflow so a third one cannot reach a release

Installs were never affected: `cargo install shep` resolves to 0.2.0 and exits 0, verified against the real registry.

`cargo publish -p shep-macros --dry-run` packages and verifies now. The new check exits 0 on this tree and exits 1 with the shep-macros entry put back. fmt, clippy, `cargo test --workspace --all-features` and doc are all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Added automated checks to ensure publishable workspace packages use local, path-only development dependencies.
  - Validation now covers standard and target-specific development dependency declarations and reports actionable errors when invalid versions are found.
  - Non-publishable workspace members are excluded from these checks.

- **Bug Fixes**
  - Updated development dependency declarations to avoid requiring versions for local workspace dependencies during publication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->