### PR TITLE
chore: release v0.2.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2058,7 +2058,7 @@ dependencies = [
 
 [[package]]
 name = "shep"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "anstyle",
  "assert_cmd",
@@ -2096,11 +2096,11 @@ dependencies = [
 
 [[package]]
 name = "shep-cli"
-version = "0.2.2"
+version = "0.2.3"
 
 [[package]]
 name = "shep-client"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "futures-util",
  "nix 0.29.0",
@@ -2116,7 +2116,7 @@ dependencies = [
 
 [[package]]
 name = "shep-core"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "annotate-snippets",
  "anstyle",
@@ -2146,7 +2146,7 @@ dependencies = [
 
 [[package]]
 name = "shep-daemon"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "bytes",
  "chrono",
@@ -2175,14 +2175,14 @@ dependencies = [
 
 [[package]]
 name = "shep-examples"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "nix 0.29.0",
 ]
 
 [[package]]
 name = "shep-macros"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "proc-macro2",
  "quote 1.0.47",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.2"
+version = "0.2.3"
 edition = "2024"
 # 1.88: serde-saphyr's let-chains need it; also the floor ratatui, sysinfo
 # and rmcp require.
@@ -27,10 +27,10 @@ license = "MIT OR Apache-2.0"
 # cargo publish strips `path`, so these need a literal version even though
 # every consumer here resolves by path. Not sourced from
 # workspace.package.version above; a release bump touches both by hand.
-shep-core = { path = "crates/shep-core", version = "0.2.2" }
-shep-daemon = { path = "crates/shep-daemon", version = "0.2.2" }
-shep-client = { path = "crates/shep-client", version = "0.2.2" }
-shep-macros = { path = "crates/shep-macros", version = "0.2.2" }
+shep-core = { path = "crates/shep-core", version = "0.2.3" }
+shep-daemon = { path = "crates/shep-daemon", version = "0.2.3" }
+shep-client = { path = "crates/shep-client", version = "0.2.3" }
+shep-macros = { path = "crates/shep-macros", version = "0.2.3" }
 serde = { version = "1", default-features = false, features = ["derive"] }
 serde_json = { version = "1", default-features = false, features = ["std"] }
 toml = { version = "0.8", default-features = false, features = ["parse", "display"] }

--- a/crates/shep-cli/CHANGELOG.md
+++ b/crates/shep-cli/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.3] - 2026-09-05
+
+
 ## [0.2.2] - 2026-09-04
 
 ### Added

--- a/crates/shep-client/CHANGELOG.md
+++ b/crates/shep-client/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.3] - 2026-09-05
+
+
 ## [0.2.2] - 2026-09-04
 
 ### Fixed

--- a/crates/shep-core/CHANGELOG.md
+++ b/crates/shep-core/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.3] - 2026-09-05
+
+
 ## [0.2.2] - 2026-09-04
 
 

--- a/crates/shep-daemon/CHANGELOG.md
+++ b/crates/shep-daemon/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.3] - 2026-09-05
+
+
 ## [0.2.2] - 2026-09-04
 
 ### Fixed

--- a/crates/shep-macros/CHANGELOG.md
+++ b/crates/shep-macros/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.3] - 2026-09-05
+
+
 ## [0.2.2] - 2026-09-04
 
 


### PR DESCRIPTION



## 🤖 New release

* `shep-core`: 0.2.2 -> 0.2.3 (✓ API compatible changes)
* `shep-daemon`: 0.2.2 -> 0.2.3 (✓ API compatible changes)
* `shep-macros`: 0.2.2 -> 0.2.3
* `shep-client`: 0.2.2 -> 0.2.3 (✓ API compatible changes)
* `shep`: 0.2.2 -> 0.2.3 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>







</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).