### PR TITLE
test(daemon): the drop test waits for the channel to close

### DIFF
--- a/crates/shep-daemon/src/watch/mod.rs
+++ b/crates/shep-daemon/src/watch/mod.rs
@@ -345,8 +345,8 @@ async fn run_group(
 ///
 /// One owner rather than a copy per suite, since every one of them
 /// drives the same debouncer at the same delay. `TEST_DELAY` and
-/// `NO_EVENT_WINDOW` are load-bearing together; see the assertion beside
-/// `dropping_the_source_stops_delivery` in `source`.
+/// `NO_EVENT_WINDOW` are load-bearing together; see the assertion at the
+/// top of `source`'s tests.
 #[cfg(test)]
 pub(crate) mod real_time {
     use core::time::Duration;

--- a/crates/shep-daemon/src/watch/source.rs
+++ b/crates/shep-daemon/src/watch/source.rs
@@ -215,14 +215,13 @@ mod tests {
     use super::*;
     use crate::watch::real_time::{NO_EVENT_WINDOW, SMOKE_DEADLINE, TEST_DELAY};
 
-    // `NO_EVENT_WINDOW` must stay several `TEST_DELAY`s wide, or a leaked
-    // debouncer's stray batch could land after the window closes and
-    // `dropping_the_source_stops_delivery` would stop catching it.
+    // `NO_EVENT_WINDOW` must stay several `TEST_DELAY`s wide: a debounced
+    // batch takes up to one delay to land, so a window narrower than that
+    // proves nothing when it stays quiet.
     const _: () = assert!(
         NO_EVENT_WINDOW.as_millis() >= TEST_DELAY.as_millis() * 4,
-        "NO_EVENT_WINDOW must stay at least 4x TEST_DELAY, or \
-         dropping_the_source_stops_delivery stops catching a leaked \
-         debouncer guard"
+        "NO_EVENT_WINDOW must stay at least 4x TEST_DELAY, or a quiet window \
+         proves nothing about a debounced event that has not landed yet"
     );
 
     /// Canonicalizes `dir`'s path: on macOS, `TempDir::path()` returns a
@@ -440,8 +439,8 @@ mod tests {
         }
 
         // fails if the debouncer guard is leaked (kept alive past the
-        // `WatchSource`'s drop): a write after the drop would still reach
-        // `rx` within the window below.
+        // `WatchSource`'s drop): the OS thread then never lets go of its
+        // sender, and the channel never closes.
         #[tokio::test]
         async fn dropping_the_source_stops_delivery() {
             let dir = tempfile::tempdir().unwrap();
@@ -461,23 +460,20 @@ mod tests {
             .await;
 
             drop(source);
-            std::fs::write(root.join("second.txt"), b"hello").unwrap();
 
-            // A stray batch naming `first.txt` is not the leak: the
-            // debouncer's OS thread may emit one final batch after the
-            // stop flag flips. Only a batch naming `second.txt`, written
-            // after the drop, means delivery did not stop.
-            let deadline = Instant::now() + NO_EVENT_WINDOW;
-            // Loop, not one recv: a first.txt straggler must not hide a
-            // second.txt leak arriving right after it in the same window.
+            // Delivery has stopped when the channel closes, which the thread
+            // does by exiting; a batch on the way out is the documented final
+            // one. A write after the drop would prove nothing: a thread still
+            // winding down can see it, and a thread that has exited cannot.
+            let deadline = Instant::now() + SMOKE_DEADLINE;
             loop {
                 let remaining = deadline.saturating_duration_since(Instant::now());
                 match timeout(remaining, rx.recv()).await {
-                    Err(_) => break,   // window elapsed with nothing further, expected
-                    Ok(None) => break, // sender dropped alongside the debouncer thread, expected
-                    Ok(Some(batch)) => assert!(
-                        !batch.paths.iter().any(|p| p.ends_with("second.txt")),
-                        "unexpected batch delivered after WatchSource was dropped: {batch:?}"
+                    Ok(None) => break,
+                    Ok(Some(_)) => continue,
+                    Err(_) => panic!(
+                        "the watcher thread outlived its WatchSource by {SMOKE_DEADLINE:?}: \
+                         the debouncer guard leaked"
                     ),
                 }
             }


### PR DESCRIPTION
Follow-up to #134, from a CodeRabbit comment that landed after the merge.

- `dropping_the_source_stops_delivery` wrote `second.txt` right after the drop and asserted it never arrived. WatchSource's own doc says the debouncer thread can still emit one batch on its way out, so that write could be delivered with nothing leaked
- it now waits for the receiver to close, which the same doc names as the shutdown signal. A channel that never closes is the leak, and the case fails saying so
- the NO_EVENT_WINDOW floor keeps its assertion, reworded to the reason that still holds

20 of 20 on the slow watch module locally, clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Clarified timing expectations for filesystem watcher tests.
  * Updated shutdown testing to allow final event batches while ensuring the receiver closes and background processing stops within the expected timeframe.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->