### PR TITLE
fix(cli): sanitize cells in the bare table renderer too

### DIFF
--- a/crates/shep-cli/src/output/table.rs
+++ b/crates/shep-cli/src/output/table.rs
@@ -2,7 +2,7 @@
 //! two pieces of `--format table` independent of any payload type.
 
 use super::Render;
-use super::width::visible_width;
+use super::width::{sanitize_cell_without_ansi, visible_width};
 
 /// Renders any payload as the padded table, returned rather than printed so
 /// a test can read it. [`emit`](super::emit) calls this for `Format::Table`.
@@ -10,7 +10,8 @@ use super::width::visible_width;
 /// Column widths come from the widest cell in each column, header included,
 /// measured in display columns via [`visible_width`] so a CJK or emoji cell
 /// pads correctly. Cells are separated by two spaces with no box-drawing
-/// characters. An empty payload still prints the header row.
+/// characters. An empty payload still prints the header row. Every cell goes
+/// through [`sanitize_cell_without_ansi`] first.
 ///
 /// # Panics
 /// If any row `T::rows()` returns has a different number of cells than
@@ -19,7 +20,19 @@ use super::width::visible_width;
 #[track_caller]
 pub fn render_table<T: Render>(data: &T) -> String {
     let headers = T::headers();
-    let rows = data.rows();
+    // Sanitised once, ahead of the width pass, so measuring and printing see
+    // the same bytes. This surface never colours, so a well-formed CSI
+    // sequence drops here where the boxed renderer keeps its own.
+    let rows: Vec<Vec<String>> = data
+        .rows()
+        .iter()
+        .map(|row| {
+            row.iter()
+                .map(String::as_str)
+                .map(sanitize_cell_without_ansi)
+                .collect()
+        })
+        .collect();
 
     for row in &rows {
         assert_eq!(
@@ -448,6 +461,16 @@ mod tests {
     fn info_with_name(name: &str) -> shep_core::protocol::ProcessInfo {
         shep_core::protocol::ProcessInfo::builder(1, name, shep_core::status::ProcStatus::Online)
             .build()
+    }
+
+    /// fails if a forged colour reaches the bare table. `shep-core`'s
+    /// `normalize()` rejects only `/`, `\`, `.` and `..` in a name, so an
+    /// escape gets this far from an app an operator started.
+    #[test]
+    fn a_name_carrying_an_escape_leaves_no_escape_in_the_table() {
+        let out = render_table(&FlockRows(vec![info_with_name("web\u{1b}[31mworker")]));
+        assert!(!out.contains('\u{1b}'), "escape survived: {out:?}");
+        assert!(out.contains("webworker"), "the printable text stays: {out}");
     }
 
     /// `MemSize`'s own Display only names a unit that divides the value

--- a/crates/shep-cli/src/output/width.rs
+++ b/crates/shep-cli/src/output/width.rs
@@ -57,6 +57,22 @@ pub(crate) fn visible_width(s: &str) -> usize {
 /// dropped.
 #[must_use]
 pub(crate) fn sanitize_cell(s: &str) -> String {
+    sanitize(s, true)
+}
+
+/// [`sanitize_cell`] for a surface that emits no colour of its own, where a
+/// well-formed ANSI escape is dropped rather than kept.
+///
+/// `bare` style colours nothing, so an escape reaching one of its cells came
+/// from an app name and has only the operator's terminal left to drive.
+#[must_use]
+pub(crate) fn sanitize_cell_without_ansi(s: &str) -> String {
+    sanitize(s, false)
+}
+
+/// The body both spellings share. `keep_ansi` decides the single
+/// difference: whether a well-formed CSI sequence is written out or dropped.
+fn sanitize(s: &str, keep_ansi: bool) -> String {
     let mut out = String::with_capacity(s.len());
     let mut chars = s.chars();
     while let Some(c) = chars.next() {
@@ -71,7 +87,7 @@ pub(crate) fn sanitize_cell(s: &str) -> String {
                         break;
                     }
                 }
-                if closed {
+                if closed && keep_ansi {
                     out.push_str(&seq);
                 }
             }


### PR DESCRIPTION
Only `render_boxed_ex` sanitized its cells. `render_table` did not, and `table_of` picks between them on `StyleLevel::boxes()`, which is false only for `bare`.

- Every cell in `render_table` now goes through sanitization, before the width pass so measuring and printing see the same bytes
- `sanitize_cell_without_ansi` drops a well-formed CSI sequence where `sanitize_cell` keeps it
- Test renders a row whose name carries an ESC and asserts no ESC byte survives

`bare` colours nothing and `render_table` reads `rows()` rather than `rows_for()`, so no shep-emitted escape reaches it. Nothing to preserve. The boxed path keeps well-formed sequences because its own colouring is made of them.

`shep-core`'s `normalize()` rejects only `/`, `\`, `.` and `..` in a name, so `\r`, `\n`, a bell or an escape in an app name reached the renderer intact. `bare_pins_the_byte_identical_plain_table` already asserted that bare must never emit an escape, but only against shep's own data.

Verified the new test fails against the CSI-preserving spelling: the rendered row still carries the escape.

Green: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`, `cargo test -p shep --lib --all-features -- --skip ::slow::` (1166 passed).

No `web/` regen, no documented behaviour moved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Plain-text tables now remove terminal formatting escape sequences from cell content, preventing them from appearing in displayed output.
  - Table column widths are calculated using sanitized text for more accurate alignment.
  - Other control-character handling remains unchanged.

- **Documentation**
  - Updated documentation to clarify how plain table output handles terminal escape sequences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->