### PR TITLE
chore: release v0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2058,7 +2058,7 @@ dependencies = [
 
 [[package]]
 name = "shep"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anstyle",
  "assert_cmd",
@@ -2096,11 +2096,11 @@ dependencies = [
 
 [[package]]
 name = "shep-cli"
-version = "0.3.0"
+version = "0.4.0"
 
 [[package]]
 name = "shep-client"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "futures-util",
  "nix 0.29.0",
@@ -2116,7 +2116,7 @@ dependencies = [
 
 [[package]]
 name = "shep-core"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "annotate-snippets",
  "anstyle",
@@ -2146,7 +2146,7 @@ dependencies = [
 
 [[package]]
 name = "shep-daemon"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "bytes",
  "chrono",
@@ -2176,14 +2176,14 @@ dependencies = [
 
 [[package]]
 name = "shep-examples"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "nix 0.29.0",
 ]
 
 [[package]]
 name = "shep-macros"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "proc-macro2",
  "quote 1.0.47",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.0"
+version = "0.4.0"
 edition = "2024"
 # 1.88: serde-saphyr's let-chains need it; also the floor ratatui, sysinfo
 # and rmcp require.
@@ -27,10 +27,10 @@ license = "MIT OR Apache-2.0"
 # cargo publish strips `path`, so these need a literal version even though
 # every consumer here resolves by path. Not sourced from
 # workspace.package.version above; a release bump touches both by hand.
-shep-core = { path = "crates/shep-core", version = "0.3.0" }
-shep-daemon = { path = "crates/shep-daemon", version = "0.3.0" }
-shep-client = { path = "crates/shep-client", version = "0.3.0" }
-shep-macros = { path = "crates/shep-macros", version = "0.3.0" }
+shep-core = { path = "crates/shep-core", version = "0.4.0" }
+shep-daemon = { path = "crates/shep-daemon", version = "0.4.0" }
+shep-client = { path = "crates/shep-client", version = "0.4.0" }
+shep-macros = { path = "crates/shep-macros", version = "0.4.0" }
 serde = { version = "1", default-features = false, features = ["derive"] }
 serde_json = { version = "1", default-features = false, features = ["std"] }
 toml = { version = "0.8", default-features = false, features = ["parse", "display"] }

--- a/crates/shep-cli/CHANGELOG.md
+++ b/crates/shep-cli/CHANGELOG.md
@@ -13,6 +13,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-09-06
+
+### Added
+
+- Dogs get their own section of the flock table
+- E opens a dog's pane from the dashboard
+- A field can offer suggestions without closing its grammar
+- An array field opens a list sub-screen
+- Control is on by default, and --read-only opts out **(BREAKING)**
+- Closing a pane with parked config offers to apply it
+
+### Changed
+
+- Eight field groups, so no group holds half the form
+
+### Fixed
+
+- Enter opens the editor on a suggested field
+- Redact the list pane's Debug, like every pane beside it
+- The read-only refusal names a flag that still exists
+- The apply menu refuses a dead link, like every action key
+- The apply menu expires, and reads the gate itself
+- Reattach four doc comments to the item they describe
+- Correct the comment on the text-only KeyPress arm
+- Mask a secret array field in the list sub-screen
+- Flip the lookout gallery's control mapping to match the new default
+
+
 ## [0.3.0] - 2026-09-05
 
 

--- a/crates/shep-client/CHANGELOG.md
+++ b/crates/shep-client/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-09-06
+
+
 ## [0.3.0] - 2026-09-05
 
 

--- a/crates/shep-core/CHANGELOG.md
+++ b/crates/shep-core/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-09-06
+
+
 ## [0.3.0] - 2026-09-05
 
 

--- a/crates/shep-daemon/CHANGELOG.md
+++ b/crates/shep-daemon/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-09-06
+
+
 ## [0.3.0] - 2026-09-05
 
 ### Added

--- a/crates/shep-macros/CHANGELOG.md
+++ b/crates/shep-macros/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-09-06
+
+
 ## [0.3.0] - 2026-09-05
 
 


### PR DESCRIPTION



## 🤖 New release

* `shep-core`: 0.3.0 -> 0.4.0 (✓ API compatible changes)
* `shep-daemon`: 0.3.0 -> 0.4.0
* `shep-macros`: 0.3.0 -> 0.4.0
* `shep-client`: 0.3.0 -> 0.4.0
* `shep`: 0.3.0 -> 0.4.0 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>





## `shep`

<blockquote>

## [0.4.0] - 2026-09-06

### Added

- Dogs get their own section of the flock table
- E opens a dog's pane from the dashboard
- A field can offer suggestions without closing its grammar
- An array field opens a list sub-screen
- Control is on by default, and --read-only opts out **(BREAKING)**
- Closing a pane with parked config offers to apply it

### Changed

- Eight field groups, so no group holds half the form

### Fixed

- Enter opens the editor on a suggested field
- Redact the list pane's Debug, like every pane beside it
- The read-only refusal names a flag that still exists
- The apply menu refuses a dead link, like every action key
- The apply menu expires, and reads the gate itself
- Reattach four doc comments to the item they describe
- Correct the comment on the text-only KeyPress arm
- Mask a secret array field in the list sub-screen
- Flip the lookout gallery's control mapping to match the new default
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).