### PR TITLE
chore: release v0.4.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2058,7 +2058,7 @@ dependencies = [
 
 [[package]]
 name = "shep"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anstyle",
  "assert_cmd",
@@ -2096,11 +2096,11 @@ dependencies = [
 
 [[package]]
 name = "shep-cli"
-version = "0.4.0"
+version = "0.4.1"
 
 [[package]]
 name = "shep-client"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "futures-util",
  "nix 0.29.0",
@@ -2116,7 +2116,7 @@ dependencies = [
 
 [[package]]
 name = "shep-core"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "annotate-snippets",
  "anstyle",
@@ -2146,7 +2146,7 @@ dependencies = [
 
 [[package]]
 name = "shep-daemon"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "bytes",
  "chrono",
@@ -2176,14 +2176,14 @@ dependencies = [
 
 [[package]]
 name = "shep-examples"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "nix 0.29.0",
 ]
 
 [[package]]
 name = "shep-macros"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "proc-macro2",
  "quote 1.0.47",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.4.0"
+version = "0.4.1"
 edition = "2024"
 # 1.88: serde-saphyr's let-chains need it; also the floor ratatui, sysinfo
 # and rmcp require.
@@ -27,10 +27,10 @@ license = "MIT OR Apache-2.0"
 # cargo publish strips `path`, so these need a literal version even though
 # every consumer here resolves by path. Not sourced from
 # workspace.package.version above; a release bump touches both by hand.
-shep-core = { path = "crates/shep-core", version = "0.4.0" }
-shep-daemon = { path = "crates/shep-daemon", version = "0.4.0" }
-shep-client = { path = "crates/shep-client", version = "0.4.0" }
-shep-macros = { path = "crates/shep-macros", version = "0.4.0" }
+shep-core = { path = "crates/shep-core", version = "0.4.1" }
+shep-daemon = { path = "crates/shep-daemon", version = "0.4.1" }
+shep-client = { path = "crates/shep-client", version = "0.4.1" }
+shep-macros = { path = "crates/shep-macros", version = "0.4.1" }
 serde = { version = "1", default-features = false, features = ["derive"] }
 serde_json = { version = "1", default-features = false, features = ["std"] }
 toml = { version = "0.8", default-features = false, features = ["parse", "display"] }

--- a/crates/shep-cli/CHANGELOG.md
+++ b/crates/shep-cli/CHANGELOG.md
@@ -13,6 +13,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1] - 2026-09-06
+
+### Fixed
+
+- Refuse a url carrying credentials, and keep a webhook token out of Debug ([#148](https://github.com/shep-pm/shep/pull/148))
+
+
 ## [0.4.0] - 2026-09-06
 
 ### Added

--- a/crates/shep-client/CHANGELOG.md
+++ b/crates/shep-client/CHANGELOG.md
@@ -10,6 +10,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1] - 2026-09-06
+
+### Fixed
+
+- Saturate the deadline grace instead of overflowing ([#146](https://github.com/shep-pm/shep/pull/146))
+
+
 ## [0.4.0] - 2026-09-06
 
 

--- a/crates/shep-core/CHANGELOG.md
+++ b/crates/shep-core/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1] - 2026-09-06
+
+
 ## [0.4.0] - 2026-09-06
 
 

--- a/crates/shep-daemon/CHANGELOG.md
+++ b/crates/shep-daemon/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1] - 2026-09-06
+
+
 ## [0.4.0] - 2026-09-06
 
 

--- a/crates/shep-macros/CHANGELOG.md
+++ b/crates/shep-macros/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1] - 2026-09-06
+
+
 ## [0.4.0] - 2026-09-06
 
 


### PR DESCRIPTION



## 🤖 New release

* `shep-core`: 0.4.0 -> 0.4.1
* `shep-daemon`: 0.4.0 -> 0.4.1
* `shep-macros`: 0.4.0 -> 0.4.1
* `shep-client`: 0.4.0 -> 0.4.1 (✓ API compatible changes)
* `shep`: 0.4.0 -> 0.4.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>




## `shep-client`

<blockquote>

## [0.4.1] - 2026-09-06

### Fixed

- Saturate the deadline grace instead of overflowing ([#146](https://github.com/shep-pm/shep/pull/146))
</blockquote>

## `shep`

<blockquote>

## [0.4.1] - 2026-09-06

### Fixed

- Refuse a url carrying credentials, and keep a webhook token out of Debug ([#148](https://github.com/shep-pm/shep/pull/148))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).