### PR TITLE
style(shep): drop em dashes from lookout's banners and frames gallery

### DIFF
--- a/crates/shep-cli/src/lookout/app.rs
+++ b/crates/shep-cli/src/lookout/app.rs
@@ -1203,6 +1203,18 @@ pub const CONFIRM_EXPIRY: Duration = Duration::from_secs(10);
 /// The sentence `r` and the action keys both give when the link is gone.
 const LINK_GONE: &str = "the shepherd is gone: nothing left to ask";
 
+/// The sentence the status bar and a refused action key both give while
+/// the link is redialling.
+///
+/// One constructor rather than a literal at each site: the banner and a
+/// refusal under it land on the same frame naming the same attempt, so a
+/// second copy is a contradiction waiting to be written. `frames.rs` pins
+/// that agreement by counting the sentence twice in one rendering, which
+/// catches a drift but only after both copies exist to drift apart.
+pub(super) fn retrying_sentence(attempt: u32) -> String {
+    format!("the shepherd stopped answering: reconnecting (attempt {attempt})")
+}
+
 /// The sentence every closed-gate refusal gives, dashboard and settings alike.
 const READ_ONLY_REFUSAL: &str = "read-only: from --read-only or lookout.allow_control";
 
@@ -3356,11 +3368,10 @@ impl App {
     /// dead link refuses the same way whichever door an operator used.
     fn link_refusal(&self) -> Option<String> {
         match self.link {
-            // Not `LINK_GONE`, which says the shepherd is gone: this is the
-            // status bar's own sentence for a redial (`view/status.rs`).
-            Link::Retrying { attempt } => Some(format!(
-                "the shepherd stopped answering: reconnecting (attempt {attempt})"
-            )),
+            // Not `LINK_GONE`, which says the shepherd is gone: a redial
+            // gets the status bar's own sentence, so a refusal and the
+            // banner above it agree on one frame.
+            Link::Retrying { attempt } => Some(retrying_sentence(attempt)),
             // The ladder is exhausted, so the shepherd really is gone.
             Link::Lost { .. } => Some(LINK_GONE.to_string()),
             _ => None,

--- a/crates/shep-cli/src/lookout/app.rs
+++ b/crates/shep-cli/src/lookout/app.rs
@@ -1201,7 +1201,7 @@ pub struct ActionState<'a> {
 pub const CONFIRM_EXPIRY: Duration = Duration::from_secs(10);
 
 /// The sentence `r` and the action keys both give when the link is gone.
-const LINK_GONE: &str = "the shepherd is gone — nothing left to ask";
+const LINK_GONE: &str = "the shepherd is gone: nothing left to ask";
 
 /// The sentence every closed-gate refusal gives, dashboard and settings alike.
 const READ_ONLY_REFUSAL: &str = "read-only: from --read-only or lookout.allow_control";
@@ -3359,7 +3359,7 @@ impl App {
             // Not `LINK_GONE`, which says the shepherd is gone: this is the
             // status bar's own sentence for a redial (`view/status.rs`).
             Link::Retrying { attempt } => Some(format!(
-                "the shepherd stopped answering \u{2014} reconnecting (attempt {attempt})"
+                "the shepherd stopped answering: reconnecting (attempt {attempt})"
             )),
             // The ladder is exhausted, so the shepherd really is gone.
             Link::Lost { .. } => Some(LINK_GONE.to_string()),

--- a/crates/shep-cli/src/lookout/app.rs
+++ b/crates/shep-cli/src/lookout/app.rs
@@ -1203,14 +1203,9 @@ pub const CONFIRM_EXPIRY: Duration = Duration::from_secs(10);
 /// The sentence `r` and the action keys both give when the link is gone.
 const LINK_GONE: &str = "the shepherd is gone: nothing left to ask";
 
-/// The sentence the status bar and a refused action key both give while
-/// the link is redialling.
+/// The redial sentence, for the status bar and for a refused action key.
 ///
-/// One constructor rather than a literal at each site: the banner and a
-/// refusal under it land on the same frame naming the same attempt, so a
-/// second copy is a contradiction waiting to be written. `frames.rs` pins
-/// that agreement by counting the sentence twice in one rendering, which
-/// catches a drift but only after both copies exist to drift apart.
+/// Both render on one frame, so they must agree exactly.
 pub(super) fn retrying_sentence(attempt: u32) -> String {
     format!("the shepherd stopped answering: reconnecting (attempt {attempt})")
 }
@@ -3368,9 +3363,7 @@ impl App {
     /// dead link refuses the same way whichever door an operator used.
     fn link_refusal(&self) -> Option<String> {
         match self.link {
-            // Not `LINK_GONE`, which says the shepherd is gone: a redial
-            // gets the status bar's own sentence, so a refusal and the
-            // banner above it agree on one frame.
+            // Not `LINK_GONE`: the ladder is still running.
             Link::Retrying { attempt } => Some(retrying_sentence(attempt)),
             // The ladder is exhausted, so the shepherd really is gone.
             Link::Lost { .. } => Some(LINK_GONE.to_string()),

--- a/crates/shep-cli/src/lookout/frames.rs
+++ b/crates/shep-cli/src/lookout/frames.rs
@@ -298,7 +298,7 @@ impl Scene {
                 "The shepherd stopped answering. Five attempts over about eight seconds before this becomes the next frame. Every pane below the table keeps describing the selected sheep from the last listing."
             }
             Self::Frozen => {
-                "The ladder ran out. Last known values stay, the uptime clock has stopped, and so has the host strip — one line ticking over on a frozen screen is a contradiction on the same frame."
+                "The ladder ran out. Last known values stay, the uptime clock has stopped, and so has the host strip: one line ticking over on a frozen screen is a contradiction on the same frame."
             }
             Self::Refused => {
                 "`x` with actions gated off. The refusal is literal, nothing about damage gets charming, and the panes below carry on."
@@ -325,7 +325,7 @@ impl Scene {
                 "The selected sheep has never written a log in this $SHEP_HOME. The feed names that cause rather than sitting blank."
             }
             Self::Cramped => {
-                "33 columns: the narrowest terminal that draws. 26 rows — a couple more than the 24-row floor for all three panes being up, so this frame has a little breathing room rather than sitting exactly on the edge. Everything truncates with an ellipsis; nothing overlaps."
+                "33 columns: the narrowest terminal that draws. 26 rows (a couple more than the 24-row floor for all three panes being up), so this frame has a little breathing room rather than sitting exactly on the edge. Everything truncates with an ellipsis; nothing overlaps."
             }
             Self::HostUnknown => {
                 "`sysinfo` reports this platform unsupported. The strip says so and keeps the flock's own totals, which lookout can always compute."
@@ -349,7 +349,7 @@ impl Scene {
                 "The shepherd refused while the request was out, and its own sentence is forwarded rather than rewritten. The sheep has left the flock in the listing behind it, so the table is one row shorter and the cursor has moved to the row below."
             }
             Self::ActionRefusedOffline => {
-                "An action key pressed while the link is coming back. The refusal names the same reconnect attempt the banner above it does, rather than the exhausted-ladder sentence — Phase 16 review Minor #8 caught the two disagreeing on one frame."
+                "An action key pressed while the link is coming back. The refusal names the same reconnect attempt the banner above it does, rather than the exhausted-ladder sentence. Phase 16 review Minor #8 caught the two disagreeing on one frame."
             }
             Self::SettingsFresh => {
                 "The settings screen on a fresh $SHEP_HOME: shep.toml holds only [interpreters], so every scalar's SOURCE column reads `the default` and its VALUE is the compiled fallback. The state most operators open this screen in."
@@ -1303,8 +1303,8 @@ fn settings_snapshot_with_dog_drift() -> SettingsSnapshot {
 /// Not a doc comment on the test: this text is read by a person opening
 /// `docs/lookout/frames.txt` with no context at all, and it is the only
 /// place that says where those frames came from.
-const GALLERY_PREAMBLE: &str = "shep lookout — Phase 16 frames
-================================
+const GALLERY_PREAMBLE: &str = "shep lookout frames
+===================
 
 These are real frames, rendered headlessly through ratatui's TestBackend by
 

--- a/crates/shep-cli/src/lookout/frames.rs
+++ b/crates/shep-cli/src/lookout/frames.rs
@@ -2056,12 +2056,9 @@ mod tests {
         }
     }
 
-    /// The two gallery files' text: the plain rendering, then the ANSI one.
+    /// The two gallery files' text: plain, then ANSI.
     ///
-    /// Split out of [`write_the_gallery`] so the ordinary suite can read the
-    /// same string that test writes. That test is `#[ignore]`d, so anything
-    /// asserted inside it runs only when somebody regenerates the gallery by
-    /// hand, which is the one moment an assertion is least needed.
+    /// Separate from the writer so a non-ignored test can read it.
     fn gallery_text() -> (String, String) {
         let mut plain = String::from(GALLERY_PREAMBLE);
         let mut ansi = String::from(GALLERY_PREAMBLE);
@@ -2080,14 +2077,6 @@ mod tests {
         (plain, ansi)
     }
 
-    /// IR-47 reaches `docs/lookout/`, which is published.
-    ///
-    /// Over the rendered gallery rather than the source constants: the
-    /// preamble, every scene's commentary and every banner a frame draws all
-    /// land in this one string, which is what a reader of the docs and an
-    /// operator on the dashboard actually meet. Nine other modules in this
-    /// crate carry the same pair of assertions; `lookout` carried none, and
-    /// eight dashes reached the published gallery through the gap.
     #[test]
     fn the_gallery_carries_no_dashes() {
         let (plain, ansi) = gallery_text();

--- a/crates/shep-cli/src/lookout/frames.rs
+++ b/crates/shep-cli/src/lookout/frames.rs
@@ -2056,6 +2056,47 @@ mod tests {
         }
     }
 
+    /// The two gallery files' text: the plain rendering, then the ANSI one.
+    ///
+    /// Split out of [`write_the_gallery`] so the ordinary suite can read the
+    /// same string that test writes. That test is `#[ignore]`d, so anything
+    /// asserted inside it runs only when somebody regenerates the gallery by
+    /// hand, which is the one moment an assertion is least needed.
+    fn gallery_text() -> (String, String) {
+        let mut plain = String::from(GALLERY_PREAMBLE);
+        let mut ansi = String::from(GALLERY_PREAMBLE);
+        for which in Scene::ALL {
+            let (label, buffer) = scene(*which);
+            let (width, height) = which.size();
+            let heading = format!(
+                "\n\n=== {label}  ({width}x{height}) ===\n{}\n\n",
+                which.caption()
+            );
+            plain.push_str(&heading);
+            plain.push_str(&render_text(&buffer));
+            ansi.push_str(&heading);
+            ansi.push_str(&render_ansi(&buffer));
+        }
+        (plain, ansi)
+    }
+
+    /// IR-47 reaches `docs/lookout/`, which is published.
+    ///
+    /// Over the rendered gallery rather than the source constants: the
+    /// preamble, every scene's commentary and every banner a frame draws all
+    /// land in this one string, which is what a reader of the docs and an
+    /// operator on the dashboard actually meet. Nine other modules in this
+    /// crate carry the same pair of assertions; `lookout` carried none, and
+    /// eight dashes reached the published gallery through the gap.
+    #[test]
+    fn the_gallery_carries_no_dashes() {
+        let (plain, ansi) = gallery_text();
+        for (file, text) in [("frames.txt", &plain), ("frames.ansi", &ansi)] {
+            assert!(!text.contains('\u{2014}'), "em dash in {file}");
+            assert!(!text.contains('\u{2013}'), "en dash in {file}");
+        }
+    }
+
     /// Writes `docs/lookout/frames.txt` and `docs/lookout/frames.ansi`.
     ///
     /// `#[ignore]`: writes into the repository, so it only runs on request.
@@ -2074,20 +2115,7 @@ mod tests {
         let dir = std::path::Path::new(concat!(env!("CARGO_MANIFEST_DIR"), "/../../docs/lookout"));
         std::fs::create_dir_all(dir).unwrap();
 
-        let mut plain = String::from(GALLERY_PREAMBLE);
-        let mut ansi = String::from(GALLERY_PREAMBLE);
-        for which in Scene::ALL {
-            let (label, buffer) = scene(*which);
-            let (width, height) = which.size();
-            let heading = format!(
-                "\n\n=== {label}  ({width}x{height}) ===\n{}\n\n",
-                which.caption()
-            );
-            plain.push_str(&heading);
-            plain.push_str(&render_text(&buffer));
-            ansi.push_str(&heading);
-            ansi.push_str(&render_ansi(&buffer));
-        }
+        let (plain, ansi) = gallery_text();
         std::fs::write(dir.join("frames.txt"), &plain).unwrap();
         std::fs::write(dir.join("frames.ansi"), &ansi).unwrap();
 

--- a/crates/shep-cli/src/lookout/snapshots/shep__lookout__frames__tests__action_refused_offline.snap
+++ b/crates/shep-cli/src/lookout/snapshots/shep__lookout__frames__tests__action_refused_offline.snap
@@ -3,7 +3,7 @@ source: crates/shep-cli/src/lookout/frames.rs
 expression: render_text(&buffer)
 ---
 shep lookout   /home/ada/.shep                                                        6 in the flock
-the shepherd stopped answering — reconnecting (attempt 3)                                           
+the shepherd stopped answering: reconnecting (attempt 3)                                            
 host  load 2.31 4.10 3.88 / 10 cores   host mem 12.4G / 32.0G   flock cpu 14.7%   flock mem 716.0M …
   ID    NAME               STATUS           PID      RESTARTS  EXIT       CPU     MEM       UPTIME  
 ────────────────────────────────────────────────────────────────────────────────────────────────────
@@ -15,4 +15,4 @@ host  load 2.31 4.10 3.88 / 10 cores   host mem 12.4G / 32.0G   flock cpu 14.7% 
   0     web                online           48211    0         -          3.4%    182.0M    1h 25m  
   1     web                online           48212    0         -          2.9%    178.0M    1h 26m  
                                                                                                     
-the shepherd stopped answering — reconnecting (attempt 3)                            control enabled
+the shepherd stopped answering: reconnecting (attempt 3)                             control enabled

--- a/crates/shep-cli/src/lookout/snapshots/shep__lookout__frames__tests__frozen.snap
+++ b/crates/shep-cli/src/lookout/snapshots/shep__lookout__frames__tests__frozen.snap
@@ -3,7 +3,7 @@ source: crates/shep-cli/src/lookout/frames.rs
 expression: render_text(&buffer)
 ---
 shep lookout   /home/ada/.shep                                                                            6 in the flock
-the shepherd has died — these values are frozen as of 2026-08-14 14:32:07                                               
+the shepherd has died: these values are frozen as of 2026-08-14 14:32:07                                                
 host  load 2.31 4.10 3.88 / 10 cores   host mem 12.4G / 32.0G   flock cpu 6.7%   flock mem 371.0M   up 6d 3h            
   ID    NAME        STATUS           PID      RESTARTS  EXIT       CPU     MEM       UPTIME    FOLD        SMIT         
 ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

--- a/crates/shep-cli/src/lookout/snapshots/shep__lookout__frames__tests__retrying.snap
+++ b/crates/shep-cli/src/lookout/snapshots/shep__lookout__frames__tests__retrying.snap
@@ -3,7 +3,7 @@ source: crates/shep-cli/src/lookout/frames.rs
 expression: render_text(&buffer)
 ---
 shep lookout   /home/ada/.shep                                                                            6 in the flock
-the shepherd stopped answering — reconnecting (attempt 3)                                                               
+the shepherd stopped answering: reconnecting (attempt 3)                                                                
 host  load 2.31 4.10 3.88 / 10 cores   host mem 12.4G / 32.0G   flock cpu 14.7%   flock mem 716.0M   up 6d 3h           
   ID    NAME        STATUS           PID      RESTARTS  EXIT       CPU     MEM       UPTIME    FOLD        SMIT         
 ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

--- a/crates/shep-cli/src/lookout/view/status.rs
+++ b/crates/shep-cli/src/lookout/view/status.rs
@@ -7,7 +7,7 @@ use ratatui::style::Style;
 use ratatui::text::{Line, Span};
 
 use super::super::app::{
-    ActionState, App, Control, InputMode, Link, RowKey, Settings, SettingsPrompt,
+    ActionState, App, Control, InputMode, Link, RowKey, Settings, SettingsPrompt, retrying_sentence,
 };
 use super::super::pane::{ConfigPane, PanePending};
 use super::flock::fit;
@@ -49,7 +49,7 @@ pub fn banner_line(app: &App) -> Option<Line<'static>> {
     match app.link() {
         Link::Live => None,
         Link::Retrying { attempt } => Some(Line::from(Span::styled(
-            format!("the shepherd stopped answering: reconnecting (attempt {attempt})"),
+            retrying_sentence(*attempt),
             palette.attention(),
         ))),
         Link::Lost { at_local } => Some(Line::from(Span::styled(

--- a/crates/shep-cli/src/lookout/view/status.rs
+++ b/crates/shep-cli/src/lookout/view/status.rs
@@ -49,11 +49,11 @@ pub fn banner_line(app: &App) -> Option<Line<'static>> {
     match app.link() {
         Link::Live => None,
         Link::Retrying { attempt } => Some(Line::from(Span::styled(
-            format!("the shepherd stopped answering — reconnecting (attempt {attempt})"),
+            format!("the shepherd stopped answering: reconnecting (attempt {attempt})"),
             palette.attention(),
         ))),
         Link::Lost { at_local } => Some(Line::from(Span::styled(
-            format!("the shepherd has died — these values are frozen as of {at_local}"),
+            format!("the shepherd has died: these values are frozen as of {at_local}"),
             palette.alarm(),
         ))),
     }

--- a/docs/lookout/README.md
+++ b/docs/lookout/README.md
@@ -32,7 +32,7 @@ cargo test -p shep --lib --all-features -- --ignored write_the_gallery
 - **Daemon death: bounded retry, then freeze, never exit.** The link task
   re-dials the shepherd 5 times, at 250/500/1000/2000/4000 ms — about 7.75 s
   of waiting — before it gives up. Once the ladder is exhausted, lookout
-  shows the frozen banner (`the shepherd has died — these values are frozen
+  shows the frozen banner (`the shepherd has died: these values are frozen
   as of <time>`), stops polling and re-dialling, and leaves the last known
   values on screen. The uptime column stops advancing with it: a frozen
   dashboard whose clock kept counting would be lying about a specific sheep

--- a/docs/lookout/README.md
+++ b/docs/lookout/README.md
@@ -14,8 +14,8 @@ phase before deciding what came next.
 
 ## Reading the frames
 
-- `frames.txt`, thirty-two scenes in plain text. Open it in any editor.
-- `frames.ansi`, the same thirty-two scenes with colour. Read it with
+- `frames.txt`, thirty-three scenes in plain text. Open it in any editor.
+- `frames.ansi`, the same thirty-three scenes with colour. Read it with
   `less -R` so the escape codes render instead of printing literally.
 
 Both files are generated, not hand-written, and both come from the same

--- a/docs/lookout/frames.ansi
+++ b/docs/lookout/frames.ansi
@@ -1,5 +1,5 @@
-shep lookout — Phase 16 frames
-================================
+shep lookout frames
+===================
 
 These are real frames, rendered headlessly through ratatui's TestBackend by
 
@@ -273,7 +273,7 @@ sheep 2  api   [0m[38;5;29monline[0m   pid 48219   restarts 1   uptime 1h 28m
 
 
 === frozen  (120x30) ===
-The ladder ran out. Last known values stay, the uptime clock has stopped, and so has the host strip — one line ticking over on a frozen screen is a contradiction on the same frame.
+The ladder ran out. Last known values stay, the uptime clock has stopped, and so has the host strip: one line ticking over on a frozen screen is a contradiction on the same frame.
 
 shep lookout   /home/ada/.shep                                                                           [0m[38;5;245m 6 in the flock[0m
 [0m[38;5;166mthe shepherd has died: these values are frozen as of 2026-08-14 14:32:07[0m                                                [0m
@@ -512,7 +512,7 @@ sheep 2  api   [0m[38;5;29monline[0m   pid 48219   restarts 1   uptime 1h 28m
 
 
 === cramped  (33x26) ===
-33 columns: the narrowest terminal that draws. 26 rows — a couple more than the 24-row floor for all three panes being up, so this frame has a little breathing room rather than sitting exactly on the edge. Everything truncates with an ellipsis; nothing overlaps.
+33 columns: the narrowest terminal that draws. 26 rows (a couple more than the 24-row floor for all three panes being up), so this frame has a little breathing room rather than sitting exactly on the edge. Everything truncates with an ellipsis; nothing overlaps.
 
 shep lookout   /h…[0m[38;5;245m 6 in the flock[0m
 [0m[38;5;245mhost  load 2.31 4.10 3.88 / 10 c…[0m
@@ -724,7 +724,7 @@ shep lookout   /home/ada/.shep                                                  
 
 
 === action_refused_offline  (100x14) ===
-An action key pressed while the link is coming back. The refusal names the same reconnect attempt the banner above it does, rather than the exhausted-ladder sentence — Phase 16 review Minor #8 caught the two disagreeing on one frame.
+An action key pressed while the link is coming back. The refusal names the same reconnect attempt the banner above it does, rather than the exhausted-ladder sentence. Phase 16 review Minor #8 caught the two disagreeing on one frame.
 
 shep lookout   /home/ada/.shep                                                       [0m[38;5;245m 6 in the flock[0m
 [0m[38;5;221mthe shepherd stopped answering: reconnecting (attempt 3)[0m                                            [0m

--- a/docs/lookout/frames.ansi
+++ b/docs/lookout/frames.ansi
@@ -241,7 +241,7 @@ need 33x6                   [0m
 The shepherd stopped answering. Five attempts over about eight seconds before this becomes the next frame. Every pane below the table keeps describing the selected sheep from the last listing.
 
 shep lookout   /home/ada/.shep                                                                           [0m[38;5;245m 6 in the flock[0m
-[0m[38;5;221mthe shepherd stopped answering — reconnecting (attempt 3)[0m                                                               [0m
+[0m[38;5;221mthe shepherd stopped answering: reconnecting (attempt 3)[0m                                                                [0m
 [0m[38;5;245mhost  load 2.31 4.10 3.88 / 10 cores   host mem 12.4G / 32.0G   flock cpu 14.7%   flock mem 716.0M   up 6d 3h           [0m
   [0m[38;5;245mID    NAME        STATUS           PID      RESTARTS  EXIT       CPU     MEM       UPTIME    FOLD        SMIT         [0m
 [0m[38;5;245m────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────[0m
@@ -276,7 +276,7 @@ sheep 2  api   [0m[38;5;29monline[0m   pid 48219   restarts 1   uptime 1h 28m
 The ladder ran out. Last known values stay, the uptime clock has stopped, and so has the host strip — one line ticking over on a frozen screen is a contradiction on the same frame.
 
 shep lookout   /home/ada/.shep                                                                           [0m[38;5;245m 6 in the flock[0m
-[0m[38;5;166mthe shepherd has died — these values are frozen as of 2026-08-14 14:32:07[0m                                               [0m
+[0m[38;5;166mthe shepherd has died: these values are frozen as of 2026-08-14 14:32:07[0m                                                [0m
 [0m[38;5;245mhost  load 2.31 4.10 3.88 / 10 cores   host mem 12.4G / 32.0G   flock cpu 6.7%   flock mem 371.0M   up 6d 3h            [0m
   [0m[38;5;245mID    NAME        STATUS           PID      RESTARTS  EXIT       CPU     MEM       UPTIME    FOLD        SMIT         [0m
 [0m[38;5;245m────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────[0m
@@ -727,7 +727,7 @@ shep lookout   /home/ada/.shep                                                  
 An action key pressed while the link is coming back. The refusal names the same reconnect attempt the banner above it does, rather than the exhausted-ladder sentence — Phase 16 review Minor #8 caught the two disagreeing on one frame.
 
 shep lookout   /home/ada/.shep                                                       [0m[38;5;245m 6 in the flock[0m
-[0m[38;5;221mthe shepherd stopped answering — reconnecting (attempt 3)[0m                                           [0m
+[0m[38;5;221mthe shepherd stopped answering: reconnecting (attempt 3)[0m                                            [0m
 [0m[38;5;245mhost  load 2.31 4.10 3.88 / 10 cores   host mem 12.4G / 32.0G   flock cpu 14.7%   flock mem 716.0M …[0m
   [0m[38;5;245mID    NAME               STATUS           PID      RESTARTS  EXIT       CPU     MEM       UPTIME  [0m
 [0m[38;5;245m────────────────────────────────────────────────────────────────────────────────────────────────────[0m
@@ -739,7 +739,7 @@ shep lookout   /home/ada/.shep                                                  
   0     web                [0m[38;5;29monline         [0m  48211    0         -          3.4%    182.0M    1h 25m  [0m
   1     web                [0m[38;5;29monline         [0m  48212    0         -          2.9%    178.0M    1h 26m  [0m
                                                                                                     [0m
-[0m[38;5;166mthe shepherd stopped answering — reconnecting (attempt 3)                           [0m[38;5;245m control enabled[0m
+[0m[38;5;166mthe shepherd stopped answering: reconnecting (attempt 3)                            [0m[38;5;245m control enabled[0m
 
 
 === settings_fresh  (120x30) ===

--- a/docs/lookout/frames.txt
+++ b/docs/lookout/frames.txt
@@ -234,7 +234,7 @@ need 33x6
 The shepherd stopped answering. Five attempts over about eight seconds before this becomes the next frame. Every pane below the table keeps describing the selected sheep from the last listing.
 
 shep lookout   /home/ada/.shep                                                                            6 in the flock
-the shepherd stopped answering — reconnecting (attempt 3)                                                               
+the shepherd stopped answering: reconnecting (attempt 3)                                                                
 host  load 2.31 4.10 3.88 / 10 cores   host mem 12.4G / 32.0G   flock cpu 14.7%   flock mem 716.0M   up 6d 3h           
   ID    NAME        STATUS           PID      RESTARTS  EXIT       CPU     MEM       UPTIME    FOLD        SMIT         
 ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
@@ -268,7 +268,7 @@ q quit   j/k select   / filter   x stop   R restart   L reload   s settings   e 
 The ladder ran out. Last known values stay, the uptime clock has stopped, and so has the host strip — one line ticking over on a frozen screen is a contradiction on the same frame.
 
 shep lookout   /home/ada/.shep                                                                            6 in the flock
-the shepherd has died — these values are frozen as of 2026-08-14 14:32:07                                               
+the shepherd has died: these values are frozen as of 2026-08-14 14:32:07                                                
 host  load 2.31 4.10 3.88 / 10 cores   host mem 12.4G / 32.0G   flock cpu 6.7%   flock mem 371.0M   up 6d 3h            
   ID    NAME        STATUS           PID      RESTARTS  EXIT       CPU     MEM       UPTIME    FOLD        SMIT         
 ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
@@ -702,7 +702,7 @@ restart api (id 2): the shepherd restarted it                                   
 An action key pressed while the link is coming back. The refusal names the same reconnect attempt the banner above it does, rather than the exhausted-ladder sentence — Phase 16 review Minor #8 caught the two disagreeing on one frame.
 
 shep lookout   /home/ada/.shep                                                        6 in the flock
-the shepherd stopped answering — reconnecting (attempt 3)                                           
+the shepherd stopped answering: reconnecting (attempt 3)                                            
 host  load 2.31 4.10 3.88 / 10 cores   host mem 12.4G / 32.0G   flock cpu 14.7%   flock mem 716.0M …
   ID    NAME               STATUS           PID      RESTARTS  EXIT       CPU     MEM       UPTIME  
 ────────────────────────────────────────────────────────────────────────────────────────────────────
@@ -714,7 +714,7 @@ host  load 2.31 4.10 3.88 / 10 cores   host mem 12.4G / 32.0G   flock cpu 14.7% 
   0     web                online           48211    0         -          3.4%    182.0M    1h 25m  
   1     web                online           48212    0         -          2.9%    178.0M    1h 26m  
                                                                                                     
-the shepherd stopped answering — reconnecting (attempt 3)                            control enabled
+the shepherd stopped answering: reconnecting (attempt 3)                             control enabled
 
 === settings_fresh  (120x30) ===
 The settings screen on a fresh $SHEP_HOME: shep.toml holds only [interpreters], so every scalar's SOURCE column reads `the default` and its VALUE is the compiled fallback. The state most operators open this screen in.

--- a/docs/lookout/frames.txt
+++ b/docs/lookout/frames.txt
@@ -1,5 +1,5 @@
-shep lookout — Phase 16 frames
-================================
+shep lookout frames
+===================
 
 These are real frames, rendered headlessly through ratatui's TestBackend by
 
@@ -265,7 +265,7 @@ out  connection pool: 14/50 in use
 q quit   j/k select   / filter   x stop   R restart   L reload   s settings   e edit   * yours   ! park… control enabled
 
 === frozen  (120x30) ===
-The ladder ran out. Last known values stay, the uptime clock has stopped, and so has the host strip — one line ticking over on a frozen screen is a contradiction on the same frame.
+The ladder ran out. Last known values stay, the uptime clock has stopped, and so has the host strip: one line ticking over on a frozen screen is a contradiction on the same frame.
 
 shep lookout   /home/ada/.shep                                                                            6 in the flock
 the shepherd has died: these values are frozen as of 2026-08-14 14:32:07                                                
@@ -495,7 +495,7 @@ this sheep has not written a log in this $SHEP_HOME
 q quit   j/k select   / filter   x stop   R restart   L reload   s settings   e edit   * yours   ! park… control enabled
 
 === cramped  (33x26) ===
-33 columns: the narrowest terminal that draws. 26 rows — a couple more than the 24-row floor for all three panes being up, so this frame has a little breathing room rather than sitting exactly on the edge. Everything truncates with an ellipsis; nothing overlaps.
+33 columns: the narrowest terminal that draws. 26 rows (a couple more than the 24-row floor for all three panes being up), so this frame has a little breathing room rather than sitting exactly on the edge. Everything truncates with an ellipsis; nothing overlaps.
 
 shep lookout   /h… 6 in the flock
 host  load 2.31 4.10 3.88 / 10 c…
@@ -699,7 +699,7 @@ host  load 2.31 4.10 3.88 / 10 cores   host mem 12.4G / 32.0G   flock cpu 14.7% 
 restart api (id 2): the shepherd restarted it                                        control enabled
 
 === action_refused_offline  (100x14) ===
-An action key pressed while the link is coming back. The refusal names the same reconnect attempt the banner above it does, rather than the exhausted-ladder sentence — Phase 16 review Minor #8 caught the two disagreeing on one frame.
+An action key pressed while the link is coming back. The refusal names the same reconnect attempt the banner above it does, rather than the exhausted-ladder sentence. Phase 16 review Minor #8 caught the two disagreeing on one frame.
 
 shep lookout   /home/ada/.shep                                                        6 in the flock
 the shepherd stopped answering: reconnecting (attempt 3)                                            

--- a/web/src/pages/docs/lookout.astro
+++ b/web/src/pages/docs/lookout.astro
@@ -56,7 +56,7 @@ const tooNarrow = `too small
 need 33x6`;
 
 const frozen = `shep lookout   /home/ada/.shep                                                                            6 in the flock
-the shepherd has died — these values are frozen as of 2026-08-14 14:32:07
+the shepherd has died: these values are frozen as of 2026-08-14 14:32:07
 host  load 2.31 4.10 3.88 / 10 cores   host mem 12.4G / 32.0G   flock cpu 6.7%   flock mem 371.0M   up 6d 3h
   ID    NAME        STATUS           PID      RESTARTS  EXIT       CPU     MEM       UPTIME    FOLD        SMIT
 ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Eight em dashes in `lookout`, in banners on screen and in the published frames gallery. IR-47 bans them. They predate `feat/config-panes` and were left out of it to avoid widening that PR.

- Three banners take a colon: redial, frozen screen, `LINK_GONE`
- Gallery commentary takes a colon, parentheses, or a full stop
- Gallery title drops "Phase 16", stale every phase since the file regenerates from the tree
- `app.rs:3362` hid a fourth, spelled `\u{2014}`. The redial sentence was built twice, so a grep for the character found one copy and missed the other. One function builds it now
- Added the em-dash assertion `lookout` was missing and nine other modules have, over the rendered gallery
- `lookout.astro` and `docs/lookout/README.md` quoted the frozen banner verbatim and described a string the binary no longer prints

Gallery byte-identical after the refactor. `README.md` keeps thirteen dashes in its own prose, separate cleanup.

fmt, clippy, `cargo test --workspace --all-features`, `astro check` and `astro build` all pass. Guard test verified by injecting a dash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Standardized reconnect and lost-connection messages to use colons instead of em dashes.
  - Updated Lookout scene captions and gallery text to remove em and en dashes.
  - Removed the “Phase 16” label from gallery output.

- **Documentation**
  - Updated Lookout documentation and web examples with revised frozen-banner wording.
  - Updated documentation to reflect 33 rendered scenes.

- **Tests**
  - Added coverage to verify gallery output remains free of em and en dashes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->