### PR TITLE
fix(daemon): write the muster roll when the registry records, not only on a bus event

### DIFF
--- a/crates/shep-daemon/src/rpc.rs
+++ b/crates/shep-daemon/src/rpc.rs
@@ -2795,6 +2795,81 @@ mod tests {
         assert_eq!(web.app.env.get("NEW").map(String::as_str), Some("1"));
     }
 
+    /// The sibling above asserts the registry; this asserts the file, which
+    /// is what a cold boot actually reads. A parked edit moves no process, so
+    /// the bus says nothing and the roll's only other schedule is the
+    /// graceful shutdown a `SIGKILL` never reaches. The store keeps the edit
+    /// either way and `overridden_for` reads it back, so a stale roll is not
+    /// a lost edit but a divergent one: the sheep comes back on the old value
+    /// under a CFG cell claiming the operator set a new one.
+    #[tokio::test(start_paused = true)]
+    async fn a_parked_env_edit_reaches_the_roll_before_a_hard_stop_can_lose_it() {
+        let h = harness(vec![ProcScript::never_exits()]);
+        start_web_with_a_secret(&h.ctx).await;
+
+        // The roll as a `shep save` left it, so the baseline is on disk
+        // whatever the writer does, and the writer subscribing after the
+        // start's own events so the edit below is all it has left to react
+        // to.
+        h.ctx.save_roll_now().await.unwrap();
+        let baseline = crate::snapshot::read(&h.ctx.snapshot_path).unwrap();
+        assert_eq!(baseline.apps[0].app.env.get("NEW"), None);
+        let writer = crate::snapshot::spawn_snapshot_writer(
+            h.ctx.snapshot_path.clone(),
+            h.ctx.supervisor.clone(),
+            h.ctx.registry.clone(),
+            h.ctx.events.subscribe(),
+        );
+        let settle = std::time::Duration::from_millis(crate::snapshot::SNAPSHOT_DEBOUNCE_MS * 2);
+        tokio::time::sleep(settle).await;
+
+        let reply = reply_of(
+            dispatch(
+                envelope(
+                    2,
+                    Request::SetSheepEnv {
+                        name: "web".to_string(),
+                        key: "NEW".to_string(),
+                        value: Some("1".to_string().into()),
+                    },
+                ),
+                &h.ctx,
+            )
+            .await,
+        );
+        assert!(reply.result.is_ok(), "{:?}", reply.result);
+        tokio::time::sleep(settle).await;
+
+        // The hard stop: the writer goes where a `SIGKILL` would have taken
+        // it, and no graceful `save_roll_now` runs after this line.
+        writer.stop().await;
+
+        let (events, _rx) = crate::bus::test_bus(64);
+        let cold = crate::supervisor::spawn_supervisor(
+            crate::fake::ScriptedRunner::new(vec![ProcScript::never_exits()]),
+            h.ctx.paths.clone(),
+            events,
+        );
+        // The cold registry, not `sheep_config`: that view clears `env` on
+        // its way out, and the registry is what the restored sheep was
+        // started from.
+        let cold_registry = crate::snapshot::FlockRegistry::new();
+        let restored = crate::snapshot::muster(&h.ctx.snapshot_path, &cold_registry, &cold)
+            .await
+            .unwrap();
+        assert_eq!(restored, vec!["web".to_string()]);
+
+        let listed = cold.list().await;
+        let came_back = cold_registry.roll(&listed, 0);
+        assert_eq!(
+            came_back.apps[0].app.env.get("NEW").map(String::as_str),
+            Some("1"),
+            "the sheep must come back on the edit its CFG cell claims: {:?}",
+            listed[0].overridden
+        );
+        cold.shutdown().await;
+    }
+
     /// `map.remove` is a no-op for a key the app's own config supplied, so
     /// without a tombstone the store comes back empty and the removal
     /// lives only in `ProcessEntry::pending`, a change the operator just

--- a/crates/shep-daemon/src/snapshot.rs
+++ b/crates/shep-daemon/src/snapshot.rs
@@ -20,6 +20,7 @@ use std::sync::{Arc, Mutex, PoisonError};
 
 use serde::{Deserialize, Serialize};
 use tempfile::NamedTempFile;
+use tokio::sync::Notify;
 use tokio::sync::broadcast::{self, error::RecvError};
 use tokio::task::JoinHandle;
 use tokio::time::{Duration, Instant, sleep_until};
@@ -72,6 +73,10 @@ pub struct SavedApp {
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FlockRegistry {
     apps: Arc<Mutex<BTreeMap<String, AppConfig>>>,
+    /// Woken by every write to `apps`, so the roll writer schedules a file
+    /// write for a change that moves no process and so publishes no
+    /// [`BusEvent::Process`] of its own.
+    dirty: Arc<Notify>,
 }
 
 impl FlockRegistry {
@@ -87,6 +92,8 @@ impl FlockRegistry {
         for app in apps {
             map.insert(app.config().name.clone(), app.config().clone());
         }
+        drop(map);
+        self.dirty.notify_one();
     }
 
     /// Records one app's config directly, for a successor rebuilding this
@@ -105,6 +112,7 @@ impl FlockRegistry {
             .lock()
             .unwrap_or_else(PoisonError::into_inner)
             .insert(config.name.clone(), config.clone());
+        self.dirty.notify_one();
     }
 
     /// Drops every recorded app, so the next [`Self::roll`] describes an
@@ -120,6 +128,7 @@ impl FlockRegistry {
             .lock()
             .unwrap_or_else(PoisonError::into_inner)
             .clear();
+        self.dirty.notify_one();
     }
 
     /// Builds the roll from the live listing, pruning names the flock no
@@ -457,6 +466,9 @@ impl SnapshotWriter {
 /// Coalesces bursts of lifecycle events (spec §13.4: one restart storm, one
 /// write) into a single [`write_atomic`] call per [`SNAPSHOT_DEBOUNCE_MS`]
 /// window. Log traffic never resets or starts the debounce timer.
+///
+/// Woken by [`FlockRegistry`]'s own writes as well as by the bus, so a config
+/// change that parks a field reaches the file without a process having moved.
 pub(crate) fn spawn_snapshot_writer(
     path: PathBuf,
     supervisor: SupervisorHandle,
@@ -465,7 +477,15 @@ pub(crate) fn spawn_snapshot_writer(
 ) -> SnapshotWriter {
     let writes = Arc::new(AtomicU64::new(0));
     let task_writes = Arc::clone(&writes);
-    let handle = tokio::spawn(run_writer(path, supervisor, registry, events, task_writes));
+    let dirty = Arc::clone(&registry.dirty);
+    let handle = tokio::spawn(run_writer(
+        path,
+        supervisor,
+        registry,
+        events,
+        dirty,
+        task_writes,
+    ));
     SnapshotWriter { handle, writes }
 }
 
@@ -477,6 +497,7 @@ async fn run_writer(
     supervisor: SupervisorHandle,
     registry: FlockRegistry,
     mut events: broadcast::Receiver<SharedEvent>,
+    dirty: Arc<Notify>,
     writes: Arc<AtomicU64>,
 ) {
     let mut deadline: Option<Instant> = None;
@@ -493,6 +514,12 @@ async fn run_writer(
                     deadline = Some(Instant::now() + Duration::from_millis(SNAPSHOT_DEBOUNCE_MS));
                 },
                 Err(RecvError::Closed) => break,
+            },
+            // A config write that parks a field moves no process, so the bus
+            // says nothing and only this arm reaches the file before the next
+            // unrelated lifecycle event or a graceful shutdown.
+            () = dirty.notified() => if deadline.is_none() {
+                deadline = Some(Instant::now() + Duration::from_millis(SNAPSHOT_DEBOUNCE_MS));
             },
             () = sleep_until(deadline.unwrap_or_else(Instant::now)), if deadline.is_some() => {
                 deadline = None;
@@ -1038,6 +1065,45 @@ mod tests {
         let roll = read(&paths.snapshot).unwrap();
         assert_eq!(roll.apps.len(), 1);
         assert_eq!(roll.apps[0].instances_running, 1);
+        writer.stop().await;
+    }
+
+    /// fails if the bus is the writer's only schedule. A config write that
+    /// parks a field moves no process, so it publishes no
+    /// [`BusEvent::Process`], and the registry's own recording is the roll's
+    /// only route to disk before the next unrelated lifecycle event or a
+    /// graceful shutdown.
+    #[tokio::test(start_paused = true)]
+    async fn writer_schedules_a_write_for_a_recording_the_bus_says_nothing_about() {
+        let dir = tempfile::tempdir().unwrap();
+        let paths = test_paths(&dir);
+        std::fs::create_dir_all(&paths.home).unwrap();
+        let (events, _keep) = crate::bus::test_bus(64);
+        let supervisor = spawn_supervisor(
+            ScriptedRunner::new(vec![ProcScript::never_exits()]),
+            paths.clone(),
+            events.clone(),
+        );
+        let registry = FlockRegistry::new();
+        let app = normalize(AppConfig::minimal("web", "./srv")).unwrap();
+        supervisor.start(vec![app.clone()]).await.unwrap();
+
+        // Subscribing here means the start's own events are already behind us,
+        // so the bus has nothing left to say about this flock.
+        let writer = spawn_snapshot_writer(
+            paths.snapshot.clone(),
+            supervisor.clone(),
+            registry.clone(),
+            events.subscribe(),
+        );
+        assert!(!paths.snapshot.exists(), "nothing has recorded yet");
+
+        registry.record(std::slice::from_ref(&app));
+        tokio::time::sleep(Duration::from_millis(SNAPSHOT_DEBOUNCE_MS + 1)).await;
+
+        assert_eq!(writer.writes(), 1, "a recording leaves the roll dirty");
+        let roll = read(&paths.snapshot).unwrap();
+        assert_eq!(roll.apps.len(), 1);
         writer.stop().await;
     }
 


### PR DESCRIPTION
A config write that parks a field publishes no `BusEvent::Process`, and that event is the only thing scheduling the muster roll's write. `overrides.json` reached disk, `flock.json` did not, and nothing rewrites the roll on a timer, so the window had no bound.

A `SIGKILL` in it did worse than lose the edit. `muster` reads only the roll, but `overridden_for` falls back to the override store, so the sheep came back on the pre-edit config with its CFG cell reporting the field overridden.

- `FlockRegistry` carries an `Arc<Notify>`, woken by `record`, `record_config` and `clear`
- `run_writer` selects on it, so a recording schedules a write the way a lifecycle event does
- No call sites change: `spawn_snapshot_writer` takes the handle off the registry it already gets

Widening `is_state_change` was the other option and is not available: the config paths publish nothing on the bus.

Costs one extra write per boot, since `muster`'s own `record` schedules one for content it just read.

Two tests, both red with `record`'s wake removed. The second parks an env edit through `SetSheepEnv`, stops the writer where a `SIGKILL` would, musters into a fresh supervisor over the same `$SHEP_HOME`, and asserts what came back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved persistence of environment edits, including changes made without a process event.
  - Environment state is now more reliably restored after an unexpected writer shutdown and subsequent cold restart.
  - Snapshot updates are triggered consistently when environment configuration changes or is cleared.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->