### PR TITLE
fix(shep): kill the dog probe's process group, not just its leader

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -543,11 +543,20 @@ cannot connect. The contract is published in `docs/dogs.md`; answering is
 optional, and a dog that does not answer is adopted with its protocol
 unknown rather than refused, which is every dog written before it.
 
-Two things it deliberately does not do, both argued at their call sites. A
+One thing it deliberately does not do, argued at its call site: a
 DAEMON-initiated restart gets no warning, since the check is CLI-side, so a
-crash or an autorestart respawn still walks into G12 row 5 unannounced. And
-`Child::kill` does not reach descendants, so a probe's grandchild can
-outlive it; closing that needs a process group rather than a patch.
+crash or an autorestart respawn still walks into G12 row 5 unannounced.
+
+**A probe's descendants are contained on unix now.** This paragraph used to
+say `Child::kill` does not reach them and that closing it needed a process
+group rather than a patch, which was right about the mechanism. `ask` in
+`crates/shep-cli/src/commands/dogs.rs` spawns with `process_group(0)` and
+`kill_probe_tree` sweeps `-pid`, the same shape `probes/os.rs` already used
+for the exec prober. Two holes stay open and are documented rather than
+closed. A descendant that calls `setsid` leaves the group, as `kill.rs`
+records for a sheep. And Windows has no process group, so the probe there
+still kills only the binary it spawned; containment would mean reaching the
+`pub(crate)` job object in `sys_windows.rs`.
 
 **There are three doors into the override store, not one.** A Flockfile
 load through `Request::ApplyConfig`, described below, is the one that

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,7 +83,7 @@ tokio = { version = "1.41", default-features = false }
 tokio-util = { version = "0.7.9", default-features = false, features = ["codec"] }
 bytes = { version = "1", default-features = false }
 futures-util = { version = "0.3", default-features = false, features = ["sink", "std"] }
-# Only shep-daemon: process-group signal delivery and process-related syscalls for the
+# process-group signal delivery and process-related syscalls for shep-daemon's
 # real ProcessRunner (kill ladder, SIGKILL tree); `user` adds geteuid for the same-uid
 # peer-cred check and passwd/group lookups for `user`/`group` spawn.
 nix = { version = "0.29", default-features = false, features = ["signal", "process", "user"] }

--- a/crates/shep-cli/src/commands/dogs.rs
+++ b/crates/shep-cli/src/commands/dogs.rs
@@ -576,7 +576,8 @@ fn ask(
     // environment: this runs a stranger's binary. `SHEP_HOME` is the home
     // this invocation resolved, or the candidate finds the live daemon's
     // socket. Stdout is piped so it cannot write on the operator's terminal.
-    match Command::new(path)
+    let mut command = Command::new(path);
+    command
         .arg(flag)
         .env_clear()
         .envs(probe_env())
@@ -584,9 +585,16 @@ fn ask(
         .env("SHEP_DOG_NAME", name)
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
-        .stderr(Stdio::null())
-        .spawn()
+        .stderr(Stdio::null());
+    // A group of the probe's own, whose id is its own pid: without one
+    // `kill_probe_tree` has no group to name and reaches only the leader.
+    #[cfg(unix)]
     {
+        use std::os::unix::process::CommandExt as _;
+        command.process_group(0);
+    }
+
+    match command.spawn() {
         Err(err) => Err(AdoptRefusal::WillNotExec {
             reason: err.to_string(),
         }),
@@ -600,10 +608,35 @@ fn ask(
                 return Err(AdoptRefusal::WillNotExec { reason });
             }
             let answer = answer_text(&mut child, reading, budget);
-            let _ = child.kill();
+            kill_probe_tree(&mut child);
             let _ = child.wait();
             Ok(answer)
         }
+    }
+}
+
+/// SIGKILLs the probe, and on unix everything it forked
+///
+/// A dog that does not recognise the flag runs its ordinary job instead, so
+/// a probe can fork before it answers. `Child::kill` reaches only the
+/// leader. A descendant that calls `setsid` leaves the group and survives.
+///
+/// Failure is never reported: an empty group answers `ESRCH`, and the
+/// caller's answer is the same either way.
+fn kill_probe_tree(child: &mut Child) {
+    // `Child` skips the syscall once it holds a status, so a child already
+    // reaped here is never signalled through a pid the OS may have recycled.
+    let _ = child.kill();
+    // POSIX holds a process group id out of the pool until the last member
+    // leaves, so `-pid` cannot name a stranger's group even after the leader
+    // is reaped. `-0` is `0`, this process's own group, so a zero pid must
+    // never reach the syscall.
+    #[cfg(unix)]
+    if let Ok(pid) = i32::try_from(child.id())
+        && pid > 0
+    {
+        let group = nix::unistd::Pid::from_raw(-pid);
+        let _ = nix::sys::signal::kill(group, nix::sys::signal::Signal::SIGKILL);
     }
 }
 
@@ -2276,6 +2309,72 @@ mod tests {
             schema["properties"]["endpoint"]["type"], "string",
             "the schema is kept as the dog wrote it, not summarised"
         );
+    }
+
+    /// How long a fork the probe left behind would go on running.
+    const PROBE_FORK_LIFETIME_SECS: u64 = 30;
+
+    /// Whether `pid` left the process table inside `budget`.
+    ///
+    /// A fork the probe abandons is reparented to init, which reaps it, so
+    /// `ESRCH` is what being gone looks like from here.
+    fn waited_out(pid: nix::unistd::Pid, budget: Duration) -> bool {
+        let started = Instant::now();
+        while started.elapsed() < budget {
+            if nix::sys::signal::kill(pid, None).is_err() {
+                return true;
+            }
+            std::thread::sleep(Duration::from_millis(5));
+        }
+        false
+    }
+
+    /// fails if a fork the probe left behind outlives the probe
+    ///
+    /// Opening a dog's config pane runs that dog's binary, and a dog that
+    /// does not recognise the flag starts its ordinary job instead. Killing
+    /// the leader alone leaves what it forked running against the live
+    /// `SHEP_HOME`, once per keystroke.
+    #[test]
+    fn a_fork_the_probe_left_behind_is_killed_with_it() {
+        let dir = tempfile::tempdir().unwrap();
+        let pid_file = dir.path().join("fork.pid");
+        // The fork writes its pid before the script answers, so an answer is
+        // proof the file is there to read. Its stdout goes to `/dev/null`: a
+        // fork holding the inherited pipe open spends the whole budget and
+        // leaves no answer to wait on.
+        let bin = two_flag_dog(
+            dir.path(),
+            &format!(
+                "sh -c 'echo $$ > {pid}.tmp; mv {pid}.tmp {pid}; exec sleep {secs}' \
+                 >/dev/null 2>&1 &\n\
+                 while [ ! -f {pid} ]; do sleep 0.01; done\n\
+                 echo '{{}}'",
+                pid = pid_file.display(),
+                secs = PROBE_FORK_LIFETIME_SECS,
+            ),
+        );
+
+        let schema = ask_schema(&bin, dir.path(), "otel", TEST_BUDGET);
+        assert!(
+            matches!(schema, DogSchema::Published(_)),
+            "the probe must answer, or the fork never wrote its pid: {schema:?}"
+        );
+        let pid = nix::unistd::Pid::from_raw(
+            std::fs::read_to_string(&pid_file)
+                .unwrap()
+                .trim()
+                .parse()
+                .unwrap(),
+        );
+
+        let gone = waited_out(pid, Duration::from_secs(5));
+        // Before the assertion: a red run must not leave the fork behind for
+        // the rest of its lifetime.
+        if !gone {
+            let _ = nix::sys::signal::kill(pid, nix::sys::signal::Signal::SIGKILL);
+        }
+        assert!(gone, "a fork the probe left behind outlived it");
     }
 
     /// A dog with a broken schema flag may still do its job.

--- a/crates/shep-cli/src/commands/dogs.rs
+++ b/crates/shep-cli/src/commands/dogs.rs
@@ -2314,17 +2314,31 @@ mod tests {
     /// How long a fork the probe left behind would go on running.
     const PROBE_FORK_LIFETIME_SECS: u64 = 30;
 
-    /// Whether `pid` left the process table inside `budget`.
+    /// How long [`waited_out`] gives a SIGKILLed fork to leave the process
+    /// table.
+    ///
+    /// The signal is unblockable, so this covers the reaping parent's
+    /// scheduling and nothing else. Five seconds against the sub-millisecond
+    /// it takes idle, sized for a loaded runner rather than for this machine.
+    const FORK_EXIT_DEADLINE: Duration = Duration::from_secs(5);
+
+    /// Gap between [`FORK_EXIT_DEADLINE`]'s retries, as
+    /// `cli_e2e.rs`'s own pid guard does it.
+    const FORK_EXIT_POLL_INTERVAL: Duration = Duration::from_millis(5);
+
+    /// Whether `pid` left the process table inside [`FORK_EXIT_DEADLINE`].
     ///
     /// A fork the probe abandons is reparented to init, which reaps it, so
-    /// `ESRCH` is what being gone looks like from here.
-    fn waited_out(pid: nix::unistd::Pid, budget: Duration) -> bool {
+    /// `ESRCH` is what being gone looks like from here. Polled rather than
+    /// awaited: the fork is nobody's child in this process, so there is no
+    /// exit status to wait on.
+    fn waited_out(pid: nix::unistd::Pid) -> bool {
         let started = Instant::now();
-        while started.elapsed() < budget {
+        while started.elapsed() < FORK_EXIT_DEADLINE {
             if nix::sys::signal::kill(pid, None).is_err() {
                 return true;
             }
-            std::thread::sleep(Duration::from_millis(5));
+            std::thread::sleep(FORK_EXIT_POLL_INTERVAL);
         }
         false
     }
@@ -2368,7 +2382,7 @@ mod tests {
                 .unwrap(),
         );
 
-        let gone = waited_out(pid, Duration::from_secs(5));
+        let gone = waited_out(pid);
         // Before the assertion: a red run must not leave the fork behind for
         // the rest of its lifetime.
         if !gone {

--- a/crates/shep-cli/src/commands/dogs.rs
+++ b/crates/shep-cli/src/commands/dogs.rs
@@ -627,10 +627,10 @@ fn kill_probe_tree(child: &mut Child) {
     // `Child` skips the syscall once it holds a status, so a child already
     // reaped here is never signalled through a pid the OS may have recycled.
     let _ = child.kill();
-    // POSIX holds a process group id out of the pool until the last member
-    // leaves, so `-pid` cannot name a stranger's group even after the leader
-    // is reaped. `-0` is `0`, this process's own group, so a zero pid must
-    // never reach the syscall.
+    // POSIX holds a group id out of the pool while the group has members, so
+    // a sweep with forks to reach cannot name a stranger's group. An empty
+    // one answers ESRCH, short of a pid wrap inside the microseconds since
+    // the reap. `-0` is `0`, this process's own group, so zero must not pass.
     #[cfg(unix)]
     if let Ok(pid) = i32::try_from(child.id())
         && pid > 0

--- a/docs/dogs.md
+++ b/docs/dogs.md
@@ -455,10 +455,10 @@ the ordinary case, not a skew, and comparing the two would report every
 dog that exists.
 
 A candidate gets one second to exit and another to have its output read,
-and an adopt runs two probes, so roughly four seconds is the worst case. It
-is killed either way, so a dog that ignores both flags and runs costs that
-time and is adopted with an unknown protocol. It cannot hang the `adopt`
-that is vetting it.
+and an adopt runs two probes, so roughly four seconds is the worst case. Its
+process group is killed either way, so a dog that ignores both flags and
+runs costs that time and is adopted with an unknown protocol. It cannot
+hang the `adopt` that is vetting it.
 
 None of the answer is written down. `[daemon] adopted_dogs` records the
 path and nothing else, and a protocol stored at adopt time would be a copy
@@ -547,7 +547,7 @@ shep runs it with `--version`, and a dog that does not RECOGNISE that flag
 ignores it and starts doing its ordinary job instead, with `SHEP_HOME`
 pointing at the live shepherd. So a rotator can rotate once and a bark dog
 can open a second subscription, for up to the budget above, before the
-process is killed.
+process and everything it forked are killed.
 
 Only dogs that ignore the flag are affected. A dog that recognises
 `--version` and exits, even without naming a protocol, does no work: its
@@ -691,8 +691,11 @@ adopt time, so the dog does not have to be running. Configure then enable is
 the order an operator wants, and it works.
 
 **Asking runs it.** Opening the pane on an adopted dog spawns that binary
-with `--schema`, waits a second for an answer, then kills it, on the same
-terms `shep adopt` asks on. That is a third party's code executing because
+with `--schema`, waits a second for an answer, then kills its whole process
+group, on the same terms `shep adopt` asks on. The group is what catches a
+dog that forks a worker before answering. A descendant that calls `setsid`
+leaves the group and survives it, and on Windows there is no group, so only
+the probe itself is killed. That is a third party's code executing because
 somebody pressed a key, so it is worth knowing before browsing the config of
 a dog you did not write. A built-in dog is shep's own binary and is never
 spawned.


### PR DESCRIPTION
The dog probe spawns a third party's binary and killed only the process it spawned, so anything it forked outlived the probe. `shep lookout`'s dog config pane probes when the pane opens, so that went from once per `shep adopt` to once per keystroke.

- `ask` spawns with `process_group(0)`; a new `kill_probe_tree` sweeps `-pid` with SIGKILL
- Same shape `probes/os.rs` already uses for the exec prober. Both APIs are safe, so `#![forbid(unsafe_code)]` here is untouched
- Test forks a grandchild that outlives the script and asserts it is gone. Watching the direct child proves nothing here
- `docs/dogs.md` and `CLAUDE.md` corrected, the latter listed this as an open limit

Signalling `-pid` after the leader is reaped is safe while the group still has members, which is the case the sweep exists for: POSIX holds the id out of the pool until the last one leaves. An empty group answers ESRCH instead, short of a pid wrap in the microseconds since the reap.

Not closed, and documented as such:

- A descendant that calls `setsid` leaves the group and survives
- Windows has no process group, so the probe there still kills only the binary it spawned

Reverting `process_group(0)` by hand turns the test red, and so does reverting the sweep on its own. Gate green: `fmt`, `clippy -D warnings`, `cargo test --workspace --all-features` (2819 passed, 0 failed), `cargo doc`.

`probes/os.rs` has the same gap on its two normal-exit arms and is not fixed here. Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Probe cleanup now terminates forked descendant processes on Unix, including when probes finish or time out.
  * Adopt, schema, and restart probes now clean up their process trees more reliably.
  * Added coverage to verify abandoned probe children are terminated.

* **Documentation**
  * Clarified restart behavior and documented remaining limitations for `setsid` descendants on Unix and process cleanup on Windows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
