### PR TITLE
chore: release v0.4.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2058,7 +2058,7 @@ dependencies = [
 
 [[package]]
 name = "shep"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "anstyle",
  "assert_cmd",
@@ -2096,7 +2096,7 @@ dependencies = [
 
 [[package]]
 name = "shep-channel"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "command-fds",
  "serde",
@@ -2107,11 +2107,11 @@ dependencies = [
 
 [[package]]
 name = "shep-cli"
-version = "0.4.3"
+version = "0.4.4"
 
 [[package]]
 name = "shep-client"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "futures-util",
  "nix 0.29.0",
@@ -2127,7 +2127,7 @@ dependencies = [
 
 [[package]]
 name = "shep-core"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "annotate-snippets",
  "anstyle",
@@ -2158,7 +2158,7 @@ dependencies = [
 
 [[package]]
 name = "shep-daemon"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "bytes",
  "chrono",
@@ -2188,14 +2188,14 @@ dependencies = [
 
 [[package]]
 name = "shep-examples"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "nix 0.29.0",
 ]
 
 [[package]]
 name = "shep-macros"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "proc-macro2",
  "quote 1.0.47",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.4.3"
+version = "0.4.4"
 edition = "2024"
 # 1.88: serde-saphyr's let-chains need it; also the floor ratatui, sysinfo
 # and rmcp require.
@@ -33,11 +33,11 @@ license = "MIT OR Apache-2.0"
 # turn an inherited dependency's default features back on but never off, so the
 # floor is set off here. shep-core wants the wire types without the client
 # feature; a future consumer that wants the client opts back in.
-shep-channel = { path = "crates/shep-channel", version = "0.4.3", default-features = false }
-shep-core = { path = "crates/shep-core", version = "0.4.3" }
-shep-daemon = { path = "crates/shep-daemon", version = "0.4.3" }
-shep-client = { path = "crates/shep-client", version = "0.4.3" }
-shep-macros = { path = "crates/shep-macros", version = "0.4.3" }
+shep-channel = { path = "crates/shep-channel", version = "0.4.4", default-features = false }
+shep-core = { path = "crates/shep-core", version = "0.4.4" }
+shep-daemon = { path = "crates/shep-daemon", version = "0.4.4" }
+shep-client = { path = "crates/shep-client", version = "0.4.4" }
+shep-macros = { path = "crates/shep-macros", version = "0.4.4" }
 serde = { version = "1", default-features = false, features = ["derive"] }
 serde_json = { version = "1", default-features = false, features = ["std"] }
 toml = { version = "0.8", default-features = false, features = ["parse", "display"] }

--- a/crates/shep-channel/CHANGELOG.md
+++ b/crates/shep-channel/CHANGELOG.md
@@ -1,0 +1,39 @@
+# Changelog
+
+All notable changes to this crate are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.4.4] - 2026-09-06
+
+### Added
+
+- Frame the wire and find the descriptor
+- Bound the outbound queue, drop metrics before readiness
+- Always reply, including to a name nobody registered
+- Serve the channel, and do nothing well without one
+
+### Changed
+
+- Move the shepherd-channel wire into its own crate
+- Split lib.rs into error, channel, and serve modules
+
+### Fixed
+
+- Declare serde/std, not inherit it by accident
+- Guard against taking the descriptor twice
+- Count a zero-capacity drop honestly, retain nothing
+- Stop lying about readiness, and catch a shutdown panic
+- Make the reader loop testable, and stop dispatch's lock spanning app code
+- Stop a metric evicting readiness, and say what is live
+- Keep a published path alive, and ship the licences
+- Address CodeRabbit review on #103
+- Release the Windows channel claim when cloning the writer fails
+- Drop the Windows handle before releasing the claim
+- Stop the Windows channel deadlocking against its own reader
+- Gate a unix-only test constant so Windows clippy is clean
+- Stop overstating PeekNamedPipe, and guard the child earlier
+- A frame that is not UTF-8 is Malformed, not Io
+- Redact Shepherd's Debug, which printed queued payloads
+

--- a/crates/shep-cli/CHANGELOG.md
+++ b/crates/shep-cli/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.4] - 2026-09-06
+
+
 ## [0.4.3] - 2026-09-06
 
 ### Fixed

--- a/crates/shep-client/CHANGELOG.md
+++ b/crates/shep-client/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.4] - 2026-09-06
+
+
 ## [0.4.3] - 2026-09-06
 
 

--- a/crates/shep-core/CHANGELOG.md
+++ b/crates/shep-core/CHANGELOG.md
@@ -10,6 +10,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.4] - 2026-09-06
+
+### Changed
+
+- Move the shepherd-channel wire into its own crate
+
+### Fixed
+
+- Keep a published path alive, and ship the licences
+- Drop the shim's `since`, which cannot be right until after the release
+
+
 ## [0.4.3] - 2026-09-06
 
 

--- a/crates/shep-daemon/CHANGELOG.md
+++ b/crates/shep-daemon/CHANGELOG.md
@@ -10,6 +10,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.4] - 2026-09-06
+
+### Changed
+
+- Move the shepherd-channel wire into its own crate
+
+
 ## [0.4.3] - 2026-09-06
 
 ### Fixed

--- a/crates/shep-macros/CHANGELOG.md
+++ b/crates/shep-macros/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.4] - 2026-09-06
+
+
 ## [0.4.3] - 2026-09-06
 
 


### PR DESCRIPTION



## 🤖 New release

* `shep-channel`: 0.4.3 -> 0.4.4
* `shep-core`: 0.4.3 -> 0.4.4 (✓ API compatible changes)
* `shep-daemon`: 0.4.3 -> 0.4.4 (✓ API compatible changes)
* `shep-macros`: 0.4.3 -> 0.4.4
* `shep-client`: 0.4.3 -> 0.4.4
* `shep`: 0.4.3 -> 0.4.4

<details><summary><i><b>Changelog</b></i></summary><p>

## `shep-channel`

<blockquote>

## [0.4.4] - 2026-09-06

### Added

- Frame the wire and find the descriptor
- Bound the outbound queue, drop metrics before readiness
- Always reply, including to a name nobody registered
- Serve the channel, and do nothing well without one

### Changed

- Move the shepherd-channel wire into its own crate
- Split lib.rs into error, channel, and serve modules

### Fixed

- Declare serde/std, not inherit it by accident
- Guard against taking the descriptor twice
- Count a zero-capacity drop honestly, retain nothing
- Stop lying about readiness, and catch a shutdown panic
- Make the reader loop testable, and stop dispatch's lock spanning app code
- Stop a metric evicting readiness, and say what is live
- Keep a published path alive, and ship the licences
- Address CodeRabbit review on #103
- Release the Windows channel claim when cloning the writer fails
- Drop the Windows handle before releasing the claim
- Stop the Windows channel deadlocking against its own reader
- Gate a unix-only test constant so Windows clippy is clean
- Stop overstating PeekNamedPipe, and guard the child earlier
- A frame that is not UTF-8 is Malformed, not Io
- Redact Shepherd's Debug, which printed queued payloads
</blockquote>

## `shep-core`

<blockquote>

## [0.4.4] - 2026-09-06

### Changed

- Move the shepherd-channel wire into its own crate

### Fixed

- Keep a published path alive, and ship the licences
- Drop the shim's `since`, which cannot be right until after the release
</blockquote>

## `shep-daemon`

<blockquote>

## [0.4.4] - 2026-09-06

### Changed

- Move the shepherd-channel wire into its own crate
</blockquote>





</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).