### PR TITLE
fix(channel): refuse an inherited descriptor that is not a socket

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -403,14 +403,16 @@ never costs clarity.
   lives in three files across two crates, each carrying its own
   `#![allow(unsafe_code)]` or `#[allow(unsafe_code)]` with per-block
   `// SAFETY:` (IR-22/23): shep-daemon's `sys.rs` (eight sites on unix) and
-  `sys_windows.rs` (ten on Windows), and shep-channel's `endpoint.rs` (two
-  sites, one per platform: taking the descriptor the shepherd names in
-  `SHEP_CHANNEL_FD`, sound because a process-global guard makes it reachable
-  at most once per process, and `PeekNamedPipe` on Windows, which
+  `sys_windows.rs` (ten on Windows), and shep-channel's `endpoint.rs`
+  (three sites, two on unix and one on Windows: probing the descriptor the
+  shepherd names in `SHEP_CHANNEL_FD` under a `ManuallyDrop` that closes
+  nothing, then taking it, sound because a process-global guard makes that
+  reachable at most once per process, and `PeekNamedPipe` on Windows, which
   `PipeReader`'s own doc comment exists to justify). This line said
   "planned" and named only `sys.rs` for the whole of the Windows port, then
   said "exactly two files" after shep-channel added a third, then said "one
-  site" in `endpoint.rs` after it had grown a second.
+  site" in `endpoint.rs` after it had grown a second, then said "two sites,
+  one per platform" after unix grew the probe.
 - Open design decisions live at the bottom of map.md and in goals.md's open
   questions — check them before making architectural calls; if a decision is
   listed there, it is the maintainer's, not yours.

--- a/crates/shep-channel/src/endpoint.rs
+++ b/crates/shep-channel/src/endpoint.rs
@@ -464,9 +464,9 @@ mod tests {
         assert_eq!(back, "still open");
     }
 
-    /// The only test here that calls `connect`. `CHANNEL_TAKEN` is
-    /// process-global, and tests share one process. A second caller
-    /// here would find the channel already taken.
+    /// The only test that takes the channel. `CHANNEL_TAKEN` is
+    /// process-global, and tests share one process. The refusal above
+    /// probes before claiming, so it leaves the guard for this one.
     ///
     /// Asserts the transition, not just the second call's error. The
     /// first call must succeed here too, or a `connect` that refused

--- a/crates/shep-channel/src/endpoint.rs
+++ b/crates/shep-channel/src/endpoint.rs
@@ -227,12 +227,43 @@ fn read_half(transport: Transport) -> ReadHalf {
 /// a later, legitimate call would be refused for no reason.
 static CHANNEL_TAKEN: AtomicBool = AtomicBool::new(false);
 
+/// Refuses a descriptor that cannot be the shepherd's channel.
+///
+/// `getsockname` answers for any socket, connected or not. A shepherd
+/// that has already closed its end still passes.
+/// It reports `ENOTSOCK` for a plain file or pipe, `EBADF` for a closed
+/// number.
+/// A socket this process owns for its own reasons passes. Nothing the
+/// kernel offers names the descriptor a parent handed over.
+///
+/// # Errors
+///
+/// [`ChannelError::Unusable`] when the descriptor is not an open socket.
+/// It is left open either way.
+#[cfg(unix)]
+fn refuse_unless_socket(fd: i32) -> Result<(), ChannelError> {
+    use std::os::fd::FromRawFd as _;
+
+    // SAFETY: `ManuallyDrop` is the invariant. The value is never dropped,
+    // so nothing closes a descriptor this process may not own.
+    // `local_addr` reads through `&self` and moves nothing.
+    #[allow(unsafe_code)]
+    let probe = core::mem::ManuallyDrop::new(unsafe { Transport::from_raw_fd(fd) });
+    probe.local_addr().map_err(|error| {
+        ChannelError::Unusable(format!(
+            "{FD_VAR}={fd} is not an open socket ({error}): the shepherd passes \
+             the channel as one end of a socketpair"
+        ))
+    })?;
+    Ok(())
+}
+
 /// Opens the endpoint, returning the reader's half and the writer's clone.
 ///
 /// # Errors
 ///
 /// - [`ChannelError::Unusable`] when the endpoint names a mechanism this
-///   platform does not have.
+///   platform does not have, or a descriptor that is not an open socket.
 /// - [`ChannelError::Io`] when the pipe cannot be opened or the descriptor
 ///   cannot be cloned.
 /// - [`ChannelError::AlreadyTaken`] when this process already took its
@@ -241,14 +272,18 @@ pub(crate) fn connect(endpoint: &Endpoint) -> Result<(ReadHalf, Transport), Chan
     let transport = match endpoint {
         #[cfg(unix)]
         Endpoint::Descriptor(fd) => {
+            // Probes before claiming, like the Windows arm below. A refusal
+            // must leave the guard alone, or one bad descriptor would refuse
+            // every later call in this process.
+            refuse_unless_socket(*fd)?;
             if CHANNEL_TAKEN.swap(true, Ordering::SeqCst) {
                 return Err(ChannelError::AlreadyTaken);
             }
             use std::os::fd::FromRawFd as _;
             // SAFETY: soundness rests on the shepherd naming a descriptor it
-            // handed this process. `from_raw_fd` validates nothing, and the
-            // floor of 3 only keeps stdio out of reach. `CHANNEL_TAKEN` above
-            // makes this arm reachable once per process.
+            // handed this process. The probe above rules out everything but
+            // another socket this process owns. `CHANNEL_TAKEN` makes this arm
+            // reachable once per process.
             #[allow(unsafe_code)]
             unsafe {
                 Transport::from_raw_fd(*fd)
@@ -318,7 +353,7 @@ pub(crate) fn connect(endpoint: &Endpoint) -> Result<(ReadHalf, Transport), Chan
 #[cfg(test)]
 mod tests {
     #[cfg(unix)]
-    use std::os::fd::IntoRawFd as _;
+    use std::os::fd::{AsRawFd as _, IntoRawFd as _};
     #[cfg(unix)]
     use std::os::unix::net::UnixStream;
 
@@ -387,6 +422,46 @@ mod tests {
             descriptor_from(" 3 "),
             Ok(Endpoint::Descriptor(FIRST_INHERITABLE_FD))
         ));
+    }
+
+    /// Fails if a descriptor that is not a socket is adopted.
+    /// Fails too if the refusal closes it.
+    /// Adopting one would write frames into a file the process opened
+    /// for itself, then close it under the owner.
+    #[cfg(unix)]
+    #[test]
+    fn a_descriptor_that_is_not_a_socket_is_refused_and_left_open() {
+        use std::io::{Read as _, Seek as _, Write as _};
+
+        let path =
+            std::env::temp_dir().join(format!("shep-channel-not-a-socket-{}", std::process::id()));
+        let mut file = std::fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .open(&path)
+            .expect("open a plain file to point the descriptor at");
+        std::fs::remove_file(&path).expect("unlink the plain file");
+
+        match connect(&Endpoint::Descriptor(file.as_raw_fd())) {
+            Err(ChannelError::Unusable(what)) => assert!(
+                what.contains("is not an open socket"),
+                "the refusal does not say what is wrong with the descriptor: {what}"
+            ),
+            other => panic!("expected a refusal, got {other:?}"),
+        }
+
+        // The point of the refusal, not a second assertion about it. A
+        // probe that closed the descriptor would leave the number free
+        // for the next `open` to hand to someone else.
+        file.write_all(b"still open")
+            .expect("write after the refusal");
+        file.rewind().expect("rewind after the refusal");
+        let mut back = String::new();
+        file.read_to_string(&mut back)
+            .expect("read after the refusal");
+        assert_eq!(back, "still open");
     }
 
     /// The only test here that calls `connect`. `CHANNEL_TAKEN` is

--- a/crates/shep-channel/src/lib.rs
+++ b/crates/shep-channel/src/lib.rs
@@ -26,9 +26,9 @@
 //!   process on its own.
 
 #![doc(test(attr(deny(warnings))))]
-// Not `forbid`: `endpoint` needs one `unsafe` block per platform.
-// One takes the inherited descriptor on unix; the other peeks a
-// Windows pipe's buffer. Each carries its own `// SAFETY:` comment.
+// Not `forbid`: `endpoint` needs unsafe to reach the channel. Two blocks
+// on unix probe the inherited descriptor and then take it. One on
+// Windows peeks a pipe's buffer. Each carries its own `// SAFETY:` comment.
 #![deny(unsafe_code)]
 
 #[cfg(feature = "client")]

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -1906,3 +1906,21 @@ The reply is `SheepFieldSet { name, key, pending }` rather than `Response::Appli
 `PROTOCOL_VERSION` did not move again. It went to 4 earlier on the same branch, for the entry above, and one bump covers every additive variant that ships with it.
 
 `verified crates/shep-core/src/protocol/request.rs (Request::SetSheepField, Response::SheepFieldSet), crates/shep-daemon/src/supervisor.rs (handle_set_sheep_field, and merge_declared's next.fields.remove(key) which is the line this exists to avoid), crates/shep-daemon/src/rpc.rs (a_field_edit_is_reported_as_an_operator_override)`
+
+## The inherited descriptor
+
+### shep-channel probes the descriptor with `getsockname`, and refuses everything but a socket
+
+`SHEP_CHANNEL_FD` names a number and `from_raw_fd` believes it. The floor of 3 keeps stdio out of reach and that was the whole of the validation: a variable naming an open log file at fd 7 was adopted, written newline-delimited JSON, and closed on drop, with no error at any point. The descriptor's real owner then wrote into whatever the next `open` recycled that number for.
+
+**Why probe at all, when it cannot prove ownership:** it cannot, and nothing the kernel offers can. A socket this process opened for its own reasons still passes, so the check narrows the hole rather than closing it. What it changes is the shape of the failure: every wrong descriptor that is not a socket becomes a named refusal at startup, and only another unix socket stays silent. The harm is not hypothetical and std states it precisely. Remove the check, run the test, and the process aborts with `IO Safety violation: owned file descriptor already closed`, which is the double close caught by std's own runtime.
+
+**Why `getsockname` and not `SO_ERROR` or `getpeername`:** review suggested `take_error()`, which is `getsockopt(SO_ERROR)` underneath. It answers only whether the number is a socket, it accepts a TCP socket, and it reads-and-clears a pending socket error the app would otherwise see. `getpeername` answers more, and the extra thing it answers is connection state, which a live channel legitimately loses. Measured on macOS: a socketpair whose far end has closed returns `EINVAL` from `peer_addr()` while `read` still returns a clean `Ok(0)`, so a probe built on it would refuse a working channel whose shepherd went away first. `getsockname` is state-independent, so it can only refuse a descriptor that was always wrong, and std's `local_addr` rejects a non-unix address family for free.
+
+All three measured against the same descriptors. A plain file, a pipe and stdout report `ENOTSOCK`; a closed number reports `EBADF`; a TCP socket passes `SO_ERROR` and fails both address calls; a live socketpair and one whose peer has closed both pass `getsockname`.
+
+The probe runs before `CHANNEL_TAKEN`, matching the Windows arm's rule that a refusal takes nothing. Otherwise one bad descriptor would refuse every later call in the process. `ManuallyDrop` is what makes the probe sound without ownership, and it is load-bearing rather than decorative: drop it while keeping the check and the same test aborts the same way.
+
+What would actually close the hole is a shepherd-side change, not a client-side one. A nonce written into the socket before the exec, or a `SHEP_CHANNEL_PID` the crate compares against `getpid()`, would both survive an environment inherited by a grandchild. Both break every app on the current contract, so neither ships here.
+
+`verified crates/shep-channel/src/endpoint.rs (refuse_unless_socket, connect's Descriptor arm, a_descriptor_that_is_not_a_socket_is_refused_and_left_open)`


### PR DESCRIPTION
`SHEP_CHANNEL_FD` names a number and `from_raw_fd` believes it. A variable pointing at an open log file was adopted, written JSON, and closed on drop, with no error anywhere. The real owner then wrote into whatever the next `open` recycled that number for.

- Probe with `getsockname` before adopting, through a `ManuallyDrop<UnixStream>` so a refusal closes nothing
- Runs before `CHANNEL_TAKEN`, so a refusal leaves the guard alone
- Test asserts the refusal and that the descriptor still works afterwards

Not `take_error()` as suggested in the review thread. `getsockopt(SO_ERROR)` accepts a TCP socket, and it reads-and-clears a pending socket error the app would otherwise see. `getpeername` refuses a real channel whose shepherd end already closed: measured on macOS, `peer_addr()` returns `EINVAL` there while `read` still returns a clean `Ok(0)`. `getsockname` is state-independent, so it can only refuse a descriptor that was always wrong, and `local_addr` rejects a non-unix address family for free.

| fd points at | `SO_ERROR` | `getsockname` | `getpeername` |
|---|---|---|---|
| file, pipe, stdout | `ENOTSOCK` | `ENOTSOCK` | `ENOTSOCK` |
| closed number | `EBADF` | `EBADF` | `EBADF` |
| TCP socket | passes | refused | refused |
| live socketpair | passes | passes | passes |
| socketpair, shepherd end closed | passes | passes | `EINVAL` |

This narrows the hole, it does not close it. A unix socket the process owns for its own reasons still passes, and nothing the kernel offers says which descriptor a parent handed over. Closing it needs a shepherd-side nonce or a `SHEP_CHANNEL_PID`, and both break every app on the current contract. Reasoning in `docs/decisions.md`.

Non-vacuity: removing the probe, and keeping the probe but dropping the `ManuallyDrop`, each abort the new test with `IO Safety violation: owned file descriptor already closed`. That is std's runtime catching the double close the check exists to prevent.

Gate green: fmt, clippy, `cargo test --workspace --all-features`, rustdoc. No wire or CLI change. Windows arm untouched.

Closes the unresolved thread on #103.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved inherited connection handling by verifying that a descriptor is an open socket before use.
  - Non-socket descriptors are now rejected safely and remain available to the caller when refused.
  - Error documentation now clearly identifies invalid descriptor types.

- **Documentation**
  - Updated safety guidance and architectural documentation to describe descriptor validation, ownership preservation, and refusal behavior.
  - Clarified platform-specific descriptor checks for Unix and Windows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->