### PR TITLE
chore: release v0.4.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2058,7 +2058,7 @@ dependencies = [
 
 [[package]]
 name = "shep"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "anstyle",
  "assert_cmd",
@@ -2096,7 +2096,7 @@ dependencies = [
 
 [[package]]
 name = "shep-channel"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "command-fds",
  "serde",
@@ -2107,11 +2107,11 @@ dependencies = [
 
 [[package]]
 name = "shep-cli"
-version = "0.4.5"
+version = "0.4.6"
 
 [[package]]
 name = "shep-client"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "futures-util",
  "nix 0.29.0",
@@ -2127,7 +2127,7 @@ dependencies = [
 
 [[package]]
 name = "shep-core"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "annotate-snippets",
  "anstyle",
@@ -2158,7 +2158,7 @@ dependencies = [
 
 [[package]]
 name = "shep-daemon"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "bytes",
  "chrono",
@@ -2188,14 +2188,14 @@ dependencies = [
 
 [[package]]
 name = "shep-examples"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "nix 0.29.0",
 ]
 
 [[package]]
 name = "shep-macros"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "proc-macro2",
  "quote 1.0.47",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.4.5"
+version = "0.4.6"
 edition = "2024"
 # 1.88: serde-saphyr's let-chains need it; also the floor ratatui, sysinfo
 # and rmcp require.
@@ -33,11 +33,11 @@ license = "MIT OR Apache-2.0"
 # turn an inherited dependency's default features back on but never off, so the
 # floor is set off here. shep-core wants the wire types without the client
 # feature; a future consumer that wants the client opts back in.
-shep-channel = { path = "crates/shep-channel", version = "0.4.5", default-features = false }
-shep-core = { path = "crates/shep-core", version = "0.4.5" }
-shep-daemon = { path = "crates/shep-daemon", version = "0.4.5" }
-shep-client = { path = "crates/shep-client", version = "0.4.5" }
-shep-macros = { path = "crates/shep-macros", version = "0.4.5" }
+shep-channel = { path = "crates/shep-channel", version = "0.4.6", default-features = false }
+shep-core = { path = "crates/shep-core", version = "0.4.6" }
+shep-daemon = { path = "crates/shep-daemon", version = "0.4.6" }
+shep-client = { path = "crates/shep-client", version = "0.4.6" }
+shep-macros = { path = "crates/shep-macros", version = "0.4.6" }
 serde = { version = "1", default-features = false, features = ["derive"] }
 serde_json = { version = "1", default-features = false, features = ["std"] }
 toml = { version = "0.8", default-features = false, features = ["parse", "display"] }

--- a/crates/shep-channel/CHANGELOG.md
+++ b/crates/shep-channel/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this crate are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.6] - 2026-09-07
+
+
 ## [0.4.5] - 2026-09-06
 
 ### Fixed

--- a/crates/shep-cli/CHANGELOG.md
+++ b/crates/shep-cli/CHANGELOG.md
@@ -13,6 +13,50 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.6] - 2026-09-07
+
+### Added
+
+- Give the palette a band, a ground and four roles
+- Add the shared gauge, sparkline, rule and band cells
+- Carry a sheep's memory ceiling on ProcessInfo
+- Retain per-sheep cpu samples across the poll
+- Add the cpu sparkline and memory gauge columns
+- Paint the selected row and its gutter edge
+- Draw the title and section bands
+- Give the host strip gauges and a flock summary
+- Merge the log paths into one row with its size
+- Give the bleats feed its chip
+- Paint the status bar and its control indicator
+- Render backgrounds and reverse video in the gallery
+- Cap the name column and give the table two rows of air
+- Group the host's two readings before the flock's numbers
+- Redraw the landing pane ([#168](https://github.com/shep-pm/shep/pull/168))
+
+### Fixed
+
+- State theme's ground rule without claiming its callers exist
+- Cover the max_memory byte conversion with a real ProcessEntry
+- Drop fabricated IR-24 citation and strengthen two cpu-history tests
+- Split the memory gauge into a styled fill and a muted tail
+- Correct stale caption text after gutter paint change
+- Give the dogs section band its own sky role
+- Gauge before value, summary ahead of host memory on strip
+- Add the detail band's cfg pending cell, drop a temp-dir width dependency, dedupe rule rendering
+- Move the detail pane's cfg cell into the truncatable rest, last
+- Reword palette-specific captions, add CFG/CPU-history gallery coverage
+- Reword the MemCeiling caption and render the log row's on-disk size
+- Scale the sparkline to a fixed ceiling, not its own peak
+- Draw the flock rules and detail divider in the line role
+- Use f32::clamp instead of chained max/min in sparkline
+- Scale the cpu sparkline to the flock, not to each row or a core
+- Declare the tempfile version the test fixtures actually need
+- Measure the detail pane's used width in columns, not chars
+- Require both log files' metadata before showing a size
+- Drop the redundant word from the bleats feed header
+- Measure the group row's used width in columns, not chars
+
+
 ## [0.4.5] - 2026-09-06
 
 

--- a/crates/shep-client/CHANGELOG.md
+++ b/crates/shep-client/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.6] - 2026-09-07
+
+
 ## [0.4.5] - 2026-09-06
 
 

--- a/crates/shep-core/CHANGELOG.md
+++ b/crates/shep-core/CHANGELOG.md
@@ -10,6 +10,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.6] - 2026-09-07
+
+### Added
+
+- Redraw the landing pane ([#168](https://github.com/shep-pm/shep/pull/168))
+
+
 ## [0.4.5] - 2026-09-06
 
 

--- a/crates/shep-daemon/CHANGELOG.md
+++ b/crates/shep-daemon/CHANGELOG.md
@@ -10,6 +10,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.6] - 2026-09-07
+
+### Added
+
+- Redraw the landing pane ([#168](https://github.com/shep-pm/shep/pull/168))
+
+
 ## [0.4.5] - 2026-09-06
 
 

--- a/crates/shep-macros/CHANGELOG.md
+++ b/crates/shep-macros/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.6] - 2026-09-07
+
+
 ## [0.4.5] - 2026-09-06
 
 


### PR DESCRIPTION



## 🤖 New release

* `shep-channel`: 0.4.5 -> 0.4.6
* `shep-core`: 0.4.5 -> 0.4.6 (✓ API compatible changes)
* `shep-daemon`: 0.4.5 -> 0.4.6 (✓ API compatible changes)
* `shep-macros`: 0.4.5 -> 0.4.6
* `shep-client`: 0.4.5 -> 0.4.6
* `shep`: 0.4.5 -> 0.4.6 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>


## `shep-core`

<blockquote>

## [0.4.6] - 2026-09-07

### Added

- Redraw the landing pane ([#168](https://github.com/shep-pm/shep/pull/168))
</blockquote>

## `shep-daemon`

<blockquote>

## [0.4.6] - 2026-09-07

### Added

- Redraw the landing pane ([#168](https://github.com/shep-pm/shep/pull/168))
</blockquote>



## `shep`

<blockquote>

## [0.4.6] - 2026-09-07

### Added

- Give the palette a band, a ground and four roles
- Add the shared gauge, sparkline, rule and band cells
- Carry a sheep's memory ceiling on ProcessInfo
- Retain per-sheep cpu samples across the poll
- Add the cpu sparkline and memory gauge columns
- Paint the selected row and its gutter edge
- Draw the title and section bands
- Give the host strip gauges and a flock summary
- Merge the log paths into one row with its size
- Give the bleats feed its chip
- Paint the status bar and its control indicator
- Render backgrounds and reverse video in the gallery
- Cap the name column and give the table two rows of air
- Group the host's two readings before the flock's numbers
- Redraw the landing pane ([#168](https://github.com/shep-pm/shep/pull/168))

### Fixed

- State theme's ground rule without claiming its callers exist
- Cover the max_memory byte conversion with a real ProcessEntry
- Drop fabricated IR-24 citation and strengthen two cpu-history tests
- Split the memory gauge into a styled fill and a muted tail
- Correct stale caption text after gutter paint change
- Give the dogs section band its own sky role
- Gauge before value, summary ahead of host memory on strip
- Add the detail band's cfg pending cell, drop a temp-dir width dependency, dedupe rule rendering
- Move the detail pane's cfg cell into the truncatable rest, last
- Reword palette-specific captions, add CFG/CPU-history gallery coverage
- Reword the MemCeiling caption and render the log row's on-disk size
- Scale the sparkline to a fixed ceiling, not its own peak
- Draw the flock rules and detail divider in the line role
- Use f32::clamp instead of chained max/min in sparkline
- Scale the cpu sparkline to the flock, not to each row or a core
- Declare the tempfile version the test fixtures actually need
- Measure the detail pane's used width in columns, not chars
- Require both log files' metadata before showing a size
- Drop the redundant word from the bleats feed header
- Measure the group row's used width in columns, not chars
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).