### PR TITLE
chore: release v0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2058,7 +2058,7 @@ dependencies = [
 
 [[package]]
 name = "shep"
-version = "0.4.6"
+version = "0.5.0"
 dependencies = [
  "anstyle",
  "assert_cmd",
@@ -2096,7 +2096,7 @@ dependencies = [
 
 [[package]]
 name = "shep-channel"
-version = "0.4.6"
+version = "0.5.0"
 dependencies = [
  "command-fds",
  "serde",
@@ -2107,11 +2107,11 @@ dependencies = [
 
 [[package]]
 name = "shep-cli"
-version = "0.4.6"
+version = "0.5.0"
 
 [[package]]
 name = "shep-client"
-version = "0.4.6"
+version = "0.5.0"
 dependencies = [
  "futures-util",
  "nix 0.29.0",
@@ -2127,7 +2127,7 @@ dependencies = [
 
 [[package]]
 name = "shep-core"
-version = "0.4.6"
+version = "0.5.0"
 dependencies = [
  "annotate-snippets",
  "anstyle",
@@ -2159,7 +2159,7 @@ dependencies = [
 
 [[package]]
 name = "shep-daemon"
-version = "0.4.6"
+version = "0.5.0"
 dependencies = [
  "bytes",
  "chrono",
@@ -2189,14 +2189,14 @@ dependencies = [
 
 [[package]]
 name = "shep-examples"
-version = "0.4.6"
+version = "0.5.0"
 dependencies = [
  "nix 0.29.0",
 ]
 
 [[package]]
 name = "shep-macros"
-version = "0.4.6"
+version = "0.5.0"
 dependencies = [
  "proc-macro2",
  "quote 1.0.47",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.4.6"
+version = "0.5.0"
 edition = "2024"
 # 1.88: serde-saphyr's let-chains need it; also the floor ratatui, sysinfo
 # and rmcp require.
@@ -33,11 +33,11 @@ license = "MIT OR Apache-2.0"
 # turn an inherited dependency's default features back on but never off, so the
 # floor is set off here. shep-core wants the wire types without the client
 # feature; a future consumer that wants the client opts back in.
-shep-channel = { path = "crates/shep-channel", version = "0.4.6", default-features = false }
-shep-core = { path = "crates/shep-core", version = "0.4.6" }
-shep-daemon = { path = "crates/shep-daemon", version = "0.4.6" }
-shep-client = { path = "crates/shep-client", version = "0.4.6" }
-shep-macros = { path = "crates/shep-macros", version = "0.4.6" }
+shep-channel = { path = "crates/shep-channel", version = "0.5.0", default-features = false }
+shep-core = { path = "crates/shep-core", version = "0.5.0" }
+shep-daemon = { path = "crates/shep-daemon", version = "0.5.0" }
+shep-client = { path = "crates/shep-client", version = "0.5.0" }
+shep-macros = { path = "crates/shep-macros", version = "0.5.0" }
 serde = { version = "1", default-features = false, features = ["derive"] }
 serde_json = { version = "1", default-features = false, features = ["std"] }
 toml = { version = "0.8", default-features = false, features = ["parse", "display"] }

--- a/crates/shep-channel/CHANGELOG.md
+++ b/crates/shep-channel/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this crate are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.0] - 2026-09-07
+
+
 ## [0.4.6] - 2026-09-07
 
 

--- a/crates/shep-cli/CHANGELOG.md
+++ b/crates/shep-cli/CHANGELOG.md
@@ -13,6 +13,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-09-07
+
+### Added
+
+- Boot ordering with dependency trees ([#166](https://github.com/shep-pm/shep/pull/166)) **(BREAKING)**
+
+
 ## [0.4.6] - 2026-09-07
 
 ### Added

--- a/crates/shep-client/CHANGELOG.md
+++ b/crates/shep-client/CHANGELOG.md
@@ -10,6 +10,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-09-07
+
+### Added
+
+- Boot ordering with dependency trees ([#166](https://github.com/shep-pm/shep/pull/166)) **(BREAKING)**
+
+
 ## [0.4.6] - 2026-09-07
 
 

--- a/crates/shep-core/CHANGELOG.md
+++ b/crates/shep-core/CHANGELOG.md
@@ -10,6 +10,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-09-07
+
+### Added
+
+- Boot ordering with dependency trees ([#166](https://github.com/shep-pm/shep/pull/166)) **(BREAKING)**
+
+
 ## [0.4.6] - 2026-09-07
 
 ### Added

--- a/crates/shep-daemon/CHANGELOG.md
+++ b/crates/shep-daemon/CHANGELOG.md
@@ -10,6 +10,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-09-07
+
+### Added
+
+- Boot ordering with dependency trees ([#166](https://github.com/shep-pm/shep/pull/166)) **(BREAKING)**
+
+
 ## [0.4.6] - 2026-09-07
 
 ### Added

--- a/crates/shep-macros/CHANGELOG.md
+++ b/crates/shep-macros/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-09-07
+
+
 ## [0.4.6] - 2026-09-07
 
 


### PR DESCRIPTION



## 🤖 New release

* `shep-channel`: 0.4.6 -> 0.5.0
* `shep-core`: 0.4.6 -> 0.5.0 (✓ API compatible changes)
* `shep-daemon`: 0.4.6 -> 0.5.0 (✓ API compatible changes)
* `shep-macros`: 0.4.6 -> 0.5.0
* `shep-client`: 0.4.6 -> 0.5.0 (✓ API compatible changes)
* `shep`: 0.4.6 -> 0.5.0 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>


## `shep-core`

<blockquote>

## [0.5.0] - 2026-09-07

### Added

- Boot ordering with dependency trees ([#166](https://github.com/shep-pm/shep/pull/166)) **(BREAKING)**
</blockquote>

## `shep-daemon`

<blockquote>

## [0.5.0] - 2026-09-07

### Added

- Boot ordering with dependency trees ([#166](https://github.com/shep-pm/shep/pull/166)) **(BREAKING)**
</blockquote>


## `shep-client`

<blockquote>

## [0.5.0] - 2026-09-07

### Added

- Boot ordering with dependency trees ([#166](https://github.com/shep-pm/shep/pull/166)) **(BREAKING)**
</blockquote>

## `shep`

<blockquote>

## [0.5.0] - 2026-09-07

### Added

- Boot ordering with dependency trees ([#166](https://github.com/shep-pm/shep/pull/166)) **(BREAKING)**
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).