### PR TITLE
refactor(lookout): one Body enum and a generated scene list

### DIFF
--- a/crates/shep-cli/src/lookout/app.rs
+++ b/crates/shep-cli/src/lookout/app.rs
@@ -1604,7 +1604,7 @@ impl App {
             },
             // The screen opens on what this read found; a failed read leaves
             // the dashboard up. A landed write's re-read and `r` land here too,
-            // with `self.settings` already `Some`, so `opening` is false and
+            // with `body` already `Body::Settings`, so `opening` is false and
             // the cursor survives.
             Msg::Settings { result } => {
                 let opening = self.settings().is_none();
@@ -1653,7 +1653,7 @@ impl App {
                     Effect::LoadSettings
                 }
                 Err(message) => {
-                    // Split so no borrow of `self.settings` is held across the
+                    // Split so no borrow of `self.body` is held across the
                     // `self.notice` assignment below.
                     if let Some((field, buffer)) = typed_text_of(&edit) {
                         if let Some(settings) = self.settings_mut() {

--- a/crates/shep-cli/src/lookout/app.rs
+++ b/crates/shep-cli/src/lookout/app.rs
@@ -1238,6 +1238,15 @@ const CPU_CEILING_FLOOR: f32 = 2.0;
 /// the other two carry their screen's whole state directly, so there is
 /// nowhere for a stale value to survive a switch. See [`App::body`]'s doc
 /// comment for why this replaced two `Option` fields.
+///
+/// One field, one variant at a time, which is what used to be two
+/// independent `Option`s (`settings`, `config_pane`) kept disjoint only by
+/// convention. That made the pair's own history reachable: opening a config
+/// pane never cleared a settings screen still parked underneath it, so an
+/// `Escape` from a pane that outraced a slower settings read could resurface
+/// a screen the operator had already walked past. With one field there is
+/// nothing left underneath to resurface — see
+/// `escape_from_a_config_pane_that_outraced_a_settings_read_lands_on_the_dashboard`.
 #[derive(Debug)]
 pub(crate) enum Body {
     /// The dashboard: flock table, host strip, sheep detail, bleats feed.
@@ -2625,6 +2634,15 @@ impl App {
     /// runs (`e` on a dog, then the settings screen closes and `e` opens a
     /// sheep), and a stale one left set is exactly the re-open behind the
     /// operator's back `config_target` exists to prevent.
+    ///
+    /// This always lands on [`Body::FlockTable`], never on whatever screen
+    /// preceded the pane. That used to be reachable the other way: a
+    /// settings screen and a config pane were once two independent
+    /// `Option`s, so closing the pane only cleared its own field and a
+    /// still-`Some` settings screen underneath resurfaced — the dashboard is
+    /// what `Escape` is supposed to reach, not a screen the operator asked
+    /// for two actions ago. `Body` makes that unrepresentable: there is only
+    /// ever one screen to close to, and it is this one.
     fn close_pane(&mut self) {
         self.body = Body::FlockTable;
         self.pane_menu = None;
@@ -6370,7 +6388,7 @@ mod tests {
         assert!(app.settings().is_none());
     }
 
-    /// `s` raises `Effect::LoadSettings` while `self.settings` is still `None`,
+    /// `s` raises `Effect::LoadSettings` while `body` is still `Body::FlockTable`,
     /// so `x` reaches `arm()`. Once the read lands, `on_settings_key` no-ops
     /// `Confirm`, so nothing could resolve the armed action.
     #[test]
@@ -6876,6 +6894,43 @@ mod tests {
         let pane = app.config_pane().expect("the reply opens the pane");
         assert_eq!(pane.target().name(), "web");
         assert_eq!(pane.fields().len(), 40);
+    }
+
+    /// `s` then `e` fire two reads; if the settings one lands first it opens
+    /// the settings screen, and the config-pane reply that follows replaces
+    /// it (`Body` cannot hold both at once). `Escape` from the config pane
+    /// must land on the dashboard, not resurrect the settings screen it
+    /// walked past on the way in — see the doc note on [`Body`] and on
+    /// [`App::close_pane`].
+    #[test]
+    fn escape_from_a_config_pane_that_outraced_a_settings_read_lands_on_the_dashboard() {
+        let mut app =
+            fixtures::with_selection(ProcessInfo::builder(9, "web", ProcStatus::Online).build());
+        let _ = app.update(Msg::Key(KeyPress::Settings));
+        let _ = app.update(Msg::Key(KeyPress::Edit));
+        let _ = app.update(Msg::Settings {
+            result: Ok(fixtures::settings_snapshot()),
+        });
+        assert!(app.settings().is_some(), "the settings reply lands first");
+        app.update(Msg::Replied {
+            sent: Sent::SheepConfig {
+                name: "web".to_string(),
+            },
+            result: Ok(Response::SheepConfig(Box::new(
+                fixtures::sheep_config_view(),
+            ))),
+        });
+        assert!(
+            app.config_pane().is_some(),
+            "the config pane reply replaces the settings screen"
+        );
+        assert!(app.settings().is_none());
+        let _ = app.update(Msg::Key(KeyPress::Escape));
+        assert!(
+            matches!(app.body(), Body::FlockTable),
+            "esc from the pane goes to the dashboard, not back to settings"
+        );
+        assert!(app.settings().is_none());
     }
 
     #[test]

--- a/crates/shep-cli/src/lookout/app.rs
+++ b/crates/shep-cli/src/lookout/app.rs
@@ -1667,10 +1667,21 @@ impl App {
                     // Split so no borrow of `self.body` is held across the
                     // `self.notice` assignment below.
                     if let Some((field, buffer)) = typed_text_of(&edit) {
-                        if let Some(settings) = self.settings_mut() {
+                        // Only when the editor is really back up. A dog
+                        // section can have replaced the settings screen with
+                        // a config pane while the write was in flight, and
+                        // `InputMode::Text` with no editor behind it sends
+                        // every later keystroke to a text handler that owns
+                        // nothing.
+                        let reopened = if let Some(settings) = self.settings_mut() {
                             settings.pending = Some(Pending::Typing { field, buffer });
+                            true
+                        } else {
+                            false
+                        };
+                        if reopened {
+                            self.mode = InputMode::Text;
                         }
-                        self.mode = InputMode::Text;
                     } else if let Some(settings) = self.settings_mut() {
                         settings.pending = None;
                     }
@@ -6977,6 +6988,33 @@ mod tests {
             "the stale settings reply leaves the pane alone"
         );
         assert!(app.settings().is_none());
+    }
+
+    /// `typed_text_of` answers for the two free-text settings fields, and
+    /// its `Some` used to arm `InputMode::Text` whether or not the editor
+    /// it types into was still there. Opening a dog section replaces the
+    /// settings screen, so a refusal landing afterwards armed a text mode
+    /// over a pane, and `on_key` then sent every later keystroke to a text
+    /// handler owning nothing.
+    #[test]
+    fn a_refused_settings_write_landing_over_a_dog_pane_does_not_arm_text_mode() {
+        let mut app = fixtures::app_in_dog_pane();
+        assert!(app.config_pane().is_some(), "the pane is open");
+
+        let _ = app.update(Msg::SettingWritten {
+            edit: SettingEdit::Set {
+                field: SettingField::MaxCronSleep,
+                value: "500ms".to_string(),
+            },
+            result: Err("max_cron_sleep is 500ms, below the 1s floor".to_string()),
+        });
+
+        assert!(app.config_pane().is_some(), "the pane survives the reply");
+        assert_ne!(
+            app.mode(),
+            InputMode::Text,
+            "there is no settings editor for the keystrokes to reach"
+        );
     }
 
     #[test]

--- a/crates/shep-cli/src/lookout/app.rs
+++ b/crates/shep-cli/src/lookout/app.rs
@@ -4169,8 +4169,9 @@ impl App {
     ///
     /// `view::draw` matches on this directly rather than calling
     /// [`Self::settings`] and [`Self::config_pane`] in sequence, which is
-    /// what a ninth pane would otherwise have to insert itself into as a
-    /// third `if let`.
+    /// the two-branch `if let` chain a new pane would otherwise have to
+    /// insert itself into. Eight more panes are planned; each becomes a new
+    /// `Body` arm instead.
     #[must_use]
     pub(crate) fn body(&self) -> &Body {
         &self.body

--- a/crates/shep-cli/src/lookout/app.rs
+++ b/crates/shep-cli/src/lookout/app.rs
@@ -1231,6 +1231,24 @@ const HISTORY: usize = 140;
 /// enough that nothing else does.
 const CPU_CEILING_FLOOR: f32 = 2.0;
 
+/// What occupies the body between the title band and the status bar.
+///
+/// A variant per pane rather than a shared "which pane is open" enum plus
+/// separate state for each: the flock table needs no state of its own, and
+/// the other two carry their screen's whole state directly, so there is
+/// nowhere for a stale value to survive a switch. See [`App::body`]'s doc
+/// comment for why this replaced two `Option` fields.
+#[derive(Debug)]
+pub(crate) enum Body {
+    /// The dashboard: flock table, host strip, sheep detail, bleats feed.
+    FlockTable,
+    /// The settings screen, opened by [`KeyPress::Settings`].
+    Settings(Settings),
+    /// An open config pane, for a sheep or a dog, opened by
+    /// [`KeyPress::Edit`].
+    ConfigPane(ConfigPane),
+}
+
 /// The whole dashboard's state.
 #[derive(Debug)]
 pub struct App {
@@ -1281,8 +1299,11 @@ pub struct App {
     lambs: Option<LambReading>,
     /// The one action this dashboard is in the middle of, or `None`.
     action: Option<Action>,
-    /// The settings screen's own state. `None` is the dashboard.
-    settings: Option<Settings>,
+    /// What the body between the title band and the status bar is showing.
+    ///
+    /// One field rather than the two `Option`s this replaced: see [`Body`]'s
+    /// doc for why.
+    body: Body,
     /// Which sheep a config pane is open for, or wanted for.
     ///
     /// Set when the read goes out, cleared when the pane closes, checked
@@ -1297,14 +1318,6 @@ pub struct App {
     /// probed once at open and reused on every re-read, so `r` never
     /// respawns the dog's binary. Cleared alongside `config_target`.
     dog_target: Option<DogProbe>,
-    /// The open config pane, or `None`. Opened by `e` on a selected sheep,
-    /// and closed by `e` or `Escape` from inside it.
-    ///
-    /// A sibling of [`Self::settings`] rather than a field on it: the two
-    /// screens open from different places and neither is reachable from the
-    /// other. `on_key` checks this one first, so a pane opened over the
-    /// dashboard owns the keyboard for as long as it is up.
-    config_pane: Option<ConfigPane>,
     /// The apply offer over the open pane, or `None`.
     ///
     /// Opened by `Escape` on a pane with parked fields and the gate open,
@@ -1350,10 +1363,9 @@ impl App {
             feed: super::tail::Tail::default(),
             lambs: None,
             action: None,
-            settings: None,
+            body: Body::FlockTable,
             config_target: None,
             dog_target: None,
-            config_pane: None,
             pane_menu: None,
             style: (StyleLevel::Full, StyleSource::Default),
             cpu_history: HashMap::new(),
@@ -1430,7 +1442,7 @@ impl App {
                 // Against the tick's own `now`, not `self.now`, which stops on
                 // a dead link: a settings edit describes a local file that is
                 // no staler for the shepherd being gone.
-                if let Some(settings) = self.settings.as_mut() {
+                if let Some(settings) = self.settings_mut() {
                     let expired = matches!(
                         settings.pending,
                         Some(Pending::Armed { at, .. } | Pending::DogArmed { at, .. })
@@ -1444,7 +1456,7 @@ impl App {
                 // armed edit that can never be sent is not worth leaving
                 // on screen either, even with a live link. `now`, not
                 // `self.now`, which that guard stops advancing.
-                if let Some(pane) = self.config_pane.as_mut()
+                if let Some(pane) = self.config_pane_mut()
                     && pane
                         .armed_at()
                         .is_some_and(|at| now.saturating_duration_since(at) >= CONFIRM_EXPIRY)
@@ -1527,7 +1539,7 @@ impl App {
                 Sent::ApplyField {
                     name, ticket, key, ..
                 } => {
-                    if let Some(pane) = self.config_pane.as_mut() {
+                    if let Some(pane) = self.config_pane_mut() {
                         pane.settle(ticket);
                     }
                     self.notice = Some(Notice {
@@ -1539,7 +1551,7 @@ impl App {
                 Sent::SetEnv {
                     name, ticket, key, ..
                 } => {
-                    if let Some(pane) = self.config_pane.as_mut() {
+                    if let Some(pane) = self.config_pane_mut() {
                         pane.settle(ticket);
                     }
                     self.notice = Some(Notice {
@@ -1559,7 +1571,7 @@ impl App {
                     Effect::None
                 }
                 Sent::SetDogSection { name, ticket, .. } => {
-                    if let Some(pane) = self.config_pane.as_mut() {
+                    if let Some(pane) = self.config_pane_mut() {
                         pane.settle(ticket);
                     }
                     self.notice = Some(Notice {
@@ -1570,7 +1582,7 @@ impl App {
                 }
                 // The arm above, against the settings screen's pending line.
                 Sent::Dog { name, enable, .. } => {
-                    if let Some(settings) = self.settings.as_mut() {
+                    if let Some(settings) = self.settings_mut() {
                         settings.pending = None;
                     }
                     let verb = if enable { "enable" } else { "disable" };
@@ -1586,7 +1598,7 @@ impl App {
             // with `self.settings` already `Some`, so `opening` is false and
             // the cursor survives.
             Msg::Settings { result } => {
-                let opening = self.settings.is_none();
+                let opening = self.settings().is_none();
                 match result {
                     Ok(snapshot) => {
                         // An action armed while the read was in flight: once
@@ -1601,7 +1613,7 @@ impl App {
                         // `Settings::cursor` clamps on every read, so a
                         // preserved `Viewport` past a shorter dogs list
                         // still lands somewhere real.
-                        let view = self.settings.as_ref().map(|settings| settings.view.clone());
+                        let view = self.settings().map(|settings| settings.view.clone());
                         let mut settings = Settings::new(snapshot);
                         if !opening {
                             if let Some(view) = view {
@@ -1610,7 +1622,7 @@ impl App {
                             let len = settings.rows().len();
                             settings.view.clamp(len);
                         }
-                        self.settings = Some(settings);
+                        self.body = Body::Settings(settings);
                     }
                     Err(message) => {
                         self.notice = Some(Notice {
@@ -1626,7 +1638,7 @@ impl App {
             // free-text fields, so a long path need not be retyped.
             Msg::SettingWritten { edit, result } => match result {
                 Ok(()) => {
-                    if let Some(settings) = self.settings.as_mut() {
+                    if let Some(settings) = self.settings_mut() {
                         settings.pending = None;
                     }
                     Effect::LoadSettings
@@ -1635,11 +1647,11 @@ impl App {
                     // Split so no borrow of `self.settings` is held across the
                     // `self.notice` assignment below.
                     if let Some((field, buffer)) = typed_text_of(&edit) {
-                        if let Some(settings) = self.settings.as_mut() {
+                        if let Some(settings) = self.settings_mut() {
                             settings.pending = Some(Pending::Typing { field, buffer });
                         }
                         self.mode = InputMode::Text;
-                    } else if let Some(settings) = self.settings.as_mut() {
+                    } else if let Some(settings) = self.settings_mut() {
                         settings.pending = None;
                     }
                     self.notice = Some(Notice {
@@ -1684,7 +1696,7 @@ impl App {
                     source,
                 }),
                 Err(message) => {
-                    if let Some(settings) = self.settings.as_mut() {
+                    if let Some(settings) = self.settings_mut() {
                         settings.pending = None;
                     }
                     self.notice = Some(Notice {
@@ -1797,7 +1809,7 @@ impl App {
         enable: bool,
         result: Result<Response, RequestError>,
     ) -> Effect {
-        if let Some(settings) = self.settings.as_mut() {
+        if let Some(settings) = self.settings_mut() {
             settings.pending = None;
         }
         let verb = if enable { "enable" } else { "disable" };
@@ -1866,34 +1878,31 @@ impl App {
         }
         match result {
             Ok(Response::SheepConfig(view)) => {
-                let carried = self.config_pane.as_ref().map(|pane| pane.view().clone());
+                let carried = self.config_pane().map(|pane| pane.view().clone());
                 // The env sub-screen is carried too: a set re-reads the
                 // whole config, and without this it would close on the
                 // very keystroke that just added a row. Its cursor rides
                 // by key, not index, since a removal would rename it.
                 let carried_env = self
-                    .config_pane
-                    .as_ref()
+                    .config_pane()
                     .and_then(ConfigPane::env)
                     .map(|env| (env.view().clone(), env.cursor_key().map(str::to_owned)));
                 // The list sub-screen rides across for the same reason,
                 // and by index rather than by name: an element has no
                 // name. See `ListPane::adopt_view`.
                 let carried_list = self
-                    .config_pane
-                    .as_ref()
+                    .config_pane()
                     .and_then(ConfigPane::list)
                     .map(|list| (list.key().to_owned(), list.view().clone()));
                 // A question the operator has not answered, or a write
                 // still out, survives the rebuild. Only `Typing` is
                 // dropped. See `ConfigPane::adopt_pending_edit`.
                 let carried_edit = self
-                    .config_pane
-                    .as_ref()
+                    .config_pane()
                     .and_then(|pane| pane.pending_edit().cloned());
                 // Carried for the same reason as the cursor: a re-read must
                 // not dismiss a help note the operator has not dismissed.
-                let carried_help = self.config_pane.as_ref().is_some_and(ConfigPane::help_open);
+                let carried_help = self.config_pane().is_some_and(ConfigPane::help_open);
                 let mut pane = ConfigPane::sheep(*view);
                 pane.adopt_pending_edit(carried_edit);
                 if let Some(carried) = carried {
@@ -1906,7 +1915,7 @@ impl App {
                     pane.adopt_list_view(&key, carried);
                 }
                 pane.set_help_open(carried_help);
-                self.config_pane = Some(pane);
+                self.body = Body::ConfigPane(pane);
                 // The rebuilt pane carries no editor, so the keyboard must
                 // not still think one is open.
                 self.release_text_mode_if_unowned();
@@ -2011,12 +2020,11 @@ impl App {
                 // rebuild replaces the pane: see `Self::on_sheep_config`,
                 // which states the argument for each. A dog pane has no env
                 // sub-screen, so only two of the three apply.
-                let carried = self.config_pane.as_ref().map(|pane| pane.view().clone());
+                let carried = self.config_pane().map(|pane| pane.view().clone());
                 let carried_edit = self
-                    .config_pane
-                    .as_ref()
+                    .config_pane()
                     .and_then(|pane| pane.pending_edit().cloned());
-                let carried_help = self.config_pane.as_ref().is_some_and(ConfigPane::help_open);
+                let carried_help = self.config_pane().is_some_and(ConfigPane::help_open);
                 let mut pane = ConfigPane::dog(
                     probe.name,
                     probe.adopted_path,
@@ -2028,10 +2036,11 @@ impl App {
                     pane.adopt_view(carried);
                 }
                 pane.set_help_open(carried_help);
-                self.config_pane = Some(pane);
-                // The settings screen is what a dog pane opens over, and it
-                // closes only now, once there is something to look at.
-                self.settings = None;
+                // The settings screen is what a dog pane opens over, and this
+                // one assignment is what closes it: `Body` holds one
+                // variant, so the pane replaces it once there is something
+                // to look at.
+                self.body = Body::ConfigPane(pane);
                 self.release_text_mode_if_unowned();
             }
             Ok(_unrecognised) => {
@@ -2075,7 +2084,7 @@ impl App {
         ticket: u64,
         result: Result<Response, RequestError>,
     ) -> Effect {
-        if let Some(pane) = self.config_pane.as_mut() {
+        if let Some(pane) = self.config_pane_mut() {
             pane.settle(ticket);
         }
         match result {
@@ -2130,7 +2139,7 @@ impl App {
         key: &str,
         result: Result<Response, RequestError>,
     ) -> Effect {
-        if let Some(pane) = self.config_pane.as_mut() {
+        if let Some(pane) = self.config_pane_mut() {
             pane.settle(ticket);
         }
         match result {
@@ -2190,7 +2199,7 @@ impl App {
         was_set: bool,
         result: Result<Response, RequestError>,
     ) -> Effect {
-        if let Some(pane) = self.config_pane.as_mut() {
+        if let Some(pane) = self.config_pane_mut() {
             pane.settle(ticket);
         }
         match result {
@@ -2239,11 +2248,11 @@ impl App {
         // settings screen and the armed-confirm check below. The two
         // screens cannot coexist, so this ordering is a documentation
         // choice, not a correctness one.
-        if self.config_pane.is_some() {
+        if self.config_pane().is_some() {
             return self.on_pane_key(key);
         }
         // The settings screen owns its own keymap while it is open.
-        if self.settings.is_some() {
+        if self.settings().is_some() {
             return self.on_settings_key(key);
         }
         // A cancelling keypress is consumed: a stray `j` cancels the confirm
@@ -2339,13 +2348,13 @@ impl App {
             // cancel-before-act rule the dashboard follows. `Escape` closing
             // rather than quitting is where this screen swaps that cascade.
             KeyPress::Settings | KeyPress::Escape => {
-                let armed = self.settings.as_ref().is_some_and(Settings::is_armed);
+                let armed = self.settings().is_some_and(Settings::is_armed);
                 if armed {
-                    if let Some(settings) = self.settings.as_mut() {
+                    if let Some(settings) = self.settings_mut() {
                         settings.pending = None;
                     }
                 } else {
-                    self.settings = None;
+                    self.body = Body::FlockTable;
                 }
             }
             // An armed candidate eats the first movement key rather than also
@@ -2355,7 +2364,7 @@ impl App {
             | KeyPress::SelectDown
             | KeyPress::SelectFirst
             | KeyPress::SelectLast => {
-                if let Some(settings) = self.settings.as_mut() {
+                if let Some(settings) = self.settings_mut() {
                     if settings.is_armed() {
                         settings.pending = None;
                     } else {
@@ -2374,7 +2383,7 @@ impl App {
             // Re-reads `shep.toml`, so another process's write shows up, and
             // the cursor survives. An armed candidate eats this key too.
             KeyPress::Refresh => {
-                if let Some(settings) = self.settings.as_mut()
+                if let Some(settings) = self.settings_mut()
                     && settings.is_armed()
                 {
                     settings.pending = None;
@@ -2386,7 +2395,7 @@ impl App {
             // the pane shows the dog's real schema and section or nothing.
             // An armed candidate eats it first, like every other key here.
             KeyPress::Edit => {
-                if let Some(settings) = self.settings.as_mut()
+                if let Some(settings) = self.settings_mut()
                     && settings.is_armed()
                 {
                     settings.pending = None;
@@ -2421,7 +2430,7 @@ impl App {
     /// listing request is needed. An adopted-but-disabled dog stays in
     /// that list: configure-then-enable is the ordinary order.
     fn probe_dog_schema(&mut self) -> Effect {
-        let Some(settings) = self.settings.as_ref() else {
+        let Some(settings) = self.settings() else {
             return Effect::None;
         };
         let Some(SettingsRow::Dog(index)) = settings.cursor() else {
@@ -2480,7 +2489,7 @@ impl App {
         if self.mode != InputMode::Text {
             return;
         }
-        let owned = self.config_pane.as_ref().is_some_and(|pane| {
+        let owned = self.config_pane().is_some_and(|pane| {
             pane.env().map_or_else(
                 || matches!(pane.pending_edit(), Some(PanePending::Typing { .. })),
                 |env| env.typing().is_some(),
@@ -2511,18 +2520,10 @@ impl App {
         if self.pane_menu.is_some() {
             return self.on_pane_menu_key(key);
         }
-        if self
-            .config_pane
-            .as_ref()
-            .is_some_and(|pane| pane.list().is_some())
-        {
+        if self.config_pane().is_some_and(|pane| pane.list().is_some()) {
             return self.on_list_key(key);
         }
-        if self
-            .config_pane
-            .as_ref()
-            .is_some_and(|pane| pane.env().is_some())
-        {
+        if self.config_pane().is_some_and(|pane| pane.env().is_some()) {
             return self.on_env_key(key);
         }
         if key == KeyPress::Quit {
@@ -2532,10 +2533,10 @@ impl App {
         // `e` and `space`: the same carve-out `on_settings_key` makes, so a
         // choice can still reach its third value instead of needing a
         // cancel in between.
-        if self.config_pane.as_ref().is_some_and(ConfigPane::is_armed)
+        if self.config_pane().is_some_and(ConfigPane::is_armed)
             && !matches!(key, KeyPress::Confirm | KeyPress::Edit | KeyPress::Cycle)
         {
-            if let Some(pane) = self.config_pane.as_mut() {
+            if let Some(pane) = self.config_pane_mut() {
                 pane.cancel();
             }
             return Effect::None;
@@ -2547,9 +2548,9 @@ impl App {
             // filter clear or a quit, exactly as it does on the settings
             // screen.
             KeyPress::Escape => {
-                let help_open = self.config_pane.as_ref().is_some_and(ConfigPane::help_open);
+                let help_open = self.config_pane().is_some_and(ConfigPane::help_open);
                 if help_open {
-                    if let Some(pane) = self.config_pane.as_mut() {
+                    if let Some(pane) = self.config_pane_mut() {
                         pane.close_help();
                     }
                 } else if let Some(menu) = self.apply_offer() {
@@ -2562,7 +2563,7 @@ impl App {
             | KeyPress::SelectDown
             | KeyPress::SelectFirst
             | KeyPress::SelectLast => {
-                if let Some(pane) = self.config_pane.as_mut() {
+                if let Some(pane) = self.config_pane_mut() {
                     match key {
                         KeyPress::SelectUp => pane.move_by(-1),
                         KeyPress::SelectDown => pane.move_by(1),
@@ -2582,7 +2583,7 @@ impl App {
             // key to use it.
             KeyPress::Confirm | KeyPress::Edit => return self.confirm_field(),
             KeyPress::Help => {
-                if let Some(pane) = self.config_pane.as_mut() {
+                if let Some(pane) = self.config_pane_mut() {
                     pane.toggle_help();
                 }
             }
@@ -2607,7 +2608,7 @@ impl App {
     /// open and is parked on [`Self::dog_target`]; re-probing would respawn
     /// somebody else's binary on a keystroke whose job is to re-read a file.
     fn reread_pane(&mut self) -> Effect {
-        let Some(pane) = self.config_pane.as_ref() else {
+        let Some(pane) = self.config_pane() else {
             return Effect::None;
         };
         let name = pane.target().name().to_owned();
@@ -2625,7 +2626,7 @@ impl App {
     /// sheep), and a stale one left set is exactly the re-open behind the
     /// operator's back `config_target` exists to prevent.
     fn close_pane(&mut self) {
-        self.config_pane = None;
+        self.body = Body::FlockTable;
         self.pane_menu = None;
         self.config_target = None;
         self.dog_target = None;
@@ -2641,7 +2642,7 @@ impl App {
         if self.control == Control::ReadOnly {
             return None;
         }
-        let pane = self.config_pane.as_ref()?;
+        let pane = self.config_pane()?;
         let parked = pane.parked_count();
         (parked > 0).then(|| PaneMenu::new(parked, pane.reload_kind(), self.now))
     }
@@ -2713,8 +2714,7 @@ impl App {
             return Effect::None;
         }
         let Some(name) = self
-            .config_pane
-            .as_ref()
+            .config_pane()
             .map(|pane| pane.target().name().to_owned())
         else {
             return Effect::None;
@@ -2799,8 +2799,7 @@ impl App {
         // `--allow-control` would not change it. A screen that answers
         // one question two ways teaches an operator to believe neither.
         if let Some((key, lock)) = self
-            .config_pane
-            .as_ref()
+            .config_pane()
             .and_then(ConfigPane::cursor_lock)
             .map(|(key, lock)| (key.to_owned(), lock))
         {
@@ -2814,7 +2813,7 @@ impl App {
             return Effect::None;
         }
         let now = self.now;
-        if let Some(pane) = self.config_pane.as_mut() {
+        if let Some(pane) = self.config_pane_mut() {
             pane.cycle(now);
         }
         Effect::None
@@ -2840,7 +2839,14 @@ impl App {
         // unique, but the counter is easier to reason about when every
         // value on it names a request that went out.
         let ticket = self.next_write_ticket;
-        let Some(pane) = self.config_pane.as_mut() else {
+        // A direct field match, not `Self::config_pane_mut`: that helper
+        // borrows the whole struct for as long as `pane` lives, and this
+        // function still needs `self.next_write_ticket` while it is in
+        // scope.
+        let Some(pane) = (match &mut self.body {
+            Body::ConfigPane(pane) => Some(pane),
+            Body::FlockTable | Body::Settings(_) => None,
+        }) else {
             return Effect::None;
         };
         let Some(edit) = pane.take_armed(ticket) else {
@@ -2915,7 +2921,7 @@ impl App {
     /// sub-screen is gated too: it exists only to write, since the
     /// shepherd never sends a value back for it to show.
     fn confirm_field(&mut self) -> Effect {
-        let Some(pane) = self.config_pane.as_ref() else {
+        let Some(pane) = self.config_pane() else {
             return Effect::None;
         };
         if pane.is_armed() {
@@ -2953,7 +2959,7 @@ impl App {
         if self.authorize_write().is_none() {
             return Effect::None;
         }
-        let Some(pane) = self.config_pane.as_mut() else {
+        let Some(pane) = self.config_pane_mut() else {
             return Effect::None;
         };
         if kind == FieldKind::Map {
@@ -2983,10 +2989,10 @@ impl App {
         if key == KeyPress::Quit {
             return Effect::Quit;
         }
-        if self.config_pane.as_ref().is_some_and(ConfigPane::is_armed)
+        if self.config_pane().is_some_and(ConfigPane::is_armed)
             && !matches!(key, KeyPress::Confirm | KeyPress::Edit)
         {
-            if let Some(pane) = self.config_pane.as_mut() {
+            if let Some(pane) = self.config_pane_mut() {
                 pane.cancel();
             }
             return Effect::None;
@@ -2995,7 +3001,7 @@ impl App {
         match key {
             KeyPress::Quit => return Effect::Quit,
             KeyPress::Escape => {
-                if let Some(pane) = self.config_pane.as_mut() {
+                if let Some(pane) = self.config_pane_mut() {
                     pane.close_list();
                 }
                 self.release_text_mode_if_unowned();
@@ -3004,7 +3010,7 @@ impl App {
             | KeyPress::SelectDown
             | KeyPress::SelectFirst
             | KeyPress::SelectLast => {
-                if let Some(list) = self.config_pane.as_mut().and_then(ConfigPane::list_mut) {
+                if let Some(list) = self.config_pane_mut().and_then(ConfigPane::list_mut) {
                     match key {
                         KeyPress::SelectUp => list.move_by(-1),
                         KeyPress::SelectDown => list.move_by(1),
@@ -3016,13 +3022,13 @@ impl App {
             }
             KeyPress::Refresh => return self.reread_pane(),
             KeyPress::Confirm | KeyPress::Edit => {
-                if self.config_pane.as_ref().is_some_and(ConfigPane::is_armed) {
+                if self.config_pane().is_some_and(ConfigPane::is_armed) {
                     return self.send_armed();
                 }
                 if self.authorize_write().is_none() {
                     return Effect::None;
                 }
-                if let Some(list) = self.config_pane.as_mut().and_then(ConfigPane::list_mut) {
+                if let Some(list) = self.config_pane_mut().and_then(ConfigPane::list_mut) {
                     list.begin_typing();
                     self.mode = InputMode::Text;
                 }
@@ -3031,7 +3037,7 @@ impl App {
                 if self.authorize_write().is_none() {
                     return Effect::None;
                 }
-                if let Some(pane) = self.config_pane.as_mut() {
+                if let Some(pane) = self.config_pane_mut() {
                     pane.arm_list_removal(now);
                 }
             }
@@ -3040,7 +3046,7 @@ impl App {
                     return Effect::None;
                 }
                 let delta = if key == KeyPress::ListMoveUp { -1 } else { 1 };
-                if let Some(pane) = self.config_pane.as_mut() {
+                if let Some(pane) = self.config_pane_mut() {
                     pane.arm_list_reorder(delta, now);
                 }
             }
@@ -3076,10 +3082,10 @@ impl App {
         if key == KeyPress::Quit {
             return Effect::Quit;
         }
-        if self.config_pane.as_ref().is_some_and(ConfigPane::is_armed)
+        if self.config_pane().is_some_and(ConfigPane::is_armed)
             && !matches!(key, KeyPress::Confirm | KeyPress::Edit)
         {
-            if let Some(pane) = self.config_pane.as_mut() {
+            if let Some(pane) = self.config_pane_mut() {
                 pane.cancel();
             }
             return Effect::None;
@@ -3087,7 +3093,7 @@ impl App {
         match key {
             KeyPress::Quit => return Effect::Quit,
             KeyPress::Escape => {
-                if let Some(pane) = self.config_pane.as_mut() {
+                if let Some(pane) = self.config_pane_mut() {
                     pane.close_env();
                 }
                 self.release_text_mode_if_unowned();
@@ -3096,7 +3102,7 @@ impl App {
             | KeyPress::SelectDown
             | KeyPress::SelectFirst
             | KeyPress::SelectLast => {
-                if let Some(env) = self.config_pane.as_mut().and_then(ConfigPane::env_mut) {
+                if let Some(env) = self.config_pane_mut().and_then(ConfigPane::env_mut) {
                     match key {
                         KeyPress::SelectUp => env.move_by(-1),
                         KeyPress::SelectDown => env.move_by(1),
@@ -3110,13 +3116,13 @@ impl App {
             // `e` does exactly what `Enter` does here, the same rule the
             // field list follows.
             KeyPress::Confirm | KeyPress::Edit => {
-                if self.config_pane.as_ref().is_some_and(ConfigPane::is_armed) {
+                if self.config_pane().is_some_and(ConfigPane::is_armed) {
                     return self.send_armed();
                 }
                 if self.authorize_write().is_none() {
                     return Effect::None;
                 }
-                if let Some(env) = self.config_pane.as_mut().and_then(ConfigPane::env_mut) {
+                if let Some(env) = self.config_pane_mut().and_then(ConfigPane::env_mut) {
                     env.begin_typing();
                     self.mode = InputMode::Text;
                 }
@@ -3150,22 +3156,14 @@ impl App {
         if key == KeyPress::Quit {
             return Effect::Quit;
         }
-        if self
-            .config_pane
-            .as_ref()
-            .is_some_and(|pane| pane.list().is_some())
-        {
+        if self.config_pane().is_some_and(|pane| pane.list().is_some()) {
             return self.on_list_text_key(key);
         }
-        if self
-            .config_pane
-            .as_ref()
-            .is_some_and(|pane| pane.env().is_some())
-        {
+        if self.config_pane().is_some_and(|pane| pane.env().is_some()) {
             return self.on_env_text_key(key);
         }
         let now = self.now;
-        let Some(pane) = self.config_pane.as_mut() else {
+        let Some(pane) = self.config_pane_mut() else {
             return Effect::None;
         };
         match key {
@@ -3197,7 +3195,12 @@ impl App {
     /// rather than what the key asked for.
     fn on_list_text_key(&mut self, key: KeyPress) -> Effect {
         let now = self.now;
-        let Some(pane) = self.config_pane.as_mut() else {
+        // See the comment in `Self::send_armed`: a direct field match, not
+        // `Self::config_pane_mut`, so `self.mode` stays reachable below.
+        let Some(pane) = (match &mut self.body {
+            Body::ConfigPane(pane) => Some(pane),
+            Body::FlockTable | Body::Settings(_) => None,
+        }) else {
             return Effect::None;
         };
         let Some(list) = pane.list_mut() else {
@@ -3230,7 +3233,12 @@ impl App {
     /// [`Self::on_env_key`] for why an env write arms before it sends.
     fn on_env_text_key(&mut self, key: KeyPress) -> Effect {
         let now = self.now;
-        let Some(pane) = self.config_pane.as_mut() else {
+        // See the comment in `Self::send_armed`: a direct field match, not
+        // `Self::config_pane_mut`, so `self.mode` stays reachable below.
+        let Some(pane) = (match &mut self.body {
+            Body::ConfigPane(pane) => Some(pane),
+            Body::FlockTable | Body::Settings(_) => None,
+        }) else {
             return Effect::None;
         };
         let Some(env) = pane.env_mut() else {
@@ -3277,7 +3285,7 @@ impl App {
         if self.authorize_write().is_none() {
             return Effect::None;
         }
-        let Some(cursor) = self.settings.as_ref().and_then(Settings::cursor) else {
+        let Some(cursor) = self.settings().and_then(Settings::cursor) else {
             return Effect::None;
         };
         match cursor {
@@ -3290,7 +3298,12 @@ impl App {
     /// already armed, so a second `space` walks one step further along the
     /// cycle. Does nothing on the two free-text fields.
     fn cycle_scalar(&mut self, field: SettingField) -> Effect {
-        let Some(settings) = self.settings.as_mut() else {
+        // See the comment in `Self::send_armed`: a direct field match, not
+        // `Self::settings_mut`, so `self.now` stays reachable below.
+        let Some(settings) = (match &mut self.body {
+            Body::Settings(settings) => Some(settings),
+            Body::FlockTable | Body::ConfigPane(_) => None,
+        }) else {
             return Effect::None;
         };
         let Some(value) = settings.next_candidate(field) else {
@@ -3319,7 +3332,12 @@ impl App {
             });
             return Effect::None;
         }
-        let Some(settings) = self.settings.as_mut() else {
+        // See the comment in `Self::send_armed`: a direct field match, not
+        // `Self::settings_mut`, so `self.now` stays reachable below.
+        let Some(settings) = (match &mut self.body {
+            Body::Settings(settings) => Some(settings),
+            Body::FlockTable | Body::ConfigPane(_) => None,
+        }) else {
             return Effect::None;
         };
         let Some(dog) = settings.snapshot.dogs.get(index) else {
@@ -3349,7 +3367,7 @@ impl App {
     /// editor is gated as well as applying it, so the refusal arrives before a
     /// whole socket path is typed.
     fn confirm_setting(&mut self) -> Effect {
-        let Some(settings) = self.settings.as_ref() else {
+        let Some(settings) = self.settings() else {
             return Effect::None;
         };
         let opens_editor = settings.pending.is_none()
@@ -3365,7 +3383,7 @@ impl App {
         let Some(authority) = self.authorize_write() else {
             return Effect::None;
         };
-        let Some(settings) = self.settings.as_mut() else {
+        let Some(settings) = self.settings_mut() else {
             return Effect::None;
         };
         if opens_editor {
@@ -3603,10 +3621,10 @@ impl App {
         // only from the dashboard, and `s` only from there too), and
         // neither can coexist with the filter box, which `Msg::Settings`'s
         // own arm closed the window on.
-        if self.config_pane.is_some() {
+        if self.config_pane().is_some() {
             return self.on_pane_text_key(key);
         }
-        if self.settings.is_some() {
+        if self.settings().is_some() {
             return self.on_settings_text_key(key);
         }
         self.on_filter_text_key(key)
@@ -3652,7 +3670,7 @@ impl App {
     /// `Enter` sends it. `TextAbandon` leaves the screen open.
     fn on_settings_text_key(&mut self, key: KeyPress) -> Effect {
         let now = self.now;
-        let Some(settings) = self.settings.as_mut() else {
+        let Some(settings) = self.settings_mut() else {
             return Effect::None;
         };
         match key {
@@ -4129,21 +4147,44 @@ impl App {
         })
     }
 
+    /// What the body between the title band and the status bar is showing.
+    ///
+    /// `view::draw` matches on this directly rather than calling
+    /// [`Self::settings`] and [`Self::config_pane`] in sequence, which is
+    /// what a ninth pane would otherwise have to insert itself into as a
+    /// third `if let`.
+    #[must_use]
+    pub(crate) fn body(&self) -> &Body {
+        &self.body
+    }
+
     /// The settings screen's own state, or `None` while the dashboard is
     /// showing.
     #[must_use]
     pub fn settings(&self) -> Option<&Settings> {
-        self.settings.as_ref()
+        match &self.body {
+            Body::Settings(settings) => Some(settings),
+            Body::FlockTable | Body::ConfigPane(_) => None,
+        }
+    }
+
+    /// [`Self::settings`]'s mutable twin, for the settings keymap and the
+    /// handlers that update a field or a pending edit in place.
+    fn settings_mut(&mut self) -> Option<&mut Settings> {
+        match &mut self.body {
+            Body::Settings(settings) => Some(settings),
+            Body::FlockTable | Body::ConfigPane(_) => None,
+        }
     }
 
     /// Tells every scrollable screen how tall the body is. Called by the
     /// event loop before each draw, so a screen's cursor never lands on a
     /// row that was not rendered.
     pub fn note_body_rows(&mut self, rows: u16) {
-        if let Some(settings) = self.settings.as_mut() {
+        if let Some(settings) = self.settings_mut() {
             settings.set_rows(usize::from(rows));
         }
-        if let Some(pane) = self.config_pane.as_mut() {
+        if let Some(pane) = self.config_pane_mut() {
             // One less than the settings screen gets: the pane spends its
             // first line on a title naming the sheep, which
             // `view::pane::pane_lines` draws before any row.
@@ -4163,7 +4204,19 @@ impl App {
     /// The open config pane, or `None` while nothing is being edited.
     #[must_use]
     pub fn config_pane(&self) -> Option<&ConfigPane> {
-        self.config_pane.as_ref()
+        match &self.body {
+            Body::ConfigPane(pane) => Some(pane),
+            Body::FlockTable | Body::Settings(_) => None,
+        }
+    }
+
+    /// [`Self::config_pane`]'s mutable twin, for the pane keymap and the
+    /// handlers that settle a write or adopt a re-read in place.
+    fn config_pane_mut(&mut self) -> Option<&mut ConfigPane> {
+        match &mut self.body {
+            Body::ConfigPane(pane) => Some(pane),
+            Body::FlockTable | Body::Settings(_) => None,
+        }
     }
 
     /// The apply offer over the open pane, or `None`.

--- a/crates/shep-cli/src/lookout/app.rs
+++ b/crates/shep-cli/src/lookout/app.rs
@@ -1609,6 +1609,17 @@ impl App {
             Msg::Settings { result } => {
                 let opening = self.settings().is_none();
                 match result {
+                    // A config pane opened while this read was in flight, so
+                    // the operator asked for the pane AFTER asking for
+                    // settings and this reply is the stale one. Adopting it
+                    // would replace the pane with a settings screen the
+                    // operator has moved on from, and leave `config_target`
+                    // and `pane_menu` describing a screen that is no longer
+                    // up. The `Body` enum stops the two coexisting; it does
+                    // not stop this handler overwriting one with the other,
+                    // which is the same race `on_sheep_config` had in the
+                    // opposite direction.
+                    Ok(_) if self.config_pane().is_some() => {}
                     Ok(snapshot) => {
                         // An action armed while the read was in flight: once
                         // the screen is up, `on_settings_key` no-ops `Confirm`
@@ -6930,6 +6941,40 @@ mod tests {
         assert!(
             matches!(app.body(), Body::FlockTable),
             "esc from the pane goes to the dashboard, not back to settings"
+        );
+        assert!(app.settings().is_none());
+    }
+
+    /// The sibling above pins the order where the settings read wins. This
+    /// is the other one, and it is the order that used to corrupt state:
+    /// the pane's own reply lands first, and the settings read arrives with
+    /// the operator two actions past caring about it. `Msg::Settings` wrote
+    /// `body` unconditionally, so the reply replaced the pane, reset the
+    /// cursor as if opening, and forced `InputMode::Normal` while
+    /// `config_target` and `pane_menu` went on describing a pane that was
+    /// no longer on screen.
+    #[test]
+    fn a_settings_read_landing_after_a_config_pane_leaves_the_pane_up() {
+        let mut app =
+            fixtures::with_selection(ProcessInfo::builder(9, "web", ProcStatus::Online).build());
+        let _ = app.update(Msg::Key(KeyPress::Settings));
+        let _ = app.update(Msg::Key(KeyPress::Edit));
+        app.update(Msg::Replied {
+            sent: Sent::SheepConfig {
+                name: "web".to_string(),
+            },
+            result: Ok(Response::SheepConfig(Box::new(
+                fixtures::sheep_config_view(),
+            ))),
+        });
+        assert!(app.config_pane().is_some(), "the pane reply lands first");
+
+        let _ = app.update(Msg::Settings {
+            result: Ok(fixtures::settings_snapshot()),
+        });
+        assert!(
+            app.config_pane().is_some(),
+            "the stale settings reply leaves the pane alone"
         );
         assert!(app.settings().is_none());
     }

--- a/crates/shep-cli/src/lookout/frames.rs
+++ b/crates/shep-cli/src/lookout/frames.rs
@@ -2404,6 +2404,17 @@ mod tests {
     fn scene_all_lists_every_variant_the_compiler_can_see() {
         let mut walked = vec![Scene::HealthyWide];
         while let Some(next) = scene_after(*walked.last().unwrap()) {
+            // Bounded, because `scene_after` is a hand-kept chain and a
+            // variant wired back at an earlier one would otherwise spin here
+            // forever. Nextest has no per-test timeout, so an unbounded walk
+            // fails as a twenty-minute job timeout with no named test rather
+            // than as an assertion.
+            assert!(
+                walked.len() < Scene::ALL.len(),
+                "scene_after cycles: walked {} scenes without reaching the end of {}",
+                walked.len(),
+                Scene::ALL.len()
+            );
             walked.push(next);
         }
         assert_eq!(walked.as_slice(), Scene::ALL);

--- a/crates/shep-cli/src/lookout/frames.rs
+++ b/crates/shep-cli/src/lookout/frames.rs
@@ -126,8 +126,41 @@ fn sgr(fg: Color, bg: Color, modifier: Modifier) -> String {
     out
 }
 
+/// Declares `Scene` and its `ALL` listing from one variant list, so the two
+/// cannot diverge by construction: a variant left out of the macro call
+/// simply does not exist, and one included is in both the enum and `ALL` by
+/// the same repetition. `scene_after`, below, still has to be kept in step
+/// by hand — its own doc explains what it catches that this macro does not.
+macro_rules! scenes {
+    (
+        $(#[$enum_doc:meta])*
+        pub enum Scene {
+            $(
+                $(#[$variant_doc:meta])*
+                $variant:ident,
+            )*
+        }
+    ) => {
+        $(#[$enum_doc])*
+        #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+        pub enum Scene {
+            $(
+                $(#[$variant_doc])*
+                $variant,
+            )*
+        }
+
+        impl Scene {
+            /// Every scene, in the order they appear in the gallery.
+            pub const ALL: &'static [Self] = &[
+                $(Self::$variant,)*
+            ];
+        }
+    };
+}
+
+scenes! {
 /// The scenes the frame snapshots pin and the gallery renders.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Scene {
     /// A healthy flock at a comfortable width, all three panes up.
     HealthyWide,
@@ -215,47 +248,9 @@ pub enum Scene {
     /// the cursor on the last one, so the view has scrolled.
     SettingsShort,
 }
+}
 
 impl Scene {
-    /// Every scene, in the order they appear in the gallery.
-    pub const ALL: &'static [Self] = &[
-        Self::HealthyWide,
-        Self::Errored,
-        Self::Grouped,
-        Self::WithDogs,
-        Self::MemCeiling,
-        Self::CfgDrift,
-        Self::Empty,
-        Self::Narrow,
-        Self::TooNarrow,
-        Self::Retrying,
-        Self::Frozen,
-        Self::Refused,
-        Self::FilterEditing,
-        Self::FilterActive,
-        Self::FilterNoMatch,
-        Self::NoDetail,
-        Self::TableOnly,
-        Self::FeedGap,
-        Self::FeedMissing,
-        Self::Cramped,
-        Self::HostUnknown,
-        Self::Lambs,
-        Self::LambsUnknown,
-        Self::Confirm,
-        Self::Acting,
-        Self::ActionRefused,
-        Self::ActionAccepted,
-        Self::ActionRefusedOffline,
-        Self::SettingsFresh,
-        Self::SettingsSet,
-        Self::SettingsConfirm,
-        Self::SettingsTyping,
-        Self::SettingsDogs,
-        Self::SettingsNarrow,
-        Self::SettingsShort,
-    ];
-
     /// The snapshot name and the gallery heading.
     #[must_use]
     pub const fn label(self) -> &'static str {
@@ -2349,6 +2344,15 @@ mod tests {
     /// below walks this chain and checks it against `ALL`, which a
     /// hand-counted length could not: a forgotten scene just left the count
     /// honest at the old number.
+    ///
+    /// The `scenes!` macro that declares `Scene` keeps a variant from being
+    /// left out of `ALL` outright — the two are generated from one list, so
+    /// they cannot disagree on membership. What that macro cannot catch is
+    /// this chain: a variant could still get an arm here that loops back on
+    /// itself or points somewhere unreachable from `HealthyWide`, compiling
+    /// fine while never being walked. That is exactly what this test's own
+    /// walk-and-compare catches, so the two mechanisms are covering
+    /// different halves of the same failure, not one covering the other.
     fn scene_after(scene: Scene) -> Option<Scene> {
         match scene {
             Scene::HealthyWide => Some(Scene::Errored),

--- a/crates/shep-cli/src/lookout/frames.rs
+++ b/crates/shep-cli/src/lookout/frames.rs
@@ -2339,10 +2339,70 @@ mod tests {
                 which.label()
             );
         }
-        // The literal 34 catches a scene added to the enum but not to
-        // `ALL`, or the reverse; `labels.len()` would not, since `insert`
-        // above already guarantees it.
-        assert_eq!(Scene::ALL.len(), 35);
+    }
+
+    /// The scene that follows `scene` in gallery order, or `None` after the
+    /// last one. Mirrors `Scene::ALL`'s own order.
+    ///
+    /// Exhaustive over [`Scene`], with no wildcard arm: a variant added to
+    /// the enum without an arm here fails to compile. `scene_all_lists_every_variant_the_compiler_can_see`
+    /// below walks this chain and checks it against `ALL`, which a
+    /// hand-counted length could not: a forgotten scene just left the count
+    /// honest at the old number.
+    fn scene_after(scene: Scene) -> Option<Scene> {
+        match scene {
+            Scene::HealthyWide => Some(Scene::Errored),
+            Scene::Errored => Some(Scene::Grouped),
+            Scene::Grouped => Some(Scene::WithDogs),
+            Scene::WithDogs => Some(Scene::MemCeiling),
+            Scene::MemCeiling => Some(Scene::CfgDrift),
+            Scene::CfgDrift => Some(Scene::Empty),
+            Scene::Empty => Some(Scene::Narrow),
+            Scene::Narrow => Some(Scene::TooNarrow),
+            Scene::TooNarrow => Some(Scene::Retrying),
+            Scene::Retrying => Some(Scene::Frozen),
+            Scene::Frozen => Some(Scene::Refused),
+            Scene::Refused => Some(Scene::FilterEditing),
+            Scene::FilterEditing => Some(Scene::FilterActive),
+            Scene::FilterActive => Some(Scene::FilterNoMatch),
+            Scene::FilterNoMatch => Some(Scene::NoDetail),
+            Scene::NoDetail => Some(Scene::TableOnly),
+            Scene::TableOnly => Some(Scene::FeedGap),
+            Scene::FeedGap => Some(Scene::FeedMissing),
+            Scene::FeedMissing => Some(Scene::Cramped),
+            Scene::Cramped => Some(Scene::HostUnknown),
+            Scene::HostUnknown => Some(Scene::Lambs),
+            Scene::Lambs => Some(Scene::LambsUnknown),
+            Scene::LambsUnknown => Some(Scene::Confirm),
+            Scene::Confirm => Some(Scene::Acting),
+            Scene::Acting => Some(Scene::ActionRefused),
+            Scene::ActionRefused => Some(Scene::ActionAccepted),
+            Scene::ActionAccepted => Some(Scene::ActionRefusedOffline),
+            Scene::ActionRefusedOffline => Some(Scene::SettingsFresh),
+            Scene::SettingsFresh => Some(Scene::SettingsSet),
+            Scene::SettingsSet => Some(Scene::SettingsConfirm),
+            Scene::SettingsConfirm => Some(Scene::SettingsTyping),
+            Scene::SettingsTyping => Some(Scene::SettingsDogs),
+            Scene::SettingsDogs => Some(Scene::SettingsNarrow),
+            Scene::SettingsNarrow => Some(Scene::SettingsShort),
+            Scene::SettingsShort => None,
+        }
+    }
+
+    /// Walks [`scene_after`] from the first scene and checks the walk names
+    /// exactly `Scene::ALL`, in the same order.
+    ///
+    /// The walk can only see variants `scene_after` was taught about, and
+    /// that match cannot compile with one missing, so a scene left out of
+    /// `ALL` shows up here as a length or order mismatch rather than as
+    /// nothing at all.
+    #[test]
+    fn scene_all_lists_every_variant_the_compiler_can_see() {
+        let mut walked = vec![Scene::HealthyWide];
+        while let Some(next) = scene_after(*walked.last().unwrap()) {
+            walked.push(next);
+        }
+        assert_eq!(walked.as_slice(), Scene::ALL);
     }
 
     /// `sgr` now draws a foreground, a background and `REVERSED`, so the

--- a/crates/shep-cli/src/lookout/view/mod.rs
+++ b/crates/shep-cli/src/lookout/view/mod.rs
@@ -27,7 +27,7 @@ use ratatui::style::Style;
 use ratatui::text::{Line, Span};
 
 use self::flock::MIN_HEIGHT;
-use super::app::{App, Link, RowKey};
+use super::app::{App, Body, Link, RowKey};
 use super::theme::Palette;
 use crate::vocabulary::Role;
 
@@ -218,34 +218,35 @@ pub fn draw(app: &App, frame: &mut Frame<'_>) {
         y += 1;
     }
 
-    // The settings screen owns the whole body between the title and the
-    // status bar. That is a swap, not an overlay: the banner, the host
-    // strip, the flock table and the two bottom panes all belong to the
-    // body this branch replaces, so none of them draw while it is open.
-    // The config pane owns the same body and is checked first, the same
-    // order `App::on_key` uses.
-    if let Some(pane) = app.config_pane() {
-        let body = Rect {
-            x: area.x,
-            y,
-            width,
-            height: body_rows(area),
-        };
-        pane::draw_pane(app, pane, body, buffer);
-        buffer.set_line(area.x, bottom, &status::status_line(app, width), width);
-        return;
-    }
-
-    if let Some(settings) = app.settings() {
-        let body = Rect {
-            x: area.x,
-            y,
-            width,
-            height: body_rows(area),
-        };
-        settings::draw_settings(app, settings, body, buffer);
-        buffer.set_line(area.x, bottom, &status::status_line(app, width), width);
-        return;
+    // The settings screen and the config pane each own the whole body
+    // between the title and the status bar: a swap, not an overlay, so
+    // nothing below draws while one is up. One `match` on `App::body`
+    // rather than two sequential `if let`s, since the two can never both
+    // be open at once.
+    match app.body() {
+        Body::ConfigPane(pane) => {
+            let body = Rect {
+                x: area.x,
+                y,
+                width,
+                height: body_rows(area),
+            };
+            pane::draw_pane(app, pane, body, buffer);
+            buffer.set_line(area.x, bottom, &status::status_line(app, width), width);
+            return;
+        }
+        Body::Settings(settings) => {
+            let body = Rect {
+                x: area.x,
+                y,
+                width,
+                height: body_rows(area),
+            };
+            settings::draw_settings(app, settings, body, buffer);
+            buffer.set_line(area.x, bottom, &status::status_line(app, width), width);
+            return;
+        }
+        Body::FlockTable => {}
     }
 
     if let Some(banner) = status::banner_line(app) {


### PR DESCRIPTION
Refactors the three files every new lookout pane has to touch, before the rest of the redesign frames from #168 land on them.

- `settings` and `config_pane` merge into one `Body` enum, so opening one pane closes the other structurally
- A `scenes!` macro generates `Scene` and `Scene::ALL` from one list, replacing a hand-bumped `ALL.len() == 35` that six coming panes would each have to bump
- `esc` from a config pane that outraced a settings read now lands on the dashboard, not a stale settings screen

Only the `esc` path changes behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **User Interface**
  - Settings and configuration screens now open exclusively, preventing inactive screens from appearing behind the current view.
  - Closing a configuration screen consistently returns to the dashboard.
  - Refreshing configuration screens preserves the cursor position, active subsection, pending edits, and help state.
  - Screen transitions and rendering are more consistent across dashboard, settings, and configuration views.
  - Navigation between available screens now follows a consistent, complete sequence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->