### PR TITLE
chore: release v0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2068,7 +2068,7 @@ dependencies = [
 
 [[package]]
 name = "shep"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "anstyle",
  "assert_cmd",
@@ -2106,7 +2106,7 @@ dependencies = [
 
 [[package]]
 name = "shep-channel"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "command-fds",
  "serde",
@@ -2117,11 +2117,11 @@ dependencies = [
 
 [[package]]
 name = "shep-cli"
-version = "0.5.1"
+version = "0.6.0"
 
 [[package]]
 name = "shep-client"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "futures-util",
  "nix 0.29.0",
@@ -2137,7 +2137,7 @@ dependencies = [
 
 [[package]]
 name = "shep-core"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "annotate-snippets",
  "anstyle",
@@ -2170,7 +2170,7 @@ dependencies = [
 
 [[package]]
 name = "shep-daemon"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "bytes",
  "chrono",
@@ -2200,14 +2200,14 @@ dependencies = [
 
 [[package]]
 name = "shep-examples"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "nix 0.29.0",
 ]
 
 [[package]]
 name = "shep-macros"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "proc-macro2",
  "quote 1.0.47",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.5.1"
+version = "0.6.0"
 edition = "2024"
 # 1.88: serde-saphyr's let-chains need it; also the floor ratatui, sysinfo
 # and rmcp require.
@@ -33,11 +33,11 @@ license = "MIT OR Apache-2.0"
 # turn an inherited dependency's default features back on but never off, so the
 # floor is set off here. shep-core wants the wire types without the client
 # feature; a future consumer that wants the client opts back in.
-shep-channel = { path = "crates/shep-channel", version = "0.5.1", default-features = false }
-shep-core = { path = "crates/shep-core", version = "0.5.1" }
-shep-daemon = { path = "crates/shep-daemon", version = "0.5.1" }
-shep-client = { path = "crates/shep-client", version = "0.5.1" }
-shep-macros = { path = "crates/shep-macros", version = "0.5.1" }
+shep-channel = { path = "crates/shep-channel", version = "0.6.0", default-features = false }
+shep-core = { path = "crates/shep-core", version = "0.6.0" }
+shep-daemon = { path = "crates/shep-daemon", version = "0.6.0" }
+shep-client = { path = "crates/shep-client", version = "0.6.0" }
+shep-macros = { path = "crates/shep-macros", version = "0.6.0" }
 serde = { version = "1", default-features = false, features = ["derive"] }
 serde_json = { version = "1", default-features = false, features = ["std"] }
 toml = { version = "0.8", default-features = false, features = ["parse", "display"] }

--- a/crates/shep-channel/CHANGELOG.md
+++ b/crates/shep-channel/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this crate are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.0] - 2026-09-07
+
+
 ## [0.5.1] - 2026-09-07
 
 

--- a/crates/shep-cli/CHANGELOG.md
+++ b/crates/shep-cli/CHANGELOG.md
@@ -13,6 +13,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-09-07
+
+### Added
+
+- Name the apps a staged restart could not restart **(BREAKING)**
+- Decode an unknown error code or process event instead of failing
+- Refuse an unrecognized request by id instead of ending the connection
+- Accept any peer at or above a protocol floor **(BREAKING)**
+- Name the protocol floor in version output
+- A protocol floor, tolerant decode, and refusals a staged restart can name ([#173](https://github.com/shep-pm/shep/pull/173)) **(BREAKING)**
+
+### Changed
+
+- Stop leaking version_text on every call
+
+### Fixed
+
+- Exit non-zero and name the apps a restart went around
+- Judge a dog's protocol against the floor rather than exact equality
+
+
 ## [0.5.1] - 2026-09-07
 
 ### Changed

--- a/crates/shep-client/CHANGELOG.md
+++ b/crates/shep-client/CHANGELOG.md
@@ -10,6 +10,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-09-07
+
+### Added
+
+- Accept any peer at or above a protocol floor **(BREAKING)**
+- A protocol floor, tolerant decode, and refusals a staged restart can name ([#173](https://github.com/shep-pm/shep/pull/173)) **(BREAKING)**
+
+### Changed
+
+- Move reply-id decode into shep-core, drop shep-client's serde dep
+
+### Fixed
+
+- Fail a caller whose reply cannot be decoded instead of leaving it waiting
+
+
 ## [0.5.1] - 2026-09-07
 
 

--- a/crates/shep-core/CHANGELOG.md
+++ b/crates/shep-core/CHANGELOG.md
@@ -10,6 +10,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-09-07
+
+### Added
+
+- Name the apps a staged restart could not restart **(BREAKING)**
+- Decode an unknown error code or process event instead of failing
+- Refuse an unrecognized request by id instead of ending the connection
+- Accept any peer at or above a protocol floor **(BREAKING)**
+- Deny unknown Flockfile keys at the parse site, not on the wire
+- A protocol floor, tolerant decode, and refusals a staged restart can name ([#173](https://github.com/shep-pm/shep/pull/173)) **(BREAKING)**
+
+### Changed
+
+- Drop hand-rolled Deserialize for RpcErrorCode and ProcessEventKind
+- Move reply-id decode into shep-core, drop shep-client's serde dep
+- Delegate parse_into to parse_into_ignoring
+
+### Fixed
+
+- Restore additionalProperties:false via schemars(deny_unknown_fields)
+- Stop reply_id from matching non-reply frames
+
+
 ## [0.5.1] - 2026-09-07
 
 

--- a/crates/shep-daemon/CHANGELOG.md
+++ b/crates/shep-daemon/CHANGELOG.md
@@ -10,6 +10,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-09-07
+
+### Added
+
+- Name the apps a staged restart could not restart **(BREAKING)**
+- Refuse an unrecognized request by id instead of ending the connection
+- Accept any peer at or above a protocol floor **(BREAKING)**
+- A protocol floor, tolerant decode, and refusals a staged restart can name ([#173](https://github.com/shep-pm/shep/pull/173)) **(BREAKING)**
+
+### Fixed
+
+- Don't publish daemon_version on an Unsupported refusal
+
+
 ## [0.5.1] - 2026-09-07
 
 

--- a/crates/shep-macros/CHANGELOG.md
+++ b/crates/shep-macros/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-09-07
+
+
 ## [0.5.1] - 2026-09-07
 
 


### PR DESCRIPTION



## 🤖 New release

* `shep-channel`: 0.5.1 -> 0.6.0
* `shep-core`: 0.5.1 -> 0.6.0 (✓ API compatible changes)
* `shep-daemon`: 0.5.1 -> 0.6.0 (✓ API compatible changes)
* `shep-macros`: 0.5.1 -> 0.6.0
* `shep-client`: 0.5.1 -> 0.6.0 (✓ API compatible changes)
* `shep`: 0.5.1 -> 0.6.0 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>


## `shep-core`

<blockquote>

## [0.6.0] - 2026-09-07

### Added

- Name the apps a staged restart could not restart **(BREAKING)**
- Decode an unknown error code or process event instead of failing
- Refuse an unrecognized request by id instead of ending the connection
- Accept any peer at or above a protocol floor **(BREAKING)**
- Deny unknown Flockfile keys at the parse site, not on the wire
- A protocol floor, tolerant decode, and refusals a staged restart can name ([#173](https://github.com/shep-pm/shep/pull/173)) **(BREAKING)**

### Changed

- Drop hand-rolled Deserialize for RpcErrorCode and ProcessEventKind
- Move reply-id decode into shep-core, drop shep-client's serde dep
- Delegate parse_into to parse_into_ignoring

### Fixed

- Restore additionalProperties:false via schemars(deny_unknown_fields)
- Stop reply_id from matching non-reply frames
</blockquote>

## `shep-daemon`

<blockquote>

## [0.6.0] - 2026-09-07

### Added

- Name the apps a staged restart could not restart **(BREAKING)**
- Refuse an unrecognized request by id instead of ending the connection
- Accept any peer at or above a protocol floor **(BREAKING)**
- A protocol floor, tolerant decode, and refusals a staged restart can name ([#173](https://github.com/shep-pm/shep/pull/173)) **(BREAKING)**

### Fixed

- Don't publish daemon_version on an Unsupported refusal
</blockquote>


## `shep-client`

<blockquote>

## [0.6.0] - 2026-09-07

### Added

- Accept any peer at or above a protocol floor **(BREAKING)**
- A protocol floor, tolerant decode, and refusals a staged restart can name ([#173](https://github.com/shep-pm/shep/pull/173)) **(BREAKING)**

### Changed

- Move reply-id decode into shep-core, drop shep-client's serde dep

### Fixed

- Fail a caller whose reply cannot be decoded instead of leaving it waiting
</blockquote>

## `shep`

<blockquote>

## [0.6.0] - 2026-09-07

### Added

- Name the apps a staged restart could not restart **(BREAKING)**
- Decode an unknown error code or process event instead of failing
- Refuse an unrecognized request by id instead of ending the connection
- Accept any peer at or above a protocol floor **(BREAKING)**
- Name the protocol floor in version output
- A protocol floor, tolerant decode, and refusals a staged restart can name ([#173](https://github.com/shep-pm/shep/pull/173)) **(BREAKING)**

### Changed

- Stop leaking version_text on every call

### Fixed

- Exit non-zero and name the apps a restart went around
- Judge a dog's protocol against the floor rather than exact equality
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).