### PR TITLE
ci: raise a one-second poll ceiling, and pin one action to node 24

### DIFF
--- a/.github/actions/nextest-report/action.yml
+++ b/.github/actions/nextest-report/action.yml
@@ -73,7 +73,7 @@ runs:
                     out.write("\n")
         if not retried and not exhausted:
             print(f"no retried tests in {path}")
-    - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+    - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: ${{ inputs.name }}
         path: target/nextest/${{ inputs.profile }}/junit.xml

--- a/crates/shep-cli/src/lookout/mod.rs
+++ b/crates/shep-cli/src/lookout/mod.rs
@@ -1126,14 +1126,25 @@ mod tests {
         // the loop leaving. `spawn_blocking` runs its closure to completion
         // whatever happens to the handle, so releasing the lock here lets it
         // land. Polled, with a ceiling so a failure reports rather than hangs.
+        //
+        // The ceiling is thirty seconds and is NOT a claim about speed. What
+        // is being asserted is that the write happens at all; how long the
+        // blocking pool takes to get to it is the runner's business, and a
+        // one-second ceiling made this the assertion that failed on
+        // `test (ubuntu-latest, stable)` at 0998ca35 while every other
+        // platform passed. Raising it rather than moving the test to
+        // `mod slow` on purpose: the `slow` tier is for a test that asserts a
+        // duration, and once the ceiling stops being an assertion this one is
+        // not that. A real regression, a write that never lands, still fails
+        // here, thirty seconds later, with the same message.
         drop(held);
         let mut written = false;
-        for _ in 0..500 {
+        for _ in 0..3_000 {
             if std::fs::read_to_string(&config).unwrap().contains("debug") {
                 written = true;
                 break;
             }
-            std::thread::sleep(Duration::from_millis(2));
+            std::thread::sleep(Duration::from_millis(10));
         }
         assert!(written, "the write that was in flight still landed");
     }

--- a/crates/shep-cli/src/lookout/mod.rs
+++ b/crates/shep-cli/src/lookout/mod.rs
@@ -1125,26 +1125,20 @@ mod tests {
         // The other half of the same property: the write was not cancelled by
         // the loop leaving. `spawn_blocking` runs its closure to completion
         // whatever happens to the handle, so releasing the lock here lets it
-        // land. Polled, with a ceiling so a failure reports rather than hangs.
-        //
-        // The ceiling is thirty seconds and is NOT a claim about speed. What
-        // is being asserted is that the write happens at all; how long the
-        // blocking pool takes to get to it is the runner's business, and a
-        // one-second ceiling made this the assertion that failed on
-        // `test (ubuntu-latest, stable)` at 0998ca35 while every other
-        // platform passed. Raising it rather than moving the test to
-        // `mod slow` on purpose: the `slow` tier is for a test that asserts a
-        // duration, and once the ceiling stops being an assertion this one is
-        // not that. A real regression, a write that never lands, still fails
-        // here, thirty seconds later, with the same message.
+        // land.
+        // A bound so a lost write reports rather than hangs, 3_000 * 10ms =
+        // thirty seconds. Not a claim about speed: when the blocking pool
+        // reaches the closure is the runner's business, not shep's.
+        const WRITE_ATTEMPTS: usize = 3_000;
+        const WRITE_POLL: Duration = Duration::from_millis(10);
         drop(held);
         let mut written = false;
-        for _ in 0..3_000 {
+        for _ in 0..WRITE_ATTEMPTS {
             if std::fs::read_to_string(&config).unwrap().contains("debug") {
                 written = true;
                 break;
             }
-            std::thread::sleep(Duration::from_millis(10));
+            std::thread::sleep(WRITE_POLL);
         }
         assert!(written, "the write that was in flight still landed");
     }


### PR DESCRIPTION
Two unrelated CI fixes, both found while merging main into `feat/secrets-store`.

- `the_loop_keeps_running_while_a_settings_write_is_stuck` gave a `spawn_blocking` write 500 * 2ms to land, which is a claim about the runner rather than about shep. Raised to 3000 * 10ms, with the comment saying the ceiling is not an assertion about speed. It costs 0.05s when the write is prompt
- not `mod slow`: that tier is for a test that asserts a duration, and once the ceiling stops being one this test does not
- `nextest-report` pinned `actions/upload-artifact` at v4.6.2, which runs on Node 20 and warned on all 16 nextest legs a run, burying the flaky-test annotations that action exists to surface. Now on 043fb46d, v7.0.1, the SHA `test.yml`'s coverage job already uses

Census of the last 60 `test` runs on main: five failures, five different tests, no repeat offender. Not a pattern, and main is green again on its last three.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated the artifact-uploading workflow to use a newer supported release.

- **Tests**
  - Improved reliability of the settings-write test by allowing more time for background operations to complete and checking progress more frequently.

- **User Impact**
  - No changes to application functionality or user-facing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->