### PR TITLE
chore: release v0.6.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2068,7 +2068,7 @@ dependencies = [
 
 [[package]]
 name = "shep"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "anstyle",
  "assert_cmd",
@@ -2106,7 +2106,7 @@ dependencies = [
 
 [[package]]
 name = "shep-channel"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "command-fds",
  "serde",
@@ -2117,11 +2117,11 @@ dependencies = [
 
 [[package]]
 name = "shep-cli"
-version = "0.6.1"
+version = "0.6.2"
 
 [[package]]
 name = "shep-client"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "futures-util",
  "nix 0.29.0",
@@ -2137,7 +2137,7 @@ dependencies = [
 
 [[package]]
 name = "shep-core"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "annotate-snippets",
  "anstyle",
@@ -2170,7 +2170,7 @@ dependencies = [
 
 [[package]]
 name = "shep-daemon"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "bytes",
  "chrono",
@@ -2200,14 +2200,14 @@ dependencies = [
 
 [[package]]
 name = "shep-examples"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "nix 0.29.0",
 ]
 
 [[package]]
 name = "shep-macros"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "proc-macro2",
  "quote 1.0.47",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.6.1"
+version = "0.6.2"
 edition = "2024"
 # 1.88: serde-saphyr's let-chains need it; also the floor ratatui, sysinfo
 # and rmcp require.
@@ -33,11 +33,11 @@ license = "MIT OR Apache-2.0"
 # turn an inherited dependency's default features back on but never off, so the
 # floor is set off here. shep-core wants the wire types without the client
 # feature; a future consumer that wants the client opts back in.
-shep-channel = { path = "crates/shep-channel", version = "0.6.1", default-features = false }
-shep-core = { path = "crates/shep-core", version = "0.6.1" }
-shep-daemon = { path = "crates/shep-daemon", version = "0.6.1" }
-shep-client = { path = "crates/shep-client", version = "0.6.1" }
-shep-macros = { path = "crates/shep-macros", version = "0.6.1" }
+shep-channel = { path = "crates/shep-channel", version = "0.6.2", default-features = false }
+shep-core = { path = "crates/shep-core", version = "0.6.2" }
+shep-daemon = { path = "crates/shep-daemon", version = "0.6.2" }
+shep-client = { path = "crates/shep-client", version = "0.6.2" }
+shep-macros = { path = "crates/shep-macros", version = "0.6.2" }
 serde = { version = "1", default-features = false, features = ["derive"] }
 serde_json = { version = "1", default-features = false, features = ["std"] }
 toml = { version = "0.8", default-features = false, features = ["parse", "display"] }

--- a/crates/shep-channel/CHANGELOG.md
+++ b/crates/shep-channel/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this crate are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.2] - 2026-09-08
+
+
 ## [0.6.1] - 2026-09-07
 
 ### Added

--- a/crates/shep-cli/CHANGELOG.md
+++ b/crates/shep-cli/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.2] - 2026-09-08
+
+
 ## [0.6.1] - 2026-09-07
 
 

--- a/crates/shep-client/CHANGELOG.md
+++ b/crates/shep-client/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.2] - 2026-09-08
+
+
 ## [0.6.1] - 2026-09-07
 
 

--- a/crates/shep-core/CHANGELOG.md
+++ b/crates/shep-core/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.2] - 2026-09-08
+
+
 ### Added
 
 - A third Flockfile template token, `{{secret:KEY}}` and

--- a/crates/shep-daemon/CHANGELOG.md
+++ b/crates/shep-daemon/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.2] - 2026-09-08
+
+
 ### Added
 
 - `Request::PutSecrets`: a provider dog pushes the values it fetched from

--- a/crates/shep-macros/CHANGELOG.md
+++ b/crates/shep-macros/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.2] - 2026-09-08
+
+
 ## [0.6.1] - 2026-09-07
 
 


### PR DESCRIPTION



## 🤖 New release

* `shep-channel`: 0.6.1 -> 0.6.2
* `shep-core`: 0.6.1 -> 0.6.2 (✓ API compatible changes)
* `shep-daemon`: 0.6.1 -> 0.6.2 (✓ API compatible changes)
* `shep-macros`: 0.6.1 -> 0.6.2
* `shep-client`: 0.6.1 -> 0.6.2
* `shep`: 0.6.1 -> 0.6.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>


## `shep-core`

<blockquote>

## [0.6.2] - 2026-09-08

### Added

- A third Flockfile template token, `{{secret:KEY}}` and
  `{{secret:namespace/KEY}}`, resolved against the secret store. A malformed
  reference is refused at config time, by the same grammar
  `secrets::SecretRef::parse` enforces, so no second parser can drift from it.
- `Request::PutSecrets` and `Response::SecretsPut`: a provider dog's values
  for one namespace and one environment. The push replaces that pair rather
  than merging into it, so a key deleted at the provider disappears on the
  next push. `entries` carries `EnvValue`, so a `{:?}` of the request cannot
  print a value.
- `secrets::is_name` is public. The daemon checks a peer's namespace and
  environment against the store's own grammar before storing anything under
  either, and a second copy of that grammar is what would drift.
- `secrets::ProviderCache`, with `secrets::NamespaceValues` and
  `secrets::PushedPairs`: what provider dogs have pushed, both the values and
  the `(namespace, environment)` pairs a push has landed for.
  `secrets::provider_cache_on_disk` reads one back from `secrets-cache.json`,
  and `secrets::SecretView::new` resolves against one. A namespaced reference
  is retriable while no provider has pushed that namespace for the
  environment being resolved, rather than while the namespace is absent
  altogether: a push carries one pair, so a dog part way through `production`
  then `staging` would otherwise leave a staging sheep `Errored` for good.

### Changed

- `PROTOCOL_VERSION` and `MIN_SUPPORTED` are 8. `AppConfig::environment` is
  what moved them: that struct is `deny_unknown_fields`, so an older peer
  refuses the whole payload rather than ignoring a key it does not know,
  which is the same reason `depends_on` moved them to 5.
  `Request::PutSecrets` and `Response::SecretsPut` rode in on the same
  commit and moved nothing. They are additive, and a daemon that has never
  heard of `put_secrets` now decodes `Request::Unrecognized` and answers
  `unsupported` naming its own protocol, instead of dropping the connection
  on an envelope it cannot read. That is the case this entry used to say
  justified a bump for an addition; the tolerant decode removed it.
  Run `shep daemon reload` after upgrading.
- `config::template::render` now takes a `secrets::SecretView` and returns
  `Result<String, RenderError>`, so a spawn can refuse on a secret it cannot
  resolve. Callers that have no store use the new `render_positional`, which
  substitutes `{{instance}}` and `{{name}}` and leaves `{{secret:...}}` alone.
  `RenderError::is_retriable` separates a namespace no provider dog has pushed
  to for that environment yet, which a later attempt can clear, from a value
  only a person will supply.
</blockquote>

## `shep-daemon`

<blockquote>

## [0.6.2] - 2026-09-08

### Added

- `Request::PutSecrets`: a provider dog pushes the values it fetched from
  Vercel, Vault or anywhere else into a namespace, and
  `{{secret:<namespace>/KEY}}` resolves against them. Push rather than pull,
  because `assemble` is a synchronous pure function on the spawn path and a
  pull would put a socket round trip and a timeout on every instance of every
  sheep.
- `$SHEP_HOME/secrets-cache.json`, owner-only, so a shepherd that restarts
  resolves a namespace before its dog's next poll comes round. It carries the
  `(namespace, environment)` pairs a provider has pushed beside the values, so
  a restart still tells "the dog has not pushed staging" from "staging has no
  such key". A dog's `persist` key in `dogs.toml` decides whether its
  namespace may reach the file, defaulting to `true`, and only the namespaces
  whose most recent push asked for it are ever written. The file is derived:
  one that will not read is skipped rather than refused.

### Changed

- `assemble` takes a `shep_core::secrets::SecretView` and returns
  `Result<SpawnSpec, AssembleError>`, so a spawn refuses on a
  `{{secret:...}}` it cannot resolve rather than handing the child the
  reference as literal text. A caller reading a spec it will not spawn wants
  the crate-private `describe` instead, which leaves an unresolvable
  reference as written.
- `BootOptions` grows an `environment` field, the environment a sheep naming
  none of its own resolves its references in. The struct is not
  `#[non_exhaustive]`, so an out-of-tree literal that named every field no
  longer compiles; `..Default::default()` is the shape that survives the
  next one.
</blockquote>





</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).