### PR TITLE
docs(web): keep the space when a line break falls next to an inline tag

### DIFF
--- a/web/src/components/landing/scenes/Scene3Flockfile.astro
+++ b/web/src/components/landing/scenes/Scene3Flockfile.astro
@@ -17,7 +17,7 @@ import SceneSection from "../SceneSection.astro";
     </div>
     <p>
       Unknown fields are a parse error rather than a shrug, and sizes are
-      strict on purpose: <code>512M</code> and <code>30s</code> parse;
+      strict on purpose: <code>512M</code> and <code>30s</code> parse;{" "}
       <code>512MB</code> and <code>1.5G</code> do not.
     </p>
   </div>

--- a/web/src/components/landing/scenes/Scene5PreRelease.astro
+++ b/web/src/components/landing/scenes/Scene5PreRelease.astro
@@ -22,9 +22,9 @@ import SceneSection from "../SceneSection.astro";
       Early days, and pre-1.0 means anything can still change. Install
       with <code>cargo install shep</code> and it runs on macOS, Linux and
       Windows. The Windows tier is the newest of the three, and it refuses
-      three things out loud rather than papering over them: a graceful
+      three things out loud rather than papering over them: a graceful{" "}
       <code>stop</code> for an app that has not opted into the shepherd
-      channel, <code>shep startup</code>, and dropping privilege with
+      channel, <code>shep startup</code>, and dropping privilege with{" "}
       <code>user</code>/<code>group</code>.
     </p>
     <a href="#chalkboard" class="cta press" style="--shadow-offset:5px; --press-offset:2px;">

--- a/web/src/pages/docs/boot-order.astro
+++ b/web/src/pages/docs/boot-order.astro
@@ -62,7 +62,7 @@ ID  NAME  STATUS  PID    RESTARTS  EXIT  CFG  CPU  MEM   UPTIME  FOLD  SMIT
     <h1>Boot order</h1>
     <ReferencePills slug="boot-order" />
     <p class="lede">
-      shep starts a flock all at once unless you tell it otherwise. Add
+      shep starts a flock all at once unless you tell it otherwise. Add{" "}
       <code>depends_on</code> to an app and it sorts the flock into stages
       instead, holding each one until the members something later waits on
       are up. An app that would have crash-looped through its restart budget
@@ -91,7 +91,7 @@ depends_on = ["api"]`}</CodeBlock>
     <p>
       That sorts into three stages, <code>db</code>, then <code>api</code>,
       then <code>web</code>. Names inside a stage are sorted, so one flock
-      always plans the same way. The whole start took 6.17 seconds, and the
+      always plans the same way. The whole start took 6.17 seconds, and the{" "}
       <code>UPTIME</code> column is where it went:
     </p>
     <CodeBlock>{stagedStart}</CodeBlock>
@@ -104,16 +104,16 @@ depends_on = ["api"]`}</CodeBlock>
 
     <h2>What ready means, and what it costs</h2>
     <p>
-      A stage advances when its members have settled. An app with
+      A stage advances when its members have settled. An app with{" "}
       <code>wait_ready</code> or a <code>readiness_probe</code> settles the
       moment it says so, and an app that exits settles at once rather than
       holding its stage for the full wait.
     </p>
     <p>
-      An app with neither has nothing to report. shep holds it
+      An app with neither has nothing to report. shep holds it{" "}
       <code>starting</code> for its own <code>listen_timeout</code>, three
       seconds by default, then calls it up and moves on. That is where the
-      6.17 seconds went: <code>db</code> cost one wait and <code>api</code>
+      6.17 seconds went: <code>db</code> cost one wait and <code>api</code>{" "}
       cost another. <code>web</code> is last, so nothing waits on it and it
       costs nothing. Only apps something depends on pay this.
     </p>
@@ -136,7 +136,7 @@ depends_on = ["db"]`}</CodeBlock>
       That <code>interval</code> is doing real work. A probe polls every ten
       seconds by default and the first poll runs at spawn, so an app needing
       fifty milliseconds to bind its port fails that first poll and has
-      nothing left to answer with before <code>listen_timeout</code>
+      nothing left to answer with before <code>listen_timeout</code>{" "}
       elapses. Measured on the flock above: 0.14 seconds at an interval of
       100ms, and the full 3.05 at the default. Set an interval shorter than
       the app's own startup time or the probe buys you nothing at boot.
@@ -150,7 +150,7 @@ depends_on = ["db"]`}</CodeBlock>
     </p>
     <p>
       A log-rotation dog is the opposite case, since it has to be running
-      before a sheep starts writing. Name it in
+      before a sheep starts writing. Name it in{" "}
       <code>[daemon] boot_first_dogs</code> and it runs ahead of everything:
     </p>
     <CodeBlock label="$SHEP_HOME/shep.toml">{`[daemon]
@@ -163,7 +163,7 @@ stage 2  web
          metrics      spawns after every stage`}</CodeBlock>
     <p class="fine">
       A name here that is not in <code>enabled_dogs</code> is inert: nothing
-      enables a dog by promoting it. A sheep may also name a dog in its own
+      enables a dog by promoting it. A sheep may also name a dog in its own{" "}
       <code>depends_on</code>, but at a boot that does not move the dog. The
       shepherd spawns dogs in two groups, the promoted ones before the
       restore and the rest after it, and neither group sits at a stage
@@ -183,7 +183,7 @@ stage 2  web
 
     <h2>When the graph is wrong</h2>
     <p>
-      What happens depends on who is watching. An operator typing
+      What happens depends on who is watching. An operator typing{" "}
       <code>shep start</code> or <code>shep add</code> is there to fix a
       typo. A machine rebooting at 4am is not, and stranding its whole flock
       over one is worse than starting it in a bad order.
@@ -206,7 +206,7 @@ stage 2  web
     </div>
     <p class="fine">
       Every "warned" above is a line in the shepherd's own log, not a notice
-      on the reply, so <code>shep start</code> and <code>shep add</code>
+      on the reply, so <code>shep start</code> and <code>shep add</code>{" "}
       print nothing about the graph and exit 0. They are in{" "}
       <code>$SHEP_HOME/logs/shepd.err.log</code>. The{" "}
       <code>autostart = false</code> warning is narrower still: it lives on
@@ -230,7 +230,7 @@ error[invalid_config]: the daemon reported InvalidConfig: dependency cycle: api 
       and refusing it would make cross-repository dependencies unusable.
     </p>
     <Callout variant="note">
-      <code>autostart</code> wins. A dependency that sets
+      <code>autostart</code> wins. A dependency that sets{" "}
       <code>autostart = false</code> stays stopped, and the sheep that
       depends on it starts in its stage as though the edge were satisfied.
       A boot writes a warning naming both to the shepherd's log; a typed{" "}
@@ -242,16 +242,16 @@ error[invalid_config]: the daemon reported InvalidConfig: dependency cycle: api 
 
     <h2>Shutdown runs backwards</h2>
     <p>
-      A shepherd going down walks the stages in reverse, so
-      <code>web</code> gets its SIGTERM, then <code>api</code>, then
+      A shepherd going down walks the stages in reverse, so{" "}
+      <code>web</code> gets its SIGTERM, then <code>api</code>, then{" "}
       <code>db</code>. A worker draining its queue drains against a database
       that is still answering. Without ordering both get signalled in the
       same millisecond.
     </p>
     <p>
-      A stage's members overlap, so a stage costs the longest
+      A stage's members overlap, so a stage costs the longest{" "}
       <code>kill_timeout</code> in it rather than the sum, 1.6 seconds by
-      default. Five stages is eight seconds against systemd's default
+      default. Five stages is eight seconds against systemd's default{" "}
       <code>TimeoutStopSec</code> of ninety, so <code>shep startup</code>'s
       unit needs nothing extra.
     </p>
@@ -284,7 +284,7 @@ error[invalid_config]: the daemon reported InvalidConfig: dependency cycle: api 
     <p>
       Both verbs ask the shepherd once per app, so an app already being
       reloaded, or one that left the flock after the walk was planned, is
-      refused on its own and the rest of the fold goes ahead.
+      refused on its own and the rest of the fold goes ahead.{" "}
       <code>shep reload</code> and <code>shep restart</code> name the app
       they went around on stderr and exit non-zero, and under{" "}
       <code>--format json</code> the same names come back under{" "}
@@ -297,7 +297,7 @@ error[invalid_config]: the daemon reported InvalidConfig: dependency cycle: api 
       reached and the restart was not refused; it is the child that could
       not start. It also empties stdout, as every verb's failure does, so a
       restart that hits both at once prints no envelope: the refused names
-      are appended to that error's own sentence on stderr instead, and the
+      are appended to that error's own sentence on stderr instead, and the{" "}
       <code>refused</code> key above is what a run reports when nothing came
       back errored.
     </p>
@@ -325,8 +325,8 @@ error[spawn_failed]: the daemon reported SpawnFailed: nothing in this batch was 
       there is nothing else in that request to order it against.
     </p>
     <p>
-      Promoting a dog fixes the boot window and only the boot window. A
-      <code>shep start web</code> typed at noon, while
+      Promoting a dog fixes the boot window and only the boot window. A{" "}
+      <code>shep start web</code> typed at noon, while{" "}
       <code>log-rotate</code> happens to be down, is a supervision problem.
       Boot ordering has no opinion about it.
     </p>
@@ -345,8 +345,8 @@ Depends on for web:
     <p class="fine">
       There is no <code>shep flock</code> column for it. The field names
       other sheep rather than saying anything about this row's own status,
-      and that table already drops columns under pressure. Under
-      <code>--format json</code> every sheep carries a
+      and that table already drops columns under pressure. Under{" "}
+      <code>--format json</code> every sheep carries a{" "}
       <code>depends_on</code> array.
     </p>
 
@@ -355,15 +355,15 @@ Depends on for web:
       <a href="/docs/first-flockfile" class="next-card">
         <div class="next-title">Your first Flockfile →</div>
         <div class="next-body">
-          <code>depends_on</code> in the full field reference, next to
+          <code>depends_on</code> in the full field reference, next to{" "}
           <code>listen_timeout</code> and <code>readiness_probe</code>.
         </div>
       </a>
       <a href="/docs/dogs" class="next-card">
         <div class="next-title">Dogs →</div>
         <div class="next-body">
-          What a dog is, how <code>shep enable</code> writes one into
-          <code>shep.toml</code>, and where <code>boot_first_dogs</code>
+          What a dog is, how <code>shep enable</code> writes one into{" "}
+          <code>shep.toml</code>, and where <code>boot_first_dogs</code>{" "}
           sits.
         </div>
       </a>

--- a/web/src/pages/docs/cli.astro
+++ b/web/src/pages/docs/cli.astro
@@ -121,13 +121,13 @@ if (coveredCount !== cliReference.verbs.length) {
     <h1>CLI reference</h1>
     <ReferencePills slug="cli" />
     <p class="lede">
-      Every verb <code>shep {workspaceVersion}</code>
+      Every verb <code>shep {workspaceVersion}</code>{" "}
       understands, generated from the binary's own <code>--help</code>. Nothing
       below is hand-typed.
     </p>
 
     <Callout variant="note">
-      <code>--home</code>, <code>--format table|json</code> and <code>-q</code>/<code>--quiet</code>
+      <code>--home</code>, <code>--format table|json</code> and <code>-q</code>/<code>--quiet</code>{" "}
       work on every verb on this page. They're global flags, flattened onto each
       subcommand rather than repeated in the prose below. See the full dump under
       "Every verb, at a glance" for exactly how they render on each one.

--- a/web/src/pages/docs/containers.astro
+++ b/web/src/pages/docs/containers.astro
@@ -33,8 +33,8 @@ notice[watch_forced]: shep dev: forcing watch on devtest — each app's own \`wa
     <ReferencePills slug="containers" />
     <p class="lede">
       Two verbs, one shape: run one Flockfile's flock in the foreground, no
-      daemonization, exit when there's nothing left to supervise.
-      <code>shep runtime</code> is that shape for a container.
+      daemonization, exit when there's nothing left to supervise.{" "}
+      <code>shep runtime</code> is that shape for a container.{" "}
       <code>shep dev</code> is the same shape for a laptop, with isolation
       swapped in for the container's own kind of disposability.
     </p>
@@ -42,19 +42,19 @@ notice[watch_forced]: shep dev: forcing watch on devtest — each app's own \`wa
     <h2>shep runtime: the container entrypoint</h2>
     <p>
       <code>shep runtime</code> boots a shepherd in-process, runs one
-      Flockfile's flock, and exits once nothing is left online.
+      Flockfile's flock, and exits once nothing is left online.{" "}
       <code>--no-restore</code> is always on. A container starts fresh from
       its Flockfile every time, never from a muster roll left on the image by
-      a previous run. Bleats stream to this process's own stdout/stderr, so
+      a previous run. Bleats stream to this process's own stdout/stderr, so{" "}
       <code>docker logs</code> is the flock's log with no extra plumbing, and
-      the shepherd is still reachable over its own socket the whole time:
-      <code>shep flock</code> from a second terminal, or
+      the shepherd is still reachable over its own socket the whole time:{" "}
+      <code>shep flock</code> from a second terminal, or{" "}
       <code>docker exec</code>, works exactly as it would against a
       daemonized one.
     </p>
     <CodeBlock label="Dockerfile">{dockerfile}</CodeBlock>
     <p class="fine">
-      <code>shep-runtime</code> is a separate binary alias for
+      <code>shep-runtime</code> is a separate binary alias for{" "}
       <code>shep runtime</code>, built so <code>ENTRYPOINT</code> doesn't need
       to spell the subcommand out. <code>SHEP_HOME</code> is never defaulted
       for you inside a container. An unset one fails fast naming the flag,
@@ -64,9 +64,9 @@ notice[watch_forced]: shep dev: forcing watch on devtest — each app's own \`wa
     <h3>Exit codes an orchestrator can act on</h3>
     <p>
       <code>shep runtime</code> exits <strong>0</strong> once the flock has
-      been empty and clean (every sheep <code>stopped</code>, none
+      been empty and clean (every sheep <code>stopped</code>, none{" "}
       <code>errored</code>) for three consecutive two-second polls: a batch
-      job finishing its work. It exits <strong>11</strong>
+      job finishing its work. It exits <strong>11</strong>{" "}
       (<code>flock_empty</code>) instead when the flock emptied with at least
       one sheep <code>errored</code> (a restart budget exhausted, or a spawn
       that never came up), so an orchestrator reading the exit status can
@@ -81,11 +81,11 @@ notice[watch_forced]: shep dev: forcing watch on devtest — each app's own \`wa
       supervisor's own process. An in-process subreaper loop would race
       tokio's own child reaping and corrupt the exact exit statuses shep
       promises elsewhere. The init instead relies on the kernel already
-      treating real PID 1 as the implicit subreaper (it never calls
-      <code>set_child_subreaper</code>), forwards
-      <code>SIGTERM</code>/<code>SIGINT</code>/<code>SIGHUP</code>/<code>SIGQUIT</code>
+      treating real PID 1 as the implicit subreaper (it never calls{" "}
+      <code>set_child_subreaper</code>), forwards{" "}
+      <code>SIGTERM</code>/<code>SIGINT</code>/<code>SIGHUP</code>/<code>SIGQUIT</code>{" "}
       to the supervisor it spawns, and reaps every orphan itself. A container
-      that skipped this step would accumulate zombies until
+      that skipped this step would accumulate zombies until{" "}
       <code>docker stop</code> waited out the full grace period before
       SIGKILLing everything mid-shutdown.
     </p>
@@ -93,7 +93,7 @@ notice[watch_forced]: shep dev: forcing watch on devtest — each app's own \`wa
     <h2>shep dev: the same shape for a laptop</h2>
     <p>
       <code>shep dev</code> runs one Flockfile's flock in an isolated,
-      throwaway foreground session: <code>$SHEP_DEV_HOME</code> (default
+      throwaway foreground session: <code>$SHEP_DEV_HOME</code> (default{" "}
       <code>~/.shep-dev</code>), forced <code>watch = true</code> on every
       app regardless of what the Flockfile says, and a full stop-and-delete
       teardown the moment the flock empties or the process is signalled,
@@ -106,7 +106,7 @@ notice[watch_forced]: shep dev: forcing watch on devtest — each app's own \`wa
       <strong><code>--home</code> and <code>$SHEP_HOME</code> are
       ignored</strong>, on purpose. Isolation is the whole feature. Without
       this, an operator who exports <code>$SHEP_HOME</code> for their real
-      flock would get a "dev" session that shares it and silently forces
+      flock would get a "dev" session that shares it and silently forces{" "}
       <code>watch = true</code> onto production apps.
     </Callout>
     <h2>Where to go next</h2>

--- a/web/src/pages/docs/dogs.astro
+++ b/web/src/pages/docs/dogs.astro
@@ -56,9 +56,9 @@ const dogLogDemo = `2026-09-02T14:22:31.412+02:00 [shep] shep started this dog; 
     <ReferencePills slug="dogs" />
     <p class="lede">
       A dog is a process the shepherd runs for its own sake, not for yours.
-      It watches the flock instead of being part of it. Two ship inside the
+      It watches the flock instead of being part of it. Two ship inside the{" "}
       <code>shep</code> binary: <code>metrics</code>, a Prometheus endpoint,
-      and <code>bark</code>, webhook alerts. You can also point
+      and <code>bark</code>, webhook alerts. You can also point{" "}
       <code>shep adopt</code> at a binary of your own and the shepherd will
       supervise it the same way.
     </p>
@@ -67,7 +67,7 @@ const dogLogDemo = `2026-09-02T14:22:31.412+02:00 [shep] shep started this dog; 
       A dog is not the same thing as a sheep with a shepherd channel: see{" "}
       <a href="/docs/shepherd-channel">the shepherd channel</a> for that.
       A sheep opens fd 3 and talks newline JSON to the daemon that already
-      owns it. A dog is a separate client: it connects to
+      owns it. A dog is a separate client: it connects to{" "}
       <code>shep.sock</code> and speaks the same wire protocol{" "}
       <code>shep flock</code> or <code>shep describe</code> would.
     </Callout>
@@ -104,7 +104,7 @@ const dogLogDemo = `2026-09-02T14:22:31.412+02:00 [shep] shep started this dog; 
       </p>
       <p>
         Takes a built-in name or one <code>shep adopt</code> has recorded,
-        and refuses anything else before it writes. A refused enable leaves
+        and refuses anything else before it writes. A refused enable leaves{" "}
         <code>shep.toml</code> untouched. The check reads{" "}
         <code>[daemon] adopted_dogs</code> rather than the shepherd, so it
         holds with nothing listening.
@@ -149,15 +149,15 @@ $ shep disable metrics`}</CodeBlock>
     <p class="fine">
       The dogs table shares its column order with the sheep table above it,
       so a dog and a sheep read the same way. <code>SOURCE</code> is the one
-      column only dogs have, and <code>CFG</code>, <code>FOLD</code> and
+      column only dogs have, and <code>CFG</code>, <code>FOLD</code> and{" "}
       <code>SMIT</code> the three only sheep have. See <a href="/docs/output#the-dogs-table">terminal
       output</a>.
     </p>
     <p class="fine">
       A dog whose <code>STATUS</code> reads <code>silent</code> is running
-      but has never spoken to the shepherd, usually because a
+      but has never spoken to the shepherd, usually because a{" "}
       <code>cargo install</code> replaced its binary and the old process is
-      still up. <code>shep bleats &lt;dog&gt;</code> has the refusal;
+      still up. <code>shep bleats &lt;dog&gt;</code> has the refusal;{" "}
       <code>shep restart &lt;dog&gt;</code> is the fix. See <a
       href="/docs/output#a-dog-that-never-answers">terminal output</a>.
     </p>
@@ -437,7 +437,7 @@ sinks = ["oncall"]`}</CodeBlock>
         built-in verb or alias, since such a dog could never be reached.
         Passing all of that, it actually spawns the binary and kills it
         immediately, because the only honest way to know whether this kernel
-        can exec a file is to ask this kernel. The <code>--version</code>
+        can exec a file is to ask this kernel. The <code>--version</code>{" "}
         probe below is that spawn, so the exec proof and the version answer
         cost one child rather than two.
       </p>
@@ -447,7 +447,7 @@ sinks = ["oncall"]`}</CodeBlock>
         <code>disable</code>'s counterpart for a third-party dog: stops it
         if running and forgets it entirely, rather than leaving it
         disabled-but-known. That is both files, the registration in{" "}
-        <code>shep.toml</code> and the dog's own <code>[&lt;name&gt;]</code>
+        <code>shep.toml</code> and the dog's own <code>[&lt;name&gt;]</code>{" "}
         section in <code>dogs.toml</code>, webhook URLs and all.{" "}
         <code>disable</code> keeps that section on purpose;{" "}
         <code>rehome</code> is the verb that does not.
@@ -755,7 +755,7 @@ protocol 6, or reinstall the dog against protocol 8, and restart it again`}</Cod
         subscription, before the process is killed.
       </p>
       <p>
-        Only dogs that ignore the flag are affected. A dog that recognises
+        Only dogs that ignore the flag are affected. A dog that recognises{" "}
         <code>--version</code> and exits, even without naming a protocol,
         does no work: its protocol is unknown and nothing overlaps. The
         trade is deliberate: the command is about to restart that dog anyway, so the
@@ -786,7 +786,7 @@ protocol 6, or reinstall the dog against protocol 8, and restart it again`}</Cod
     <p class="fine">
       <code>&lt;crate&gt;</code> is the package name on crates.io, which is not
       always what you call the dog. A dog's adopted name, its binary name and
-      its crate name are three separate things: <code>shep-log-rotate</code>
+      its crate name are three separate things: <code>shep-log-rotate</code>{" "}
       installs a binary of the same name that is usually adopted as{" "}
       <code>log-rotate</code>. Cargo wants the crate.
     </p>

--- a/web/src/pages/docs/examples.astro
+++ b/web/src/pages/docs/examples.astro
@@ -97,15 +97,15 @@ const polyglotRows: ExampleRow[] = [
       Every page in this section describes what shep does. This one is
       seven tiny programs and a Flockfile that make it happen where you can
       watch: a probe waiting, a stop signal being ignored, a memory ceiling
-      firing, a crash loop backing off. Everything lives under
-      <code>examples/</code> — a workspace member of its own, built by
-      <code>cargo build --release</code> but never on the path a plain
+      firing, a crash loop backing off. Everything lives under{" "}
+      <code>examples/</code> — a workspace member of its own, built by{" "}
+      <code>cargo build --release</code> but never on the path a plain{" "}
       <code>cargo install shep</code> walks.
     </p>
     <p>
       That first set is Rust on purpose: it needs nothing but a Rust
-      toolchain, works from a fresh clone, and is what
-      <code>examples/Flockfile.toml</code> starts. A second layer,
+      toolchain, works from a fresh clone, and is what{" "}
+      <code>examples/Flockfile.toml</code> starts. A second layer,{" "}
       <code>examples/Flockfile.polyglot.toml</code>, runs the same ideas
       against Node, Bun, Python and Go — the stacks most shep operators
       actually run, and the ones the Rust set structurally can't stand in
@@ -129,15 +129,15 @@ const polyglotRows: ExampleRow[] = [
       polyglot layer</a> below for the same rule hitting a missing
       runtime). This file declares no <code>depends_on</code>, so it is one
       stage in file order, and on a non-Unix host it does not run straight
-      through as shown. Comment out
+      through as shown. Comment out{" "}
       <code>stubborn</code>'s <code>[[app]]</code> block to run the other
       six.
     </Callout>
 
     <Callout variant="careful">
-      No config edits needed otherwise. Every path in
-      <code>examples/Flockfile.toml</code> is relative to
-      <code>examples/</code> itself — a Flockfile app with no
+      No config edits needed otherwise. Every path in{" "}
+      <code>examples/Flockfile.toml</code> is relative to{" "}
+      <code>examples/</code> itself — a Flockfile app with no{" "}
       <code>cwd</code> runs where its Flockfile lives — so cloning the repo
       and running the commands below just works, on a Unix host.
     </Callout>
@@ -146,7 +146,7 @@ const polyglotRows: ExampleRow[] = [
     <p>
       Two of the seven — <code>leaky</code> and <code>crasher</code> — restart
       on purpose and by design, and <code>shep start</code> registers into
-      whatever <code>$SHEP_HOME</code> is already pointed at. The
+      whatever <code>$SHEP_HOME</code> is already pointed at. The{" "}
       <code>export</code> below is not optional: skip it and this starts
       inside your own real daemon, alongside whatever it's already
       supervising.
@@ -196,8 +196,8 @@ timeout  = "1s"`}</CodeBlock>
       <div><span class="prompt">$</span> touch /tmp/shep-examples-sentinel</div>
     </div>
     <p class="fine">
-      The next poll — within <code>interval</code> — flips
-      <code>http-server-gated-by-sentinel</code> from <code>starting</code> to
+      The next poll — within <code>interval</code> — flips{" "}
+      <code>http-server-gated-by-sentinel</code> from <code>starting</code> to{" "}
       <code>online</code>.
     </p>
 
@@ -208,8 +208,8 @@ timeout  = "1s"`}</CodeBlock>
       signal nothing can trap. The field that governs how long shep waits
       before that escalation on a plain <code>shep stop</code>/
       <code>restart</code>/<code>delete</code> is <code>kill_timeout</code>,
-      not <code>graceful_timeout</code>: the latter only governs a
-      <em>reload</em>'s drain window for the old instance. This example sets
+      not <code>graceful_timeout</code>: the latter only governs a{" "}
+      <em>reload</em>'s drain window for the old instance. This example sets{" "}
       <code>kill_timeout</code> to 3 seconds, short enough to watch land:
     </p>
     <div class="terminal">
@@ -217,14 +217,14 @@ timeout  = "1s"`}</CodeBlock>
     </div>
     <p class="fine">
       Roughly three seconds pass — one <code>"caught SIGTERM, still not
-      dying"</code> line in its log, then silence — before
+      dying"</code> line in its log, then silence — before{" "}
       <code>shep flock</code> reports it stopped by <code>SIGKILL</code>.
     </p>
 
     <h2 id="polyglot">The polyglot layer</h2>
     <p>
-      <code>examples/Flockfile.polyglot.toml</code> needs, per app,
-      <code>node</code>, <code>bun</code>, <code>python3</code>, or
+      <code>examples/Flockfile.polyglot.toml</code> needs, per app,{" "}
+      <code>node</code>, <code>bun</code>, <code>python3</code>, or{" "}
       <code>go</code> — never all four to run any single one of them.
       Two setup steps, once, before the runtimes that need them:
     </p>
@@ -263,7 +263,7 @@ timeout  = "1s"`}</CodeBlock>
       stays online, and the failure names it
       (<code>this start already has children running and leaves them
       alone: node-http, node-http-cluster</code>), but nothing after it is
-      even attempted in that same invocation. Missing <code>bun</code> would silently keep
+      even attempted in that same invocation. Missing <code>bun</code> would silently keep{" "}
       <code>python-app</code> and <code>go-http</code> from starting too,
       not just <code>bun-http</code>. If a runtime isn't installed, comment
       out that app's <code>[[app]]</code> block rather than leaving it in.
@@ -274,8 +274,8 @@ timeout  = "1s"`}</CodeBlock>
     <h3>One file, two runtimes</h3>
     <p>
       <code>node-http</code> and <code>bun-http</code> run the exact same
-      script, <code>examples/polyglot/node-http.js</code> — only
-      <code>interpreter</code> changes, from <code>"node"</code> to
+      script, <code>examples/polyglot/node-http.js</code> — only{" "}
+      <code>interpreter</code> changes, from <code>"node"</code> to{" "}
       <code>"bun"</code>:
     </p>
     <CodeBlock label="examples/Flockfile.polyglot.toml">{`[[app]]
@@ -291,7 +291,7 @@ interpreter = "bun"
 args        = ["19095"]`}</CodeBlock>
     <p class="fine">
       shep never inspects the script; <code>interpreter</code> is a plain
-      program name, spawned with the script as its first argument. A
+      program name, spawned with the script as its first argument. A{" "}
       <code>shep.toml</code> <code>[interpreters]</code> table does the same
       job automatically, by extension, so every app in a flock doesn't
       have to spell <code>interpreter</code> out by hand:
@@ -301,7 +301,7 @@ js = "node"
 py = "python3"`}</CodeBlock>
     <p class="fine">
       An app's own <code>interpreter</code> field, when it sets one — as
-      every interpreted app in <code>examples/Flockfile.polyglot.toml</code>
+      every interpreted app in <code>examples/Flockfile.polyglot.toml</code>{" "}
       does, though <code>go-http</code> sets none because a compiled binary
       runs directly — always wins over the extension map. The map exists for a flock of
       apps that all use the same handful of extensions and would rather
@@ -310,8 +310,8 @@ py = "python3"`}</CodeBlock>
 
     <h3>instances, without reuse_port</h3>
     <p>
-      <code>node-http-cluster</code> is the same script again,
-      <code>instances = 4</code>. Each instance gets its own
+      <code>node-http-cluster</code> is the same script again,{" "}
+      <code>instances = 4</code>. Each instance gets its own{" "}
       <code>SHEP_INSTANCE</code> env var (0 through 3), and the script adds
       that to its base port: four separate listeners on 19091 through
       19094, not one port shared four ways. A <code>readiness_probe</code> is what
@@ -328,7 +328,7 @@ py = "python3"`}</CodeBlock>
       overlap: an app that claims it wrongly gets a replacement that takes{" "}
       <code>EADDRINUSE</code>.
       This example offsets the port rather than sharing it, so the question
-      never arises: four listeners, four ports, nothing to share. See
+      never arises: four listeners, four ports, nothing to share. See{" "}
       <a href="/docs/from-pm2">Coming from pm2</a> for how this compares to
       pm2's own cluster mode.
     </p>
@@ -350,8 +350,8 @@ args        = ["19096"]`}</CodeBlock>
 
     <h3>A build step, then no interpreter</h3>
     <p>
-      <code>go-http</code> is compiled, not interpreted:
-      <code>examples/polyglot/go-http/build.sh</code> runs
+      <code>go-http</code> is compiled, not interpreted:{" "}
+      <code>examples/polyglot/go-http/build.sh</code> runs{" "}
       <code>go build</code> first, and the Flockfile entry that follows has
       no <code>interpreter</code> field at all — a native executable
       already runs itself.
@@ -367,7 +367,7 @@ args        = ["19096"]`}</CodeBlock>
       <div><span class="prompt">$</span> ./target/release/shep serve examples/polyglot/static-site --port 19098</div>
     </div>
     <p class="fine">
-      See <a href="/docs/serve">Serve</a> for <code>--bind</code>,
+      See <a href="/docs/serve">Serve</a> for <code>--bind</code>,{" "}
       <code>--auth</code>, and everything else it refuses by default.
     </p>
 

--- a/web/src/pages/docs/first-flockfile.astro
+++ b/web/src/pages/docs/first-flockfile.astro
@@ -160,7 +160,7 @@ const fieldGroups: FieldGroup[] = [
     <ReferencePills slug="first-flockfile" />
     <p class="lede">
       <a href="/docs/getting-started">Getting started</a> showed a two-field
-      Flockfile and moved on. This page is what's underneath: every field
+      Flockfile and moved on. This page is what's underneath: every field{" "}
       <code>AppConfig</code> understands, the four formats and ten filenames
       config discovery will find on its own, and the grammar that turns a
       typo into a parse error instead of a surprise at 3am.
@@ -198,7 +198,7 @@ script = "./server"`}</CodeBlock>
     </p>
     <p>
       A template that ships its secrets blank, <code>env = &#123; DB_HOST =
-      "", DB_PASSWORD = "" &#125;</code>, has one more problem:
+      "", DB_PASSWORD = "" &#125;</code>, has one more problem:{" "}
       <code>shep start</code> would spawn the app against those blanks and
       leave it crash-looping. <code>shep add Flockfile.toml</code> takes the
       same targets and the same load and spawns nothing, so the app lands
@@ -206,7 +206,7 @@ script = "./server"`}</CodeBlock>
       once it has real values.
     </p>
     <p class="fine">
-      Naming a sheep reads no Flockfile at all. <code>shep start web</code>
+      Naming a sheep reads no Flockfile at all. <code>shep start web</code>{" "}
       starts the sheep called <code>web</code> from the config the shepherd
       already holds. Three things are a load, and nothing else is: a path you
       name, a Flockfile discovered in the directory you ran the command from,
@@ -264,10 +264,10 @@ script = "./server"`}</CodeBlock>
     <p>
       TOML, YAML, JSON, and JSON5 all parse the same document shape: a list
       of app tables under one <code>app</code> key (<code>[[app]]</code> in
-      TOML). <code>shep start</code> always takes an explicit
+      TOML). <code>shep start</code> always takes an explicit{" "}
       <code>&lt;TARGET&gt;</code>: clap refuses with "the following required
-      arguments were not provided" if you leave it off. Discovery belongs to
-      <code>shep runtime</code> and <code>shep dev</code>, whose
+      arguments were not provided" if you leave it off. Discovery belongs to{" "}
+      <code>shep runtime</code> and <code>shep dev</code>, whose{" "}
       <code>[TARGET]</code> is optional: run either with no argument and it
       searches the current directory for these ten names, in order, and
       stops at the first one it finds:
@@ -294,18 +294,18 @@ flockfile.json5`}</CodeBlock>
       shep gives <code>node</code> 30 seconds to hand the config back and
       exit, then kills it. Exporting the config is not enough by itself: a
       module that leaves a server listening or a timer armed keeps node's
-      event loop alive, so node never exits. An unattended
+      event loop alive, so node never exits. An unattended{" "}
       <code>shep start</code> ends in a refusal instead of waiting forever.
     </p>
     <p class="fine">
       A pm2 <code>ecosystem.config.js</code> is not a Flockfile shep can read
-      this way. shep never parses pm2's config format at all. That's what
-      <code>shep import</code> is for: it reads a real <code>dump.pm2</code>
-      and writes a Flockfile, once, rather than teaching <code>start</code>
+      this way. shep never parses pm2's config format at all. That's what{" "}
+      <code>shep import</code> is for: it reads a real <code>dump.pm2</code>{" "}
+      and writes a Flockfile, once, rather than teaching <code>start</code>{" "}
       a second config dialect. See <a href="/docs/from-pm2">Coming from pm2</a>.
     </p>
     <Callout variant="careful">
-      Without <code>--flockfile</code>, <code>shep start server.js</code>
+      Without <code>--flockfile</code>, <code>shep start server.js</code>{" "}
       still means exactly what it always has: run <code>server.js</code> as
       a script, not as config. <code>cd</code>-ing into a cloned repository
       and running <code>shep runtime</code> or <code>shep dev</code> with no
@@ -344,7 +344,7 @@ flockfile.json5`}</CodeBlock>
       </div>
     </div>
     <p>
-      <code>512M</code> and <code>30s</code> parse. <code>512MB</code>,
+      <code>512M</code> and <code>30s</code> parse. <code>512MB</code>,{" "}
       <code>1.5G</code>, and <code>30S</code> all fail: a fractional size,
       a two-letter unit, and an uppercase duration suffix, each rejected by
       the same strict grammar rather than rounded, guessed, or silently
@@ -388,11 +388,11 @@ unknown field \`max_memory_restart\`, expected one of \`name\`, \`script\`, \`ar
 
     <h3>Paths</h3>
     <p>
-      Four fields hold one: <code>script</code>, <code>cwd</code>,
+      Four fields hold one: <code>script</code>, <code>cwd</code>,{" "}
       <code>out_file</code> and <code>err_file</code>. All four expand a
       leading <code>~/</code> to your home directory, because a Flockfile is
       read from a file rather than typed at a shell, and nothing would
-      otherwise expand it: shep would look for a directory literally named
+      otherwise expand it: shep would look for a directory literally named{" "}
       <code>~</code>.
     </p>
     <p class="fine">
@@ -443,10 +443,10 @@ DB_PASSWORD = "{{secret:DB_PASSWORD}}"`}</CodeBlock>
     </p>
     <CodeBlock label="an unclosed token">{`error[invalid_config]: the daemon reported InvalidConfig: sheep \`z-worker\`, env.WORKER: a \`{{\` in this value is never closed by a \`}}\``}</CodeBlock>
     <p>
-      Doubling the braces escapes them: <code>{'{{{{'}</code> and
-      <code>{'}}}}'}</code> render as one literal <code>{'{{'}</code> and
+      Doubling the braces escapes them: <code>{'{{{{'}</code> and{" "}
+      <code>{'}}}}'}</code> render as one literal <code>{'{{'}</code> and{" "}
       <code>{'}}'}</code>. Single braces are left alone and never need
-      escaping, so a JSON blob, a regex quantifier like
+      escaping, so a JSON blob, a regex quantifier like{" "}
       <code>{'{2,3}'}</code>, or a Go or Helm template passed through as an
       arg all survive untouched.
     </p>
@@ -488,11 +488,11 @@ DB_PASSWORD = "{{secret:DB_PASSWORD}}"`}</CodeBlock>
 
     <h2>The full field reference</h2>
     <p>
-      Every field <code>AppConfig</code> accepts, grouped by what it's for.
+      Every field <code>AppConfig</code> accepts, grouped by what it's for.{" "}
       <code>readiness_probe</code> and <code>liveness_probe</code> each take
       a nested object: <code>kind</code> (<code>http</code>/<code
-      >tcp</code>/<code>exec</code>), <code>target</code>, and optional
-      <code>interval</code> (10s), <code>timeout</code> (5s), and
+      >tcp</code>/<code>exec</code>), <code>target</code>, and optional{" "}
+      <code>interval</code> (10s), <code>timeout</code> (5s), and{" "}
       <code>failure_threshold</code> (3). <code>depends_on</code> has a page
       of its own: see <a href="/docs/boot-order">boot order</a>.
     </p>
@@ -524,13 +524,13 @@ DB_PASSWORD = "{{secret:DB_PASSWORD}}"`}</CodeBlock>
     <Callout variant="note">
       A permanently broken app (bad config, missing dependency: it exits
       before <code>min_uptime</code> every time) still errors out once it
-      hits <code>max_restarts</code>, but the default
+      hits <code>max_restarts</code>, but the default{" "}
       <code>exp_backoff_restart_delay</code> of 100ms, growing ×1.5 each
-      attempt, changes how long that takes. At the default
+      attempt, changes how long that takes. At the default{" "}
       <code>max_restarts = 16</code>, reaching <code>Errored</code> now
-      takes roughly 50-70s instead of well under a second. Set
+      takes roughly 50-70s instead of well under a second. Set{" "}
       <code>exp_backoff_restart_delay = "0"</code> to go back to failing
-      fast, provided <code>restart_delay</code> is unset -- a fixed
+      fast, provided <code>restart_delay</code> is unset -- a fixed{" "}
       <code>restart_delay</code> takes precedence and still applies its
       own wait on every restart, even with the backoff disabled.
     </Callout>
@@ -538,9 +538,9 @@ DB_PASSWORD = "{{secret:DB_PASSWORD}}"`}</CodeBlock>
     <h2>Get the schema directly</h2>
     <p>
       Everything above is generated from the same source the parser uses,
-      so it can't drift from what <code>shep</code> actually accepts.
+      so it can't drift from what <code>shep</code> actually accepts.{" "}
       <code>shep schema</code> prints it as JSON Schema, and the same output
-      is committed at <code>crates/shep-core/assets/flockfile.schema.json</code>
+      is committed at <code>crates/shep-core/assets/flockfile.schema.json</code>{" "}
       for an editor to point at:
     </p>
     <CodeBlock>{`$ shep schema | head -20
@@ -565,13 +565,13 @@ DB_PASSWORD = "{{secret:DB_PASSWORD}}"`}</CodeBlock>
         }
       },`}</CodeBlock>
     <p class="fine">
-      That's the real first twenty lines, unedited. <code>head -20</code>
-      stops just after <code>"app"</code> closes and before
-      <code>"dog"</code> begins, and the <code>"$schema"</code>
+      That's the real first twenty lines, unedited. <code>head -20</code>{" "}
+      stops just after <code>"app"</code> closes and before{" "}
+      <code>"dog"</code> begins, and the <code>"$schema"</code>{" "}
       key's own description is one long escaped line explaining itself,
-      not the tidied multi-line prose above. The full document closes
+      not the tidied multi-line prose above. The full document closes{" "}
       <code>"app"</code>, adds the <code>"dog"</code> key described below,
-      then <code>"additionalProperties": false</code> and a
+      then <code>"additionalProperties": false</code> and a{" "}
       <code>"$defs"</code> section with one entry per Flockfile field.
       Run the command yourself to see the rest.
     </p>
@@ -582,7 +582,7 @@ DB_PASSWORD = "{{secret:DB_PASSWORD}}"`}</CodeBlock>
       the key existed, a Flockfile carrying any of it was refused outright, so
       an operator could not register their app at all. shep does not read what
       is under <code>dog</code>, does not validate it, and promises nothing
-      about it. The table itself is required, though: <code>dog = 5</code> and
+      about it. The table itself is required, though: <code>dog = 5</code> and{" "}
       <code>dog = ["a"]</code> are refused, because otherwise this would be
       the one key in the document where a typo does not fail loudly. What is
       inside it is the dog's: the dog that owns a key is the only thing that
@@ -620,7 +620,7 @@ DB_PASSWORD = "{{secret:DB_PASSWORD}}"`}</CodeBlock>
       <a href="/docs/json-output" class="next-card">
         <div class="next-title">JSON output →</div>
         <div class="next-body">
-          How this same config surfaces back out through
+          How this same config surfaces back out through{" "}
           <code>shep flock --format json</code>.
         </div>
       </a>

--- a/web/src/pages/docs/folds.astro
+++ b/web/src/pages/docs/folds.astro
@@ -23,7 +23,7 @@ import CodeBlock from "../../components/docs/CodeBlock.astro";
     <p class="lede">
       A fold is a label, nothing more. It doesn't isolate a sheep's
       filesystem, network, or resources. It just gives a group of sheep a
-      name you can select, list, and read off the flock table, so
+      name you can select, list, and read off the flock table, so{" "}
       <code>backend</code> and <code>jobs</code> don't have to be regexes
       you keep retyping.
     </p>
@@ -31,8 +31,8 @@ import CodeBlock from "../../components/docs/CodeBlock.astro";
     <h2>Setting one</h2>
     <p>
       Add <code>fold = "&lt;name&gt;"</code> to any app in a Flockfile. A
-      sheep with no <code>fold</code> field simply has none. It prints
-      <code>-</code> in the table and <code>null</code> under
+      sheep with no <code>fold</code> field simply has none. It prints{" "}
+      <code>-</code> in the table and <code>null</code> under{" "}
       <code>--format json</code>.
     </p>
     <CodeBlock label="Flockfile.toml">{`[[app]]
@@ -54,7 +54,7 @@ fold   = "jobs"`}</CodeBlock>
     <p>
       <code>shep fold &lt;name&gt;</code> lists exactly that fold. Nothing
       else in the flock. It's <code>shep flock</code> pre-filtered, plus one
-      thing the plain flock table never shows: a <strong>Lambs</strong>
+      thing the plain flock table never shows: a <strong>Lambs</strong>{" "}
       section under any sheep that has spawned children of its own, one per
       sheep, listing every parent-pid descendant by PID and name:
     </p>
@@ -74,12 +74,12 @@ PID    NAME
 64785  sleep`}</CodeBlock>
     <p>
       A sheep with no children of its own gets no Lambs section at all. The
-      two above both happen to fork workers, which is why both get one. See
+      two above both happen to fork workers, which is why both get one. See{" "}
       <a href="/docs/json-output">JSON output</a> for how the same data
       surfaces as the <code>lambs</code> array under <code>--format json</code>.
     </p>
     <p>
-      A fold name that matches nothing is the same <code>not_found</code>
+      A fold name that matches nothing is the same <code>not_found</code>{" "}
       error any other selector gives you, exit code 3, not an empty list:
     </p>
     <CodeBlock>{`$ shep fold nonexistent
@@ -88,10 +88,10 @@ error[not_found]: the daemon reported NotFound: selector matched no registered s
     <h2>Selecting one from any verb</h2>
     <p>
       Every verb accepts <code>fold:&lt;name&gt;</code> in place of a name,
-      an id, a <code>/regex/</code>, a glob, <code>name:slot</code>
-      (<code>web:2</code>, one instance of a multi-instance app), or
-      <code>all</code>. That is <code>stop</code>, <code>restart</code>,
-      <code>reload</code>, <code>delete</code>, <code>bleats</code>,
+      an id, a <code>/regex/</code>, a glob, <code>name:slot</code>{" "}
+      (<code>web:2</code>, one instance of a multi-instance app), or{" "}
+      <code>all</code>. That is <code>stop</code>, <code>restart</code>,{" "}
+      <code>reload</code>, <code>delete</code>, <code>bleats</code>,{" "}
       <code>trigger</code>, <code>start</code>, and the rest. It reaches
       every sheep carrying that fold in one call:
     </p>
@@ -102,14 +102,14 @@ ID  NAME    STATUS   PID    RESTARTS  EXIT     CFG  CPU  MEM    UPTIME  FOLD    
 1   worker  stopped  -      0         SIGTERM  -    -    -      0s      backend  -`}</CodeBlock>
     <p>
       The listing is the whole flock, not just the fold. Every lifecycle verb
-      prints it that way, so <code>cron</code> is there and still online. See
+      prints it that way, so <code>cron</code> is there and still online. See{" "}
       <a href="/docs/output#after-a-lifecycle-command">terminal output</a>.
     </p>
 
     <h2>Folds on <code>start</code></h2>
     <p>
       <code>shep start</code> takes selectors like every other verb, and it
-      also takes the things only it can take: a script path, a Flockfile, or
+      also takes the things only it can take: a script path, a Flockfile, or{" "}
       <code>-</code> for Flockfile JSON on stdin. That makes some targets
       ambiguous, so it resolves one in a fixed order and the first tier that
       matches wins.
@@ -130,7 +130,7 @@ ID  NAME    STATUS   PID    RESTARTS  EXIT     CFG  CPU  MEM    UPTIME  FOLD    
     <p>
       Only sheep the flock already has can be reached this way. A fold is a
       field on a registered sheep, so there is nothing for a fold to
-      register. A sheep that is already running is reported and left alone;
+      register. A sheep that is already running is reported and left alone;{" "}
       <code>restart</code> is the verb that replaces one.
     </p>
     <CodeBlock>{`$ shep start fold:backed
@@ -149,18 +149,18 @@ error[not_found]: no sheep is in a fold called typo`}</CodeBlock>
 
     <Callout variant="note">
       Selector parsing checks shapes in a fixed order, and it matters if a
-      name is ambiguous with something else: the literal word
-      <code>all</code>, then a <code>fold:</code> prefix, then
+      name is ambiguous with something else: the literal word{" "}
+      <code>all</code>, then a <code>fold:</code> prefix, then{" "}
       <code>/regex/</code> slashes, then (if the whole string is ASCII
       digits) a numeric id, then a glob, then <code>name:slot</code>. Only
       after all six fail does it fall back to treating the string as a plain
       name. A sheep named <code>2</code> is the practical edge of this:
       typing <code>2</code> as a selector always means "id 2", never "the
-      sheep named 2", even if those aren't the same sheep. <code>fold:</code>
-      names don't collide with any of this: the prefix is checked for before
+      sheep named 2", even if those aren't the same sheep. <code>fold:</code>{" "}
+      names don't collide with any of this: the prefix is checked for before{" "}
       <code>/regex/</code> or a bare number, so a fold can be named anything,
-      including <code>all</code> or a number, and
-      <code>fold:&lt;that name&gt;</code> still reaches it. A glob like
+      including <code>all</code> or a number, and{" "}
+      <code>fold:&lt;that name&gt;</code> still reaches it. A glob like{" "}
       <code>web*</code> is checked before <code>name:slot</code>, so it still
       matches every instance of an app rather than being read as a name with
       a stray colon; and since a colon is no longer legal in a sheep name at
@@ -173,7 +173,7 @@ error[not_found]: no sheep is in a fold called typo`}</CodeBlock>
       Folds carry no uniqueness constraint and no nesting: a name is a flat
       string, and two sheep can share one with nothing else in common. There
       is no <code>shep fold create</code> or config listing every fold that
-      exists; a fold exists exactly as long as some sheep's
+      exists; a fold exists exactly as long as some sheep's{" "}
       <code>fold</code> field names it, and disappears the moment the last
       one does. If you're picturing folds as something closer to a
       Kubernetes namespace or a cgroup, that's the wrong mental model.
@@ -185,14 +185,14 @@ error[not_found]: no sheep is in a fold called typo`}</CodeBlock>
       <a href="/docs/first-flockfile" class="next-card">
         <div class="next-title">Your first Flockfile →</div>
         <div class="next-body">
-          Every field a Flockfile understands, including <code>fold</code>
+          Every field a Flockfile understands, including <code>fold</code>{" "}
           itself, and the strict grammars that catch typos.
         </div>
       </a>
       <a href="/docs/json-output" class="next-card">
         <div class="next-title">JSON output →</div>
         <div class="next-body">
-          How a fold (or its absence) actually serializes under
+          How a fold (or its absence) actually serializes under{" "}
           <code>--format json</code>.
         </div>
       </a>

--- a/web/src/pages/docs/from-pm2.astro
+++ b/web/src/pages/docs/from-pm2.astro
@@ -109,10 +109,10 @@ const verbTable: { pm2: string; shep: string; note?: string }[] = [
 
     <h2>What it reads</h2>
     <p>
-      Exactly one file: <code>~/.pm2/dump.pm2</code>, or whatever path
+      Exactly one file: <code>~/.pm2/dump.pm2</code>, or whatever path{" "}
       <code>--from</code> names: whichever <code>pm2 save</code> last wrote.
       It does not read <code>ecosystem.config.js</code> or any other pm2
-      config format, and it never touches pm2's own state: nothing under
+      config format, and it never touches pm2's own state: nothing under{" "}
       <code>~/.pm2</code> is written or deleted by anything on this page.
     </p>
     <p>
@@ -125,10 +125,10 @@ const verbTable: { pm2: string; shep: string; note?: string }[] = [
 
     <VerbSignature verb="import" usage="shep import [OPTIONS]">
       <p>
-        <code>--from &lt;path&gt;</code> to read a dump somewhere other than
+        <code>--from &lt;path&gt;</code> to read a dump somewhere other than{" "}
         <code>~/.pm2/dump.pm2</code>, <code>--out &lt;path&gt;</code> to
-        write somewhere other than <code>./Flockfile.toml</code>,
-        <code>--dry-run</code> to print and write nothing, and
+        write somewhere other than <code>./Flockfile.toml</code>,{" "}
+        <code>--dry-run</code> to print and write nothing, and{" "}
         <code>--force</code> to overwrite an existing Flockfile. Full flag
         reference on the <a href="/docs/cli">CLI page</a>.
       </p>
@@ -138,7 +138,7 @@ const verbTable: { pm2: string; shep: string; note?: string }[] = [
     <p>
       The repo ships a synthetic three-app dump for exactly this: one
       clustered Node API, one Bun worker with a declared env block, and one
-      one-shot migration script. This is the real output of running
+      one-shot migration script. This is the real output of running{" "}
       <code>shep import --dry-run</code> against it.
     </p>
     <CodeBlock label="$ shep import --from dump.pm2.json --dry-run">{`notice[read]: read 4 instance rows for 3 apps from dump.pm2.json
@@ -179,12 +179,12 @@ script = "/srv/migrate/bin/migrate"
 args = ["--once"]
 cwd = "/srv/migrate"`}</CodeBlock>
     <p class="fine">
-      Every notice lands on stderr in both <code>--format table</code> and
+      Every notice lands on stderr in both <code>--format table</code> and{" "}
       <code>--format json</code>; stdout stays clean Flockfile TOML either
       way, so <code>shep import --dry-run &gt; Flockfile.toml</code> is safe
-      to pipe. A normal run (no <code>--dry-run</code>) writes
+      to pipe. A normal run (no <code>--dry-run</code>) writes{" "}
       <code>./Flockfile.toml</code>, or wherever <code>--out</code> names,
-      and refuses to overwrite an existing file unless you pass
+      and refuses to overwrite an existing file unless you pass{" "}
       <code>--force</code>.
     </p>
 
@@ -251,7 +251,7 @@ cwd = "/srv/migrate"`}</CodeBlock>
       pm2's cluster master holds one listen socket and hands connections to
       its workers. shep has no such master. It binds nothing on any app's
       behalf. Running N instances of an app on one port only works if the
-      app arranges the sharing itself, with <code>SO_REUSEPORT</code>
+      app arranges the sharing itself, with <code>SO_REUSEPORT</code>{" "}
       (Node's <code>reusePort: true</code> listen option, which needs
       Node&nbsp;≥&nbsp;22.12). Without that, every instance past the first
       hits <code>EADDRINUSE</code> the moment it starts.
@@ -267,7 +267,7 @@ cwd = "/srv/migrate"`}</CodeBlock>
       that overlaps its two instances. An app with no probe already overlaps,
       and so does one using <code>wait_ready</code>, neither of which needs
       the field. <code>import</code> still will not write it for you, because
-      only you know whether the app really does call
+      only you know whether the app really does call{" "}
       <code>reusePort: true</code>. The work is the app&rsquo;s either way.
       If it was never written to share the socket, cluster mode does not
       work under shep however the Flockfile is written.
@@ -327,7 +327,7 @@ server {
       keeps sending requests at a port nothing is listening on. Open-source
       nginx only does this passive kind of checking, watching real requests
       fail, not active probing; that's an nginx Plus feature, so don't expect
-      more from the free build. <code>Upgrade</code> and
+      more from the free build. <code>Upgrade</code> and{" "}
       <code>Connection</code> are there for websockets, and cost nothing if
       the app doesn't use them.
     </p>
@@ -338,7 +338,7 @@ server {
       shorthand only holds up to ten instances.
     </Callout>
     <p>
-      Past ten, pass a base and let the app add its own slot, since
+      Past ten, pass a base and let the app add its own slot, since{" "}
       <code>SHEP_INSTANCE</code> is always injected:
     </p>
     <CodeBlock label="Flockfile.toml">{`[[app]]
@@ -355,9 +355,9 @@ PORT_BASE = "3000"`}</CodeBlock>
     <p>
       If the app sets <code>SO_REUSEPORT</code> on its own listener, every
       instance binds the same port and the kernel spreads connections between
-      them, no proxy required. That's close to what Node's
+      them, no proxy required. That's close to what Node's{" "}
       <code>cluster</code> module does with its own shared-socket scheme,
-      except it runs in the OS and works for any language. Set
+      except it runs in the OS and works for any language. Set{" "}
       <code>reuse_port = true</code> in the Flockfile to tell shep the app
       does this, so a reload knows it's safe to overlap the old and new
       instances rather than draining one before starting the other. shep
@@ -373,34 +373,34 @@ PORT_BASE = "3000"`}</CodeBlock>
       app it runs: <code>PATH</code>, <code>JAVA_HOME</code>, whatever else
       your login session happened to have set. None of that was ever the
       app's own configuration, and a daemon started by systemd or launchd
-      has no login shell behind it to reproduce it. <code>shep import</code>
+      has no login shell behind it to reproduce it. <code>shep import</code>{" "}
       applies one rule per key:
     </p>
     <ul>
       <li>
-        A key <strong>declared</strong> in the app's own <code>env_*</code>
+        A key <strong>declared</strong> in the app's own <code>env_*</code>{" "}
         block is always written.
       </li>
       <li>
         A key that isn't declared, but matches a closed list of shell noise
         (<code>PATH</code>, <code>SHLVL</code>, <code>SSH_TTY</code>, ...)
-        or pm2's own injected variables (<code>PM2_HOME</code>,
+        or pm2's own injected variables (<code>PM2_HOME</code>,{" "}
         <code>pm_id</code>, ...), is dropped silently.
       </li>
       <li>
         Everything else is <strong>named on stderr and left out</strong> of
-        the Flockfile. The importer doesn't guess whether a stray
+        the Flockfile. The importer doesn't guess whether a stray{" "}
         <code>DATABASE_URL</code> is the app's real configuration or more
         session noise the closed list doesn't happen to know. You decide
         where it belongs.
       </li>
     </ul>
     <p>
-      <code>PATH</code> specifically is never written into an app's
-      <code>env</code>, no matter how it got into the dump. Instead,
+      <code>PATH</code> specifically is never written into an app's{" "}
+      <code>env</code>, no matter how it got into the dump. Instead,{" "}
       <code>shep startup</code> captures the <code>PATH</code> of the shell
       that installed it straight into the systemd unit or launchd plist, so
-      an interpreter under <code>~/.bun/bin</code> or <code>~/.cargo/bin</code>
+      an interpreter under <code>~/.bun/bin</code> or <code>~/.cargo/bin</code>{" "}
       is still findable after a reboot with no login shell behind the daemon
       at all.
     </p>
@@ -408,7 +408,7 @@ PORT_BASE = "3000"`}</CodeBlock>
     <h2>What it costs to run</h2>
     <p>
       Measured on one machine on 2026-08-29: shep 0.1.12 against pm2 7.0.4 on
-      node v26.5.0. Both tools ran the same two shell scripts under the same
+      node v26.5.0. Both tools ran the same two shell scripts under the same{" "}
       <code>/bin/sh</code>, with logs going to each tool's own default file
       capture, and the daemon is what was sampled rather than the children.
     </p>
@@ -448,7 +448,7 @@ PORT_BASE = "3000"`}</CodeBlock>
     <p>
       The RSS gap is structural rather than clever: pm2's daemon is a node
       process and pays that runtime's floor whatever it does. Everything here
-      is reproducible from
+      is reproducible from{" "}
       <code>benches/versus-pm2/versus-pm2.sh</code> in the repository, which
       drives the published npm package as a black box and keeps its raw
       samples.
@@ -490,7 +490,7 @@ PORT_BASE = "3000"`}</CodeBlock>
         <strong>Dotfiles are refused by default.</strong> pm2's serve
         publishes them; shep 404s any path with a dotfile component unless
         you pass <code>--hidden</code>. <code>shep serve .</code> on a repo
-        checkout would otherwise publish <code>.env</code> and the whole
+        checkout would otherwise publish <code>.env</code> and the whole{" "}
         <code>.git</code> history.
       </li>
       <li>
@@ -501,20 +501,20 @@ PORT_BASE = "3000"`}</CodeBlock>
       </li>
     </ul>
     <p class="fine">
-      There's no <code>PM2_SERVE_*</code> environment compatibility: pass
-      <code>--port</code>, <code>--bind</code>, <code>--spa</code> and
+      There's no <code>PM2_SERVE_*</code> environment compatibility: pass{" "}
+      <code>--port</code>, <code>--bind</code>, <code>--spa</code> and{" "}
       <code>--auth &lt;file&gt;</code> on the command line instead.
     </p>
 
     <h2>pm2-runtime vs. shep runtime</h2>
     <p>
-      <code>shep-runtime</code> is the container-entrypoint alias for
+      <code>shep-runtime</code> is the container-entrypoint alias for{" "}
       <code>shep runtime</code>: a foreground, no-daemon supervisor that
       reads a Flockfile, boots the flock in-process, and exits once it
-      empties: 0 if every sheep stopped clean, 11 if one ended
+      empties: 0 if every sheep stopped clean, 11 if one ended{" "}
       <code>errored</code>, so an orchestrator can tell "finished" from
       "died". At PID 1 it also reaps re-parented zombies and forwards
-      signals, which a container that skips this step accumulates until
+      signals, which a container that skips this step accumulates until{" "}
       <code>docker stop</code> waits out the full grace period.
     </p>
 
@@ -547,10 +547,10 @@ PORT_BASE = "3000"`}</CodeBlock>
 
     <h2>Rolling back</h2>
     <p>
-      <code>shep unstartup</code> disables and removes whatever unit
+      <code>shep unstartup</code> disables and removes whatever unit{" "}
       <code>startup</code> installed. Run unprivileged, it prints the same
       kind of paste-able <code>sudo</code> command <code>startup</code> does.
-      A machine that never ran <code>startup</code> reports the unit
+      A machine that never ran <code>startup</code> reports the unit{" "}
       <code>absent</code> and exits successfully. Nothing left to guess at.
       Nothing here is destructive to pm2 itself except the one step in the
       runbook that says so.

--- a/web/src/pages/docs/getting-started.astro
+++ b/web/src/pages/docs/getting-started.astro
@@ -30,7 +30,7 @@ import CodeBlock from "../../components/docs/CodeBlock.astro";
       shep is pre-1.0, so anything here can still change. macOS, Linux and
       Windows all work; the Windows tier is newer, and two limits are worth
       knowing before you rely on it — <code>shep stop</code> has no graceful
-      signal to send unless your app reads the shepherd channel, and
+      signal to send unless your app reads the shepherd channel, and{" "}
       <code>shep startup</code> is not built there.
     </Callout>
 
@@ -47,18 +47,18 @@ import CodeBlock from "../../components/docs/CodeBlock.astro";
       <div><span class="prompt">$</span> ./target/release/shep --help</div>
     </div>
     <p class="fine">
-      Rust 1.88 or newer, edition 2024, if you build from source. Put
+      Rust 1.88 or newer, edition 2024, if you build from source. Put{" "}
       <code>target/release/shep</code> on your PATH, or keep typing the full
       path. Everything below works either way.
     </p>
     <p class="fine">
-      Two more things that belong to this step.
+      Two more things that belong to this step.{" "}
       <code>shep completions &lt;shell&gt;</code> prints a completion script
       for bash, elvish, fish, powershell or zsh, to redirect wherever your
       shell reads them from. It completes verbs and flags and stops there:
       sheep names, fold names and anything else the shepherd knows are never
-      completed, because the script never talks to one. And
-      <code>shep welcome</code> reprints the greeting a fresh
+      completed, because the script never talks to one. And{" "}
+      <code>shep welcome</code> reprints the greeting a fresh{" "}
       <code>$SHEP_HOME</code> shows once on its own: the sheep, the home it
       set up, and the five commands worth knowing.
     </p>
@@ -108,7 +108,7 @@ import CodeBlock from "../../components/docs/CodeBlock.astro";
       predates the handover and has nothing to hand over with.
     </p>
     <Callout variant="careful">
-      Skip <code>shep daemon reload</code> and the new binary answers
+      Skip <code>shep daemon reload</code> and the new binary answers{" "}
       <code>shep --version</code> while the running shepherd is still the
       old one. shep refuses most verbs against a version-skewed shepherd and
       names this exact command as the fix.
@@ -131,11 +131,11 @@ import CodeBlock from "../../components/docs/CodeBlock.astro";
 
     <h2>2. Write a Flockfile</h2>
     <p>
-      Two fields is a complete one. <code>Flockfile.toml</code>,
+      Two fields is a complete one. <code>Flockfile.toml</code>,{" "}
       <code>.yaml</code>, <code>.json</code> and <code>.json5</code> all
-      work. <code>shep start</code> below takes the path explicitly;
+      work. <code>shep start</code> below takes the path explicitly;{" "}
       <code>shep runtime</code> and <code>shep dev</code> can find one on
-      their own instead, by searching ten filenames in a fixed order: see
+      their own instead, by searching ten filenames in a fixed order: see{" "}
       <a href="/docs/first-flockfile">Your first Flockfile</a>.
     </p>
     <div class="file-panel">
@@ -148,15 +148,15 @@ import CodeBlock from "../../components/docs/CodeBlock.astro";
     </div>
     <Callout variant="note">
       Unknown fields are a parse error, not a shrug. A typo tells you at
-      load instead of at 3am. Durations and sizes are strict on purpose:
-      <code>512M</code> and <code>30s</code> parse; <code>512MB</code>,
+      load instead of at 3am. Durations and sizes are strict on purpose:{" "}
+      <code>512M</code> and <code>30s</code> parse; <code>512MB</code>,{" "}
       <code>1.5G</code> and <code>30S</code> do not.
     </Callout>
 
     <h3>Scripts that need an interpreter</h3>
     <p>
       <code>script</code> is run directly, so a compiled binary or a file
-      with a shebang and the executable bit needs nothing further. A plain
+      with a shebang and the executable bit needs nothing further. A plain{" "}
       <code>server.js</code> has neither, and shep will not guess: guessing
       is how a process manager ends up with opinions you did not ask for.
     </p>
@@ -172,7 +172,7 @@ sh = "sh"`}</CodeBlock>
     <p>
       From then on <code>shep start server.js</code> works. Edit the table,
       add an extension, or delete the whole thing to turn it off. An
-      individual app can override it with its own
+      individual app can override it with its own{" "}
       <code>interpreter</code> field, and a single run can override both
       with <code>--interpreter</code>; the last one named wins.
     </p>
@@ -201,15 +201,15 @@ sh = "sh"`}</CodeBlock>
       The CPU column prints <code>-</code> rather than <code>0.0%</code> when
       a reading is unavailable, because a confident zero is worse than an
       obvious blank. <code>EXIT</code> uses the same convention, and shows
-      why a stopped sheep stopped. <code>CFG</code> reads <code>-</code>
-      until a sheep has config waiting on it; see
+      why a stopped sheep stopped. <code>CFG</code> reads <code>-</code>{" "}
+      until a sheep has config waiting on it; see{" "}
       <a href="/docs/overrides">Overrides</a>.
     </p>
 
     <h2>4. Watch what it prints</h2>
     <p>
-      <code>shep bleats</code> follows the logs; <code>--no-follow</code>
-      prints the tail and exits. If you prefer the boring word,
+      <code>shep bleats</code> follows the logs; <code>--no-follow</code>{" "}
+      prints the tail and exits. If you prefer the boring word,{" "}
       <code>shep logs</code> is the same command and always will be.
     </p>
     <div class="alias-grid">

--- a/web/src/pages/docs/json-output.astro
+++ b/web/src/pages/docs/json-output.astro
@@ -31,7 +31,7 @@ import CodeBlock from "../../components/docs/CodeBlock.astro";
     <p>
       Every non-streaming command wraps its payload in the same three
       fields: a schema version, the verb name, and the data itself. One
-      verb adds a fourth, and only sometimes; see
+      verb adds a fourth, and only sometimes; see{" "}
       <a href="#refused">a reload that was refused part of its fold</a>.
       Here's <code>shep flock --format json</code> against a two-sheep
       flock:
@@ -86,7 +86,7 @@ import CodeBlock from "../../components/docs/CodeBlock.astro";
 }`}</CodeBlock>
     <p>
       <code>command</code> is the verb you typed, spelled out in full:
-      run it as <code>shep ls --format json</code> and <code>command</code>
+      run it as <code>shep ls --format json</code> and <code>command</code>{" "}
       still reads <code>"flock"</code>, because that's what the daemon
       answered to, not the alias that got you there. <code>data</code> is
       always the same shape for a given command: a single object for
@@ -96,7 +96,7 @@ import CodeBlock from "../../components/docs/CodeBlock.astro";
 
     <h2>Errors get their own envelope</h2>
     <p>
-      A failed command prints a different, smaller shape to stderr, no
+      A failed command prints a different, smaller shape to stderr, no{" "}
       <code>command</code> key, because the command never produced a
       result:
     </p>
@@ -108,11 +108,11 @@ import CodeBlock from "../../components/docs/CodeBlock.astro";
   }
 }`}</CodeBlock>
     <p>
-      <code>code</code> is the same word that appears in
+      <code>code</code> is the same word that appears in{" "}
       <code>error[&lt;code&gt;]: …</code> under the default table format,
-      and it's the same taxonomy as the process exit code: <code>3</code>
-      for <code>not_found</code>, <code>4</code> for
-      <code>invalid_config</code>, and so on. A script can switch on
+      and it's the same taxonomy as the process exit code: <code>3</code>{" "}
+      for <code>not_found</code>, <code>4</code> for{" "}
+      <code>invalid_config</code>, and so on. A script can switch on{" "}
       <code>error.code</code> without parsing English, and the exit status
       confirms it independently.
     </p>
@@ -179,11 +179,11 @@ import CodeBlock from "../../components/docs/CodeBlock.astro";
         coded against still applies.
       </li>
       <li>
-        Don't assume every key is present on every row. <code>dog</code>
-        is <code>null</code> for a plain sheep. <code>lambs</code> is
+        Don't assume every key is present on every row. <code>dog</code>{" "}
+        is <code>null</code> for a plain sheep. <code>lambs</code> is{" "}
         <code>null</code> from <code>shep flock</code> (the plain listing
         never walks the process tree) but a populated array (empty if the
-        sheep has spawned no children of its own) from both
+        sheep has spawned no children of its own) from both{" "}
         <code>shep describe</code> and <code>shep fold</code>, since fold
         renders the same per-sheep detail the table format's Lambs section
         shows. Check the key itself, not which command you ran, if you're
@@ -194,14 +194,14 @@ import CodeBlock from "../../components/docs/CodeBlock.astro";
         has stopped at least once under this daemon, and afterwards holds
         one of two shapes: <code>{'{"code": 1, "signal": null}'}</code> for a
         normal exit, or <code>{'{"code": null, "signal": 15}'}</code> for
-        one ended by a signal. Both are never set at once, and both being
+        one ended by a signal. Both are never set at once, and both being{" "}
         <code>null</code> is not a state the daemon produces. It is the
         field that distinguishes a process that started and crashed from one
         that never started at all, which the <code>status</code> alone
         cannot: both read <code>errored</code>.
       </li>
       <li>
-        <code>cpu_percent</code> reads <code>null</code>, not
+        <code>cpu_percent</code> reads <code>null</code>, not{" "}
         <code>0</code>, when a sample wasn't available yet. A fresh sheep
         a few hundred milliseconds old, most often. Table format prints the
         same case as <code>-</code>, for the same reason: a confident zero
@@ -211,17 +211,17 @@ import CodeBlock from "../../components/docs/CodeBlock.astro";
         <code>handshook</code> is about dogs and is <code>null</code> for
         every sheep. <code>false</code> is the one to act on: the dog's
         process is up and the shepherd has never heard from it, so it is
-        not doing its job. <code>status</code> still reads
+        not doing its job. <code>status</code> still reads{" "}
         <code>online</code> there, truthfully — it describes the process.
         Table format shows this row as <code>silent</code>.
       </li>
       <li>
-        <code>dog_stale</code> is the other half of that and is
+        <code>dog_stale</code> is the other half of that and is{" "}
         <code>null</code> for every sheep. <code>true</code> means the
         shepherd has given up: it restarted the dog once for never answering,
         that did not help, and it will not restart it again. You cannot work
         this out from <code>handshook</code> — a dog spawned a second ago and
-        a dog the shepherd will never touch again are both
+        a dog the shepherd will never touch again are both{" "}
         <code>false</code>. Why it gave up is in that dog's own log rather
         than on the row, because the shepherd could only see the evidence at
         the moment it happened: <code>shep bleats &lt;dog&gt;</code>.
@@ -229,12 +229,12 @@ import CodeBlock from "../../components/docs/CodeBlock.astro";
       <li>
         <code>smit</code> is <code>null</code> until a dog attaches one over
         the client protocol's <code>SetSmit</code> request. shep stores and
-        reports the string verbatim, and never parses it — see
+        reports the string verbatim, and never parses it — see{" "}
         <a href="/docs/terminology">terminology</a>.
       </li>
       <li>
-        <code>max_memory</code> is the sheep's memory ceiling in bytes, or
-        <code>null</code> when it has none configured. It's the same number
+        <code>max_memory</code> is the sheep's memory ceiling in bytes, or{" "}
+        <code>null</code> when it has none configured. It's the same number{" "}
         <code>--format table</code> and lookout's <code>MEM/CEIL</code> gauge
         divide against; a <code>null</code> here is why that gauge draws an
         all-tail bar instead of a fraction.
@@ -244,13 +244,13 @@ import CodeBlock from "../../components/docs/CodeBlock.astro";
     <Callout variant="note">
       <code>shep bleats --format json</code> is the one exception. A log
       follow has no end, so there's nothing to close an envelope around:
-      it prints one JSON object per line, newline-delimited, with no
+      it prints one JSON object per line, newline-delimited, with no{" "}
       <code>command</code> or <code>data</code> wrapper.
     </Callout>
     <CodeBlock label="shep bleats web --format json">{`{"schema_version":1,"id":0,"name":"web","stream":"out","instance":null,"line":"…"}`}</CodeBlock>
     <p>
       <code>instance</code> is the sheep's slot within its app, when that
-      app has more than one instance registered; <code>null</code>
+      app has more than one instance registered; <code>null</code>{" "}
       otherwise, and also <code>null</code> for a backlog line read from a
       log file several instances share, since nothing in that file says
       which one wrote it.
@@ -258,12 +258,12 @@ import CodeBlock from "../../components/docs/CodeBlock.astro";
 
     <h2>Table format is not a lesser version of this</h2>
     <p>
-      The default <code>--format table</code> and <code>--format json</code>
+      The default <code>--format table</code> and <code>--format json</code>{" "}
       render from the same underlying data (there's no separate code path
       that could drift between them) but table adds human formatting JSON
-      doesn't: <code>uptime_ms: 1019</code> becomes <code>1s</code>,
+      doesn't: <code>uptime_ms: 1019</code> becomes <code>1s</code>,{" "}
       <code>memory_bytes: 1212416</code> becomes <code>1.2M</code>. If
-      you're piping shep's output anywhere, reach for
+      you're piping shep's output anywhere, reach for{" "}
       <code>--format json</code> and do the formatting yourself rather than
       parsing the table's columns.
     </p>

--- a/web/src/pages/docs/kv.astro
+++ b/web/src/pages/docs/kv.astro
@@ -61,7 +61,7 @@ KEY  VALUE`;
 
     <Callout variant="note">
       Reaching for this to configure a <em>sheep</em>? Put it in the
-      Flockfile. Configuring a <em>dog</em>? Put it under
+      Flockfile. Configuring a <em>dog</em>? Put it under{" "}
       <code>[&lt;name&gt;]</code> in <code>dogs.toml</code>. This store is
       only for what's left after those two.
     </Callout>
@@ -70,11 +70,11 @@ KEY  VALUE`;
     <CodeBlock>{threeVerbs}</CodeBlock>
     <p>
       <code>shep set &lt;key&gt; &lt;value&gt;</code> writes a key, replacing
-      whatever was there. <code>shep get &lt;key&gt;</code> prints one value;
-      <code>shep get</code> with no key lists everything.
-      <code>shep unset &lt;key&gt;</code> removes one key;
+      whatever was there. <code>shep get &lt;key&gt;</code> prints one value;{" "}
+      <code>shep get</code> with no key lists everything.{" "}
+      <code>shep unset &lt;key&gt;</code> removes one key;{" "}
       <code>shep unset --all</code> empties the store: a flag, not a key
-      named <code>all</code>, because nothing stops you having a key called
+      named <code>all</code>, because nothing stops you having a key called{" "}
       <code>all</code> and <code>shep unset all</code> would then mean
       something different depending on your own store.
     </p>
@@ -83,7 +83,7 @@ KEY  VALUE`;
     <p>Run against a fresh <code>$SHEP_HOME</code>, no shepherd listening:</p>
     <CodeBlock>{realOutput}</CodeBlock>
     <p class="fine">
-      A key that was never there answers <code>NotFound</code> on both
+      A key that was never there answers <code>NotFound</code> on both{" "}
       <code>get</code> and <code>unset</code>, exit code 3 either way: a
       script can write <code>shep get feature.flag || echo default</code> and
       trust the exit code rather than parsing output to tell "empty" from
@@ -93,8 +93,8 @@ KEY  VALUE`;
     <h2>The key grammar</h2>
     <p>
       A key is <code>[A-Za-z0-9._-]</code>, one to 128 bytes, and can't start
-      with a dot. <strong>A dot is part of a name, not a path</strong>:
-      <code>bark.cooldown</code> is one flat key, not a nested object, and
+      with a dot. <strong>A dot is part of a name, not a path</strong>:{" "}
+      <code>bark.cooldown</code> is one flat key, not a nested object, and{" "}
       <code>shep get bark</code> won't find it. This is deliberate: a
       nesting grammar here would be a second config language, with its own
       quoting rules, for a store that's explicitly not the primary one. The
@@ -108,13 +108,13 @@ KEY  VALUE`;
     <h2>No shepherd required</h2>
     <p>
       <code>shep set</code>/<code>get</code>/<code>unset</code> never touch
-      the socket: they read and write <code>$SHEP_HOME/kv.json</code>
-      directly, the same way <code>shep enable</code> writes
+      the socket: they read and write <code>$SHEP_HOME/kv.json</code>{" "}
+      directly, the same way <code>shep enable</code> writes{" "}
       <code>shep.toml</code> with nothing listening. That's what makes this
       store usable during provisioning, before any shepherd has ever booted
-      on the machine. A dog reads the same store through
-      <code>shep_core::kv</code> rather than over the wire: a
-      <code>0600</code> file inside a <code>0700</code>
+      on the machine. A dog reads the same store through{" "}
+      <code>shep_core::kv</code> rather than over the wire: a{" "}
+      <code>0600</code> file inside a <code>0700</code>{" "}
       <code>$SHEP_HOME</code>, opened by a process running as the same user,
       already has every property a socket round trip would have bought it.
     </p>
@@ -127,8 +127,8 @@ KEY  VALUE`;
       the race simply waits its turn; neither write is silently dropped. The
       file itself is written through a <code>BTreeMap</code>, so keys are
       always in sorted order and two writes of the same content produce
-      byte-identical files: safe to keep in a dotfiles repository,
-      <code>git add</code> and diff like any other small config file. Mode is
+      byte-identical files: safe to keep in a dotfiles repository,{" "}
+      <code>git add</code> and diff like any other small config file. Mode is{" "}
       <code>0600</code>.
     </p>
     <h2>Where to go next</h2>
@@ -137,15 +137,15 @@ KEY  VALUE`;
       <a href="/docs/lookout" class="next-card">
         <div class="next-title">Lookout →</div>
         <div class="next-body">
-          <code>lookout.allow_control</code> is a KV key: set it with
-          <code>shep set</code> instead of the <code>--allow-control</code>
+          <code>lookout.allow_control</code> is a KV key: set it with{" "}
+          <code>shep set</code> instead of the <code>--allow-control</code>{" "}
           flag if you'd rather it stick.
         </div>
       </a>
       <a href="/docs/dogs" class="next-card">
         <div class="next-title">Dogs →</div>
         <div class="next-body">
-          Per-dog settings live under <code>[&lt;name&gt;]</code> in
+          Per-dog settings live under <code>[&lt;name&gt;]</code> in{" "}
           <code>dogs.toml</code>, not here. This page explains where the
           line falls.
         </div>

--- a/web/src/pages/docs/lookout.astro
+++ b/web/src/pages/docs/lookout.astro
@@ -291,7 +291,7 @@ esc/s close   j/k select   g… control enabled`;
 
     <h2>The flock table</h2>
     <p>
-      Every frame below is real: rendered headlessly through ratatui's
+      Every frame below is real: rendered headlessly through ratatui's{" "}
       <code>TestBackend</code> by a pinned snapshot test, not mocked up for
       this page. A <code>&gt;</code> gutter to the left of ID marks the
       selected sheep. <code>j</code>/<code>k</code> move the selection one
@@ -371,8 +371,8 @@ esc/s close   j/k select   g… control enabled`;
     <h2>Filtering the table</h2>
     <p>
       <code>/</code> opens a query box in the status bar; typing narrows the
-      table to sheep whose name contains it, case-insensitively, as you type.
-      <code>Enter</code> applies the query and closes the box, <code>Esc</code>
+      table to sheep whose name contains it, case-insensitively, as you type.{" "}
+      <code>Enter</code> applies the query and closes the box, <code>Esc</code>{" "}
       clears it back to the whole flock, and both leave the cursor on a real
       row: if the sheep it was on drops out of the narrowed set, the
       selection moves to whatever now sits in the same position rather than
@@ -393,11 +393,11 @@ esc/s close   j/k select   g… control enabled`;
       detail pane goes (everything on it but the log paths already sits in
       the row above it). Below 18 the feed goes with it, and below 14 the
       host strip goes too, leaving only the flock table. Within the table,
-      narrow widths drop columns one at a time, in this order:
+      narrow widths drop columns one at a time, in this order:{" "}
       <code>MEM/CEIL</code>, <code>CPU 20s</code>, CFG, SMIT, FOLD, EXIT,
-      RESTARTS, PID, MEM, CPU, and finally UPTIME, leaving
+      RESTARTS, PID, MEM, CPU, and finally UPTIME, leaving{" "}
       <code>ID NAME STATUS</code> as the floor. <code>MEM/CEIL</code> is a
-      gauge of a sheep's memory against its ceiling and <code>CPU 20s</code>
+      gauge of a sheep's memory against its ceiling and <code>CPU 20s</code>{" "}
       is a sparkline of its CPU history; both restate a number CPU and MEM
       already carry, so they go first. A terminal needs 148 columns for the
       gauge and 136 for the sparkline, wider than every frame on this page,
@@ -407,10 +407,10 @@ esc/s close   j/k select   g… control enabled`;
       its own column.
     </p>
     <p class="fine">
-      <code>CFG</code> drops third, right after <code>MEM/CEIL</code> and
+      <code>CFG</code> drops third, right after <code>MEM/CEIL</code> and{" "}
       <code>CPU 20s</code> and still ahead of <code>SMIT</code>, which is
       not where the <a href="/docs/output">CLI table</a> puts it. The frames
-      on this page are 120 columns wide, and tying <code>CFG</code> to
+      on this page are 120 columns wide, and tying <code>CFG</code> to{" "}
       <code>EXIT</code>'s tier the way that table does would have pushed the
       full set past 120 and quietly taken <code>SMIT</code> off every frame
       in the gallery. Dropping <code>CFG</code> on its own leaves a
@@ -460,8 +460,8 @@ esc/s close   j/k select   g… control enabled`;
     </p>
     <CodeBlock label="120×30, gate closed">{refused}</CodeBlock>
     <p>
-      With the gate open, three keys arm an action on the selected sheep:
-      <code>x</code> stops it, <code>R</code> restarts it, <code>L</code>
+      With the gate open, three keys arm an action on the selected sheep:{" "}
+      <code>x</code> stops it, <code>R</code> restarts it, <code>L</code>{" "}
       reloads it. There's no <code>start</code> key; lookout only ever acts
       on a sheep already in the flock. Arming doesn't send anything by
       itself, it puts a question in the status bar naming the verb and the
@@ -486,17 +486,17 @@ esc/s close   j/k select   g… control enabled`;
     <p>
       This is a fat-finger catch, not a security boundary: lookout runs as
       your own process under your own uid, so the shepherd has no way to
-      refuse a keystroke it can't tell apart from you typing
+      refuse a keystroke it can't tell apart from you typing{" "}
       <code>shep stop</code> yourself. Every color on screen is also
       redundant with text, so <code>NO_COLOR</code> and a 16-color terminal
       lose decoration, never information.
     </p>
     <h2>Settings</h2>
     <p>
-      <code>s</code> opens a full-screen settings view over
+      <code>s</code> opens a full-screen settings view over{" "}
       <code>shep.toml</code>: the four daemon fields, the whistle gate, the
       style level, and the dogs table's own enable/disable, each with a
-      SOURCE column and a note on what it takes to apply. <code>s</code>
+      SOURCE column and a note on what it takes to apply. <code>s</code>{" "}
       or <code>Esc</code> closes it again, back to the flock table.
     </p>
     <p>
@@ -507,10 +507,10 @@ esc/s close   j/k select   g… control enabled`;
     </p>
     <CodeBlock label="120×30, a fresh $SHEP_HOME">{settingsFresh}</CodeBlock>
     <p>
-      SOURCE reads <code>the default</code> when <code>shep.toml</code>
+      SOURCE reads <code>the default</code> when <code>shep.toml</code>{" "}
       doesn't mention the field at all, and the VALUE column shows the
-      compiled fallback instead of anything from disk. A fresh
-      <code>$SHEP_HOME</code> ships a <code>shep.toml</code> holding only
+      compiled fallback instead of anything from disk. A fresh{" "}
+      <code>$SHEP_HOME</code> ships a <code>shep.toml</code> holding only{" "}
       <code>[interpreters]</code>, so this is the state you land in the
       first time you open the screen: every field on it is a guess about
       what the daemon assumes, not a record of what anyone wrote. Once a
@@ -523,24 +523,24 @@ esc/s close   j/k select   g… control enabled`;
       story: IN FILE says whether <code>[daemon] enabled_dogs</code> names
       the dog, SOURCE says whether it's built in or adopted from a path, and
       RUNNING joins both against the live flock. The three can disagree, and
-      when they do that's the point of showing all three: <code>otel</code>
+      when they do that's the point of showing all three: <code>otel</code>{" "}
       above is running with nothing enabling it, <code>ledger</code> is
       enabled and not running, and <code>bark</code> is enabled, running,
-      and still <code>silent</code> because it never finished a handshake.
-      <code>space</code> arms a toggle on the selected dog and <code>Enter</code>
+      and still <code>silent</code> because it never finished a handshake.{" "}
+      <code>space</code> arms a toggle on the selected dog and <code>Enter</code>{" "}
       sends it; unlike a scalar edit, this reaches the shepherd directly and
       needs no reload.
     </p>
     <Callout variant="careful">
       A <code>[daemon]</code> edit only ever changes <code>shep.toml</code>.
-      The shepherd itself can be started with <code>SHEP_LOG_LEVEL</code>,
+      The shepherd itself can be started with <code>SHEP_LOG_LEVEL</code>,{" "}
       <code>SHEP_SOCKET</code>, or the matching <code>--log-level</code> /
       <code>--socket</code> flags, and shep's own precedence puts those above
       the file. Lookout has no way to see what the shepherd was booted with,
-      so setting <code>log_level</code> here and running
+      so setting <code>log_level</code> here and running{" "}
       <code>shep daemon reload</code> can do nothing at all if the process
       was started with <code>SHEP_LOG_LEVEL</code> set, and nothing on
-      screen will say so. <code>[style]</code> is not an exception:
+      screen will say so. <code>[style]</code> is not an exception:{" "}
       <code>--style</code> and <code>$SHEP_STYLE</code> outrank the file
       there too. The difference is that those layers belong to lookout's own
       process, so lookout can see them. SOURCE names the one in force, the
@@ -549,19 +549,19 @@ esc/s close   j/k select   g… control enabled`;
       winning.
     </Callout>
     <p>
-      The confirm names exactly this risk when it's <code>[daemon]</code>
+      The confirm names exactly this risk when it's <code>[daemon]</code>{" "}
       that's armed:
     </p>
     <CodeBlock label="180×30, armed">{settingsConfirm}</CodeBlock>
     <p>
-      <code>log_level</code>, <code>log_json</code>, and
+      <code>log_level</code>, <code>log_json</code>, and{" "}
       <code>allow_control</code> cycle through a fixed set of values, and the
-      cycle only ever moves a field from <code>the default</code> to
+      cycle only ever moves a field from <code>the default</code> to{" "}
       <code>shep.toml</code>, never back: <code>space</code> proposes the
-      next value, it's never "unset". <code>socket</code> and
+      next value, it's never "unset". <code>socket</code> and{" "}
       <code>max_cron_sleep</code> are the only two fields this screen can put
       back to the default, because they're free text, and clearing the
-      editor back to an empty line is what unsets them. <code>style level</code>
+      editor back to an empty line is what unsets them. <code>style level</code>{" "}
       is optional too, but <code>shep style</code> is what owns it and can't
       clear it either, so this screen doesn't offer to.
     </p>
@@ -587,7 +587,7 @@ esc/s close   j/k select   g… control enabled`;
       <li><code>r</code> re-reads <code>shep.toml</code> from disk</li>
     </ul>
     <p class="fine">
-      An armed candidate is cancelled, not acted on, by any movement key, by
+      An armed candidate is cancelled, not acted on, by any movement key, by{" "}
       <code>r</code>, or by <code>s</code>: the same rule the dashboard's own
       action keys follow, where a stray keystroke right after arming backs
       out of the question instead of both dismissing it and doing something
@@ -601,14 +601,14 @@ esc/s close   j/k select   g… control enabled`;
       every Flockfile field, the value in force, and what changing it would
       cost. Fields sit under eight headers: process, logging, inputs,
       restart, readiness, shutdown, watch, cron. It writes as well, behind
-      the same gate. Under
-      <code>--read-only</code> the edit keys refuse the same way
+      the same gate. Under{" "}
+      <code>--read-only</code> the edit keys refuse the same way{" "}
       <code>x</code> does. A row
       marked <code>=</code> or <code>~</code> gives its own reason instead,
       in both states, because the flag would not have helped it.
     </p>
     <p class="fine">
-      A field whose grammar accepts a bare number, such as
+      A field whose grammar accepts a bare number, such as{" "}
       <code>max_memory</code> or <code>kill_timeout</code>, shows its
       resolved value rather than the digits on disk: <code>64</code> reads
       as <code>64 B</code>, and <code>1600</code> as <code>1600ms</code>,
@@ -636,13 +636,13 @@ esc/s close   j/k select   g… control enabled`;
         <code>~</code> the pane has no widget for the shape, and nothing
         more. A Flockfile writes these the usual way, so the cost column
         beside them reports a real cost rather than <code>read-only</code>.
-        Two fields: <code>liveness_probe</code> and
+        Two fields: <code>liveness_probe</code> and{" "}
         <code>readiness_probe</code>.
       </li>
     </ul>
     <p class="fine">
       Both are glyphs rather than a colour on purpose. The narrowest terminal
-      the pane draws into has already dropped the cost column, and
+      the pane draws into has already dropped the cost column, and{" "}
       <code>plain</code> style has no colour to read, so a greyed-out row
       would be the only signal left in the case where it says least.
     </p>
@@ -667,12 +667,12 @@ esc/s close   j/k select   g… control enabled`;
     </ul>
     <p class="fine">
       Read it before you write, not after. It says what kind of field this
-      is, and a particular write can land differently: <code>watch</code>
-      says <code>now</code> and waits for a reload if the
-      <code>cwd</code> it needs is itself still parked, and
+      is, and a particular write can land differently: <code>watch</code>{" "}
+      says <code>now</code> and waits for a reload if the{" "}
+      <code>cwd</code> it needs is itself still parked, and{" "}
       <code>autostart</code> says <code>next start</code> and takes effect
       immediately, because shep reads it at muster. The status bar after the
-      write is the one that reports what actually happened, and the
+      write is the one that reports what actually happened, and the{" "}
       <code>!</code> flag on the row carries it afterwards.
     </p>
     <p>Keys, local to the pane while it's open:</p>
@@ -685,7 +685,7 @@ esc/s close   j/k select   g… control enabled`;
       </li>
       <li>
         <code>space</code> proposes the other value for a bool, the next one
-        for a choice, or the next suggestion for <code>kill_signal</code>
+        for a choice, or the next suggestion for <code>kill_signal</code>{" "}
         and <code>cron_restart</code>. Press it again to walk another step.
         A suggestion is not a closed list: <code>e</code> still types
         anything else.
@@ -698,9 +698,9 @@ esc/s close   j/k select   g… control enabled`;
       </li>
       <li>
         <code>e</code> or <code>Enter</code> on an array field opens a list
-        sub-screen instead: <code>d</code> removes the selected element,
+        sub-screen instead: <code>d</code> removes the selected element,{" "}
         <code>K</code>/<code>J</code> move it, and <code>e</code>/
-        <code>Enter</code> edits it, or adds one from the
+        <code>Enter</code> edits it, or adds one from the{" "}
         <code>+ new</code> row. Each arms the whole array, same as a
         scalar; a second <code>e</code>/<code>Enter</code> sends it.
       </li>
@@ -717,16 +717,16 @@ esc/s close   j/k select   g… control enabled`;
     </ul>
     <p>
       One edit changes one field, and it is recorded as yours: the key picks
-      up the <code>*</code> marker here and in <code>shep flock</code>'s
+      up the <code>*</code> marker here and in <code>shep flock</code>'s{" "}
       <code>CFG</code> column, and a later <code>shep start</code> of the
-      app's Flockfile leaves it alone. Nothing else in the config moves,
+      app's Flockfile leaves it alone. Nothing else in the config moves,{" "}
       <code>instances</code> included.
     </p>
     <p class="fine">
       A field the running child already holds parks until the next spawn. The
       status bar says which of the two happened. <code>Esc</code> on a pane
-      with anything still parked offers to close the gap there and then:
-      <code>L</code> reloads the sheep, <code>R</code> restarts it, and
+      with anything still parked offers to close the gap there and then:{" "}
+      <code>L</code> reloads the sheep, <code>R</code> restarts it, and{" "}
       <code>Esc</code> again leaves the fields parked. Nothing is at risk
       either way, since every one of them is already sitting in the
       override store; the offer only decides when the running sheep catches
@@ -737,10 +737,10 @@ esc/s close   j/k select   g… control enabled`;
     <p>
       <code>e</code> or <code>Enter</code> on the <code>env</code> row opens
       a sub-screen of that sheep's env key names. No value ever appears
-      there, because the shepherd never sends one: every key reads
+      there, because the shepherd never sends one: every key reads{" "}
       <code>&lt;set&gt;</code>. <code>e</code> or <code>Enter</code> on a
       key types a new value for it, and applying an empty one removes the
-      key. Either on the <code>+ new</code> row takes
+      key. Either on the <code>+ new</code> row takes{" "}
       <code>KEY=value</code>. <code>Esc</code> goes back to the field list;
       a second <code>Esc</code> from there closes the pane.
     </p>
@@ -762,18 +762,18 @@ esc/s close   j/k select   g… control enabled`;
 
     <h2>The dog config pane</h2>
     <p>
-      <code>e</code> on a dog row opens its config, over that dog's
+      <code>e</code> on a dog row opens its config, over that dog's{" "}
       <code>[&lt;name&gt;]</code> section in <code>dogs.toml</code>. It
-      works the same whether the row sits in the dashboard's own
+      works the same whether the row sits in the dashboard's own{" "}
       <code>Dogs</code> section or the settings screen's dogs table. It
       used to refuse there and point you at <code>s</code> for settings
-      instead; now the row itself is enough. Inside the pane,
+      instead; now the row itself is enough. Inside the pane,{" "}
       <code>e</code> is the field list's own edit key, the same as on a
       sheep's config; only <code>Esc</code> closes it.
     </p>
     <p>
       The form comes from the dog. Shep asks the binary for its schema when
-      the pane opens rather than reading one it stored, because
+      the pane opens rather than reading one it stored, because{" "}
       <code>cargo install</code> replaces a dog with nothing watching and a
       stale schema mislabels which field is a credential. A built-in dog
       answers without being spawned at all. A dog that publishes no schema
@@ -796,16 +796,16 @@ esc/s close   j/k select   g… control enabled`;
     </p>
     <CodeBlock>{`shep publishes the change; bark decides what to reload`}</CodeBlock>
     <p>
-      A field the dog marks as a credential reads <code>&lt;set&gt;</code>
+      A field the dog marks as a credential reads <code>&lt;set&gt;</code>{" "}
       and never its value, and the editor on it opens empty. Typing a new one
       replaces it; nothing here can show you what it replaced. A table or a
-      list gets <code>~</code>, the same glyph a sheep's
+      list gets <code>~</code>, the same glyph a sheep's{" "}
       <code>args</code> gets and for the same reason.
     </p>
     <p>
-      A write sends the section whole, so the comments and key order in
+      A write sends the section whole, so the comments and key order in{" "}
       <code>dogs.toml</code> survive it. Applying an empty value removes the
-      key, which puts the dog back on its own default. Neither
+      key, which puts the dog back on its own default. Neither{" "}
       <code>*</code> nor <code>!</code> appears: a dog has no Flockfile to
       differ from, and <code>dogs.toml</code> is the one copy of its
       settings.
@@ -821,7 +821,7 @@ esc/s close   j/k select   g… control enabled`;
       <a href="/docs/kv" class="next-card">
         <div class="next-title">The KV store →</div>
         <div class="next-body">
-          <code>lookout.allow_control</code> lives here too: the same store
+          <code>lookout.allow_control</code> lives here too: the same store{" "}
           <code>shep set</code>/<code>get</code>/<code>unset</code> read and
           write directly, no shepherd required.
         </div>

--- a/web/src/pages/docs/not-built.astro
+++ b/web/src/pages/docs/not-built.astro
@@ -41,28 +41,28 @@ import Callout from "../../components/docs/Callout.astro";
       it got right is worth more than a tidy page.
     </p>
     <p>
-      The day-to-day loop works: <code>start</code>, <code>stop</code>,
-      <code>restart</code>, <code>reload</code>, <code>flock</code>,
-      <code>describe</code>, <code>bleats</code>, <code>delete</code>,
-      <code>save</code>/<code>muster</code>, <code>lookout</code>,
+      The day-to-day loop works: <code>start</code>, <code>stop</code>,{" "}
+      <code>restart</code>, <code>reload</code>, <code>flock</code>,{" "}
+      <code>describe</code>, <code>bleats</code>, <code>delete</code>,{" "}
+      <code>save</code>/<code>muster</code>, <code>lookout</code>,{" "}
       <code>whistle</code> and the dogs — over a named pipe instead of a unix
       socket, with each sheep contained in a job object instead of a process
       group.
     </p>
     <Callout variant="careful">
-      <strong>These limits are real and are not going to be papered over.</strong>
+      <strong>These limits are real and are not going to be papered over.</strong>{" "}
       Windows has nothing SIGTERM-shaped that can be delivered to an
-      arbitrary process, so <code>shep stop</code> waits out the app's whole
+      arbitrary process, so <code>shep stop</code> waits out the app's whole{" "}
       <code>kill_timeout</code> and then terminates it — unless the app opts
       into the shepherd channel with <code>shutdown_with_message</code>,
-      which is the supported graceful path there. And
+      which is the supported graceful path there. And{" "}
       <code>shep startup</code> is not built: boot-time supervision on
       Windows means a Service Control Manager service, a different program
       shape rather than a fifth unit template. Run <code>shep start</code> in
       your own session, or wrap <code>shep runtime</code> in NSSM or WinSW.
     </Callout>
     <p>
-      The estimate's own shape predictions all held. The 145
+      The estimate's own shape predictions all held. The 145{" "}
       <code>cfg(unix)</code> sites really were the cheap part — only ten
       files in the CLI contained a Unix API call at all, and four whole
       module trees contained none. The cost concentrated exactly where it
@@ -78,13 +78,13 @@ import Callout from "../../components/docs/Callout.astro";
       <li>
         <strong>The shepherd channel is not fd 3.</strong> It is a named pipe
         whose path arrives as <code>$SHEP_CHANNEL_PIPE</code>; the app opens
-        it itself. The wire format is untouched, so
-        <code>shep trigger</code>'s correlation id survives unchanged.
+        it itself. The wire format is untouched, so{" "}
+        <code>shep trigger</code>'s correlation id survives unchanged.{" "}
         <code>SHEP_CHANNEL_FD</code> is deliberately not set there, so an app
         can branch on which variable is present rather than on the platform.
       </li>
       <li>
-        <strong><code>user</code>/<code>group</code> refuse permanently.</strong>
+        <strong><code>user</code>/<code>group</code> refuse permanently.</strong>{" "}
         Dropping privilege on Windows needs a logon session or a
         primary-token privilege: a different feature, not a different call.
       </li>
@@ -92,7 +92,7 @@ import Callout from "../../components/docs/Callout.astro";
     <p class="fine">
       Two things the estimate did not anticipate, both found only by running
       the code: a Windows child started with a genuinely empty environment
-      fails before <code>main</code> (many Win32 APIs read
+      fails before <code>main</code> (many Win32 APIs read{" "}
       <code>%SystemRoot%</code>), and an append-mode handle cannot be
       truncated there, which broke <code>shep start</code>'s autostart
       outright. Neither is visible to a compiler.

--- a/web/src/pages/docs/output.astro
+++ b/web/src/pages/docs/output.astro
@@ -46,7 +46,7 @@ import CodeBlock from "../../components/docs/CodeBlock.astro";
       is using: 160M and 4G both land in the same tier, and on a flock where
       everything is large the whole column is one colour and tells you
       nothing. A third tier would have to be the fault colour, which would
-      paint a healthy 4G service as though it had broken. Use
+      paint a healthy 4G service as though it had broken. Use{" "}
       <code>--format json</code> when the exact number is the thing you
       need.
     </p>
@@ -88,12 +88,12 @@ import CodeBlock from "../../components/docs/CodeBlock.astro";
     <h3>The EXIT column</h3>
     <p>
       A sheep that is not running shows why it stopped: an exit code, or a
-      signal name. A running one shows <code>-</code>, the same convention
+      signal name. A running one shows <code>-</code>, the same convention{" "}
       <code>PID</code> and <code>CPU</code> use for a value that has no
       honest answer yet.
     </p>
     <p>
-      It tells two failures apart that <code>status</code> alone cannot.
+      It tells two failures apart that <code>status</code> alone cannot.{" "}
       <code>errored</code> with fifteen restarts says only that a sheep is
       not up. <code>EXIT 1</code> says it started and crashed; an empty EXIT
       on that same row says it never started at all.
@@ -104,21 +104,21 @@ import CodeBlock from "../../components/docs/CodeBlock.astro";
       A sheep with config waiting on it, or with settings of its own, is
       marked here; every other sheep reads <code>-</code>. <code>!2</code> means two fields are parked for
       this sheep's next spawn, left there by a Flockfile load that would have
-      had to kill the process to apply them, and
+      had to kill the process to apply them, and{" "}
       <code>shep reload &lt;name&gt;</code> promotes them.
     </p>
     <p>
-      A count and not the names, because the names are what
+      A count and not the names, because the names are what{" "}
       <code>shep describe</code> lists underneath its table and a
-      three-character cell has room for one number. See
+      three-character cell has room for one number. See{" "}
       <a href="/docs/overrides">Overrides</a>.
     </p>
     <p class="fine">
       The cell has a second marker, <code>*2</code>, for fields an operator
       has taken ownership of, whether or not the sheep's current Flockfile
-      declares them. The door that writes them is
-      <a href="/docs/lookout">the config pane</a>:
-      <code>e</code> on a sheep in <code>shep lookout</code>, behind
+      declares them. The door that writes them is{" "}
+      <a href="/docs/lookout">the config pane</a>:{" "}
+      <code>e</code> on a sheep in <code>shep lookout</code>, behind{" "}
       <code>--allow-control</code>. Pending takes the cell when a sheep has
       both: a parked field is one command away from taking effect, while an
       override has been true since the last load.
@@ -127,7 +127,7 @@ import CodeBlock from "../../components/docs/CodeBlock.astro";
     <h2 id="grouped-instances">Multi-instance apps group</h2>
     <p>
       An app with <code>instances</code> above 1 gets a header row above its
-      slots, in <code>full</code> or <code>plain</code>: <code>web ×3</code>
+      slots, in <code>full</code> or <code>plain</code>: <code>web ×3</code>{" "}
       in <code>NAME</code>, and a <code>↳ :0</code> row beneath it per
       instance, which is also what <code>web:0</code> selects. A
       single-instance app is unchanged, no group row and no suffix:
@@ -141,12 +141,12 @@ import CodeBlock from "../../components/docs/CodeBlock.astro";
 │ 2  │  ↳ :2  │ (o.o) online │ 74804 │ 0        │ -    │ -   │ 0.0% │ 3.0M │ 33s    │      │      │
 └────┴────────┴──────────────┴───────┴──────────┴──────┴─────┴──────┴──────┴────────┴──────┴──────┘`}</CodeBlock>
     <p>
-      The group row rolls up rather than picking a winner: <code>STATUS</code>
+      The group row rolls up rather than picking a winner: <code>STATUS</code>{" "}
       is the shared word when every instance agrees, else a count per state
-      like <code>2 up, 1 down</code>. <code>RESTARTS</code>, <code>CPU</code>
-      and <code>MEM</code> sum across the instances, and <code>UPTIME</code>
-      is the minimum, time since the last disruption. <code>ID</code> and
-      <code>PID</code> are blank, since neither has a single answer, and
+      like <code>2 up, 1 down</code>. <code>RESTARTS</code>, <code>CPU</code>{" "}
+      and <code>MEM</code> sum across the instances, and <code>UPTIME</code>{" "}
+      is the minimum, time since the last disruption. <code>ID</code> and{" "}
+      <code>PID</code> are blank, since neither has a single answer, and{" "}
       <code>FOLD</code> and <code>SMIT</code> sit only on the group row and
       stay blank on the instance rows beneath it, since both are per-app
       already. When a selector or filter matches only some of an app's
@@ -194,16 +194,16 @@ Dogs
     <p>
       <code>CFG</code>, <code>FOLD</code> and <code>SMIT</code> are missing
       from the dogs table because they are impossible for a dog rather than
-      merely empty: a dog belongs to no fold, a smit is a mark a dog paints
+      merely empty: a dog belongs to no fold, a smit is a mark a dog paints{" "}
       <em>on</em> a sheep, and no Flockfile load ever reaches a dog, so
       nothing can park config on one. A column that reads <code>-</code> on
       every row teaches nothing.
     </p>
     <p>
       Colours match too, column for column. Same face and status colour, same
-      restart colour above zero, same ramps for CPU and MEM, same
-      <code>EXIT</code>. So the same dog reads the same way under
-      <code>shep dogs</code>, under <code>shep flock</code>, and after
+      restart colour above zero, same ramps for CPU and MEM, same{" "}
+      <code>EXIT</code>. So the same dog reads the same way under{" "}
+      <code>shep dogs</code>, under <code>shep flock</code>, and after{" "}
       <code>shep restart log-rotate</code>.
     </p>
 
@@ -211,7 +211,7 @@ Dogs
     <p>
       A dog is a peer as well as a process. It dials back to the shepherd
       and keeps a connection open, and one that never manages it is not
-      doing its job however alive it looks. So <code>online</code> becomes
+      doing its job however alive it looks. So <code>online</code> becomes{" "}
       <code>silent</code>, in amber, with a puzzled face instead of a
       grazing one.
     </p>
@@ -224,7 +224,7 @@ Dogs
       What that adds is whether the shepherd has given up. A dog silent past
       five seconds is restarted once from the binary on disk; if the
       restarted dog stays silent, the shepherd stops and never restarts it
-      again. Nothing on the row changes when that happens — it still reads
+      again. Nothing on the row changes when that happens — it still reads{" "}
       <code>silent</code>, because the process is still up and still has not
       answered — so <code>shep describe</code> is the only place that says
       so.
@@ -243,8 +243,8 @@ Dogs
     <p class="fine">
       Only <code>online</code> is replaced. <code>starting</code> already
       says the connection is not up yet, and a dog is silent for a moment
-      every time it starts. <code>--format json</code> carries both facts as
-      <code>handshook</code> and <code>dog_stale</code>, beside a
+      every time it starts. <code>--format json</code> carries both facts as{" "}
+      <code>handshook</code> and <code>dog_stale</code>, beside a{" "}
       <code>status</code> that still reads <code>online</code> — true of the
       process, which is what that field has always described.
     </p>
@@ -253,14 +253,14 @@ Dogs
     <p>
       It is the only column in shep carrying a trust distinction, so the two
       values do not look alike. <code>built-in</code> is shep running its own
-      code, and is muted like any other label you read past.
+      code, and is muted like any other label you read past.{" "}
       <code>adopted</code> is a third-party binary running at the shepherd's
       own trust level, from a path you supplied, with no sandbox around it.
       That gets the same colour a restart count above zero gets: worth a
       glance, not a fault, because you chose it.
     </p>
     <p>
-      <code>enable</code>, <code>disable</code>, <code>adopt</code> and
+      <code>enable</code>, <code>disable</code>, <code>adopt</code> and{" "}
       <code>rehome</code> print a one-row confirmation with the same
       treatment. Their <code>STATUS</code> holds either a status or a
       sentence saying why no shepherd answered, and only a status is
@@ -283,7 +283,7 @@ Dogs
     <Callout variant="note">
       Seven tables carry no colour at all, deliberately: <code>describe</code>'s
       lamb tree, <code>delete</code>'s id list, <code>unset</code>'s count, the
-      two saved-roll tables, the KV store, and
+      two saved-roll tables, the KV store, and{" "}
       <code>shep dogs --available</code>. Each is either pure data shep has no
       opinion about, or a single column that is also the whole content, where
       muting would fade the table and distinguish nothing.
@@ -297,7 +297,7 @@ Dogs
 
     <h2 id="after-a-lifecycle-command">After a lifecycle command</h2>
     <p>
-      <code>start</code>, <code>stop</code>, <code>restart</code>,
+      <code>start</code>, <code>stop</code>, <code>restart</code>,{" "}
       <code>reload</code>, <code>delete</code> and <code>stock</code> all
       print the whole flock afterwards, not only the sheep they touched. The
       question after starting one app is usually what everything else is
@@ -318,7 +318,7 @@ Dogs
 └────┴────────────┴────────┴───────┴──────────┴──────┴──────┴──────┴────────┴─────────┘`}</CodeBlock>
     <p>
       That is the same output <code>shep flock</code> gives, dogs table and
-      all, so <code>shep restart log-rotate</code> and <code>shep flock</code>
+      all, so <code>shep restart log-rotate</code> and <code>shep flock</code>{" "}
       draw the same dog the same way. See <a href="#the-dogs-table">the dogs
       table</a> for why it is a second table rather than another row.
     </p>
@@ -329,28 +329,28 @@ Dogs
     </p>
     <CodeBlock label="shep delete koji">{`notice[delete]: deleted 1 sheep, id 5`}</CodeBlock>
     <Callout variant="note">
-      <code>--format json</code> is not widened. A script that runs
-      <code>shep stop web --format json</code> asked about
-      <code>web</code>, so <code>data</code> holds the rows for
+      <code>--format json</code> is not widened. A script that runs{" "}
+      <code>shep stop web --format json</code> asked about{" "}
+      <code>web</code>, so <code>data</code> holds the rows for{" "}
       <code>web</code>. Use <code>shep flock --format json</code> when you
       want the flock.
     </Callout>
 
     <h2 id="row-order">Row order</h2>
     <p>
-      Every listing shep prints is sorted by name, then by id. That covers
-      <code>shep flock</code>, every lifecycle verb above,
-      <code>shep lookout</code>, and the tables
-      <code>signal</code>, <code>whisper</code> and <code>trigger</code>
+      Every listing shep prints is sorted by name, then by id. That covers{" "}
+      <code>shep flock</code>, every lifecycle verb above,{" "}
+      <code>shep lookout</code>, and the tables{" "}
+      <code>signal</code>, <code>whisper</code> and <code>trigger</code>{" "}
       print.
     </p>
     <p>
       Ids are handed out in registration order, which is a fact about your
-      shell history rather than about the flock, and they move: a
+      shell history rather than about the flock, and they move: a{" "}
       <code>delete all</code> followed by a fresh start renumbers everything.
       Names do not. The id breaks ties, so the four instances of an app
       stocked to four stay in a fixed order instead of shuffling between
-      refreshes, and it is still what you type at
+      refreshes, and it is still what you type at{" "}
       <code>shep stop 11</code>.
     </p>
 
@@ -370,9 +370,9 @@ Dogs
     <p>
       Two things narrowed there. The status word went before any whole
       column did, leaving the face, which is five columns rather than
-      fifteen. Then <code>SMIT</code>, <code>FOLD</code>, <code>CFG</code>,
+      fifteen. Then <code>SMIT</code>, <code>FOLD</code>, <code>CFG</code>,{" "}
       <code>EXIT</code> and <code>CPU</code> dropped, in that order, and the
-      footer says so.
+      footer says so.{" "}
       <code>SMIT</code> goes first: it is by far the widest column, so
       dropping it buys back the most room.
     </p>
@@ -391,7 +391,7 @@ Dogs
     <h2>What a pipe gets</h2>
     <p>
       Redirect it and the boxes, colour and faces all go away. This is not a
-      setting; a non-terminal stdout forces it, and so does
+      setting; a non-terminal stdout forces it, and so does{" "}
       <code>--format json</code>:
     </p>
     <CodeBlock label="shep flock | cat">{`ID  NAME  STATUS   PID    RESTARTS  EXIT  CFG  CPU   MEM   UPTIME  FOLD     SMIT
@@ -399,8 +399,8 @@ Dogs
 0   web   online   68630  0         -     -    0.0%  3.0M  5m 10s  backend  -`}</CodeBlock>
     <p>
       None of the pretty rendering survives a pipe, which is the point. The
-      columns themselves do move between releases though. <code>CFG</code>,
-      <code>EXIT</code> and <code>SMIT</code> are all recent, so parse
+      columns themselves do move between releases though. <code>CFG</code>,{" "}
+      <code>EXIT</code> and <code>SMIT</code> are all recent, so parse{" "}
       <code>--format json</code> instead if a script depends on the shape.
     </p>
 
@@ -437,9 +437,9 @@ notice[style]: full (from $SHEP_STYLE)`}</CodeBlock>
 
     <h3>NO_COLOR</h3>
     <p>
-      <a href="https://no-color.org/">The <code>NO_COLOR</code> convention</a>
+      <a href="https://no-color.org/">The <code>NO_COLOR</code> convention</a>{" "}
       is honoured at every level, and it is a separate axis rather than a
-      fourth level. It removes colour and leaves the layout alone, so
+      fourth level. It removes colour and leaves the layout alone, so{" "}
       <code>full</code> under <code>NO_COLOR</code> still draws boxes and
       still shows faces:
     </p>
@@ -456,7 +456,7 @@ notice[style]: full (from $SHEP_STYLE)`}</CodeBlock>
       mustering forty processes does not paint a field.
     </p>
     <Callout variant="note">
-      Never on an error, and never after <code>kill</code>,
+      Never on an error, and never after <code>kill</code>,{" "}
       <code>delete</code> or <code>stop</code>. Errors keep their colour,
       because red is information, and lose everything else. A sheep beside a
       failure makes it harder to read, and a cheerful one after deleting a

--- a/web/src/pages/docs/overrides.astro
+++ b/web/src/pages/docs/overrides.astro
@@ -158,7 +158,7 @@ const store = `$ cat $SHEP_HOME/overrides.json
 
     <h2>Why a template and not just config</h2>
     <p>
-      The alternative was letting <code>shep start Flockfile.toml</code>
+      The alternative was letting <code>shep start Flockfile.toml</code>{" "}
       overwrite whatever it found. That reads fine on a laptop and is
       indefensible on a host: a Flockfile arrives through the app's own
       repository, so anybody who can merge a pull request could lower a
@@ -168,14 +168,14 @@ const store = `$ cat $SHEP_HOME/overrides.json
     <p>
       So a load appends. It writes the settings nobody has established yet
       and leaves everything else exactly as it is, which means the worst a
-      merged change can do to a running flock is nothing.
+      merged change can do to a running flock is nothing.{" "}
       <code>--reset=&lt;mode&gt;</code> is how you say the file wins, and it is
       something a person types.
     </p>
     <Callout variant="note">
-      A Flockfile is read when you name a file, or when
+      A Flockfile is read when you name a file, or when{" "}
       <code>shep start</code> with no target finds one in the directory you
-      ran it from. Naming a <em>sheep</em> reads no file at all:
+      ran it from. Naming a <em>sheep</em> reads no file at all:{" "}
       <code>shep start web</code> starts <code>web</code> from the config the
       shepherd already holds, and cannot be turned into a load by anything
       sitting in the current directory.
@@ -191,12 +191,12 @@ const store = `$ cat $SHEP_HOME/overrides.json
       All three are about the load a merged pull request can cause, which is
       the one with no flag on it, and that is the bound worth knowing: an
       unreviewed template cannot cost you a process. <code>--reset</code> is a
-      person asking for the template's shape, and a shape includes a count.
+      person asking for the template's shape, and a shape includes a count.{" "}
       <a href="#the-reset-flags-reshape-the-flock">Three of the four modes can
       kill</a>, and it has a section of its own below.
     </p>
     <p class="fine">
-      A dog is refused outright, at every depth. A Flockfile that names
+      A dog is refused outright, at every depth. A Flockfile that names{" "}
       <code>metrics</code> gets <code>metrics is a dog, and a dog's config
       comes from `shep adopt` rather than from a Flockfile</code> and nothing
       merges. A dog runs at the shepherd's own trust level, so a file that
@@ -212,9 +212,9 @@ const store = `$ cat $SHEP_HOME/overrides.json
     <CodeBlock label="Flockfile.toml">{template}</CodeBlock>
     <CodeBlock>{firstLoad}</CodeBlock>
     <p>
-      Nothing to report on a first load: the app was not in the flock, so
+      Nothing to report on a first load: the app was not in the flock, so{" "}
       <code>shep start</code> registered and started it, and every key in the
-      file became one somebody has now spoken for. Add a
+      file became one somebody has now spoken for. Add a{" "}
       <code>max_memory</code> and a <code>cwd</code> pointing somewhere else,
       and load the same file again:
     </p>
@@ -233,7 +233,7 @@ const store = `$ cat $SHEP_HOME/overrides.json
     <p>
       <code>!1</code> in <code>CFG</code> means one field is parked on this
       sheep. <code>*1</code> means one field an operator has taken ownership
-      of, whether or not the current Flockfile declares it, and
+      of, whether or not the current Flockfile declares it, and{" "}
       <code>-</code> means neither.
       It is a count rather than a list because the cell is three characters
       wide; <code>shep describe</code> is where the names are:
@@ -252,7 +252,7 @@ const store = `$ cat $SHEP_HOME/overrides.json
     </p>
     <CodeBlock>{promote}</CodeBlock>
     <p class="fine">
-      Identity is the one thing a promotion re-resolves. Changing
+      Identity is the one thing a promotion re-resolves. Changing{" "}
       <code>user</code> or <code>group</code> sends shep back to the passwd
       database, because an operator who changed who a sheep runs as means
       it; every other promotion reuses the credentials resolved at the
@@ -261,7 +261,7 @@ const store = `$ cat $SHEP_HOME/overrides.json
 
     <h2>A second load does not repeat the first</h2>
     <p>
-      Once a key has been established, the file stops speaking for it. Move
+      Once a key has been established, the file stops speaking for it. Move{" "}
       <code>max_memory</code> to <code>2G</code> and load again and shep says
       nothing at all, because the key is one somebody has already set:
     </p>
@@ -288,7 +288,7 @@ const store = `$ cat $SHEP_HOME/overrides.json
       <div class="row"><span><code>--reset=all</code></span><span>Everything goes back to the file, <code>env</code> and the instance count included, and the sheep's override record is dropped.</span></div>
     </div>
     <p>
-      <code>env</code> is the axis that splits data from policy.
+      <code>env</code> is the axis that splits data from policy.{" "}
       <code>env</code> is the one field holding something an operator
       supplied rather than tuned, and a reset that took an app's database
       credentials away as a side effect of putting its restart budget back
@@ -311,16 +311,16 @@ const store = `$ cat $SHEP_HOME/overrides.json
     <p>
       <code>instances</code> is the one setting that changes the shape of a
       flock rather than the value of a field, which is why a plain load holds
-      it out of scope however unestablished it is. <code>file</code>,
+      it out of scope however unestablished it is. <code>file</code>,{" "}
       <code>policy</code> and <code>all</code> do not. Each puts the count
       back to what it resolves to under that mode, and putting a count back
-      down deletes the instances above it, through the same path
+      down deletes the instances above it, through the same path{" "}
       <code>shep delete</code> takes. Only <code>env</code> leaves it alone,
       the same as a plain load.
     </p>
     <p>
       <code>file</code> and the other two resolve an undeclared count
-      differently, and that difference is the whole reason <code>file</code>
+      differently, and that difference is the whole reason <code>file</code>{" "}
       exists. A Flockfile that declares <code>instances</code> gets it applied
       under any of the three, the same as any other declared key.
     </p>
@@ -329,29 +329,29 @@ const store = `$ cat $SHEP_HOME/overrides.json
       something about it under <code>policy</code> or <code>all</code>: it
       says 1, because that is what a fresh start off that file would run. So
       an app you scaled to four with <code>shep stock</code> goes to one
-      against a file that has no opinion about instances at all.
+      against a file that has no opinion about instances at all.{" "}
       <code>--reset=file</code> is the mode that survives exactly this case:
-      it only puts back what the template declares, so an undeclared
+      it only puts back what the template declares, so an undeclared{" "}
       <code>instances</code> is left running at whatever count it already
-      had. Write the count you want into the template and
+      had. Write the count you want into the template and{" "}
       <code>--reset=file</code> applies it like any other declared field.
     </Callout>
     <CodeBlock>{resetScales}</CodeBlock>
     <p>
       Four instances, a <code>policy</code> reset against a two-line
       Flockfile that does not mention <code>instances</code>, one instance
-      left. Nothing there is a bug and nothing was silent: the report names
-      <code>instances</code> among what it applied.
+      left. Nothing there is a bug and nothing was silent: the report names{" "}
+      <code>instances</code> among what it applied.{" "}
       <code>--reset=file</code> against the same file would have left all
       four running, because the file says nothing to put back. Against a
       file that declares <code>instances = 2</code>, <code>file</code> would
-      have settled at two, the same as <code>policy</code> or <code>all</code>
+      have settled at two, the same as <code>policy</code> or <code>all</code>{" "}
       would have.
     </p>
     <p class="fine">
       The table <code>start</code> prints is a snapshot taken while the
       departures are still leaving, which is why it can still show a row on
-      its way out with <code>0B</code> against it. The
+      its way out with <code>0B</code> against it. The{" "}
       <code>shep flock</code> underneath is the settled count.
     </p>
 
@@ -395,13 +395,13 @@ const store = `$ cat $SHEP_HOME/overrides.json
     <CodeBlock>{addFirst}</CodeBlock>
     <p>
       The empty values above are why it exists. Starting that file spawns a
-      process against an empty database URL: it crashes,
+      process against an empty database URL: it crashes,{" "}
       <code>autorestart</code> spends the restart budget on it, and the app
       has to be stopped before anyone can configure it. Registering first
       puts the steps in the order they belong.
     </p>
     <p class="fine">
-      The <code>1</code> under RESTARTS is not something <code>add</code>
+      The <code>1</code> under RESTARTS is not something <code>add</code>{" "}
       did. <code>shep start &lt;name&gt;</code> brings a stopped sheep up
       through the same request <code>shep restart</code> uses, and has
       counted it that way since before this verb existed.
@@ -419,7 +419,7 @@ const store = `$ cat $SHEP_HOME/overrides.json
       Running <code>shep add</code> again changes nothing and prints nothing,
       the way a second load of an unchanged file does. Naming a sheep instead
       of a file says so out loud, because a name reads no Flockfile at all
-      and leaves nothing to register:
+      and leaves nothing to register:{" "}
       <code>notice[add]: web is already registered; nothing to add.</code>
     </p>
 
@@ -435,9 +435,9 @@ const store = `$ cat $SHEP_HOME/overrides.json
       The awkward consequence is deletion. Removing a line from a Flockfile
       does not remove the setting, once the setting is established: the file
       has stopped mentioning it, and a load that acted on an absence would
-      be overwriting by omission. <code>--reset=policy</code> or
+      be overwriting by omission. <code>--reset=policy</code> or{" "}
       <code>--reset=all</code> puts a deleted setting back to shep's own
-      default, since it is now a key the file is silent on; <code>all</code>
+      default, since it is now a key the file is silent on; <code>all</code>{" "}
       does the same for a deleted <code>env</code> key.
     </p>
 
@@ -457,16 +457,16 @@ const store = `$ cat $SHEP_HOME/overrides.json
       later load can tell "the file used to say this and no longer does"
       apart from "the file never mentioned it". <code>fields</code> is the
       other half: settings an operator has taken ownership of, whether or
-      not the current file declares them, which is what a <code>*N</code> in
+      not the current file declares them, which is what a <code>*N</code> in{" "}
       <code>CFG</code> counts.
     </p>
     <p>
-      The door that writes <code>fields</code> is
+      The door that writes <code>fields</code> is{" "}
       <a href="/docs/lookout">the config pane</a>: <code>e</code> on a sheep
       in <code>shep lookout</code>, behind <code>--allow-control</code>. One
       key at a time, and the value is recorded as yours rather than spent,
-      so the key keeps its <code>*</code> and a later <code>shep start</code>
-      of the app's Flockfile leaves it alone. There is no flag on
+      so the key keeps its <code>*</code> and a later <code>shep start</code>{" "}
+      of the app's Flockfile leaves it alone. There is no flag on{" "}
       <code>shep start</code> that sets one field: a load is a template
       arriving through a pull request, and an operator's own value is not a
       thing a template says.
@@ -474,7 +474,7 @@ const store = `$ cat $SHEP_HOME/overrides.json
     <p class="fine">
       A pane edit is not a <code>--reset=file</code> at one key, which is
       what it used to send. That merge is a template load, so it moved the
-      field correctly and then dropped the override for it, and the
+      field correctly and then dropped the override for it, and the{" "}
       <code>*</code> the operator had just earned never appeared.
     </p>
     <p class="fine">
@@ -489,7 +489,7 @@ const store = `$ cat $SHEP_HOME/overrides.json
       Per app, and the rest of the file still loads: one bad app in a file of
       eleven costing the other ten their load is the failure that would make
       people stop running this against anything real. What changes is the
-      exit code, which goes non-zero the moment any app was refused, so
+      exit code, which goes non-zero the moment any app was refused, so{" "}
       <code>shep start Flockfile.toml &amp;&amp; deploy</code> stops instead
       of carrying on with a config that did not land.
     </p>

--- a/web/src/pages/docs/serve.astro
+++ b/web/src/pages/docs/serve.astro
@@ -37,7 +37,7 @@ $ curl -o /dev/null -w '%{http_code}\\n' http://127.0.0.1:8080/link.html
     <ReferencePills slug="serve" />
     <p class="lede">
       <code>shep serve &lt;dir&gt;</code> registers a sheep whose command line
-      is this same invocation, canonicalized, with <code>--foreground</code>
+      is this same invocation, canonicalized, with <code>--foreground</code>{" "}
       appended: the worker answering every request <em>is</em> the
       registered sheep, so <code>shep describe</code> shows exactly what
       restarts if it dies. It's hand-rolled (six small modules over an HTTP
@@ -56,16 +56,16 @@ $ curl -o /dev/null -w '%{http_code}\\n' http://127.0.0.1:8080/link.html
     <p>
       Every default below is the safe one, and every unsafe one is a named
       flag rather than a config file nobody reads. Binds loopback
-      (<code>127.0.0.1:8080</code>) unless you pass a wider
+      (<code>127.0.0.1:8080</code>) unless you pass a wider{" "}
       <code>--bind</code>, which prints a stderr notice naming what it just
-      exposed. These four requests were run against a real
-      <code>shep serve</code> process, docroot containing an
+      exposed. These four requests were run against a real{" "}
+      <code>shep serve</code> process, docroot containing an{" "}
       <code>index.html</code>, a <code>.env</code>, and a symlink:
     </p>
     <CodeBlock>{requestCodes}</CodeBlock>
     <p>
       Traversal is refused in every encoding it was tried in, not just the
-      literal one. Dotfiles 404: serving a repo checkout with
+      literal one. Dotfiles 404: serving a repo checkout with{" "}
       <code>shep serve .</code> would otherwise publish <code>.env</code> and
       the whole <code>.git</code> history. And <strong>any</strong> symlink
       under the docroot 404s by default, not only one that leaves it: an
@@ -89,13 +89,13 @@ $ curl -o /dev/null -w '%{http_code}\\n' http://127.0.0.1:8080/link.html
 
     <h2>The rest of the flags</h2>
     <p>
-      <code>--listing</code> turns on directory listings for a folder with no
+      <code>--listing</code> turns on directory listings for a folder with no{" "}
       <code>index.html</code>, off by default, since a listing publishes
       every filename under it. <code>--hidden</code> serves dotfiles, mainly
-      for <code>.well-known/acme-challenge</code>. <code>--spa</code> serves
+      for <code>.well-known/acme-challenge</code>. <code>--spa</code> serves{" "}
       <code>index.html</code> for a path that doesn't exist, only for
-      requests that accept HTML, so a missing script still 404s.
-      <code>--auth &lt;file&gt;</code> requires one <code>user:password</code>
+      requests that accept HTML, so a missing script still 404s.{" "}
+      <code>--auth &lt;file&gt;</code> requires one <code>user:password</code>{" "}
       line, mode <code>0600</code>, on every request. Sent as plain HTTP
       basic auth, base64 rather than encryption, so put a real proxy in front
       if that matters.
@@ -103,9 +103,9 @@ $ curl -o /dev/null -w '%{http_code}\\n' http://127.0.0.1:8080/link.html
     <p class="fine">
       What isn't here: range requests, conditional requests, ETags,
       compression, keep-alive, TLS, or HTTP/2
-      <NotBuilt note="range/conditional requests are v1.1 candidates" />.
+      <NotBuilt note="range/conditional requests are v1.1 candidates" />.{" "}
       <code>shep serve</code> takes no configuration from the environment:
-      pass <code>--port</code>, <code>--bind</code>, <code>--spa</code>,
+      pass <code>--port</code>, <code>--bind</code>, <code>--spa</code>,{" "}
       <code>--auth</code> and the flags above on the command line instead.
       The visible cost today is no video seeking and a full re-read per
       request.

--- a/web/src/pages/docs/startup.astro
+++ b/web/src/pages/docs/startup.astro
@@ -61,7 +61,7 @@ removed  /Library/LaunchDaemons/io.github.turtiesocks.shep.deploy.plist  absent`
     <p class="lede">
       <code>shep startup</code> writes an init unit for the target user:
       systemd, launchd, openrc, or a BSD <code>rc.d</code> script, picked
-      automatically for the running host or named explicitly with
+      automatically for the running host or named explicitly with{" "}
       <code>--init</code>. <code>shep unstartup</code> takes it back out.
       Neither talks to a running shepherd; both write and remove a single
       unit file.
@@ -76,11 +76,11 @@ removed  /Library/LaunchDaemons/io.github.turtiesocks.shep.deploy.plist  absent`
     <CodeBlock label="real output, unprivileged, macOS">{realOutput}</CodeBlock>
     <p class="fine">
       A unit that was never installed reports <code>absent</code> rather than
-      failing. There's nothing left to guess at, on either verb. Under
+      failing. There's nothing left to guess at, on either verb. Under{" "}
       <code>sudo</code>, the unit is built for <code>$SUDO_USER</code> rather
       than root, so it supervises the flock the operator actually has, and
-      its <code>$SHEP_HOME</code> is that user's own <code>~/.shep</code>
-      unless <code>--home</code> or a <code>$SHEP_HOME</code> that survived
+      its <code>$SHEP_HOME</code> is that user's own <code>~/.shep</code>{" "}
+      unless <code>--home</code> or a <code>$SHEP_HOME</code> that survived{" "}
       <code>sudo</code> says otherwise. shep won't create that
       directory for another user, since root would own it and the daemon
       couldn't open it. If it isn't there yet, run any shep verb as that
@@ -91,29 +91,29 @@ removed  /Library/LaunchDaemons/io.github.turtiesocks.shep.deploy.plist  absent`
 
     <h2>The PATH capture, and its one trap</h2>
     <p>
-      A daemon started by systemd or launchd has no login shell and no
-      <code>.bashrc</code>/<code>.profile</code> behind it. Without help,
+      A daemon started by systemd or launchd has no login shell and no{" "}
+      <code>.bashrc</code>/<code>.profile</code> behind it. Without help,{" "}
       <code>PATH</code> at boot would be whatever minimal default the init
-      system starts with, and any app whose interpreter lives outside
+      system starts with, and any app whose interpreter lives outside{" "}
       <code>/usr/bin</code>/<code>/bin</code> would fail to spawn on the very
       first boot after migration, silently, until someone reboots the box
-      again to find out why. <code>shep startup</code> captures the
+      again to find out why. <code>shep startup</code> captures the{" "}
       <code>PATH</code> of the shell that ran it directly into the unit
-      (<code>Environment="PATH=..."</code> on systemd, the plist's
+      (<code>Environment="PATH=..."</code> on systemd, the plist's{" "}
       <code>EnvironmentVariables</code> on launchd): the mechanism that
-      makes an interpreter installed under <code>~/.bun/bin</code> or
+      makes an interpreter installed under <code>~/.bun/bin</code> or{" "}
       <code>~/.cargo/bin</code> findable after a reboot.
     </p>
     <Callout variant="careful">
       <code>sudo</code> on most distributions replaces <code>PATH</code> with
       its own <code>secure_path</code> before your command ever runs: often
       dropping the exact <code>~/.bun</code> or <code>~/.cargo</code> entry
-      the capture above exists to preserve. shep can't tell a sanitized
+      the capture above exists to preserve. shep can't tell a sanitized{" "}
       <code>PATH</code> from an untouched one after the fact, but it knows
       when it's running under <code>sudo</code> and warns at install time,
       naming the <code>PATH</code> about to go into the unit. If it's
       missing something, rerun as <code>sudo --preserve-env=PATH shep
-      startup ...</code> instead (after <code>shep unstartup</code>, since
+      startup ...</code> instead (after <code>shep unstartup</code>, since{" "}
       <code>startup</code> refuses to overwrite the unit it just wrote).
     </Callout>
 
@@ -208,9 +208,9 @@ removed  /Library/LaunchDaemons/io.github.turtiesocks.shep.deploy.plist  absent`
 
     <h2>Honestly: openrc and the BSDs are untested</h2>
     <p>
-      All four unit renderers (systemd, launchd, openrc, FreeBSD/OpenBSD
+      All four unit renderers (systemd, launchd, openrc, FreeBSD/OpenBSD{" "}
       <code>rc.d</code>) are pinned by exact-string tests, the same tier the
-      systemd unit has always had, since it too has only ever been
+      systemd unit has always had, since it too has only ever been{" "}
       <em>rendered</em>, on a Mac. That's a real and adequate tier for text.
       It is not a claim that the openrc or BSD scripts work: no FreeBSD,
       OpenBSD, or openrc host exists on this project's own machines, and
@@ -220,11 +220,11 @@ removed  /Library/LaunchDaemons/io.github.turtiesocks.shep.deploy.plist  absent`
     </p>
     <p>
       One functional difference is already known, not just untested: openrc
-      has no <code>sd_notify</code> analogue, so its script's
+      has no <code>sd_notify</code> analogue, so its script's{" "}
       <code>start_post()</code> polls the shepherd's own control socket
       instead and blocks the "started" verdict until the first request is
       answered: the same milestone <code>READY=1</code> proves on systemd,
-      one step later. FreeBSD gets the same poll through
+      one step later. FreeBSD gets the same poll through{" "}
       <code>start_postcmd</code>. OpenBSD's <code>rc.subr</code> has no
       documented post-start hook at all; its script reports started as soon
       as the process is spawned and says so in its own header comment,

--- a/web/src/pages/docs/talking-to-a-sheep.astro
+++ b/web/src/pages/docs/talking-to-a-sheep.astro
@@ -174,7 +174,7 @@ ID  NAME    OUTCOME   DETAIL
       signal the app does not handle still has a kernel default, and for most
       of the nine that default is to terminate the process. A sheep that
       never installed a <code>SIGUSR1</code> handler is killed by one, the
-      row still says <code>delivered</code>, and the exit shows up in the
+      row still says <code>delivered</code>, and the exit shows up in the{" "}
       <code>EXIT</code> column like any other:
     </p>
     <CodeBlock>{untrapped}</CodeBlock>

--- a/web/src/pages/docs/terminology.astro
+++ b/web/src/pages/docs/terminology.astro
@@ -70,8 +70,8 @@ const toneFor = (built: "yes" | "partly" | "no") =>
       <h3>Sheepdogs and sheep were separate ideas from the start</h3>
       <p>
         So "dog" never means the daemon. The shepherd is the shepherd. Dogs
-        are plugins that work for it: <code>metrics</code> and
-        <code>bark</code> ship inside the binary, and
+        are plugins that work for it: <code>metrics</code> and{" "}
+        <code>bark</code> ship inside the binary, and{" "}
         <code>shep adopt</code> runs anyone else's.
       </p>
     </div>


### PR DESCRIPTION
Astro collapses whitespace inside a text node the way JSX does, so a line that ends right before a tag, or a tag that closes at the end of a line with prose resuming on the next, loses the space between them. `code` has `padding: 1px 6px` so the page still looks right, and only the text content is wrong: `/docs/first-flockfile` served "every field`AppConfig`understands" to screen readers and to anyone copying the paragraph.

- 388 spots across 21 built pages, each fixed with `{" "}` at the line break
- No prose reworded, no lines rejoined: all 403 changed lines differ from the original only by that suffix
- `/docs/boot-order` (24) and the landing page (2) were not in the original count
- `<em>` and `<strong>` have it in six places, and two code pills in `kv.astro` were glued together the same way
- `<code>SIGKILL</code>ing` in `lifecycle.astro` matches the grep on purpose, so the pages land at 1 rather than 0

`npx astro build` 27 pages, `npx astro check` 0 errors 0 warnings. The one hint is a pre-existing unused function in `src/data/cliReference.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the overrides guide with current reset options, file-loading behavior, environment and instance-count effects, `shep add`, operator-owned settings, and expanded examples.
  - Improved rendered spacing and text formatting across documentation pages, without changing documented behavior or APIs.
  - Corrected minor whitespace and presentation issues in the landing-page scenes and documentation content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->