### PR TITLE
refactor(daemon): stop repeating two struct literals in supervisor.rs

### DIFF
--- a/crates/shep-daemon/src/supervisor.rs
+++ b/crates/shep-daemon/src/supervisor.rs
@@ -2075,6 +2075,30 @@ struct SheepSlot {
 }
 
 impl SheepSlot {
+    /// A registered sheep with nothing attached: no mailboxes, no marker, no
+    /// timer, at epoch zero.
+    ///
+    /// The base every literal in this module builds from, so a field added
+    /// here is written once and a caller overwrites only what it owns. Not a
+    /// `Default`: `entry` has no blank value.
+    fn new(entry: ProcessEntry) -> Self {
+        Self {
+            entry,
+            ctl: None,
+            log_ctl: None,
+            to_child: None,
+            signals: None,
+            to_stdin: None,
+            manual: None,
+            pending_delete: false,
+            epoch: 0,
+            ready_tx: None,
+            actions: ActionWaits::default(),
+            ready_failed: false,
+            restart_due: None,
+        }
+    }
+
     /// This sheep's shepherd-channel sender while something is still there to
     /// receive on it, and `None` when nothing is.
     ///
@@ -3105,24 +3129,7 @@ impl<R: ProcessRunner> Actor<R> {
             last_exit: None,
         };
         let info = to_info(&entry, &self.smits);
-        self.sheep.insert(
-            id,
-            SheepSlot {
-                entry,
-                ctl: None,
-                log_ctl: None,
-                to_child: None,
-                signals: None,
-                to_stdin: None,
-                manual: None,
-                pending_delete: false,
-                epoch: 0,
-                ready_tx: None,
-                actions: ActionWaits::default(),
-                ready_failed: false,
-                restart_due: None,
-            },
-        );
+        self.sheep.insert(id, SheepSlot::new(entry));
         Registration::Fresh(info)
     }
 
@@ -3201,24 +3208,7 @@ impl<R: ProcessRunner> Actor<R> {
                     dog,
                     last_exit: None,
                 };
-                self.sheep.insert(
-                    id,
-                    SheepSlot {
-                        entry,
-                        ctl: None,
-                        log_ctl: None,
-                        to_child: None,
-                        signals: None,
-                        to_stdin: None,
-                        manual: None,
-                        pending_delete: false,
-                        epoch: 0,
-                        ready_tx: None,
-                        actions: ActionWaits::default(),
-                        ready_failed: false,
-                        restart_due: None,
-                    },
-                );
+                self.sheep.insert(id, SheepSlot::new(entry));
                 let info = self.refuse_spawn(id, true, &err);
                 // A retriable refusal is not a failed start: the sheep is
                 // registered, waiting, and comes up on its own once the
@@ -3305,19 +3295,13 @@ impl<R: ProcessRunner> Actor<R> {
                 self.sheep.insert(
                     id,
                     SheepSlot {
-                        entry,
                         ctl: Some(handles.ctl),
                         log_ctl: Some(log_ctl),
                         to_child: Some(to_child),
                         signals: Some(handles.signals),
                         to_stdin: Some(to_stdin),
-                        manual: None,
-                        pending_delete: false,
-                        epoch: 0,
                         ready_tx,
-                        actions: ActionWaits::default(),
-                        ready_failed: false,
-                        restart_due: None,
+                        ..SheepSlot::new(entry)
                     },
                 );
                 self.emit(ProcessEventKind::Start, info.clone(), true);
@@ -3349,24 +3333,7 @@ impl<R: ProcessRunner> Actor<R> {
                     last_exit: None,
                 };
                 let info = to_info(&entry, &self.smits);
-                self.sheep.insert(
-                    id,
-                    SheepSlot {
-                        entry,
-                        ctl: None,
-                        log_ctl: None,
-                        to_child: None,
-                        signals: None,
-                        to_stdin: None,
-                        manual: None,
-                        pending_delete: false,
-                        epoch: 0,
-                        ready_tx: None,
-                        actions: ActionWaits::default(),
-                        ready_failed: false,
-                        restart_due: None,
-                    },
-                );
+                self.sheep.insert(id, SheepSlot::new(entry));
                 self.emit(ProcessEventKind::Errored, info, true);
                 // `error` names neither the app nor the path, and the caller
                 // adds the name. `spec.program` and `spec.cwd` verbatim: they
@@ -3506,12 +3473,6 @@ impl<R: ProcessRunner> Actor<R> {
             self.sheep.insert(
                 id,
                 SheepSlot {
-                    entry,
-                    ctl: None,
-                    log_ctl: None,
-                    to_child: None,
-                    signals: None,
-                    to_stdin: None,
                     // A marker is only claimed against a sheep with a live
                     // task: there is no ladder here to re-arm and no
                     // `Msg::Exited` coming to clear one.
@@ -3520,8 +3481,6 @@ impl<R: ProcessRunner> Actor<R> {
                     // that consumes it is this slot's next spawn's.
                     pending_delete: carried.pending_delete().unwrap_or(false),
                     epoch: carried.epoch(),
-                    ready_tx: None,
-                    actions: ActionWaits::default(),
                     // Restored: it needs no task to act on it, and `respawn`
                     // clears it at the spawn that answers it.
                     ready_failed,
@@ -3529,6 +3488,7 @@ impl<R: ProcessRunner> Actor<R> {
                     // wait does not start the delay over: the re-arm below
                     // computes a fresh timer from this absolute moment.
                     restart_due: carried.restart_due(),
+                    ..SheepSlot::new(entry)
                 },
             );
             // Nothing but this raises `Msg::RestartDue`, so a carried
@@ -3607,7 +3567,6 @@ impl<R: ProcessRunner> Actor<R> {
         self.sheep.insert(
             id,
             SheepSlot {
-                entry,
                 ctl: Some(handles.ctl),
                 log_ctl: Some(log_ctl),
                 to_child: Some(to_child),
@@ -3619,7 +3578,6 @@ impl<R: ProcessRunner> Actor<R> {
                 pending_delete: carried.pending_delete().unwrap_or(false),
                 epoch: carried.epoch(),
                 ready_tx,
-                actions: ActionWaits::default(),
                 // Restored: `reload_eligible` reads it beside the status, so a
                 // rollback reload can replace an instance that never reached
                 // `Online`.
@@ -3627,6 +3585,7 @@ impl<R: ProcessRunner> Actor<R> {
                 // Restored verbatim, though always `None` in practice: a sheep
                 // with a pid is not `WaitingRestart`.
                 restart_due: carried.restart_due(),
+                ..SheepSlot::new(entry)
             },
         );
         // The ladder that would kill a carried `manual` sheep went with the
@@ -5690,19 +5649,13 @@ impl<R: ProcessRunner> Actor<R> {
                 self.sheep.insert(
                     new_id,
                     SheepSlot {
-                        entry,
                         ctl: Some(handles.ctl),
                         log_ctl: Some(log_ctl),
                         to_child: Some(to_child),
                         signals: Some(handles.signals),
                         to_stdin: Some(to_stdin),
-                        manual: None,
-                        pending_delete: false,
-                        epoch: 0,
                         ready_tx: Some(ready_tx),
-                        actions: ActionWaits::default(),
-                        ready_failed: false,
-                        restart_due: None,
+                        ..SheepSlot::new(entry)
                     },
                 );
                 // The instance being replaced announces itself before its
@@ -9749,19 +9702,9 @@ mod tests {
         entry.status = ProcStatus::Stopping;
         let (ctl_tx, ctl_rx) = mpsc::channel(1);
         let slot = SheepSlot {
-            entry,
             ctl: Some(ctl_tx),
-            log_ctl: None,
-            to_child: None,
-            signals: None,
-            to_stdin: None,
-            manual: None,
-            pending_delete: false,
             epoch,
-            ready_tx: None,
-            actions: ActionWaits::default(),
-            ready_failed: false,
-            restart_due: None,
+            ..SheepSlot::new(entry)
         };
         let mut sheep = HashMap::new();
         sheep.insert(0, slot);
@@ -9859,19 +9802,8 @@ mod tests {
         sheep.insert(
             0,
             SheepSlot {
-                entry,
                 ctl: Some(ctl_tx),
-                log_ctl: None,
-                to_child: None,
-                signals: None,
-                to_stdin: None,
-                manual: None,
-                pending_delete: false,
-                epoch: 0,
-                ready_tx: None,
-                actions: ActionWaits::default(),
-                ready_failed: false,
-                restart_due: None,
+                ..SheepSlot::new(entry)
             },
         );
         let (events, _events_rx) = crate::bus::test_bus(16);
@@ -10515,24 +10447,7 @@ mod tests {
         let paths = test_paths(dir);
         let app = normalize(app).unwrap();
         let mut sheep = HashMap::new();
-        sheep.insert(
-            0,
-            SheepSlot {
-                entry: armed_entry(0, 0, 1111, app, &paths),
-                ctl: None,
-                log_ctl: None,
-                to_child: None,
-                signals: None,
-                to_stdin: None,
-                manual: None,
-                pending_delete: false,
-                epoch: 0,
-                ready_tx: None,
-                actions: ActionWaits::default(),
-                ready_failed: false,
-                restart_due: None,
-            },
-        );
+        sheep.insert(0, SheepSlot::new(armed_entry(0, 0, 1111, app, &paths)));
         let (events, _events_rx) = crate::bus::test_bus(64);
         let (tx, rx) = mpsc::channel(MAILBOX_CAPACITY);
         let provider_secrets = Arc::new(ProviderSecrets::load(&paths.secrets_cache));
@@ -10577,24 +10492,7 @@ mod tests {
             let app = app_with(name, |config| config.fold = Some("svc".to_string()));
             let mut entry = armed_entry(id, 0, 1111 + id, app, &paths);
             entry.dog = dog;
-            sheep.insert(
-                id,
-                SheepSlot {
-                    entry,
-                    ctl: None,
-                    log_ctl: None,
-                    to_child: None,
-                    signals: None,
-                    to_stdin: None,
-                    manual: None,
-                    pending_delete: false,
-                    epoch: 0,
-                    ready_tx: None,
-                    actions: ActionWaits::default(),
-                    ready_failed: false,
-                    restart_due: None,
-                },
-            );
+            sheep.insert(id, SheepSlot::new(entry));
         }
         let (events, _events_rx) = crate::bus::test_bus(64);
         let (tx, rx) = mpsc::channel(MAILBOX_CAPACITY);
@@ -10760,21 +10658,13 @@ mod tests {
         for instance in 0..instances {
             sheep.insert(
                 instance,
-                SheepSlot {
-                    entry: armed_entry(instance, instance, 1111 + instance, app.clone(), &paths),
-                    ctl: None,
-                    log_ctl: None,
-                    to_child: None,
-                    signals: None,
-                    to_stdin: None,
-                    manual: None,
-                    pending_delete: false,
-                    epoch: 0,
-                    ready_tx: None,
-                    actions: ActionWaits::default(),
-                    ready_failed: false,
-                    restart_due: None,
-                },
+                SheepSlot::new(armed_entry(
+                    instance,
+                    instance,
+                    1111 + instance,
+                    app.clone(),
+                    &paths,
+                )),
             );
         }
         let (events, _events_rx) = crate::bus::test_bus(64);
@@ -13648,19 +13538,8 @@ mod tests {
         actor.sheep.insert(
             id,
             SheepSlot {
-                entry: armed_entry(id, 0, 2000 + id, app, &paths),
-                ctl: None,
-                log_ctl: None,
                 to_child,
-                signals: None,
-                to_stdin: None,
-                manual: None,
-                pending_delete: false,
-                epoch: 0,
-                ready_tx: None,
-                actions: ActionWaits::default(),
-                ready_failed: false,
-                restart_due: None,
+                ..SheepSlot::new(armed_entry(id, 0, 2000 + id, app, &paths))
             },
         );
         id
@@ -17944,21 +17823,13 @@ mod tests {
                 next_id += 1;
                 sheep.insert(
                     id,
-                    SheepSlot {
-                        entry: armed_entry(id, instance, APPLY_FIRST_PID + id, app.clone(), &paths),
-                        ctl: None,
-                        log_ctl: None,
-                        to_child: None,
-                        signals: None,
-                        to_stdin: None,
-                        manual: None,
-                        pending_delete: false,
-                        epoch: 0,
-                        ready_tx: None,
-                        actions: ActionWaits::default(),
-                        ready_failed: false,
-                        restart_due: None,
-                    },
+                    SheepSlot::new(armed_entry(
+                        id,
+                        instance,
+                        APPLY_FIRST_PID + id,
+                        app.clone(),
+                        &paths,
+                    )),
                 );
             }
         }

--- a/crates/shep-daemon/src/supervisor.rs
+++ b/crates/shep-daemon/src/supervisor.rs
@@ -8330,6 +8330,42 @@ mod tests {
         }
     }
 
+    /// A bare actor over `sheep`, running `scripts` and reachable at `tx`.
+    ///
+    /// The bus receiver is dropped here, as every fixture already dropped its
+    /// own: a bus with no subscriber still takes every send.
+    ///
+    /// `next_id` is one past the slots, which the contiguous ids every fixture
+    /// assigns make right. A case that needs another value, or `extras`,
+    /// writes it with struct-update syntax over this.
+    fn test_actor(
+        paths: ShepPaths,
+        scripts: Vec<ProcScript>,
+        sheep: HashMap<u32, SheepSlot>,
+        tx: mpsc::Sender<Msg>,
+    ) -> Actor<ScriptedRunner> {
+        let (events, _events_rx) = crate::bus::test_bus(64);
+        let provider_secrets = Arc::new(ProviderSecrets::load(&paths.secrets_cache));
+        Actor {
+            runner: ScriptedRunner::new(scripts),
+            next_id: sheep.len() as u32,
+            paths,
+            events,
+            host_environment: DEFAULT_ENVIRONMENT.to_string(),
+            provider_secrets,
+            tx,
+            sheep,
+            next_deadline: 0,
+            next_action_stamp: 0,
+            pending: Vec::new(),
+            shutting_down: false,
+            extras: None,
+            registry: ExtrasRegistry::default(),
+            reloads: HashMap::new(),
+            smits: Smits::new(),
+        }
+    }
+
     // --- The readiness gate ---
 
     #[tokio::test(start_paused = true)]
@@ -9708,27 +9744,8 @@ mod tests {
         };
         let mut sheep = HashMap::new();
         sheep.insert(0, slot);
-        let (events, _events_rx) = crate::bus::test_bus(16);
         let (tx, _rx) = mpsc::channel(16);
-        let provider_secrets = Arc::new(ProviderSecrets::load(&paths.secrets_cache));
-        let actor = Actor {
-            runner: ScriptedRunner::new(vec![]),
-            paths,
-            events,
-            host_environment: DEFAULT_ENVIRONMENT.to_string(),
-            provider_secrets,
-            tx,
-            sheep,
-            next_id: 1,
-            next_deadline: 0,
-            next_action_stamp: 0,
-            pending: Vec::new(),
-            shutting_down: false,
-            extras: None,
-            registry: ExtrasRegistry::default(),
-            reloads: HashMap::new(),
-            smits: Smits::new(),
-        };
+        let actor = test_actor(paths, Vec::new(), sheep, tx);
         (actor, ctl_rx)
     }
 
@@ -9806,27 +9823,8 @@ mod tests {
                 ..SheepSlot::new(entry)
             },
         );
-        let (events, _events_rx) = crate::bus::test_bus(16);
         let (tx, _mailbox) = mpsc::channel(16);
-        let provider_secrets = Arc::new(ProviderSecrets::load(&paths.secrets_cache));
-        let mut actor = Actor {
-            runner: ScriptedRunner::new(vec![]),
-            paths,
-            events,
-            host_environment: DEFAULT_ENVIRONMENT.to_string(),
-            provider_secrets,
-            tx,
-            sheep,
-            next_id: 1,
-            next_deadline: 0,
-            next_action_stamp: 0,
-            pending: Vec::new(),
-            shutting_down: false,
-            extras: None,
-            registry: ExtrasRegistry::default(),
-            reloads: HashMap::new(),
-            smits: Smits::new(),
-        };
+        let mut actor = test_actor(paths, Vec::new(), sheep, tx);
         let entry = actor
             .sheep
             .get(&0)
@@ -10448,27 +10446,8 @@ mod tests {
         let app = normalize(app).unwrap();
         let mut sheep = HashMap::new();
         sheep.insert(0, SheepSlot::new(armed_entry(0, 0, 1111, app, &paths)));
-        let (events, _events_rx) = crate::bus::test_bus(64);
         let (tx, rx) = mpsc::channel(MAILBOX_CAPACITY);
-        let provider_secrets = Arc::new(ProviderSecrets::load(&paths.secrets_cache));
-        let actor = Actor {
-            runner: ScriptedRunner::new(scripts),
-            paths,
-            events,
-            host_environment: DEFAULT_ENVIRONMENT.to_string(),
-            provider_secrets,
-            tx,
-            sheep,
-            next_id: 1,
-            next_deadline: 0,
-            next_action_stamp: 0,
-            pending: Vec::new(),
-            shutting_down: false,
-            extras: None,
-            registry: ExtrasRegistry::default(),
-            reloads: HashMap::new(),
-            smits: Smits::new(),
-        };
+        let actor = test_actor(paths, scripts, sheep, tx);
         (actor, rx)
     }
 
@@ -10494,27 +10473,8 @@ mod tests {
             entry.dog = dog;
             sheep.insert(id, SheepSlot::new(entry));
         }
-        let (events, _events_rx) = crate::bus::test_bus(64);
         let (tx, rx) = mpsc::channel(MAILBOX_CAPACITY);
-        let provider_secrets = Arc::new(ProviderSecrets::load(&paths.secrets_cache));
-        let actor = Actor {
-            runner: ScriptedRunner::new(Vec::new()),
-            paths,
-            events,
-            host_environment: DEFAULT_ENVIRONMENT.to_string(),
-            provider_secrets,
-            tx,
-            sheep,
-            next_id: DOG_ID + 1,
-            next_deadline: 0,
-            next_action_stamp: 0,
-            pending: Vec::new(),
-            shutting_down: false,
-            extras: None,
-            registry: ExtrasRegistry::default(),
-            reloads: HashMap::new(),
-            smits: Smits::new(),
-        };
+        let actor = test_actor(paths, Vec::new(), sheep, tx);
         (actor, rx)
     }
 
@@ -10667,27 +10627,8 @@ mod tests {
                 )),
             );
         }
-        let (events, _events_rx) = crate::bus::test_bus(64);
         let (tx, _rx) = mpsc::channel(MAILBOX_CAPACITY);
-        let provider_secrets = Arc::new(ProviderSecrets::load(&paths.secrets_cache));
-        Actor {
-            runner: ScriptedRunner::new(scripts),
-            paths,
-            events,
-            host_environment: DEFAULT_ENVIRONMENT.to_string(),
-            provider_secrets,
-            tx,
-            sheep,
-            next_id: instances,
-            next_deadline: 0,
-            next_action_stamp: 0,
-            pending: Vec::new(),
-            shutting_down: false,
-            extras: None,
-            registry: ExtrasRegistry::default(),
-            reloads: HashMap::new(),
-            smits: Smits::new(),
-        }
+        test_actor(paths, scripts, sheep, tx)
     }
 
     /// Every registered slot's stored instance count, ascending by id.
@@ -15156,28 +15097,9 @@ mod tests {
         dir: &tempfile::TempDir,
         scripts: Vec<ProcScript>,
     ) -> Actor<ScriptedRunner> {
-        let (events, _events_rx) = crate::bus::test_bus(64);
         let (tx, _rx) = mpsc::channel(MAILBOX_CAPACITY);
         let paths = test_paths(dir);
-        let provider_secrets = Arc::new(ProviderSecrets::load(&paths.secrets_cache));
-        Actor {
-            runner: ScriptedRunner::new(scripts),
-            paths,
-            events,
-            host_environment: DEFAULT_ENVIRONMENT.to_string(),
-            provider_secrets,
-            tx,
-            sheep: HashMap::new(),
-            next_id: 0,
-            next_deadline: 0,
-            next_action_stamp: 0,
-            pending: Vec::new(),
-            shutting_down: false,
-            extras: None,
-            registry: ExtrasRegistry::default(),
-            reloads: HashMap::new(),
-            smits: Smits::new(),
-        }
+        test_actor(paths, scripts, HashMap::new(), tx)
     }
 
     /// The name this test process is already running under, the only user a
@@ -17846,28 +17768,13 @@ mod tests {
             },
             stats: idle_stats(),
         };
-        let (events, _events_rx) = crate::bus::test_bus(64);
         let (tx, _rx) = mpsc::channel(MAILBOX_CAPACITY);
-        let provider_secrets = Arc::new(ProviderSecrets::load(&paths.secrets_cache));
+        // Enough scripts for a scale-up to come up: without them a case
+        // that scales would assert on a shortfall rather than the apply.
+        let scripts = vec![ProcScript::never_exits(); 4];
         let actor = Actor {
-            // Enough scripts for a scale-up to come up: without them a case
-            // that scales would assert on a shortfall rather than the apply.
-            runner: ScriptedRunner::new(vec![ProcScript::never_exits(); 4]),
-            paths,
-            events,
-            host_environment: DEFAULT_ENVIRONMENT.to_string(),
-            provider_secrets,
-            tx,
-            sheep,
-            next_id,
-            next_deadline: 0,
-            next_action_stamp: 0,
-            pending: Vec::new(),
-            shutting_down: false,
             extras: Some(extras),
-            registry: ExtrasRegistry::default(),
-            reloads: HashMap::new(),
-            smits: Smits::new(),
+            ..test_actor(paths, scripts, sheep, tx)
         };
         (actor, enforcer)
     }


### PR DESCRIPTION
Two CodeRabbit nitpicks from #167, deferred out of that PR at the time. One commit each.

- `SheepSlot::new(entry)` replaces 16 hand-written 13-field literals. Nine sites become one call, seven write only the fields they own over `..SheepSlot::new(entry)`
- `test_actor(paths, scripts, sheep, tx)` replaces seven copies of the same 16-field `Actor` literal in the tests, plus the bus and `ProviderSecrets::load` wiring ahead of each one
- `next_id` now comes from `sheep.len()`, which every fixture already matched by hand

`Default` does not work for the first one: `SheepSlot::entry` is a `ProcessEntry`, which has no `Default` of its own.

No behaviour change. fmt, clippy `-D warnings` and `cargo test --workspace --all-features` all exit 0, 3192 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized internal slot initialization across process spawning, reloading, and test scenarios.
  * Consolidated test actor setup for more consistent test execution.
  * Updated scaling tests to use multiple persistent test processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->