### PR TITLE
refactor(core): fold five copies of the store lock into one file_lock

### DIFF
--- a/crates/shep-core/src/barks.rs
+++ b/crates/shep-core/src/barks.rs
@@ -8,9 +8,10 @@
 //! any unparseable line, since this file is read during an incident.
 //!
 //! The two writers are separate OS processes, so a [`crate::file_lock`] on
-//! a sibling `<path>.lock` serializes them; shep-core, not shep-daemon, is
-//! where that lock belongs.
+//! a sibling `<path>.lock` serializes them.
 
+// The lock type lives in shep-core rather than shep-daemon so both writers
+// can name it.
 use core::fmt;
 use std::io::Write as _;
 use std::path::Path;

--- a/crates/shep-core/src/barks.rs
+++ b/crates/shep-core/src/barks.rs
@@ -7,15 +7,17 @@
 //! writer that dies mid-rewrite never leaves a fragment. [`read`] skips
 //! any unparseable line, since this file is read during an incident.
 //!
-//! The two writers are separate OS processes, so a shared advisory lock
-//! on a sibling `<path>.lock` serializes them; shep-core, not
-//! shep-daemon, is where that lock belongs.
+//! The two writers are separate OS processes, so a [`crate::file_lock`] on
+//! a sibling `<path>.lock` serializes them; shep-core, not shep-daemon, is
+//! where that lock belongs.
 
 use core::fmt;
 use std::io::Write as _;
 use std::path::Path;
 
 use serde::{Deserialize, Serialize};
+
+use crate::file_lock::FileLock;
 
 /// Cap the ring keeps itself under when nobody configured one.
 pub const DEFAULT_MAX_BYTES: u64 = 1024 * 1024;
@@ -121,7 +123,7 @@ impl From<serde_json::Error> for BarkError {
 pub fn append(path: &Path, bark: &Bark, max_bytes: u64) -> Result<(), BarkError> {
     // Held until this returns, so the read and the final rename are one
     // transaction as far as any other writer is concerned.
-    let _lock = RingLock::acquire(path)?;
+    let _lock = FileLock::acquire(path)?;
 
     let mut lines = read_lines(path)?;
     let new_line = serde_json::to_string(bark)?;
@@ -188,7 +190,7 @@ fn ring_bytes(lines: &[String]) -> u64 {
 ///
 /// The name is unique per call, not a fixed `<path>.tmp`: two writers
 /// racing on a shared name can have one `rename` consume the other's
-/// staging file. [`RingLock`] already keeps two appenders apart; this is
+/// staging file. [`FileLock`] already keeps two appenders apart; this is
 /// the second lock for a caller that reaches `write_ring` another way.
 fn write_ring(path: &Path, lines: &[String]) -> Result<(), BarkError> {
     let parent = path.parent().unwrap_or_else(|| Path::new("."));
@@ -209,118 +211,6 @@ fn write_ring(path: &Path, lines: &[String]) -> Result<(), BarkError> {
     // published them durable.
     crate::atomic_file::sync_dir(parent)?;
     Ok(())
-}
-
-/// An exclusive advisory lock over one bark ring, held for as long as the
-/// value lives and released when it drops, including on an early `?` or
-/// if the process dies holding it.
-///
-/// The lock is on a sibling `<path>.lock`, never on the ring itself:
-/// `append` replaces the ring's inode with every `rename`, so a lock on
-/// the ring itself would guard an inode the next append immediately
-/// unlinks, excluding nothing. The lock file is never renamed, rewritten,
-/// or read, and stays on disk between appends so both writers keep
-/// agreeing on which file it is.
-struct RingLock {
-    /// `flock(2)` is released by this handle's `Drop`. Named with a
-    /// leading underscore because it is held, never read.
-    #[cfg(unix)]
-    _flock: nix::fcntl::Flock<std::fs::File>,
-    /// The lock file, opened with `share_mode(0)` so no other handle,
-    /// same-process or not, can open it while this one is live. Released
-    /// by this handle's `Drop`, named with a leading underscore because
-    /// it is held, never read.
-    #[cfg(windows)]
-    _handle: std::fs::File,
-}
-
-impl RingLock {
-    /// Blocks until this process holds the ring's lock exclusively.
-    ///
-    /// # Errors
-    /// The lock file could not be created beside `path`, or `flock` failed
-    /// for a reason other than contention (contention blocks rather than
-    /// failing).
-    #[cfg(unix)]
-    fn acquire(path: &Path) -> std::io::Result<Self> {
-        use nix::fcntl::{Flock, FlockArg};
-        use std::os::unix::fs::OpenOptionsExt as _;
-
-        let file = std::fs::OpenOptions::new()
-            .write(true)
-            .create(true)
-            .truncate(false)
-            .mode(crate::atomic_file::OWNER_ONLY_FILE_MODE)
-            .open(lock_path(path))?;
-
-        // `LockExclusive` blocks; the non-blocking variant would need a
-        // retry loop and a deadline, and an append that waits its turn is
-        // exactly the behaviour wanted here.
-        Flock::lock(file, FlockArg::LockExclusive)
-            .map(|flock| Self { _flock: flock })
-            .map_err(|(_file, errno)| std::io::Error::from(errno))
-    }
-
-    /// Blocks until this process holds the ring's lock exclusively.
-    ///
-    /// `share_mode(0)` denies every other handle, same process or not,
-    /// while this one is live: an OS-enforced exclusivity rather than
-    /// `flock`'s advisory one. It gives no blocking wait, though: a
-    /// contended open fails at once with `ERROR_SHARING_VIOLATION`, so
-    /// this polls on a short sleep until it succeeds.
-    ///
-    /// # Errors
-    /// The lock file could not be created beside `path`, or the open failed
-    /// for a reason other than sharing contention.
-    #[cfg(windows)]
-    fn acquire(path: &Path) -> std::io::Result<Self> {
-        use std::os::windows::fs::OpenOptionsExt as _;
-
-        /// Windows' `ERROR_SHARING_VIOLATION`: another handle already holds
-        /// share access this open's `share_mode(0)` denies. Hardcoded
-        /// since this crate has no other Windows-only dependency.
-        const ERROR_SHARING_VIOLATION: i32 = 32;
-
-        /// How long a contended retry sleeps before trying again. Short
-        /// enough that a lock held for one `append`'s duration (a read, a
-        /// write, a rename) costs this loop only a few iterations, long
-        /// enough not to spin the CPU while it waits.
-        const RETRY_INTERVAL: std::time::Duration = std::time::Duration::from_millis(2);
-
-        let lock_path = lock_path(path);
-        loop {
-            match std::fs::OpenOptions::new()
-                .write(true)
-                .create(true)
-                .truncate(false)
-                .share_mode(0)
-                .open(&lock_path)
-            {
-                Ok(handle) => return Ok(Self { _handle: handle }),
-                Err(error) if error.raw_os_error() == Some(ERROR_SHARING_VIOLATION) => {
-                    std::thread::sleep(RETRY_INTERVAL);
-                }
-                Err(error) => return Err(error),
-            }
-        }
-    }
-}
-
-/// The lock file that guards `path`: its own name with `.lock` appended,
-/// so it sits in `$SHEP_HOME` next to the ring and inherits that
-/// directory's `0700`.
-///
-/// `cfg(any(unix, windows))`: [`RingLock::acquire`] locks it for real on
-/// both platforms, through `flock(2)` on unix and an exclusive
-/// `share_mode(0)` open on windows.
-#[cfg(any(unix, windows))]
-fn lock_path(path: &Path) -> std::path::PathBuf {
-    let mut name = path
-        .file_name()
-        .map(std::ffi::OsStr::to_os_string)
-        .unwrap_or_default();
-    name.push(".lock");
-    path.parent().unwrap_or_else(|| Path::new(".")).join(name)
 }
 
 #[cfg(test)]

--- a/crates/shep-core/src/config_lock.rs
+++ b/crates/shep-core/src/config_lock.rs
@@ -1,12 +1,9 @@
 //! The staging file a config is written through, and the old name for the
 //! lock its writers hold.
-//!
-//! Lives in `shep-core`, not `shep-cli`, because `dogs.toml` has a
-//! daemon-side writer and a type the daemon cannot name is a type it
-//! cannot hold. `shep-cli`'s three existing writers of `shep.toml` and
-//! `dogs.toml` keep using this one, imported back in through a
-//! `pub(super) use`.
 
+// In shep-core rather than shep-cli because `dogs.toml` has a daemon-side
+// writer, and a type the daemon cannot name is a type it cannot hold.
+// shep-cli's three writers import both back through a `pub(super) use`.
 use std::path::Path;
 
 /// The lock a config file's writers hold across their read-modify-write.

--- a/crates/shep-core/src/config_lock.rs
+++ b/crates/shep-core/src/config_lock.rs
@@ -1,31 +1,30 @@
-//! The exclusive advisory lock a config file's writers hold across their
-//! read-modify-write, and the staging file they write the new value
-//! through.
+//! The staging file a config is written through, and the old name for the
+//! lock its writers hold.
 //!
-//! Lives in `shep-core`, not `shep-cli`, because `dogs.toml` is gaining a
+//! Lives in `shep-core`, not `shep-cli`, because `dogs.toml` has a
 //! daemon-side writer and a type the daemon cannot name is a type it
 //! cannot hold. `shep-cli`'s three existing writers of `shep.toml` and
 //! `dogs.toml` keep using this one, imported back in through a
 //! `pub(super) use`.
-//!
-//! Deliberately not consolidated with [`crate::overrides`]'s own
-//! `OverridesLock`, which is the same `flock(2)`/`share_mode(0)` shape
-//! against a different lock file. The two crates that hold a [`ConfigLock`]
-//! already agree on its ordering (`shep.toml` outer, `dogs.toml` inner, per
-//! `dog_migration.rs`'s own header), and unifying the two lock types is a
-//! separate, later change.
 
-use std::path::{Path, PathBuf};
+use std::path::Path;
+
+/// The lock a config file's writers hold across their read-modify-write.
+///
+/// The old name for [`crate::file_lock::FileLock`], which every store
+/// under `$SHEP_HOME` now takes. Kept so a caller that named the lock
+/// through this module keeps compiling.
+pub use crate::file_lock::FileLock as ConfigLock;
 
 /// Creates the staging file a config is written through, in `parent` so
 /// the later `rename` stays within one filesystem.
 ///
 /// The create-at-mode reasoning lives with
-/// [`crate::atomic_file::create_staging_file`], which four stores now
-/// share. What is left here is the pair of names, and this wrapper is
-/// where they stay: `commands::dog_migration` writes `dogs.toml` through
-/// the same staging name as `shep.toml`, and two call sites spelling that
-/// pair out separately is how the two would drift.
+/// [`crate::atomic_file::create_staging_file`], which every store shares.
+/// What is left here is the pair of names, and this wrapper is where they
+/// stay: `commands::dog_migration` writes `dogs.toml` through the same
+/// staging name as `shep.toml`, and two call sites spelling that pair out
+/// separately is how the two would drift.
 ///
 /// # Errors
 /// The staging file could not be created in `parent`.
@@ -33,146 +32,9 @@ pub fn create_config_file(parent: &Path) -> std::io::Result<tempfile::NamedTempF
     crate::atomic_file::create_staging_file(parent, "shep", ".toml.tmp")
 }
 
-/// An exclusive advisory lock over one config file, held for as long as
-/// the value lives and released when it drops (including on an early `?`,
-/// and by the kernel if the process dies holding it).
-///
-/// Keyed on the path it is given rather than on `shep.toml` specifically:
-/// `shep-cli`'s `ShepToml::edit` takes one over `shep.toml`, and
-/// `commands::dog_migration` takes one over `dogs.toml`, which has two
-/// writers of its own. Whenever both are held at once, `shep.toml`'s is
-/// taken first, which is the whole of what keeps the two orderings from
-/// deadlocking; `migrate_dog_sections` is the one caller that holds both,
-/// and it says so at the point it nests them.
-///
-/// The lock is on a sibling `<name>.lock`, never on the config itself,
-/// and that is the whole design decision, the same one `barks::RingLock`
-/// records: `ShepToml::save` finishes by `rename`ing a new file over the
-/// config, which replaces the inode. A lock taken on the config would be a
-/// lock on an inode the very next successful save unlinks; the next writer
-/// would open the *new* inode, find it unlocked, and the two would be
-/// excluding nothing. The lock file is never renamed, never rewritten and
-/// never read; it exists only to be an inode with a stable identity, and
-/// it is left on disk between edits on purpose so both writers keep
-/// agreeing on which one it is.
-///
-/// Derives `Debug` rather than opting out: the fields are a held OS lock
-/// handle (a `flock(2)` wrapper on unix, a bare `File` on Windows), never a
-/// secret, so there is nothing here for a redacted impl to protect.
-#[derive(Debug)]
-pub struct ConfigLock {
-    /// `flock(2)` is released by this handle's `Drop`. Named with a
-    /// leading underscore because it is held, never read.
-    #[cfg(unix)]
-    _flock: nix::fcntl::Flock<std::fs::File>,
-    /// The lock file, opened with `share_mode(0)`. The same primitive and
-    /// the same sibling-file shape [`crate::kv`] and [`crate::barks`] use;
-    /// see either for the full argument.
-    #[cfg(windows)]
-    _handle: std::fs::File,
-}
-
-impl ConfigLock {
-    /// Blocks until this process holds `path`'s lock exclusively.
-    ///
-    /// # Errors
-    /// The single open that creates the lock file beside `path` and takes
-    /// exclusive share access on it failed for a reason other than
-    /// contention. A sharing violation is retried, not returned.
-    #[cfg(windows)]
-    pub fn acquire(path: &Path) -> std::io::Result<Self> {
-        use std::os::windows::fs::OpenOptionsExt as _;
-
-        /// Another handle already holds share access this open denies.
-        const ERROR_SHARING_VIOLATION: i32 = 32;
-        /// How long a contended retry sleeps. The unix arm blocks in the
-        /// kernel; this polls, for the reason `shep_core::kv` documents.
-        const RETRY_INTERVAL: std::time::Duration = std::time::Duration::from_millis(2);
-
-        let lock_path = lock_path(path);
-        loop {
-            match std::fs::OpenOptions::new()
-                .write(true)
-                .create(true)
-                .truncate(false)
-                .share_mode(0)
-                .open(&lock_path)
-            {
-                Ok(handle) => return Ok(Self { _handle: handle }),
-                Err(error) if error.raw_os_error() == Some(ERROR_SHARING_VIOLATION) => {
-                    std::thread::sleep(RETRY_INTERVAL);
-                }
-                Err(error) => return Err(error),
-            }
-        }
-    }
-
-    /// Blocks until this process holds `path`'s lock exclusively.
-    ///
-    /// # Errors
-    /// The lock file could not be created beside `path`, or `flock` failed
-    /// for a reason other than contention (contention blocks rather than
-    /// failing).
-    #[cfg(unix)]
-    pub fn acquire(path: &Path) -> std::io::Result<Self> {
-        use std::os::unix::fs::OpenOptionsExt as _;
-
-        use nix::fcntl::{Flock, FlockArg};
-
-        let file = std::fs::OpenOptions::new()
-            .write(true)
-            .create(true)
-            .truncate(false)
-            .mode(crate::atomic_file::OWNER_ONLY_FILE_MODE)
-            .open(lock_path(path))?;
-
-        // `LockExclusive` blocks; the non-blocking variant would need a
-        // retry loop and a deadline, and a `shep enable` that waits its
-        // turn behind a concurrent `shep adopt` is exactly the behaviour
-        // wanted here.
-        Flock::lock(file, FlockArg::LockExclusive)
-            .map(|flock| Self { _flock: flock })
-            .map_err(|(_file, errno)| std::io::Error::from(errno))
-    }
-}
-
-/// The lock file that guards `path`: its own name with `.lock` appended,
-/// so it sits in `$SHEP_HOME` next to the config and inherits that
-/// directory's `0700`.
-fn lock_path(path: &Path) -> PathBuf {
-    let mut name = path
-        .file_name()
-        .map(std::ffi::OsStr::to_os_string)
-        .unwrap_or_default();
-    name.push(".lock");
-    path.parent().unwrap_or_else(|| Path::new(".")).join(name)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn a_second_acquire_on_the_same_path_blocks_until_the_first_drops() {
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("dogs.toml");
-        let first = ConfigLock::acquire(&path).unwrap();
-        let path2 = path.clone();
-        let (tx, rx) = std::sync::mpsc::channel();
-        let t = std::thread::spawn(move || {
-            let _second = ConfigLock::acquire(&path2).unwrap();
-            tx.send(()).unwrap();
-        });
-        assert!(
-            rx.recv_timeout(std::time::Duration::from_millis(200))
-                .is_err(),
-            "must block"
-        );
-        drop(first);
-        rx.recv_timeout(std::time::Duration::from_secs(5))
-            .expect("must proceed once released");
-        t.join().unwrap();
-    }
 
     #[test]
     fn a_staged_config_file_is_owner_only_named_for_the_pair_and_lands_where_asked() {

--- a/crates/shep-core/src/file_lock.rs
+++ b/crates/shep-core/src/file_lock.rs
@@ -1,0 +1,173 @@
+//! One exclusive advisory lock, keyed on the file it guards.
+//!
+//! Every store under `$SHEP_HOME` that publishes a new value by `rename`
+//! holds this across its whole read-modify-write: `kv.json`,
+//! `overrides.json`, `secrets.json`, `barks.jsonl`, `shep.toml` and
+//! `dogs.toml`. `flock(2)` on unix, an exclusive `share_mode(0)` open on
+//! Windows.
+//!
+//! Separate from [`crate::atomic_file`], which is the replace itself. This
+//! is what keeps two of those replaces apart, and it is held across reads
+//! the replace never sees.
+
+use std::path::{Path, PathBuf};
+
+/// An exclusive advisory lock over one file, held for as long as the value
+/// lives and released when it drops, including on an early `?` and by the
+/// kernel if the process dies holding it.
+///
+/// The lock is on a sibling `<name>.lock`, never on the guarded file
+/// itself, and that is the whole design decision: a store finishes its
+/// write by `rename`ing a new file over the old one, which replaces the
+/// inode. A lock on the store would guard an inode the next successful
+/// write unlinks, and the writer after that would open the new inode, find
+/// it unlocked, and exclude nothing. The lock file is never renamed,
+/// rewritten or read; it is an inode with a stable identity, left on disk
+/// between writes so every writer keeps agreeing on which one it is.
+///
+/// Two are held at once only over `shep.toml` and `dogs.toml`, in that
+/// order, which is what keeps the callers that nest them from deadlocking;
+/// `commands::dog_migration` says so where it nests them.
+///
+/// Derives `Debug`: the fields are a held OS lock handle (a `flock(2)`
+/// wrapper on unix, a bare `File` on Windows), never a secret.
+#[derive(Debug)]
+pub struct FileLock {
+    /// `flock(2)` is released by this handle's `Drop`. Named with a
+    /// leading underscore because it is held, never read.
+    #[cfg(unix)]
+    _flock: nix::fcntl::Flock<std::fs::File>,
+    /// The lock file, opened with `share_mode(0)` so no other handle,
+    /// same-process or not, can open it while this one is live. Released
+    /// by `Drop`, the same role `_flock` plays on unix, and named with a
+    /// leading underscore for the same reason.
+    #[cfg(windows)]
+    _handle: std::fs::File,
+}
+
+impl FileLock {
+    /// Blocks until this process holds `path`'s lock exclusively.
+    ///
+    /// # Errors
+    /// The lock file could not be created beside `path`, or `flock` failed
+    /// for a reason other than contention (contention blocks rather than
+    /// failing).
+    #[cfg(unix)]
+    pub fn acquire(path: &Path) -> std::io::Result<Self> {
+        use std::os::unix::fs::OpenOptionsExt as _;
+
+        use nix::fcntl::{Flock, FlockArg};
+
+        let file = std::fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .mode(crate::atomic_file::OWNER_ONLY_FILE_MODE)
+            .open(lock_path(path))?;
+
+        // `LockExclusive` blocks; the non-blocking variant would need a
+        // retry loop and a deadline, and a writer that waits its turn
+        // behind another is exactly the behaviour wanted here.
+        Flock::lock(file, FlockArg::LockExclusive)
+            .map(|flock| Self { _flock: flock })
+            .map_err(|(_file, errno)| std::io::Error::from(errno))
+    }
+
+    /// Blocks until this process holds `path`'s lock exclusively.
+    ///
+    /// `share_mode(0)` denies every other open, in this process or another,
+    /// giving the same exclusivity as unix `flock` through a different
+    /// door. It gives no blocking wait, though: a contended open fails at
+    /// once with `ERROR_SHARING_VIOLATION`, so this polls on a short sleep
+    /// until it succeeds.
+    ///
+    /// # Errors
+    /// The lock file could not be created beside `path`, or the open failed
+    /// for a reason other than sharing contention (contention retries
+    /// rather than failing).
+    #[cfg(windows)]
+    pub fn acquire(path: &Path) -> std::io::Result<Self> {
+        use std::os::windows::fs::OpenOptionsExt as _;
+
+        /// Windows' `ERROR_SHARING_VIOLATION`: another handle already holds
+        /// share access this open's `share_mode(0)` denies. Hardcoded
+        /// rather than pulled from `windows-sys`, since this crate has no
+        /// other Windows-only dependency.
+        const ERROR_SHARING_VIOLATION: i32 = 32;
+
+        /// How long a contended retry sleeps before trying again. Short
+        /// enough that a lock held for one write's duration (a handful of
+        /// small file operations) costs this loop only a few iterations,
+        /// long enough not to spin the CPU while it waits.
+        const RETRY_INTERVAL: std::time::Duration = std::time::Duration::from_millis(2);
+
+        let lock_path = lock_path(path);
+        loop {
+            match std::fs::OpenOptions::new()
+                .write(true)
+                .create(true)
+                .truncate(false)
+                .share_mode(0)
+                .open(&lock_path)
+            {
+                Ok(handle) => return Ok(Self { _handle: handle }),
+                Err(error) if error.raw_os_error() == Some(ERROR_SHARING_VIOLATION) => {
+                    std::thread::sleep(RETRY_INTERVAL);
+                }
+                Err(error) => return Err(error),
+            }
+        }
+    }
+}
+
+/// The lock file that guards `path`: its own name with `.lock` appended, so
+/// it sits in `$SHEP_HOME` next to the file it guards and inherits that
+/// directory's `0700`.
+fn lock_path(path: &Path) -> PathBuf {
+    let mut name = path
+        .file_name()
+        .map(std::ffi::OsStr::to_os_string)
+        .unwrap_or_default();
+    name.push(".lock");
+    path.parent().unwrap_or_else(|| Path::new(".")).join(name)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_lock_file_is_a_sibling_of_the_file_it_guards() {
+        let path = Path::new("/var/lib/shep/kv.json");
+        assert_eq!(lock_path(path), Path::new("/var/lib/shep/kv.json.lock"));
+    }
+
+    #[test]
+    fn a_second_acquire_on_the_same_path_blocks_until_the_first_drops() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("dogs.toml");
+        let first = FileLock::acquire(&path).unwrap();
+        let path2 = path.clone();
+        let (tx, rx) = std::sync::mpsc::channel();
+        let t = std::thread::spawn(move || {
+            let _second = FileLock::acquire(&path2).unwrap();
+            tx.send(()).unwrap();
+        });
+        assert!(
+            rx.recv_timeout(std::time::Duration::from_millis(200))
+                .is_err(),
+            "must block"
+        );
+        drop(first);
+        rx.recv_timeout(std::time::Duration::from_secs(5))
+            .expect("must proceed once released");
+        t.join().unwrap();
+    }
+
+    #[test]
+    fn two_different_paths_do_not_exclude_each_other() {
+        let dir = tempfile::tempdir().unwrap();
+        let _kv = FileLock::acquire(&dir.path().join("kv.json")).unwrap();
+        let _secrets = FileLock::acquire(&dir.path().join("secrets.json")).unwrap();
+    }
+}

--- a/crates/shep-core/src/kv.rs
+++ b/crates/shep-core/src/kv.rs
@@ -4,9 +4,9 @@
 //! and dog runtime tweaks. Not the primary config path: a Flockfile
 //! configures a sheep, `shep.toml` the shepherd and its dogs. A file rather
 //! than an RPC, so `shep set`/`get`/`unset` work with no shepherd running.
-//! Every mutation is a read-modify-rename under an exclusive lock on a
-//! sibling `kv.json.lock`, staged through a temp file: the same shape
-//! `barks::append` uses, so do not reimplement it here.
+//! Every mutation is a read-modify-rename under a [`crate::file_lock`] on
+//! a sibling `kv.json.lock`, staged through a temp file: the same shape
+//! every other store uses, so do not reimplement it here.
 //!
 //! Keys match `[A-Za-z0-9._-]`, 1 to [`MAX_KEY_BYTES`], not starting with
 //! `.`; a dot is part of a key's name, not a path.
@@ -15,12 +15,10 @@ use core::fmt;
 use std::collections::BTreeMap;
 use std::io::Write as _;
 use std::path::Path;
-// `PathBuf` backs `lock_path` below, gated the same way for both platform
-// arms of `KvLock`.
-#[cfg(any(unix, windows))]
-use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
+
+use crate::file_lock::FileLock;
 
 /// The on-disk format's version.
 ///
@@ -143,111 +141,6 @@ fn check_key(key: &str) -> Result<(), KvError> {
     }
 }
 
-/// The lock file that guards `path`: its own name with `.lock` appended, so
-/// it sits in `$SHEP_HOME` next to the store and inherits that directory's
-/// `0700`.
-///
-/// `cfg(any(unix, windows))` alongside its two callers: [`KvLock::acquire`]
-/// names a real lock file on both platforms now, unix through `flock(2)` and
-/// windows through an exclusive `share_mode(0)` open.
-#[cfg(any(unix, windows))]
-fn lock_path(path: &Path) -> PathBuf {
-    let mut name = path
-        .file_name()
-        .map(std::ffi::OsStr::to_os_string)
-        .unwrap_or_default();
-    name.push(".lock");
-    path.parent().unwrap_or_else(|| Path::new(".")).join(name)
-}
-
-/// An exclusive advisory lock over one kv store, released when it drops,
-/// including by the kernel if the process dies holding it.
-///
-/// On a sibling `kv.json.lock`, never on the store itself: `rename`
-/// replaces the store's inode, which would orphan a lock held on it.
-struct KvLock {
-    /// `flock(2)` is released by this handle's `Drop`. Named with a leading
-    /// underscore because it is held, never read.
-    #[cfg(unix)]
-    _flock: nix::fcntl::Flock<std::fs::File>,
-    /// The lock file, opened with `share_mode(0)` so no other handle can
-    /// open it while this one is live; released by `Drop`, the same role
-    /// `_flock` plays on unix. Named with a leading underscore because it
-    /// is held, never read.
-    #[cfg(windows)]
-    _handle: std::fs::File,
-}
-
-impl KvLock {
-    /// Blocks until this process holds the store's lock exclusively.
-    ///
-    /// # Errors
-    /// The lock file could not be created beside `path`, or `flock` failed
-    /// for a reason other than contention (contention blocks rather than
-    /// failing).
-    #[cfg(unix)]
-    fn acquire(path: &Path) -> std::io::Result<Self> {
-        use nix::fcntl::{Flock, FlockArg};
-        use std::os::unix::fs::OpenOptionsExt as _;
-
-        let file = std::fs::OpenOptions::new()
-            .write(true)
-            .create(true)
-            .truncate(false)
-            .mode(crate::atomic_file::OWNER_ONLY_FILE_MODE)
-            .open(lock_path(path))?;
-
-        Flock::lock(file, FlockArg::LockExclusive)
-            .map(|flock| Self { _flock: flock })
-            .map_err(|(_file, errno)| std::io::Error::from(errno))
-    }
-
-    /// Blocks until this process holds the store's lock exclusively.
-    ///
-    /// `share_mode(0)` denies every other open, in this process or another,
-    /// giving the same exclusivity as unix `flock`. A contended open fails
-    /// immediately with `ERROR_SHARING_VIOLATION` rather than blocking, so
-    /// this polls on a short sleep until it succeeds.
-    ///
-    /// # Errors
-    /// The lock file could not be created beside `path`, or the open failed
-    /// for a reason other than sharing contention (contention retries rather
-    /// than failing).
-    #[cfg(windows)]
-    fn acquire(path: &Path) -> std::io::Result<Self> {
-        use std::os::windows::fs::OpenOptionsExt as _;
-
-        /// Windows' `ERROR_SHARING_VIOLATION`: another handle already holds
-        /// share access this open's `share_mode(0)` denies. Hardcoded rather
-        /// than pulled from `windows-sys`, since this crate has no other
-        /// Windows-only dependency.
-        const ERROR_SHARING_VIOLATION: i32 = 32;
-
-        /// How long a contended retry sleeps before trying again. Short
-        /// enough that a lock held for a normal `set`/`get`'s duration (a
-        /// handful of small file operations) costs this loop only a few
-        /// iterations, long enough not to spin the CPU while it waits.
-        const RETRY_INTERVAL: std::time::Duration = std::time::Duration::from_millis(2);
-
-        let lock_path = lock_path(path);
-        loop {
-            match std::fs::OpenOptions::new()
-                .write(true)
-                .create(true)
-                .truncate(false)
-                .share_mode(0)
-                .open(&lock_path)
-            {
-                Ok(handle) => return Ok(Self { _handle: handle }),
-                Err(error) if error.raw_os_error() == Some(ERROR_SHARING_VIOLATION) => {
-                    std::thread::sleep(RETRY_INTERVAL);
-                }
-                Err(error) => return Err(error),
-            }
-        }
-    }
-}
-
 /// Reads `path` under the lock the caller already holds.
 ///
 /// A missing file reads as an empty, current-version store: `shep get`
@@ -300,7 +193,7 @@ fn write_file(path: &Path, file: &KvFile) -> Result<(), KvError> {
 pub fn all(path: &Path) -> Result<BTreeMap<String, String>, KvError> {
     // Taking the lock here too costs one extra `open`, but it orders this
     // read against `set`/`unset`'s read-modify-rename instead of racing it.
-    let _lock = KvLock::acquire(path)?;
+    let _lock = FileLock::acquire(path)?;
     Ok(read_file(path)?.entries)
 }
 
@@ -336,7 +229,7 @@ pub fn set(path: &Path, key: &str, value: &str) -> Result<(), KvError> {
         });
     }
 
-    let _lock = KvLock::acquire(path)?;
+    let _lock = FileLock::acquire(path)?;
     let mut file = read_file(path)?;
     file.version = KV_VERSION;
     file.entries.insert(key.to_string(), value.to_string());
@@ -352,7 +245,7 @@ pub fn set(path: &Path, key: &str, value: &str) -> Result<(), KvError> {
 pub fn unset(path: &Path, key: &str) -> Result<bool, KvError> {
     check_key(key)?;
 
-    let _lock = KvLock::acquire(path)?;
+    let _lock = FileLock::acquire(path)?;
     let mut file = read_file(path)?;
     let was_present = file.entries.remove(key).is_some();
     if was_present {
@@ -370,7 +263,7 @@ pub fn unset(path: &Path, key: &str) -> Result<bool, KvError> {
 /// store that does not exist clears to `0` rather than failing: `shep unset
 /// --all` on a fresh machine is a success that removed nothing.
 pub fn clear(path: &Path) -> Result<u32, KvError> {
-    let _lock = KvLock::acquire(path)?;
+    let _lock = FileLock::acquire(path)?;
     let file = read_file(path)?;
     let count = u32::try_from(file.entries.len()).unwrap_or(u32::MAX);
     if count > 0 {

--- a/crates/shep-core/src/kv.rs
+++ b/crates/shep-core/src/kv.rs
@@ -5,12 +5,13 @@
 //! configures a sheep, `shep.toml` the shepherd and its dogs. A file rather
 //! than an RPC, so `shep set`/`get`/`unset` work with no shepherd running.
 //! Every mutation is a read-modify-rename under a [`crate::file_lock`] on
-//! a sibling `kv.json.lock`, staged through a temp file: the same shape
-//! every other store uses, so do not reimplement it here.
+//! a sibling `kv.json.lock`, staged through a temp file.
 //!
 //! Keys match `[A-Za-z0-9._-]`, 1 to [`MAX_KEY_BYTES`], not starting with
 //! `.`; a dot is part of a key's name, not a path.
 
+// Every store writes through this same shape. Take `file_lock` and
+// `atomic_file` rather than open-coding another copy here.
 use core::fmt;
 use std::collections::BTreeMap;
 use std::io::Write as _;

--- a/crates/shep-core/src/lib.rs
+++ b/crates/shep-core/src/lib.rs
@@ -25,14 +25,16 @@
 pub mod atomic_file;
 pub mod barks;
 pub mod config;
-// The lock a config file's writers hold across their read-modify-write, and
-// the staging file they write through. Lives here rather than in shep-cli
-// (where it was born) so shep-daemon can hold it too, once it starts writing
-// `dogs.toml`.
+// The staging file `shep.toml` and `dogs.toml` are written through, and the
+// old name for the lock their writers hold. Lives here rather than in
+// shep-cli (where it was born) so shep-daemon can hold it too.
 pub mod config_lock;
 // The probe contract both sides of a dog's `--version`/`--schema` answer
 // parse: flag names, the answer grammar, the schema's secret marker key.
 pub mod dogs;
+// One advisory lock, keyed on the file it guards. Every store that
+// publishes a new value by `rename` holds it across the whole cycle.
+pub mod file_lock;
 pub mod kv;
 // One definition of the log-line timestamp for the writer and every reader:
 // the daemon stamps, and three different file readers in shep-cli strip.

--- a/crates/shep-core/src/overrides.rs
+++ b/crates/shep-core/src/overrides.rs
@@ -7,20 +7,17 @@
 //! declare. A load merges the two: declared keys win, then the override,
 //! then the built-in default.
 //!
-//! Same on-disk shape as [`crate::kv`]: a read-modify-rename under an
-//! exclusive lock on a sibling `overrides.json.lock`, copied rather than
-//! shared since `KvLock` is private to its module.
+//! Same on-disk shape as [`crate::kv`]: a read-modify-rename under a
+//! [`crate::file_lock`] on a sibling `overrides.json.lock`.
 
 use core::fmt;
 use std::collections::{BTreeMap, BTreeSet};
 use std::io::Write as _;
 use std::path::Path;
-// `PathBuf` backs `lock_path` below, gated the same way for both platform
-// arms of `OverridesLock`.
-#[cfg(any(unix, windows))]
-use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
+
+use crate::file_lock::FileLock;
 
 /// The on-disk format's version.
 ///
@@ -132,110 +129,6 @@ impl From<serde_json::Error> for OverridesError {
     }
 }
 
-/// The lock file that guards `path`: its own name with `.lock` appended, so
-/// it sits in `$SHEP_HOME` next to the store and inherits that directory's
-/// `0700`.
-///
-/// Copied from `kv::lock_path`: see that module's doc for why a sibling
-/// file rather than a lock on the store itself.
-#[cfg(any(unix, windows))]
-fn lock_path(path: &Path) -> PathBuf {
-    let mut name = path
-        .file_name()
-        .map(std::ffi::OsStr::to_os_string)
-        .unwrap_or_default();
-    name.push(".lock");
-    path.parent().unwrap_or_else(|| Path::new(".")).join(name)
-}
-
-/// An exclusive advisory lock over one overrides store, released when it
-/// drops.
-///
-/// Mirrors `kv::KvLock`: a lock on a sibling `overrides.json.lock`, never
-/// on the store itself.
-struct OverridesLock {
-    /// `flock(2)` is released by this handle's `Drop`. Named with a leading
-    /// underscore because it is held, never read.
-    #[cfg(unix)]
-    _flock: nix::fcntl::Flock<std::fs::File>,
-    /// The lock file, opened with `share_mode(0)` so no other handle,
-    /// same-process or not, read or write, can open it while this one is
-    /// live. Released by this handle's `Drop`, the same role `_flock` plays
-    /// on unix. Named with a leading underscore because it is held, never
-    /// read.
-    #[cfg(windows)]
-    _handle: std::fs::File,
-}
-
-impl OverridesLock {
-    /// Blocks until this process holds the store's lock exclusively.
-    ///
-    /// # Errors
-    /// The lock file could not be created beside `path`, or `flock` failed
-    /// for a reason other than contention (contention blocks rather than
-    /// failing).
-    #[cfg(unix)]
-    fn acquire(path: &Path) -> std::io::Result<Self> {
-        use nix::fcntl::{Flock, FlockArg};
-        use std::os::unix::fs::OpenOptionsExt as _;
-
-        let file = std::fs::OpenOptions::new()
-            .write(true)
-            .create(true)
-            .truncate(false)
-            .mode(crate::atomic_file::OWNER_ONLY_FILE_MODE)
-            .open(lock_path(path))?;
-
-        Flock::lock(file, FlockArg::LockExclusive)
-            .map(|flock| Self { _flock: flock })
-            .map_err(|(_file, errno)| std::io::Error::from(errno))
-    }
-
-    /// Blocks until this process holds the store's lock exclusively.
-    ///
-    /// `flock(2)` has no Windows equivalent, but `share_mode(0)` gives the
-    /// same exclusivity through a different door: see `kv::KvLock::acquire`
-    /// (windows) for the full reasoning this mirrors, including why it polls
-    /// on a short sleep rather than blocking.
-    ///
-    /// # Errors
-    /// The lock file could not be created beside `path`, or the open failed
-    /// for a reason other than sharing contention (contention retries rather
-    /// than failing).
-    #[cfg(windows)]
-    fn acquire(path: &Path) -> std::io::Result<Self> {
-        use std::os::windows::fs::OpenOptionsExt as _;
-
-        /// Windows' `ERROR_SHARING_VIOLATION`: another handle already holds
-        /// share access this open's `share_mode(0)` denies. Hardcoded rather
-        /// than pulled from `windows-sys`, matching `kv::KvLock::acquire`.
-        const ERROR_SHARING_VIOLATION: i32 = 32;
-
-        /// How long a contended retry sleeps before trying again. Short
-        /// enough that a lock held for a normal `put`/`get`'s duration (a
-        /// handful of small file operations) costs this loop only a few
-        /// iterations, long enough not to spin the CPU while it waits.
-        const RETRY_INTERVAL: std::time::Duration = std::time::Duration::from_millis(2);
-
-        let lock_path = lock_path(path);
-        loop {
-            match std::fs::OpenOptions::new()
-                .write(true)
-                .create(true)
-                .truncate(false)
-                .share_mode(0)
-                .open(&lock_path)
-            {
-                Ok(handle) => return Ok(Self { _handle: handle }),
-                Err(error) if error.raw_os_error() == Some(ERROR_SHARING_VIOLATION) => {
-                    std::thread::sleep(RETRY_INTERVAL);
-                }
-                Err(error) => return Err(error),
-            }
-        }
-    }
-}
-
 /// Reads `path` under the lock the caller already holds.
 ///
 /// A missing file reads as an empty, current-version store: a fresh
@@ -292,7 +185,7 @@ fn write_file(path: &Path, file: &OverridesFile) -> Result<(), OverridesError> {
 pub fn all(path: &Path) -> Result<BTreeMap<String, AppOverrides>, OverridesError> {
     // Taking the lock here too costs one extra `open`, but it orders this
     // read against a writer's read-modify-rename instead of racing it.
-    let _lock = OverridesLock::acquire(path)?;
+    let _lock = FileLock::acquire(path)?;
     Ok(read_file(path)?.apps)
 }
 
@@ -316,7 +209,7 @@ pub fn get(path: &Path, name: &str) -> Result<Option<AppOverrides>, OverridesErr
 /// - [`OverridesError::Io`]: the lock, the temp file, the `fsync` or the
 ///   `rename` failed.
 pub fn put(path: &Path, name: &str, value: &AppOverrides) -> Result<(), OverridesError> {
-    let _lock = OverridesLock::acquire(path)?;
+    let _lock = FileLock::acquire(path)?;
     let mut file = read_file(path)?;
     file.version = OVERRIDES_VERSION;
     file.apps.insert(name.to_string(), value.clone());
@@ -329,7 +222,7 @@ pub fn put(path: &Path, name: &str, value: &AppOverrides) -> Result<(), Override
 ///
 /// The same set [`put`] returns: `FutureVersion`, `Decode`, `Io`.
 pub fn remove(path: &Path, name: &str) -> Result<bool, OverridesError> {
-    let _lock = OverridesLock::acquire(path)?;
+    let _lock = FileLock::acquire(path)?;
     let mut file = read_file(path)?;
     let was_present = file.apps.remove(name).is_some();
     if was_present {
@@ -358,7 +251,7 @@ pub fn update(
     if changes.is_empty() {
         return Ok(());
     }
-    let _lock = OverridesLock::acquire(path)?;
+    let _lock = FileLock::acquire(path)?;
     let mut file = read_file(path)?;
     for (name, change) in changes {
         match change {

--- a/crates/shep-core/src/secrets.rs
+++ b/crates/shep-core/src/secrets.rs
@@ -5,23 +5,19 @@
 //! through [`SecretView`], which reads the sheep's own environment and then
 //! [`ALL_ENVIRONMENTS`], never another named environment.
 //!
-//! Same on-disk shape as [`crate::kv`]: a read-modify-rename under an
-//! exclusive lock on a sibling `secrets.json.lock`, copied rather than
-//! shared since `KvLock` is private to its module.
+//! Same on-disk shape as [`crate::kv`]: a read-modify-rename under a
+//! [`crate::file_lock`] on a sibling `secrets.json.lock`.
 
 use core::fmt;
 use std::collections::{BTreeMap, BTreeSet};
 use std::io::Write as _;
 use std::path::Path;
-// `PathBuf` backs `lock_path` below, gated the same way for both platform
-// arms of `SecretLock`.
-#[cfg(any(unix, windows))]
-use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
 
 use crate::config::AppConfig;
 use crate::config::template;
+use crate::file_lock::FileLock;
 
 /// The on-disk format's version.
 ///
@@ -196,111 +192,6 @@ fn check_environment(environment: &str) -> Result<(), SecretError> {
     }
 }
 
-/// The lock file that guards `path`: its own name with `.lock` appended, so
-/// it sits in `$SHEP_HOME` next to the store and inherits that directory's
-/// `0700`.
-///
-/// `cfg(any(unix, windows))` alongside its two callers: [`SecretLock::acquire`]
-/// names a real lock file on both platforms, unix through `flock(2)` and
-/// windows through an exclusive `share_mode(0)` open.
-#[cfg(any(unix, windows))]
-fn lock_path(path: &Path) -> PathBuf {
-    let mut name = path
-        .file_name()
-        .map(std::ffi::OsStr::to_os_string)
-        .unwrap_or_default();
-    name.push(".lock");
-    path.parent().unwrap_or_else(|| Path::new(".")).join(name)
-}
-
-/// An exclusive advisory lock over one secret store, released when it drops,
-/// including by the kernel if the process dies holding it.
-///
-/// On a sibling `secrets.json.lock`, never on the store itself: `rename`
-/// replaces the store's inode, which would orphan a lock held on it.
-struct SecretLock {
-    /// `flock(2)` is released by this handle's `Drop`. Named with a leading
-    /// underscore because it is held, never read.
-    #[cfg(unix)]
-    _flock: nix::fcntl::Flock<std::fs::File>,
-    /// The lock file, opened with `share_mode(0)` so no other handle can
-    /// open it while this one is live; released by `Drop`, the same role
-    /// `_flock` plays on unix. Named with a leading underscore because it
-    /// is held, never read.
-    #[cfg(windows)]
-    _handle: std::fs::File,
-}
-
-impl SecretLock {
-    /// Blocks until this process holds the store's lock exclusively.
-    ///
-    /// # Errors
-    /// The lock file could not be created beside `path`, or `flock` failed
-    /// for a reason other than contention (contention blocks rather than
-    /// failing).
-    #[cfg(unix)]
-    fn acquire(path: &Path) -> std::io::Result<Self> {
-        use nix::fcntl::{Flock, FlockArg};
-        use std::os::unix::fs::OpenOptionsExt as _;
-
-        let file = std::fs::OpenOptions::new()
-            .write(true)
-            .create(true)
-            .truncate(false)
-            .mode(crate::atomic_file::OWNER_ONLY_FILE_MODE)
-            .open(lock_path(path))?;
-
-        Flock::lock(file, FlockArg::LockExclusive)
-            .map(|flock| Self { _flock: flock })
-            .map_err(|(_file, errno)| std::io::Error::from(errno))
-    }
-
-    /// Blocks until this process holds the store's lock exclusively.
-    ///
-    /// `share_mode(0)` denies every other open, in this process or another,
-    /// giving the same exclusivity as unix `flock`. A contended open fails
-    /// immediately with `ERROR_SHARING_VIOLATION` rather than blocking, so
-    /// this polls on a short sleep until it succeeds.
-    ///
-    /// # Errors
-    /// The lock file could not be created beside `path`, or the open failed
-    /// for a reason other than sharing contention (contention retries rather
-    /// than failing).
-    #[cfg(windows)]
-    fn acquire(path: &Path) -> std::io::Result<Self> {
-        use std::os::windows::fs::OpenOptionsExt as _;
-
-        /// Windows' `ERROR_SHARING_VIOLATION`: another handle already holds
-        /// share access this open's `share_mode(0)` denies. Hardcoded rather
-        /// than pulled from `windows-sys`, since this crate has no other
-        /// Windows-only dependency.
-        const ERROR_SHARING_VIOLATION: i32 = 32;
-
-        /// How long a contended retry sleeps before trying again. Short
-        /// enough that a lock held for a normal `set`/`unset`'s duration (a
-        /// handful of small file operations) costs this loop only a few
-        /// iterations, long enough not to spin the CPU while it waits.
-        const RETRY_INTERVAL: std::time::Duration = std::time::Duration::from_millis(2);
-
-        let lock_path = lock_path(path);
-        loop {
-            match std::fs::OpenOptions::new()
-                .write(true)
-                .create(true)
-                .truncate(false)
-                .share_mode(0)
-                .open(&lock_path)
-            {
-                Ok(handle) => return Ok(Self { _handle: handle }),
-                Err(error) if error.raw_os_error() == Some(ERROR_SHARING_VIOLATION) => {
-                    std::thread::sleep(RETRY_INTERVAL);
-                }
-                Err(error) => return Err(error),
-            }
-        }
-    }
-}
-
 /// Reads whichever version of the store `path` currently names.
 ///
 /// A missing file reads as an empty, current-version store: reading against
@@ -408,7 +299,7 @@ pub fn set(path: &Path, key: &str, environment: &str, value: &str) -> Result<(),
         });
     }
 
-    let _lock = SecretLock::acquire(path)?;
+    let _lock = FileLock::acquire(path)?;
     let mut file = read_file(path)?;
     file.version = SECRETS_VERSION;
     file.entries
@@ -431,7 +322,7 @@ pub fn unset(path: &Path, key: &str, environment: &str) -> Result<bool, SecretEr
     check_key(key)?;
     check_environment(environment)?;
 
-    let _lock = SecretLock::acquire(path)?;
+    let _lock = FileLock::acquire(path)?;
     let mut file = read_file(path)?;
     let Some(by_environment) = file.entries.get_mut(key) else {
         return Ok(false);


### PR DESCRIPTION
Five copies of the same advisory file lock in shep-core: `KvLock`, `OverridesLock`, `SecretLock`, `RingLock`, and the public `ConfigLock`. The Windows `share_mode(0)` retry loop was in all five, so a fix to it had to land five times, on a platform the macOS gate never compiles.

- One `pub struct FileLock` in `crates/shep-core/src/file_lock.rs`, keyed on the path it guards
- `kv`, `overrides`, `secrets` and `barks` call it, their own lock types gone
- `config_lock` keeps `create_config_file` and re-exports `FileLock` as `ConfigLock`, so shep-daemon and shep-cli are untouched
- Module docs that called the duplication deliberate now point at `crate::file_lock`
- 620 lines out, 224 in

Own module rather than `atomic_file.rs`: the lock is not a step of the replace, it is what keeps two replaces apart, and it is held across reads the replace never sees.

Not breaking. No public path removed, no signature changed. `config_lock.rs` said unifying the lock types was "a separate, later change", so this is that.

No behaviour change. `kv::tests::two_concurrent_writers_lose_nothing` and its siblings in overrides and barks are untouched and green.

Gate green, each command run on its own: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`, `cargo test --workspace --all-features` (40 suites, no failures), and `cargo doc` with `RUSTDOCFLAGS="-D warnings"`. Also `cargo check --workspace --all-targets --all-features --target x86_64-pc-windows-gnu` on its own `CARGO_TARGET_DIR`, which is the only thing here that compiles the deduplicated Windows arm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Reliability**
  - Improved cross-process coordination for configuration, key-value, override, secret, and append-based file operations.
  - Lock acquisition now consistently waits until access is available and releases automatically afterward.
  - Standardized file locking across supported platforms for more predictable concurrent access.
  - Added coverage for lock release, contention, and independent file locking behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->