### PR TITLE
feat(cli): accept leading environment assignments on start and add

### DIFF
--- a/crates/shep-cli/src/cli.rs
+++ b/crates/shep-cli/src/cli.rs
@@ -722,6 +722,19 @@ pub struct StartArgs {
     /// no Flockfile there, `shep start` brings a shepherd up with nothing
     /// running yet, and `shep add` has nothing it could register.
     ///
+    /// A target may be preceded by `NAME=VALUE` assignments, read the way a
+    /// shell reads them: `shep start KOJI_TOKEN=secret ./koji` registers koji
+    /// with that variable set and records it, so a later `shep start koji`
+    /// needs no assignment. A name takes a letter or `_` and then letters,
+    /// digits or `_`, which is what makes `./A=1` a path and `1A=1` a target.
+    /// Quote the value and never the pair: `shep start "A=x y" ./koji`.
+    ///
+    /// Assignments take one target, and it must be a script path or a sheep
+    /// the flock already has. A Flockfile or a fold can name several sheep,
+    /// and an assignment names none of them. The value passes through this
+    /// command line, so it reaches `ps` and your shell history; write
+    /// `{{secret:NAME}}` to read a credential from `shep secret` instead.
+    ///
     /// Several are handled in turn, not atomically: if the second fails the
     /// first has already landed, and the exit code is the first failure.
     /// `--name` is refused with more than one, since a name is unique to one

--- a/crates/shep-cli/src/commands/lifecycle.rs
+++ b/crates/shep-cli/src/commands/lifecycle.rs
@@ -1088,8 +1088,9 @@ async fn load(
                 "an assignment needs a target; `{word}` is one word, so drop the quotes and \
                  let the shell split it"
             ),
-            None => "an assignment needs a target: a script path, or a sheep the flock has"
-                .to_string(),
+            None => {
+                "an assignment needs a target: a script path, or a sheep the flock has".to_string()
+            }
         };
         return streams.fail(ExitCode::Usage, &message);
     }
@@ -1432,8 +1433,9 @@ async fn load_one(
     // is up with it either way, which is what makes this a notice.
     for name in &registered {
         if let Err(reason) = set_assignments(client, name, assignments).await {
-            let message =
-                format!("{reason}; it is set for this spawn, but a Flockfile load could replace it");
+            let message = format!(
+                "{reason}; it is set for this spawn, but a Flockfile load could replace it"
+            );
             streams.aside(mode.verb(), &message);
         }
     }
@@ -1893,7 +1895,10 @@ mod tests {
 
         let (assignments, rest) = split_assignments(&targets);
 
-        assert!(assignments.is_empty(), "a name holds letters, digits and `_`");
+        assert!(
+            assignments.is_empty(),
+            "a name holds letters, digits and `_`"
+        );
         assert_eq!(rest, targets);
     }
 
@@ -1903,7 +1908,10 @@ mod tests {
 
         let (assignments, rest) = split_assignments(&targets);
 
-        assert!(assignments.is_empty(), "the first non-assignment ends the run");
+        assert!(
+            assignments.is_empty(),
+            "the first non-assignment ends the run"
+        );
         assert_eq!(rest, targets);
     }
 
@@ -1924,7 +1932,10 @@ mod tests {
         let (assignments, rest) = split_assignments(&targets);
 
         assert!(assignments.is_empty(), "a name may not start with a digit");
-        assert_eq!(rest, targets, "the word stays a target, as a shell leaves it");
+        assert_eq!(
+            rest, targets,
+            "the word stays a target, as a shell leaves it"
+        );
     }
 
     #[test]
@@ -3013,23 +3024,23 @@ mod tests {
         std::fs::write(&script, "#!/bin/sh\nsleep 1\n").unwrap();
 
         let sock = shep_client::testing::control_address(dir.path());
-        let (client, mut envelopes) = fake_client_answering(&sock, |request: &Request| match request
-        {
-            Request::ListFlock => Response::Flock(Vec::new()),
-            Request::Start { apps } => Response::Started(
-                apps.iter()
-                    .map(|app| {
-                        ProcessInfo::builder(0, app.name.as_str(), ProcStatus::Online).build()
-                    })
-                    .collect(),
-            ),
-            Request::SetSheepEnv { name, key, .. } => Response::SheepEnvSet {
-                name: name.clone(),
-                key: key.clone(),
-            },
-            _ => Response::Pong,
-        })
-        .await;
+        let (client, mut envelopes) =
+            fake_client_answering(&sock, |request: &Request| match request {
+                Request::ListFlock => Response::Flock(Vec::new()),
+                Request::Start { apps } => Response::Started(
+                    apps.iter()
+                        .map(|app| {
+                            ProcessInfo::builder(0, app.name.as_str(), ProcStatus::Online).build()
+                        })
+                        .collect(),
+                ),
+                Request::SetSheepEnv { name, key, .. } => Response::SheepEnvSet {
+                    name: name.clone(),
+                    key: key.clone(),
+                },
+                _ => Response::Pong,
+            })
+            .await;
 
         let mut args = start_args("KOJI_TOKEN=s3cret");
         args.targets.push(script.to_string_lossy().into_owned());
@@ -3198,7 +3209,9 @@ mod tests {
         while let Ok(envelope) = envelopes.try_recv() {
             match envelope.body {
                 Request::Add { apps } => {
-                    registered = apps.first().and_then(|app| app.env.get("KOJI_TOKEN").cloned());
+                    registered = apps
+                        .first()
+                        .and_then(|app| app.env.get("KOJI_TOKEN").cloned());
                 }
                 Request::SetSheepEnv { key, .. } => recorded.push(key),
                 _ => {}
@@ -3223,7 +3236,10 @@ mod tests {
         }
         .to_string();
 
-        assert!(said.contains("`1A`"), "the refusal names the bad name: {said}");
+        assert!(
+            said.contains("`1A`"),
+            "the refusal names the bad name: {said}"
+        );
         assert!(
             said.contains("letter"),
             "and says what a name may hold: {said}"

--- a/crates/shep-cli/src/commands/lifecycle.rs
+++ b/crates/shep-cli/src/commands/lifecycle.rs
@@ -17,7 +17,7 @@ use shep_core::config::{
 };
 use shep_core::paths::ShepPaths;
 use shep_core::protocol::{
-    ProcessInfo, Request, Response, SelectorSpec, SheepApplied, SheepRefusal,
+    EnvValue, ProcessInfo, Request, Response, SelectorSpec, SheepApplied, SheepRefusal,
 };
 use shep_core::selector::ProcessSelector;
 
@@ -255,6 +255,46 @@ fn evaluate_js_flockfile(path: &Path, budget: Duration) -> Result<String, Target
         detail: format!("node printed non-UTF-8 output for {}", path.display()),
         node_missing: false,
     })
+}
+
+/// `word` read as a `NAME=VALUE` assignment, or `None` when the name is one
+/// no shell would accept
+///
+/// The name is a letter or `_` followed by letters, digits or `_`. A value
+/// may hold anything, `=` included, since only the first `=` separates the
+/// two. `execve` itself validates no name, but one a shell cannot expand is
+/// a variable the sheep's own wrapper script could never read.
+fn assignment(word: &str) -> Option<(&str, &str)> {
+    let (name, value) = word.split_once('=')?;
+    let mut chars = name.chars();
+    let first = chars.next()?;
+    if !first.is_ascii_alphabetic() && first != '_' {
+        return None;
+    }
+    if !chars.all(|c| c.is_ascii_alphanumeric() || c == '_') {
+        return None;
+    }
+    Some((name, value))
+}
+
+/// Splits the leading assignments off `targets`, returning them and what is
+/// left
+///
+/// The shell's own rule: leading words that parse as assignments are the
+/// environment, and the first word that does not ends the run. So `A=1
+/// ./koji B=2` leaves `B=2` a target, exactly as a shell leaves it an
+/// argument. A repeated name takes its last value.
+fn split_assignments(targets: &[String]) -> (BTreeMap<String, String>, &[String]) {
+    let mut env = BTreeMap::new();
+    let mut rest = targets;
+    while let Some((word, tail)) = rest.split_first() {
+        let Some((name, value)) = assignment(word) else {
+            break;
+        };
+        env.insert(name.to_string(), value.to_string());
+        rest = tail;
+    }
+    (env, rest)
 }
 
 /// Resolves `target` into the [`AppConfig`]s `start` should register
@@ -1015,13 +1055,21 @@ async fn load(
     interpreters: &BTreeMap<String, String>,
     mode: Load,
 ) -> ExitCode {
+    let (assignments, targets) = split_assignments(&args.targets);
+    // An environment belongs to one sheep for the reason a name does, and
+    // the shell has no analogue to borrow: one assignment prefix there
+    // introduces one command.
+    if !assignments.is_empty() && targets.len() > 1 {
+        let message = "an assignment takes one target: an environment belongs to one sheep";
+        return streams.fail(ExitCode::Usage, message);
+    }
     // `--name` renames the sheep a target becomes, and a name is unique to
     // one sheep, so it cannot mean anything across several targets.
-    if args.name.is_some() && args.targets.len() > 1 {
+    if args.name.is_some() && targets.len() > 1 {
         let message = "--name takes one target: a name belongs to one sheep";
         return streams.fail(ExitCode::Usage, message);
     }
-    if args.targets.is_empty() {
+    if targets.is_empty() {
         let mut started = Vec::new();
         let code = load_one(
             client,
@@ -1032,6 +1080,7 @@ async fn load(
             interpreters,
             &mut started,
             mode,
+            &assignments,
         )
         .await;
         // Printed whenever the verb succeeded, not only when it touched a
@@ -1048,7 +1097,7 @@ async fn load(
     // already up. The exit code is the first failure.
     let mut failure: Option<ExitCode> = None;
     let mut started = Vec::new();
-    for target in &args.targets {
+    for target in targets {
         let code = load_one(
             client,
             streams,
@@ -1058,6 +1107,7 @@ async fn load(
             interpreters,
             &mut started,
             mode,
+            &assignments,
         )
         .await;
         if code != ExitCode::Success {
@@ -1077,6 +1127,44 @@ async fn load(
     failure.unwrap_or(ExitCode::Success)
 }
 
+/// Records each assignment as an operator override on every app that just
+/// registered
+///
+/// [`Request::Start`] and [`Request::Add`] write nothing to the override
+/// store, so a value only the config carries is one the next Flockfile load
+/// replaces. The sheep holds the value either way, so a failure here is a
+/// notice rather than a refusal.
+async fn record_assignments(
+    client: &Client,
+    streams: &mut Streams<'_>,
+    assignments: &BTreeMap<String, String>,
+    registered: &BTreeSet<&str>,
+    mode: Load,
+) {
+    for name in registered {
+        for (key, value) in assignments {
+            let body = Request::SetSheepEnv {
+                name: (*name).to_string(),
+                key: key.clone(),
+                value: Some(EnvValue::from(value.clone())),
+            };
+            let reason = match client.request(body).await {
+                Ok(Response::SheepEnvSet { .. }) => continue,
+                Ok(_unrecognised) => {
+                    "the shepherd answered with something this client does not understand"
+                        .to_string()
+                }
+                Err(err) => err.to_string(),
+            };
+            let message = format!(
+                "{name}: {key} is set for this spawn but was not recorded as an override, so a \
+                 Flockfile load could replace it ({reason})"
+            );
+            streams.aside(mode.verb(), &message);
+        }
+    }
+}
+
 /// One target's worth of [`load`]
 ///
 /// `interpreters` is read once by the caller rather than per target.
@@ -1090,6 +1178,7 @@ async fn load_one(
     interpreters: &BTreeMap<String, String>,
     started: &mut Vec<shep_core::protocol::ProcessInfo>,
     mode: Load,
+    assignments: &BTreeMap<String, String>,
 ) -> ExitCode {
     // Everything from here to `resolve_target` is the precedence in
     // `StartArgs::targets`' own help: a sheep by id or name, then a fold,
@@ -1194,6 +1283,13 @@ async fn load_one(
             app.config.cwd = Some(cwd.clone());
         }
     }
+    // After the file's own values, since an assignment is something an
+    // operator typed for this one sheep.
+    for app in &mut apps {
+        for (key, value) in assignments {
+            app.config.env.insert(key.clone(), value.clone());
+        }
+    }
     apply_interpreters(&mut apps, interpreters, args.interpreter.as_deref());
     // The bare-name rule again, now the target is a set of named apps: a
     // name the flock already has is that sheep. Without it `shep start
@@ -1274,6 +1370,7 @@ async fn load_one(
         .filter(|app| registered.contains(app.config.name.as_str()))
         .collect();
     let recorded = apply_declared(client, streams, &established, ResetDepth::None, mode).await;
+    record_assignments(client, streams, assignments, &registered, mode).await;
     started.extend(procs);
     first_failure(
         applied,
@@ -1685,6 +1782,94 @@ mod tests {
         fake_client_answering, fake_client_capturing_envelopes, fake_client_replying_err,
     };
     use shep_core::protocol::RpcErrorCode;
+
+    #[test]
+    fn an_empty_value_is_an_empty_string_and_not_a_removal() {
+        let targets = ["A=".to_string(), "./koji".to_string()];
+
+        let (assignments, _rest) = split_assignments(&targets);
+
+        assert_eq!(assignments.get("A").map(String::as_str), Some(""));
+    }
+
+    #[test]
+    fn only_the_first_equals_separates_a_name_from_its_value() {
+        let targets = ["A=x=y".to_string(), "./koji".to_string()];
+
+        let (assignments, _rest) = split_assignments(&targets);
+
+        assert_eq!(assignments.get("A").map(String::as_str), Some("x=y"));
+    }
+
+    #[test]
+    fn a_repeated_name_takes_its_last_value() {
+        let targets = ["A=1".to_string(), "A=2".to_string(), "./koji".to_string()];
+
+        let (assignments, rest) = split_assignments(&targets);
+
+        assert_eq!(assignments.get("A").map(String::as_str), Some("2"));
+        assert_eq!(rest, ["./koji".to_string()]);
+    }
+
+    #[test]
+    fn a_path_is_a_target_even_when_it_holds_an_equals_sign() {
+        let targets = ["./A=1".to_string()];
+
+        let (assignments, rest) = split_assignments(&targets);
+
+        assert!(assignments.is_empty(), "a name may not hold a separator");
+        assert_eq!(rest, targets);
+    }
+
+    #[test]
+    fn a_name_holding_a_dash_is_not_an_assignment() {
+        let targets = ["A-B=1".to_string(), "./koji".to_string()];
+
+        let (assignments, rest) = split_assignments(&targets);
+
+        assert!(assignments.is_empty(), "a name holds letters, digits and `_`");
+        assert_eq!(rest, targets);
+    }
+
+    #[test]
+    fn an_assignment_after_the_target_stays_a_target() {
+        let targets = ["./koji".to_string(), "B=2".to_string()];
+
+        let (assignments, rest) = split_assignments(&targets);
+
+        assert!(assignments.is_empty(), "the first non-assignment ends the run");
+        assert_eq!(rest, targets);
+    }
+
+    #[test]
+    fn assignments_with_nothing_after_them_leave_no_target() {
+        let targets = ["A=1".to_string()];
+
+        let (assignments, rest) = split_assignments(&targets);
+
+        assert_eq!(assignments.get("A").map(String::as_str), Some("1"));
+        assert!(rest.is_empty());
+    }
+
+    #[test]
+    fn a_name_a_shell_would_reject_is_not_an_assignment() {
+        let targets = ["1A=1".to_string(), "./koji".to_string()];
+
+        let (assignments, rest) = split_assignments(&targets);
+
+        assert!(assignments.is_empty(), "a name may not start with a digit");
+        assert_eq!(rest, targets, "the word stays a target, as a shell leaves it");
+    }
+
+    #[test]
+    fn leading_assignments_come_off_the_front() {
+        let targets = ["A=1".to_string(), "./koji".to_string()];
+
+        let (assignments, rest) = split_assignments(&targets);
+
+        assert_eq!(assignments.get("A").map(String::as_str), Some("1"));
+        assert_eq!(rest, ["./koji".to_string()]);
+    }
 
     #[tokio::test]
     async fn a_discovered_flockfile_is_started_when_no_target_was_given() {
@@ -2753,6 +2938,109 @@ mod tests {
     /// The command line supplied every value, including a `cwd` of wherever
     /// the operator stood, so applying it would move a running app's
     /// directory.
+    #[tokio::test]
+    async fn an_assignment_is_recorded_as_an_operator_override() {
+        use shep_core::status::ProcStatus;
+
+        let dir = tempfile::tempdir().unwrap();
+        let script = dir.path().join("zam");
+        std::fs::write(&script, "#!/bin/sh\nsleep 1\n").unwrap();
+
+        let sock = shep_client::testing::control_address(dir.path());
+        let (client, mut envelopes) = fake_client_answering(&sock, |request: &Request| match request
+        {
+            Request::ListFlock => Response::Flock(Vec::new()),
+            Request::Start { apps } => Response::Started(
+                apps.iter()
+                    .map(|app| {
+                        ProcessInfo::builder(0, app.name.as_str(), ProcStatus::Online).build()
+                    })
+                    .collect(),
+            ),
+            Request::SetSheepEnv { name, key, .. } => Response::SheepEnvSet {
+                name: name.clone(),
+                key: key.clone(),
+            },
+            _ => Response::Pong,
+        })
+        .await;
+
+        let mut args = start_args("KOJI_TOKEN=s3cret");
+        args.targets.push(script.to_string_lossy().into_owned());
+        let (code, _printed, said) = start_against_with_args(&client, &args).await;
+
+        assert_eq!(code, ExitCode::Success, "{said}");
+        let mut recorded = Vec::new();
+        while let Ok(envelope) = envelopes.try_recv() {
+            if let Request::SetSheepEnv { name, key, value } = envelope.body {
+                recorded.push((name, key, value.map(|v| v.as_str().to_string())));
+            }
+        }
+        assert_eq!(
+            recorded,
+            vec![(
+                "zam".to_string(),
+                "KOJI_TOKEN".to_string(),
+                Some("s3cret".to_string())
+            )],
+            "without the override record a later Flockfile load overwrites the value"
+        );
+    }
+
+    #[tokio::test]
+    async fn an_assignment_reaches_the_env_of_the_sheep_it_registers() {
+        let dir = tempfile::tempdir().unwrap();
+        let script = dir.path().join("zam");
+        std::fs::write(&script, "#!/bin/sh\nsleep 1\n").unwrap();
+
+        let sock = shep_client::testing::control_address(dir.path());
+        let (client, mut envelopes) = fake_client_capturing_envelopes(&sock).await;
+        let mut args = start_args("KOJI_TOKEN=s3cret");
+        args.targets.push(script.to_string_lossy().into_owned());
+        let _ = start_against_with_args(&client, &args).await;
+
+        let sent = next_start(&mut envelopes).await;
+        match sent.body {
+            Request::Start { apps } => {
+                assert_eq!(apps.len(), 1);
+                assert_eq!(
+                    apps[0].env.get("KOJI_TOKEN").map(String::as_str),
+                    Some("s3cret"),
+                    "the first spawn must already carry the value"
+                );
+            }
+            other => panic!("expected a Start request, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn an_assignment_with_more_than_one_target_is_refused() {
+        use shep_client::testing::fake_client_answering;
+
+        let dir = tempfile::tempdir().unwrap();
+        let script = dir.path().join("zam");
+        std::fs::write(&script, "#!/bin/sh\nsleep 1\n").unwrap();
+        let path = shep_client::testing::control_address(dir.path());
+        let (client, mut envelopes) =
+            fake_client_answering(&path, a_daemon_for(a_clustered_flock(&[0, 1, 2]), &[])).await;
+
+        let mut args = start_args("A=1");
+        args.targets.push(script.to_string_lossy().into_owned());
+        args.targets.push(script.to_string_lossy().into_owned());
+        let (code, printed, said) = start_against_with_args(&client, &args).await;
+
+        assert_eq!(code, ExitCode::Usage);
+        assert!(printed.is_empty(), "a refusal prints no data envelope");
+        assert!(
+            said.contains("one target"),
+            "the refusal must say an environment belongs to one sheep: {said}"
+        );
+        assert!(
+            applies(&mut envelopes).is_empty(),
+            "a refused assignment loads nothing"
+        );
+    }
+
     #[tokio::test]
     async fn a_bare_script_target_applies_nothing() {
         use shep_client::testing::fake_client_answering;

--- a/crates/shep-cli/src/commands/lifecycle.rs
+++ b/crates/shep-cli/src/commands/lifecycle.rs
@@ -80,11 +80,23 @@ impl std::fmt::Display for TargetError {
                 write!(f, "failed to read {}: {source}", path.display())
             }
             Self::Flockfile(err) => write!(f, "{err}"),
-            Self::Unresolvable { target } => write!(
-                f,
-                "{target} is not a sheep, a fold, `-`, a recognised Flockfile, or an \
-                 existing path"
-            ),
+            Self::Unresolvable { target } => {
+                write!(
+                    f,
+                    "{target} is not a sheep, a fold, `-`, a recognised Flockfile, or an \
+                     existing path"
+                )?;
+                // Only for a word that could have been an assignment and was
+                // not: a name holding a separator was always a path.
+                match target.split_once('=') {
+                    Some((name, _)) if !name.is_empty() && !name.contains(['/', '\\']) => write!(
+                        f,
+                        "; `{name}` is not a name an assignment can use, which takes a letter \
+                         or `_` and then letters, digits or `_`"
+                    ),
+                    _ => Ok(()),
+                }
+            }
             Self::UnknownFlockfileFormat { path } => write!(
                 f,
                 "--flockfile needs a .toml, .yaml, .yml, .json, .json5 or .js file; {} is none of those",
@@ -1063,6 +1075,24 @@ async fn load(
         let message = "an assignment takes one target: an environment belongs to one sheep";
         return streams.fail(ExitCode::Usage, message);
     }
+    // A word holding whitespace is one a shell never hands over: the
+    // operator quoted the assignment and its target together, which is the
+    // one spelling that would need shep to split and requote for itself.
+    if !assignments.is_empty() && targets.is_empty() {
+        let quoted = args
+            .targets
+            .iter()
+            .find(|word| word.split_whitespace().count() > 1);
+        let message = match quoted {
+            Some(word) => format!(
+                "an assignment needs a target; `{word}` is one word, so drop the quotes and \
+                 let the shell split it"
+            ),
+            None => "an assignment needs a target: a script path, or a sheep the flock has"
+                .to_string(),
+        };
+        return streams.fail(ExitCode::Usage, &message);
+    }
     // `--name` renames the sheep a target becomes, and a name is unique to
     // one sheep, so it cannot mean anything across several targets.
     if args.name.is_some() && targets.len() > 1 {
@@ -1127,42 +1157,38 @@ async fn load(
     failure.unwrap_or(ExitCode::Success)
 }
 
-/// Records each assignment as an operator override on every app that just
-/// registered
+/// Sets each assignment on `name` as an operator override
 ///
-/// [`Request::Start`] and [`Request::Add`] write nothing to the override
-/// store, so a value only the config carries is one the next Flockfile load
-/// replaces. The sheep holds the value either way, so a failure here is a
-/// notice rather than a refusal.
-async fn record_assignments(
+/// One request per key, since [`Request::SetSheepEnv`] carries one. The
+/// first failure stops the run and comes back unphrased: a value the sheep
+/// is already running with is a notice, and one it has never seen is a
+/// refusal, and only the caller knows which it has.
+///
+/// # Errors
+/// The first key the shepherd did not record, and why.
+async fn set_assignments(
     client: &Client,
-    streams: &mut Streams<'_>,
+    name: &str,
     assignments: &BTreeMap<String, String>,
-    registered: &BTreeSet<&str>,
-    mode: Load,
-) {
-    for name in registered {
-        for (key, value) in assignments {
-            let body = Request::SetSheepEnv {
-                name: (*name).to_string(),
-                key: key.clone(),
-                value: Some(EnvValue::from(value.clone())),
-            };
-            let reason = match client.request(body).await {
-                Ok(Response::SheepEnvSet { .. }) => continue,
-                Ok(_unrecognised) => {
-                    "the shepherd answered with something this client does not understand"
-                        .to_string()
-                }
-                Err(err) => err.to_string(),
-            };
-            let message = format!(
-                "{name}: {key} is set for this spawn but was not recorded as an override, so a \
-                 Flockfile load could replace it ({reason})"
-            );
-            streams.aside(mode.verb(), &message);
+) -> Result<(), String> {
+    for (key, value) in assignments {
+        let body = Request::SetSheepEnv {
+            name: name.to_string(),
+            key: key.clone(),
+            value: Some(EnvValue::from(value.clone())),
+        };
+        match client.request(body).await {
+            Ok(Response::SheepEnvSet { .. }) => {}
+            Ok(_unrecognised) => {
+                return Err(format!(
+                    "{name}: the shepherd answered {key} with something this client does not \
+                     understand"
+                ));
+            }
+            Err(err) => return Err(format!("{name}: {key} was not recorded ({err})")),
         }
     }
+    Ok(())
 }
 
 /// One target's worth of [`load`]
@@ -1204,11 +1230,31 @@ async fn load_one(
                 // to a sheep reads no file, so `shep start web` cannot apply
                 // whatever Flockfile sits in the operator's directory. A
                 // reset flag is refused: there is no template to reset to.
+                // Instances of one name are one sheep; two names are two, and
+                // an assignment names neither of them.
                 if let Some(flag) = reset_flag(args) {
                     let message = format!(
                         "{flag} needs a Flockfile to reset to; {token} names a sheep, not a file"
                     );
                     return streams.fail(ExitCode::Usage, &message);
+                }
+                // Instances of one name are one sheep; two names are two, and
+                // an assignment names neither of them. Recorded before the
+                // resume below, which is the spawn that promotes it.
+                if !assignments.is_empty() {
+                    let names: BTreeSet<&str> =
+                        matched.iter().map(|info| info.name.as_str()).collect();
+                    if names.len() > 1 {
+                        let message = format!(
+                            "an assignment takes a script path or one sheep; {token} names several"
+                        );
+                        return streams.fail(ExitCode::Usage, &message);
+                    }
+                    for name in &names {
+                        if let Err(reason) = set_assignments(client, name, assignments).await {
+                            return streams.fail(ExitCode::Failure, &reason);
+                        }
+                    }
                 }
                 return match mode {
                     Load::Start => {
@@ -1268,6 +1314,17 @@ async fn load_one(
     {
         let message =
             format!("{flag} needs a Flockfile to reset to; {target} is a script, not a Flockfile");
+        return streams.fail(ExitCode::Usage, &message);
+    }
+
+    // A file may declare several apps and an assignment names none of them,
+    // so nothing says which one the operator meant. Tested on the declared
+    // set for the reason the reset above is: it is what a file supplies.
+    if !assignments.is_empty() && apps.iter().any(|app| !app.declared.is_empty()) {
+        let message = format!(
+            "an assignment takes a script path or one sheep; {target} is a Flockfile, which \
+             may declare several"
+        );
         return streams.fail(ExitCode::Usage, &message);
     }
 
@@ -1370,7 +1427,16 @@ async fn load_one(
         .filter(|app| registered.contains(app.config.name.as_str()))
         .collect();
     let recorded = apply_declared(client, streams, &established, ResetDepth::None, mode).await;
-    record_assignments(client, streams, assignments, &registered, mode).await;
+    // `Start` and `Add` write nothing to the override store, so a value only
+    // the config carries is one the next Flockfile load replaces. The sheep
+    // is up with it either way, which is what makes this a notice.
+    for name in &registered {
+        if let Err(reason) = set_assignments(client, name, assignments).await {
+            let message =
+                format!("{reason}; it is set for this spawn, but a Flockfile load could replace it");
+            streams.aside(mode.verb(), &message);
+        }
+    }
     started.extend(procs);
     first_failure(
         applied,
@@ -3011,6 +3077,240 @@ mod tests {
             }
             other => panic!("expected a Start request, got {other:?}"),
         }
+    }
+
+    #[tokio::test]
+    async fn an_assignment_on_an_existing_sheep_is_recorded_before_it_resumes() {
+        use shep_client::testing::fake_client_answering;
+        use shep_core::status::ProcStatus;
+
+        let dir = tempfile::tempdir().unwrap();
+        let sock = shep_client::testing::control_address(dir.path());
+        let flock = vec![ProcessInfo::builder(0, "zam", ProcStatus::Stopped).build()];
+        let (client, mut envelopes) =
+            fake_client_answering(&sock, move |request: &Request| match request {
+                Request::ListFlock => Response::Flock(flock.clone()),
+                Request::SetSheepEnv { name, key, .. } => Response::SheepEnvSet {
+                    name: name.clone(),
+                    key: key.clone(),
+                },
+                Request::Restart { .. } => Response::Restarted {
+                    accepted: vec![ProcessInfo::builder(0, "zam", ProcStatus::Online).build()],
+                    refused: Vec::new(),
+                },
+                _ => Response::Pong,
+            })
+            .await;
+
+        let mut args = start_args("A=1");
+        args.targets.push("zam".to_string());
+        let (code, _printed, said) = start_against_with_args(&client, &args).await;
+
+        assert_eq!(code, ExitCode::Success, "{said}");
+        let mut order = Vec::new();
+        while let Ok(envelope) = envelopes.try_recv() {
+            match envelope.body {
+                Request::SetSheepEnv { key, .. } => order.push(format!("set {key}")),
+                Request::Restart { .. } => order.push("restart".to_string()),
+                _ => {}
+            }
+        }
+        assert_eq!(
+            order,
+            ["set A", "restart"],
+            "the value must be recorded before the sheep comes back up"
+        );
+    }
+
+    #[tokio::test]
+    async fn an_assignment_on_a_target_matching_several_sheep_is_refused() {
+        use shep_client::testing::fake_client_answering;
+        use shep_core::status::ProcStatus;
+
+        let dir = tempfile::tempdir().unwrap();
+        let sock = shep_client::testing::control_address(dir.path());
+        let flock = vec![
+            ProcessInfo::builder(0, "web", ProcStatus::Online).build(),
+            ProcessInfo::builder(1, "api", ProcStatus::Online).build(),
+        ];
+        let (client, mut envelopes) = fake_client_answering(&sock, a_daemon_for(flock, &[])).await;
+
+        let mut args = start_args("A=1");
+        args.targets.push("all".to_string());
+        let (code, printed, said) = start_against_with_args(&client, &args).await;
+
+        assert_eq!(code, ExitCode::Usage);
+        assert!(printed.is_empty(), "a refusal prints no data envelope");
+        assert!(
+            said.contains("one sheep"),
+            "the refusal must say an environment belongs to one sheep: {said}"
+        );
+        assert!(
+            respawns(&mut envelopes).is_empty(),
+            "a refused assignment restarts nothing"
+        );
+    }
+
+    #[tokio::test]
+    async fn an_assignment_reaches_the_env_of_a_sheep_add_registers() {
+        use shep_client::testing::fake_client_answering;
+        use shep_core::status::ProcStatus;
+
+        let dir = tempfile::tempdir().unwrap();
+        let script = dir.path().join("zam");
+        std::fs::write(&script, "#!/bin/sh\nsleep 1\n").unwrap();
+        let sock = shep_client::testing::control_address(dir.path());
+        let (client, mut envelopes) =
+            fake_client_answering(&sock, |request: &Request| match request {
+                Request::ListFlock => Response::Flock(Vec::new()),
+                Request::Add { apps } => Response::Added(
+                    apps.iter()
+                        .map(|app| {
+                            ProcessInfo::builder(0, app.name.as_str(), ProcStatus::Stopped).build()
+                        })
+                        .collect(),
+                ),
+                Request::SetSheepEnv { name, key, .. } => Response::SheepEnvSet {
+                    name: name.clone(),
+                    key: key.clone(),
+                },
+                _ => Response::Pong,
+            })
+            .await;
+
+        let mut args = start_args("KOJI_TOKEN=s3cret");
+        args.targets.push(script.to_string_lossy().into_owned());
+        let mut out = Vec::new();
+        let mut err = Vec::new();
+        let code = {
+            let mut streams = Streams {
+                out: &mut out,
+                err: &mut err,
+                style: crate::style::Presentation::BARE,
+                fmt: Format::Table,
+            };
+            add(&client, &mut streams, &args, None, &BTreeMap::new()).await
+        };
+        assert_eq!(code, ExitCode::Success, "{}", String::from_utf8_lossy(&err));
+
+        let mut registered = None;
+        let mut recorded = Vec::new();
+        while let Ok(envelope) = envelopes.try_recv() {
+            match envelope.body {
+                Request::Add { apps } => {
+                    registered = apps.first().and_then(|app| app.env.get("KOJI_TOKEN").cloned());
+                }
+                Request::SetSheepEnv { key, .. } => recorded.push(key),
+                _ => {}
+            }
+        }
+        assert_eq!(
+            registered.as_deref(),
+            Some("s3cret"),
+            "add registers the value it was given"
+        );
+        assert_eq!(
+            recorded,
+            ["KOJI_TOKEN"],
+            "and records it as an override, exactly as start does"
+        );
+    }
+
+    #[test]
+    fn a_target_that_looks_like_an_assignment_says_why_it_is_not_one() {
+        let said = TargetError::Unresolvable {
+            target: "1A=1".to_string(),
+        }
+        .to_string();
+
+        assert!(said.contains("`1A`"), "the refusal names the bad name: {said}");
+        assert!(
+            said.contains("letter"),
+            "and says what a name may hold: {said}"
+        );
+    }
+
+    #[test]
+    fn a_path_holding_an_equals_sign_gets_no_assignment_note() {
+        let said = TargetError::Unresolvable {
+            target: "./A=1".to_string(),
+        }
+        .to_string();
+
+        assert!(
+            !said.contains("letter"),
+            "a path was never a candidate assignment: {said}"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_quoted_assignment_and_target_says_to_drop_the_quotes() {
+        use shep_client::testing::fake_client_answering;
+
+        let dir = tempfile::tempdir().unwrap();
+        let sock = shep_client::testing::control_address(dir.path());
+        let (client, _envelopes) =
+            fake_client_answering(&sock, a_daemon_for(Vec::new(), &[])).await;
+
+        let args = start_args("ABC=xyz /tmp/x/koji");
+        let (code, printed, said) = start_against_with_args(&client, &args).await;
+
+        assert_eq!(code, ExitCode::Usage);
+        assert!(printed.is_empty(), "a refusal prints no data envelope");
+        assert!(
+            said.contains("drop the quotes"),
+            "one quoted word is the shape a shell never produces: {said}"
+        );
+    }
+
+    #[tokio::test]
+    async fn an_assignment_with_no_target_at_all_is_refused() {
+        use shep_client::testing::fake_client_answering;
+
+        let dir = tempfile::tempdir().unwrap();
+        let sock = shep_client::testing::control_address(dir.path());
+        let (client, _envelopes) =
+            fake_client_answering(&sock, a_daemon_for(Vec::new(), &[])).await;
+
+        let args = start_args("A=1");
+        let (code, _printed, said) = start_against_with_args(&client, &args).await;
+
+        assert_eq!(code, ExitCode::Usage);
+        assert!(
+            said.contains("needs a target"),
+            "an environment with nothing to set it on: {said}"
+        );
+    }
+
+    #[tokio::test]
+    async fn an_assignment_on_a_flockfile_is_refused() {
+        use shep_client::testing::fake_client_answering;
+
+        let dir = tempfile::tempdir().unwrap();
+        let flockfile = dir.path().join("Flockfile.toml");
+        std::fs::write(
+            &flockfile,
+            "[[app]]\nname = \"web\"\nscript = \"/bin/sleep\"\n",
+        )
+        .unwrap();
+        let sock = shep_client::testing::control_address(dir.path());
+        let (client, mut envelopes) =
+            fake_client_answering(&sock, a_daemon_for(Vec::new(), &[])).await;
+
+        let mut args = start_args("A=1");
+        args.targets.push(flockfile.to_string_lossy().into_owned());
+        let (code, printed, said) = start_against_with_args(&client, &args).await;
+
+        assert_eq!(code, ExitCode::Usage);
+        assert!(printed.is_empty(), "a refusal prints no data envelope");
+        assert!(
+            said.contains("Flockfile"),
+            "the refusal must say a file may declare several sheep: {said}"
+        );
+        assert!(
+            applies(&mut envelopes).is_empty(),
+            "a refused assignment loads nothing"
+        );
     }
 
     #[tokio::test]

--- a/web/src/data/cli-reference.generated.txt
+++ b/web/src/data/cli-reference.generated.txt
@@ -92,6 +92,17 @@ Arguments:
           `shep start` brings a shepherd up with nothing running yet, and `shep add` has nothing it
           could register.
           
+          A target may be preceded by `NAME=VALUE` assignments, read the way a shell reads them:
+          `shep start KOJI_TOKEN=secret ./koji` registers koji with that variable set and records
+          it, so a later `shep start koji` needs no assignment. A name takes a letter or `_` and
+          then letters, digits or `_`, which is what makes `./A=1` a path and `1A=1` a target. Quote
+          the value and never the pair: `shep start "A=x y" ./koji`.
+          
+          Assignments take one target, and it must be a script path or a sheep the flock already
+          has. A Flockfile or a fold can name several sheep, and an assignment names none of them.
+          The value passes through this command line, so it reaches `ps` and your shell history;
+          write `{{secret:NAME}}` to read a credential from `shep secret` instead.
+          
           Several are handled in turn, not atomically: if the second fails the first has already
           landed, and the exit code is the first failure. `--name` is refused with more than one,
           since a name is unique to one sheep.
@@ -216,6 +227,17 @@ Arguments:
           Omit the targets to read the Flockfile in the current directory. With no Flockfile there,
           `shep start` brings a shepherd up with nothing running yet, and `shep add` has nothing it
           could register.
+          
+          A target may be preceded by `NAME=VALUE` assignments, read the way a shell reads them:
+          `shep start KOJI_TOKEN=secret ./koji` registers koji with that variable set and records
+          it, so a later `shep start koji` needs no assignment. A name takes a letter or `_` and
+          then letters, digits or `_`, which is what makes `./A=1` a path and `1A=1` a target. Quote
+          the value and never the pair: `shep start "A=x y" ./koji`.
+          
+          Assignments take one target, and it must be a script path or a sheep the flock already
+          has. A Flockfile or a fold can name several sheep, and an assignment names none of them.
+          The value passes through this command line, so it reaches `ps` and your shell history;
+          write `{{secret:NAME}}` to read a credential from `shep secret` instead.
           
           Several are handled in turn, not atomically: if the second fails the first has already
           landed, and the exit code is the first failure. `--name` is refused with more than one,

--- a/web/src/pages/docs/overrides.astro
+++ b/web/src/pages/docs/overrides.astro
@@ -13,6 +13,10 @@
  * parks nothing, and on macOS a /tmp path and its /private/tmp resolution
  * differ enough to park one for a reason no reader could reproduce.
  *
+ * `assignment` and `fillIn` were run on 2026-09-07, each in a throwaway
+ * $SHEP_HOME of its own, when a leading `NAME=VALUE` became something
+ * `shep start` and `shep add` accept.
+ *
  * `addFirst` is the exception: run on 2026-09-03, when `shep add` shipped,
  * in a throwaway $SHEP_HOME of its own. Its RESTARTS column reads 1 on the
  * third command and that is the real output, not a paste error. `shep start
@@ -117,6 +121,34 @@ ID  NAME   STATUS  PID    RESTARTS  EXIT  CFG  CPU  MEM   UPTIME  FOLD  SMIT
 $ shep flock
 ID  NAME  STATUS  PID    RESTARTS  EXIT  CFG  CPU  MEM   UPTIME  FOLD  SMIT
 0   web   online  96556  0         -     -    -    1.2M  5s      -     -`;
+
+const assignment = `$ shep start KOJI_TOKEN=s3cret ./koji --name koji
+ID  NAME  STATUS  PID   RESTARTS  EXIT  CFG  CPU  MEM    UPTIME  FOLD  SMIT
+0   koji  online  9970  0         -     *1   -    32.0K  0s      -     -
+
+$ cat $SHEP_HOME/overrides.json
+{
+  "version": 1,
+  "apps": {
+    "koji": {
+      "fields": {
+        "env": {
+          "KOJI_TOKEN": "s3cret"
+        }
+      },
+      "declared": [],
+      "declared_env": []
+    }
+  }
+}`;
+
+const fillIn = `$ shep add Flockfile.toml
+ID  NAME  STATUS   PID  RESTARTS  EXIT  CFG  CPU  MEM  UPTIME  FOLD  SMIT
+0   web   stopped  -    0         -     -    -    -    0s      -     -
+
+$ shep start DB_HOST=db.internal web
+ID  NAME  STATUS  PID    RESTARTS  EXIT  CFG  CPU  MEM    UPTIME  FOLD  SMIT
+0   web   online  16628  1         -     *1   -    32.0K  0s      -     -`;
 
 const store = `$ cat $SHEP_HOME/overrides.json
 {
@@ -406,15 +438,19 @@ const store = `$ cat $SHEP_HOME/overrides.json
       through the same request <code>shep restart</code> uses, and has
       counted it that way since before this verb existed.
     </p>
-    <Callout variant="careful">
-      The middle step is the one shep has no verb for yet, for an
-      established key holding a plain value. Filling one in today means
-      editing the Flockfile and loading it with <code>--reset=env</code>,
-      which hands <code>env</code> back to the file and touches nothing
+    <p>
+      The middle step is an assignment on the start that brings it up, and it
+      works for a key the file established as well as one nobody has spoken
+      for:
+    </p>
+    <CodeBlock>{fillIn}</CodeBlock>
+    <p class="fine">
+      <code>--reset=env</code> is the other direction, handing{" "}
+      <code>env</code> back to whatever the file says and touching nothing
       else, not even <code>instances</code>. A key holding a{" "}
-      <code>{'{{secret:...}}'}</code> reference does not have this gap: the
-      Flockfile never needs a second edit, only <code>shep secret set</code>.
-    </Callout>
+      <code>{'{{secret:...}}'}</code> reference needs neither: the Flockfile
+      is written once and <code>shep secret set</code> carries the value.
+    </p>
     <p>
       Running <code>shep add</code> again changes nothing and prints nothing,
       the way a second load of an unchanged file does. Naming a sheep instead
@@ -422,6 +458,48 @@ const store = `$ cat $SHEP_HOME/overrides.json
       and leaves nothing to register:{" "}
       <code>notice[add]: web is already registered; nothing to add.</code>
     </p>
+
+    <h2>Setting one from the command line</h2>
+    <p>
+      An assignment in front of a target is an override, written the way a
+      shell writes one:
+    </p>
+    <CodeBlock>{assignment}</CodeBlock>
+    <p>
+      The value lands twice and both halves matter. In the sheep's{" "}
+      <code>env</code>, so the first spawn carries it and a later{" "}
+      <code>shep stop koji</code> and <code>shep start koji</code> need no
+      assignment. And in the store above, so a Flockfile that later declares{" "}
+      <code>KOJI_TOKEN</code> is skipped rather than obeyed. Without that
+      second half a template arriving through the app's own repository would
+      win at the next spawn, which is the thing this page exists to stop.
+    </p>
+    <p>
+      The name follows the shell's rule: a letter or <code>_</code>, then
+      letters, digits or <code>_</code>. That is what makes{" "}
+      <code>./A=1</code> a path and <code>1A=1</code> a target rather than an
+      assignment, so a file called <code>A=1</code> is reached here the same
+      way it is reached in a shell. Only the first <code>=</code> separates
+      the two, so <code>A=x=y</code> is the value <code>x=y</code>, and a
+      repeated name takes its last value.
+    </p>
+    <p>
+      One target, and it is a script path or a sheep the flock already has. A
+      Flockfile or a fold can name several sheep and an assignment names none
+      of them, so both refuse. So does a single quoted{" "}
+      <code>"A=1 ./koji"</code>: quoting is what stops a shell splitting, and
+      splitting it a second time would need shep to invent its own quoting
+      rules for a value holding a space.
+    </p>
+    <Callout variant="careful">
+      The value passes through shep's own command line, so it is in{" "}
+      <code>ps</code> for as long as that command runs and in this shell's
+      history for good. It is not in <code>ps</code> for the sheep, which
+      holds it in <code>env</code> rather than <code>args</code>. For a
+      credential, write{" "}
+      <code>KOJI_TOKEN={'{{secret:KOJI_TOKEN}}'}</code> and let{" "}
+      <a href="/docs/secrets">secrets</a> carry the value instead.
+    </Callout>
 
     <h2>A template may add, never overwrite</h2>
     <p>

--- a/web/src/pages/docs/overrides.astro
+++ b/web/src/pages/docs/overrides.astro
@@ -539,15 +539,22 @@ const store = `$ cat $SHEP_HOME/overrides.json
       <code>CFG</code> counts.
     </p>
     <p>
-      The door that writes <code>fields</code> is{" "}
+      Two doors write <code>fields</code>. The first is{" "}
       <a href="/docs/lookout">the config pane</a>: <code>e</code> on a sheep
       in <code>shep lookout</code>, behind <code>--allow-control</code>. One
       key at a time, and the value is recorded as yours rather than spent,
       so the key keeps its <code>*</code> and a later <code>shep start</code>{" "}
-      of the app's Flockfile leaves it alone. There is no flag on{" "}
-      <code>shep start</code> that sets one field: a load is a template
-      arriving through a pull request, and an operator's own value is not a
-      thing a template says.
+      of the app's Flockfile leaves it alone. The second is a leading{" "}
+      <code>NAME=VALUE</code> on <code>shep start</code> or{" "}
+      <code>shep add</code>, which records the same way and reaches{" "}
+      <code>env</code> alone.
+    </p>
+    <p>
+      Neither is a flag, and there is still no flag on{" "}
+      <code>shep start</code> that sets an arbitrary field: a load is a
+      template arriving through a pull request, and an operator's own value
+      is not a thing a template says. An assignment gets past that because
+      it is the operator speaking rather than the file.
     </p>
     <p class="fine">
       A pane edit is not a <code>--reset=file</code> at one key, which is

--- a/web/src/pages/docs/secrets.astro
+++ b/web/src/pages/docs/secrets.astro
@@ -231,6 +231,14 @@ Secrets for worker:
     </p>
     <CodeBlock>{cliDemo}</CodeBlock>
     <p class="fine">
+      A leading <code>NAME=VALUE</code> on <code>shep start</code> or{" "}
+      <code>shep add</code> carries the same exposure, through shep's own
+      command line rather than the sheep's. Write{" "}
+      <code>KOJI_TOKEN={'{{secret:KOJI_TOKEN}}'}</code> there and the
+      reference is what reaches <code>ps</code> and your history, while the
+      value is read from this store at spawn.
+    </p>
+    <p class="fine">
       <code>--env</code> is exact: <code>unset DB_PASSWORD --env staging</code>{" "}
       touches the <code>staging</code> slot alone and leaves <code>all</code>{" "}
       standing. Omit <code>--env</code> on <code>set</code> or{" "}


### PR DESCRIPTION
`shep start ABC=xyz ./koji` refused the target, and there was no flag to set a variable from the command line either.

- Leading `NAME=VALUE` words on `shep start` and `shep add`, read the way a shell reads them
- Value goes into the sheep's `env` and into `overrides.json`, so a later `shep start koji` needs no assignment and a Flockfile declaring the same key cannot replace it
- One target, and it is a script path or a sheep the flock already has. A Flockfile, a fold or a wildcard can name several sheep, so those refuse
- `1A=1` and `./A=1` stay targets, same as in a shell. The refusal now says why
- The quoted `"A=1 ./koji"` form refuses and says to drop the quotes

Checked on a live daemon in a throwaway `$SHEP_HOME`: the value survives a Flockfile that declares `KOJI_TOKEN = ""`, and with the override record deleted the same load overwrites it with the empty string.

Docs regenerated and updated. The callout in `overrides.astro` saying shep had no verb for filling in an established key was true and is not any more.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - `shep start` and `shep add` now support leading `NAME=VALUE` assignments for individual script or sheep targets.
  - Assignments persist as overrides and apply when restarting the target.
  - Assignment values can fill new or existing environment keys.

- **Documentation**
  - Added syntax, validation, persistence, and target restriction guidance.
  - Documented that command-line values may appear in process listings and shell history, with secret-reference guidance for sensitive credentials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->