### PR TITLE
feat(lookout): give the bleats feed the whole screen, with filters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2085,6 +2085,7 @@ dependencies = [
  "predicates",
  "proptest",
  "ratatui",
+ "regex",
  "ring",
  "rmcp",
  "schemars",

--- a/crates/shep-cli/Cargo.toml
+++ b/crates/shep-cli/Cargo.toml
@@ -186,6 +186,10 @@ schemars.workspace = true
 # see the workspace `Cargo.toml`'s comments on each.
 time.workspace = true
 instability.workspace = true
+# The bleats pane's match axis: an operator can give `/pattern/` to search
+# by regex instead of literal text. Adds zero crates: shep-core already
+# resolves this version for its own selector matching.
+regex.workspace = true
 
 [dev-dependencies]
 # `test-util` for `#[tokio::test(start_paused = true)]`, `crate::http`'s "a

--- a/crates/shep-cli/src/lookout/app.rs
+++ b/crates/shep-cli/src/lookout/app.rs
@@ -24,6 +24,7 @@ use shep_core::status::ProcStatus;
 
 use super::field::{FieldKind, FieldSet};
 use super::pane::{ConfigPane, FieldValue, Lock, PaneEdit, PanePending, PaneTarget, ReloadKind};
+use super::pane_bleats::BleatsPane;
 use super::theme::Palette;
 use super::viewport::Viewport;
 use crate::commands::settings::{SettingEdit, SettingField, SettingsSnapshot, settings_field_set};
@@ -114,6 +115,9 @@ pub enum KeyPress {
     ListMoveUp,
     /// `J`: the same, moving down.
     ListMoveDown,
+    /// `b`: opens the full-screen bleats pane on the selected sheep. Does
+    /// nothing with no sheep selected, the way `e` does.
+    Bleats,
 }
 
 /// Everything that can change the dashboard.
@@ -1256,6 +1260,9 @@ pub(crate) enum Body {
     /// An open config pane, for a sheep or a dog, opened by
     /// [`KeyPress::Edit`].
     ConfigPane(ConfigPane),
+    /// The bleats feed given the whole screen, opened by
+    /// [`KeyPress::Bleats`].
+    Bleats(BleatsPane),
 }
 
 /// The whole dashboard's state.
@@ -2286,6 +2293,11 @@ impl App {
         if self.settings().is_some() {
             return self.on_settings_key(key);
         }
+        // The bleats pane owns the keyboard while it is open, the same as
+        // the other two full-screen panes above.
+        if self.bleats_pane().is_some() {
+            return self.on_bleats_key(key);
+        }
         // A cancelling keypress is consumed: a stray `j` cancels the confirm
         // and does not also move the selection, or the next reflexive Enter
         // acts on a target the operator lost track of. Cancelling is silent.
@@ -2366,6 +2378,52 @@ impl App {
             // `h` names a field's help text, and the dashboard has no
             // field selected.
             KeyPress::Help => Effect::None,
+            // Opens on the selected sheep, or does nothing without one, the
+            // same shape `KeyPress::Edit` follows above.
+            KeyPress::Bleats => self.ask_for_bleats(),
+        }
+    }
+
+    /// `b`: opens the full-screen bleats pane on the selected sheep. A
+    /// group or an empty selection asks for nothing, the same shape
+    /// [`Self::ask_for_config`] follows.
+    fn ask_for_bleats(&mut self) -> Effect {
+        if let Some(sheep @ RowKey::Sheep(_)) = self.selected() {
+            self.body = Body::Bleats(BleatsPane::new(sheep));
+        }
+        Effect::None
+    }
+
+    /// The bleats pane's own keymap, in force while [`Self::bleats_pane`] is
+    /// `Some`. There is nothing on this screen to move or edit: `Escape`
+    /// closes it, and everything else is inert.
+    fn on_bleats_key(&mut self, key: KeyPress) -> Effect {
+        match key {
+            KeyPress::Quit => Effect::Quit,
+            KeyPress::Escape => {
+                self.close_pane();
+                Effect::None
+            }
+            KeyPress::SelectUp
+            | KeyPress::SelectDown
+            | KeyPress::SelectFirst
+            | KeyPress::SelectLast
+            | KeyPress::Refresh
+            | KeyPress::Action(_)
+            | KeyPress::Confirm
+            | KeyPress::FilterStart
+            | KeyPress::TextChar(_)
+            | KeyPress::TextBackspace
+            | KeyPress::TextApply
+            | KeyPress::TextAbandon
+            | KeyPress::Settings
+            | KeyPress::Cycle
+            | KeyPress::Edit
+            | KeyPress::Help
+            | KeyPress::ListRemove
+            | KeyPress::ListMoveUp
+            | KeyPress::ListMoveDown
+            | KeyPress::Bleats => Effect::None,
         }
     }
 
@@ -2445,7 +2503,8 @@ impl App {
             | KeyPress::Help
             | KeyPress::ListRemove
             | KeyPress::ListMoveUp
-            | KeyPress::ListMoveDown => {}
+            | KeyPress::ListMoveDown
+            | KeyPress::Bleats => {}
         }
         Effect::None
     }
@@ -2627,7 +2686,8 @@ impl App {
             | KeyPress::TextAbandon
             | KeyPress::ListRemove
             | KeyPress::ListMoveUp
-            | KeyPress::ListMoveDown => {}
+            | KeyPress::ListMoveDown
+            | KeyPress::Bleats => {}
         }
         Effect::None
     }
@@ -2721,7 +2781,8 @@ impl App {
             | KeyPress::TextAbandon
             | KeyPress::ListRemove
             | KeyPress::ListMoveUp
-            | KeyPress::ListMoveDown => Effect::None,
+            | KeyPress::ListMoveDown
+            | KeyPress::Bleats => Effect::None,
         }
     }
 
@@ -2885,7 +2946,7 @@ impl App {
         // scope.
         let Some(pane) = (match &mut self.body {
             Body::ConfigPane(pane) => Some(pane),
-            Body::FlockTable | Body::Settings(_) => None,
+            Body::FlockTable | Body::Settings(_) | Body::Bleats(_) => None,
         }) else {
             return Effect::None;
         };
@@ -3098,7 +3159,8 @@ impl App {
             | KeyPress::TextBackspace
             | KeyPress::TextApply
             | KeyPress::TextAbandon
-            | KeyPress::Help => {}
+            | KeyPress::Help
+            | KeyPress::Bleats => {}
         }
         Effect::None
     }
@@ -3178,7 +3240,8 @@ impl App {
             | KeyPress::Help
             | KeyPress::ListRemove
             | KeyPress::ListMoveUp
-            | KeyPress::ListMoveDown => {}
+            | KeyPress::ListMoveDown
+            | KeyPress::Bleats => {}
         }
         Effect::None
     }
@@ -3239,7 +3302,7 @@ impl App {
         // `Self::config_pane_mut`, so `self.mode` stays reachable below.
         let Some(pane) = (match &mut self.body {
             Body::ConfigPane(pane) => Some(pane),
-            Body::FlockTable | Body::Settings(_) => None,
+            Body::FlockTable | Body::Settings(_) | Body::Bleats(_) => None,
         }) else {
             return Effect::None;
         };
@@ -3277,7 +3340,7 @@ impl App {
         // `Self::config_pane_mut`, so `self.mode` stays reachable below.
         let Some(pane) = (match &mut self.body {
             Body::ConfigPane(pane) => Some(pane),
-            Body::FlockTable | Body::Settings(_) => None,
+            Body::FlockTable | Body::Settings(_) | Body::Bleats(_) => None,
         }) else {
             return Effect::None;
         };
@@ -3342,7 +3405,7 @@ impl App {
         // `Self::settings_mut`, so `self.now` stays reachable below.
         let Some(settings) = (match &mut self.body {
             Body::Settings(settings) => Some(settings),
-            Body::FlockTable | Body::ConfigPane(_) => None,
+            Body::FlockTable | Body::ConfigPane(_) | Body::Bleats(_) => None,
         }) else {
             return Effect::None;
         };
@@ -3376,7 +3439,7 @@ impl App {
         // `Self::settings_mut`, so `self.now` stays reachable below.
         let Some(settings) = (match &mut self.body {
             Body::Settings(settings) => Some(settings),
-            Body::FlockTable | Body::ConfigPane(_) => None,
+            Body::FlockTable | Body::ConfigPane(_) | Body::Bleats(_) => None,
         }) else {
             return Effect::None;
         };
@@ -4205,7 +4268,7 @@ impl App {
     pub fn settings(&self) -> Option<&Settings> {
         match &self.body {
             Body::Settings(settings) => Some(settings),
-            Body::FlockTable | Body::ConfigPane(_) => None,
+            Body::FlockTable | Body::ConfigPane(_) | Body::Bleats(_) => None,
         }
     }
 
@@ -4214,7 +4277,7 @@ impl App {
     fn settings_mut(&mut self) -> Option<&mut Settings> {
         match &mut self.body {
             Body::Settings(settings) => Some(settings),
-            Body::FlockTable | Body::ConfigPane(_) => None,
+            Body::FlockTable | Body::ConfigPane(_) | Body::Bleats(_) => None,
         }
     }
 
@@ -4247,7 +4310,7 @@ impl App {
     pub fn config_pane(&self) -> Option<&ConfigPane> {
         match &self.body {
             Body::ConfigPane(pane) => Some(pane),
-            Body::FlockTable | Body::Settings(_) => None,
+            Body::FlockTable | Body::Settings(_) | Body::Bleats(_) => None,
         }
     }
 
@@ -4256,7 +4319,16 @@ impl App {
     fn config_pane_mut(&mut self) -> Option<&mut ConfigPane> {
         match &mut self.body {
             Body::ConfigPane(pane) => Some(pane),
-            Body::FlockTable | Body::Settings(_) => None,
+            Body::FlockTable | Body::Settings(_) | Body::Bleats(_) => None,
+        }
+    }
+
+    /// The open bleats pane, or `None` on any other screen.
+    #[must_use]
+    pub fn bleats_pane(&self) -> Option<&BleatsPane> {
+        match &self.body {
+            Body::Bleats(pane) => Some(pane),
+            Body::FlockTable | Body::Settings(_) | Body::ConfigPane(_) => None,
         }
     }
 
@@ -7022,6 +7094,36 @@ mod tests {
         let mut app = fixtures::app_with(Vec::new(), fixtures::plain());
         assert_eq!(app.update(Msg::Key(KeyPress::Edit)), Effect::None);
         assert!(app.config_pane().is_none());
+    }
+
+    /// The pane opens on whatever was selected and pins it: full screen
+    /// leaves no table to change a selection with.
+    #[test]
+    fn b_opens_the_pane_on_the_selected_sheep() {
+        let mut app =
+            fixtures::with_selection(ProcessInfo::builder(9, "web", ProcStatus::Online).build());
+        let _ = app.update(Msg::Key(KeyPress::Bleats));
+        let pane = app.bleats_pane().expect("the pane is open");
+        assert!(matches!(pane.sheep(), RowKey::Sheep(id) if *id == 9));
+    }
+
+    /// `close_pane` always lands on the dashboard, never on whatever screen
+    /// preceded the pane. Same rule the config pane follows.
+    #[test]
+    fn esc_from_the_bleats_pane_lands_on_the_dashboard() {
+        let mut app =
+            fixtures::with_selection(ProcessInfo::builder(9, "web", ProcStatus::Online).build());
+        let _ = app.update(Msg::Key(KeyPress::Bleats));
+        let _ = app.update(Msg::Key(KeyPress::Escape));
+        assert!(matches!(app.body(), Body::FlockTable));
+    }
+
+    /// `b` with nothing selected asks for nothing, the way `e` does.
+    #[test]
+    fn b_with_nothing_selected_opens_no_pane() {
+        let mut app = fixtures::app_with(Vec::new(), fixtures::plain());
+        let _ = app.update(Msg::Key(KeyPress::Bleats));
+        assert!(app.bleats_pane().is_none());
     }
 
     /// A group has no single sheep, so `selected_row` answers `None` for

--- a/crates/shep-cli/src/lookout/app.rs
+++ b/crates/shep-cli/src/lookout/app.rs
@@ -4321,6 +4321,30 @@ impl App {
         }
     }
 
+    /// The row whose log files the feed should read: the bleats pane's
+    /// pinned sheep while that pane is open, and the selection otherwise.
+    ///
+    /// The two are not the same and the difference is operator-visible. The
+    /// pane pins one sheep for its lifetime, but `Msg::Snapshot` reseats the
+    /// selection whatever screen is showing, so a pinned sheep leaving the
+    /// flock moves the selection to another one. Reading the selection here
+    /// would then draw that other sheep's lines under a title still naming
+    /// the pinned sheep, which is one sheep's output presented as another's.
+    ///
+    /// `None` once the pinned sheep is gone, so the pane shows its own
+    /// "no longer in the flock" title over nothing rather than over somebody
+    /// else's log.
+    #[must_use]
+    pub fn feed_row(&self) -> Option<&Row> {
+        match self.bleats_pane() {
+            Some(pane) => match pane.sheep() {
+                RowKey::Sheep(id) => self.flock.get(id),
+                _ => None,
+            },
+            None => self.selected_row(),
+        }
+    }
+
     /// The selected row's app name: a sheep's own, or a group row's.
     ///
     /// Unlike [`Self::selected_row`] this answers for a group too: a config
@@ -7439,6 +7463,51 @@ mod tests {
 
     /// The pane opens on whatever was selected and pins it: full screen
     /// leaves no table to change a selection with.
+    /// The feed follows the pinned sheep, not the selection.
+    ///
+    /// The pane pins one sheep for its lifetime, but `Msg::Snapshot` reseats
+    /// the selection whatever screen is showing. So a pinned sheep leaving
+    /// the flock moved the selection to another one, and the next refresh
+    /// read that sheep's log files while the title still named the pinned
+    /// one: one sheep's output under another sheep's heading.
+    ///
+    /// Asserts the row the feed reads, which is the thing that was wrong.
+    /// Asserting the rendered title would have passed throughout, because
+    /// the title was always right.
+    #[test]
+    fn the_feed_follows_the_pinned_sheep_when_the_selection_moves() {
+        let mut app = fixtures::app_with(
+            vec![
+                ProcessInfo::builder(9, "web", ProcStatus::Online).build(),
+                ProcessInfo::builder(4, "billing", ProcStatus::Online).build(),
+            ],
+            fixtures::plain(),
+        );
+        app.select(RowKey::Sheep(9));
+        let _ = app.update(Msg::Key(KeyPress::Bleats));
+        assert_eq!(
+            app.feed_row().map(|row| row.info.id),
+            Some(9),
+            "the pane opened on 9"
+        );
+
+        // 9 leaves the flock. The reseat moves the selection to 4.
+        let _ = app.update(Msg::Snapshot {
+            rows: vec![ProcessInfo::builder(4, "billing", ProcStatus::Online).build()],
+            at: Instant::now(),
+        });
+        assert_eq!(
+            app.selected(),
+            Some(RowKey::Sheep(4)),
+            "the selection did move, which is the setup for the bug"
+        );
+        assert_eq!(
+            app.feed_row().map(|row| row.info.id),
+            None,
+            "and the feed reads nothing rather than billing's log"
+        );
+    }
+
     #[test]
     fn b_opens_the_pane_on_the_selected_sheep() {
         let mut app =
@@ -7749,6 +7818,15 @@ mod tests {
             assert!(
                 position(first) <= position(last) + 1,
                 "step {step} jumped from {last} to {first}, leaving a gap: \
+                 {before:?} then {after:?}"
+            );
+            // Two-sided. The check above catches a page that steps over
+            // lines; this one catches a page that barely steps at all, which
+            // `page_amount_down` returning a constant 1 would do while
+            // satisfying the first assertion trivially.
+            assert!(
+                position(first) + 1 >= position(before[0].as_str()) + before.len(),
+                "step {step} moved by almost nothing, so it is not a page: \
                  {before:?} then {after:?}"
             );
         }

--- a/crates/shep-cli/src/lookout/app.rs
+++ b/crates/shep-cli/src/lookout/app.rs
@@ -2511,9 +2511,7 @@ impl App {
             }
             // `k`/`Up`: one line toward older lines.
             KeyPress::SelectUp => {
-                if let Some(pane) = self.bleats_pane_mut() {
-                    pane.scroll_up(1);
-                }
+                self.scroll_bleats_back(1);
                 Effect::None
             }
             // `j`/`Down`: one line toward the newest.
@@ -2539,9 +2537,7 @@ impl App {
                 let amount = self
                     .bleats_pane()
                     .map_or(1, |pane| super::view::bleats_full::page_amount_up(self, pane));
-                if let Some(pane) = self.bleats_pane_mut() {
-                    pane.page_up(amount);
-                }
+                self.scroll_bleats_back(amount);
                 Effect::None
             }
             // `ctrl-d`: toward the newest line, and sized by its own
@@ -4318,6 +4314,24 @@ impl App {
         match &self.selected {
             Some(RowKey::Sheep(id)) => self.flock.get(id),
             _ => None,
+        }
+    }
+
+    /// Scrolls the bleats pane back by `amount`, then holds the offset at the
+    /// last value that changes the frame.
+    ///
+    /// The ceiling has to live here rather than on the pane: it depends on
+    /// the surviving lines and their wrapped heights, which the pane cannot
+    /// see. Without it `scroll_up` saturating-adds forever and `j` stops
+    /// appearing to work, since the render clamps while the stored value
+    /// keeps climbing.
+    fn scroll_bleats_back(&mut self, amount: usize) {
+        let ceiling = self.bleats_pane().map_or(0, |pane| {
+            super::view::bleats_full::max_scroll_offset(self, pane)
+        });
+        if let Some(pane) = self.bleats_pane_mut() {
+            pane.scroll_up(amount);
+            pane.clamp_scroll(ceiling);
         }
     }
 
@@ -7747,6 +7761,36 @@ mod tests {
     ///
     /// Walks in one direction and asserts every line across the windows,
     /// because paging back is symmetric and would hide the gap.
+    /// Over-scrolling does not make `j` stop working.
+    ///
+    /// `scroll_up` saturating-adds and the clamp lived only in the render, so
+    /// the stored offset climbed past anything that changes the frame.
+    /// Measured before the ceiling: a 20-line feed with a 5-row body left the
+    /// offset at 39 after 40 `k` presses, where 15 was the most that did
+    /// anything, and the operator then pressed `j` 25 times before the window
+    /// moved. `G` and `f` escape that; `j` is the reflex and it did nothing.
+    #[test]
+    fn over_scrolling_back_does_not_deaden_the_scroll_forward() {
+        let mut app = fixtures::bleats_pane_with_lines(20);
+        app.note_body_rows(6);
+        app.note_body_width(80);
+
+        for _ in 0..40 {
+            let _ = app.update(Msg::Key(KeyPress::SelectUp));
+        }
+        let parked =
+            fixtures::render_all(&super::super::view::bleats_full::draw_lines(&app, 80, 6));
+
+        let _ = app.update(Msg::Key(KeyPress::SelectDown));
+        let after_one =
+            fixtures::render_all(&super::super::view::bleats_full::draw_lines(&app, 80, 6));
+        assert_ne!(
+            parked, after_one,
+            "one press forward has to move the window, however far back the \
+             operator scrolled"
+        );
+    }
+
     #[test]
     fn wrapped_pages_leave_no_line_unseen() {
         let mut app = fixtures::bleats_pane_with_mixed_line_lengths();

--- a/crates/shep-cli/src/lookout/app.rs
+++ b/crates/shep-cli/src/lookout/app.rs
@@ -2385,8 +2385,9 @@ impl App {
     }
 
     /// `b`: opens the full-screen bleats pane on the selected sheep. A
-    /// group or an empty selection asks for nothing, the same shape
-    /// [`Self::ask_for_config`] follows.
+    /// group row or an empty selection is refused rather than opening on a
+    /// stand-in: the pane is pinned to one sheep for its whole lifetime
+    /// ([`BleatsPane`]), and a group has no single sheep to pin it to.
     fn ask_for_bleats(&mut self) -> Effect {
         if let Some(sheep @ RowKey::Sheep(_)) = self.selected() {
             self.body = Body::Bleats(BleatsPane::new(sheep));

--- a/crates/shep-cli/src/lookout/app.rs
+++ b/crates/shep-cli/src/lookout/app.rs
@@ -1517,7 +1517,13 @@ impl App {
                 // fixed for the connection's lifetime (see `RefreshFeed`'s
                 // own doc). The dashboard raises nothing here, or every
                 // lookout would poll twice as often for nothing.
-                if matches!(self.body, Body::Bleats(_)) {
+                // `Link::Lost` too: `Msg::Bleats` throws the tail away
+                // while the link is down, so every read would be work done
+                // and discarded once a second. `Msg::Snapshot` and
+                // `select_at` guard on the same thing, and
+                // `a_frozen_dashboard_does_not_re_read_anything` states the
+                // rule.
+                if matches!(self.body, Body::Bleats(_)) && !matches!(self.link, Link::Lost { .. }) {
                     Effect::RefreshFeed
                 } else {
                     Effect::None
@@ -2574,10 +2580,18 @@ impl App {
                 }
                 Effect::None
             }
-            // `N`: the same, toward the oldest matching line.
+            // `N`: the same, toward the oldest matching line, through
+            // `scroll_bleats_back` so it takes the ceiling `k` and `ctrl-u`
+            // take. Calling `match_prev` directly would climb past the
+            // oldest surviving match and then `n`, `j` and `ctrl-d` would
+            // all stop appearing to work until the offset drained. The
+            // matcher guard is read here because the scroll happens here.
             KeyPress::MatchPrev => {
-                if let Some(pane) = self.bleats_pane_mut() {
-                    pane.match_prev();
+                let stepping = self
+                    .bleats_pane()
+                    .is_some_and(|pane| pane.filters().matcher.is_some());
+                if stepping {
+                    self.scroll_bleats_back(1);
                 }
                 Effect::None
             }
@@ -7769,6 +7783,54 @@ mod tests {
     /// offset at 39 after 40 `k` presses, where 15 was the most that did
     /// anything, and the operator then pressed `j` 25 times before the window
     /// moved. `G` and `f` escape that; `j` is the reflex and it did nothing.
+    /// Holding `N` past the oldest match does not deaden `n` either.
+    ///
+    /// `k` and `ctrl-u` route through the clamp; `N` called `match_prev`
+    /// directly and climbed past it. The existing `n`/`N` test presses `N`
+    /// once, so it never reached the ceiling.
+    #[test]
+    fn over_stepping_back_through_matches_does_not_deaden_the_step_forward() {
+        let mut app = fixtures::bleats_pane_with_lines(20);
+        app.note_body_rows(6);
+        app.note_body_width(80);
+        app.bleats_pane_mut_for_tests()
+            .expect("open")
+            .set_match("line".to_string());
+
+        for _ in 0..40 {
+            let _ = app.update(Msg::Key(KeyPress::MatchPrev));
+        }
+        let parked =
+            fixtures::render_all(&super::super::view::bleats_full::draw_lines(&app, 80, 6));
+        let _ = app.update(Msg::Key(KeyPress::MatchNext));
+        let after_one =
+            fixtures::render_all(&super::super::view::bleats_full::draw_lines(&app, 80, 6));
+        assert_ne!(parked, after_one, "one step forward has to move the window");
+    }
+
+    /// A frozen lookout with the pane open stops re-reading the log files.
+    ///
+    /// `Msg::Bleats` throws the tail away while the link is down, so every
+    /// read was work done and discarded once a second. `Msg::Snapshot` and
+    /// `select_at` already guard on the same thing.
+    #[test]
+    fn a_frozen_lookout_does_not_re_read_the_pane_s_log() {
+        let mut app =
+            fixtures::with_selection(ProcessInfo::builder(9, "web", ProcStatus::Online).build());
+        let _ = app.update(Msg::Key(KeyPress::Bleats));
+        let now = Instant::now();
+        assert_eq!(app.update(Msg::Tick { now }), Effect::RefreshFeed);
+
+        let _ = app.update(Msg::Frozen {
+            at_local: "2026-09-08 09:00:00".to_string(),
+        });
+        assert_eq!(
+            app.update(Msg::Tick { now }),
+            Effect::None,
+            "a read whose result Msg::Bleats discards is not worth doing"
+        );
+    }
+
     #[test]
     fn over_scrolling_back_does_not_deaden_the_scroll_forward() {
         let mut app = fixtures::bleats_pane_with_lines(20);

--- a/crates/shep-cli/src/lookout/app.rs
+++ b/crates/shep-cli/src/lookout/app.rs
@@ -7656,6 +7656,53 @@ mod tests {
     /// Asserts every line across the two windows, not the offset: an
     /// operator reading history by paging silently misses the gap, so a
     /// test that only watched the number move would too.
+    /// Wrapped paging leaves no line unseen either, over a feed whose older
+    /// lines are far longer than its newest.
+    ///
+    /// Measured: with the page sized from the tail, three steps into the
+    /// wrapped stretch showed `old-32..old-35` where the step before showed
+    /// `new-4..new-15`, skipping eight lines no screen ever drew, and the
+    /// next step skipped eight more. Sized from the current window instead,
+    /// the same walk is contiguous.
+    ///
+    /// That is the Task 7 defect one level harder: there the jump was one
+    /// row too many, here it is most of a screen. Both were invisible for
+    /// the same reason, that paging back cancels the error out.
+    ///
+    /// `note_body_width` matters as much as `note_body_rows` here. The
+    /// wrap-aware path is skipped entirely while the pane's width is `0`,
+    /// which is what a test that never reports one leaves it as, so a test
+    /// missing that call passes against a page size that was never wrapped.
+    ///
+    /// Walks in one direction and asserts every line across the windows,
+    /// because paging back is symmetric and would hide the gap.
+
+    #[test]
+    fn wrapped_pages_leave_no_line_unseen() {
+        let mut app = fixtures::bleats_pane_with_mixed_line_lengths();
+        let _ = app.update(Msg::Key(KeyPress::WrapToggle));
+        app.note_body_rows(13); // 1 title, no chip, so 12 body rows
+        app.note_body_width(60);
+
+        let mut seen = String::new();
+        for _ in 0..12 {
+            seen.push_str(&fixtures::render_all(
+                &super::super::view::bleats_full::draw_lines(&app, 60, 13),
+            ));
+            let _ = app.update(Msg::Key(KeyPress::PageUp));
+        }
+
+        // Every `old-` line the walk passed over must have been drawn in one
+        // of the windows. A gap means a page stepped over lines that no
+        // screen ever showed.
+        for n in 30..40 {
+            assert!(
+                seen.contains(&format!("old-{n} ")),
+                "old-{n} fell between two wrapped pages"
+            );
+        }
+    }
+
     #[test]
     fn consecutive_pages_leave_no_line_unseen_while_a_chip_is_showing() {
         let mut app = fixtures::bleats_pane_with_lines(40);

--- a/crates/shep-cli/src/lookout/app.rs
+++ b/crates/shep-cli/src/lookout/app.rs
@@ -2397,12 +2397,18 @@ impl App {
 
     /// The bleats pane's own keymap, in force while [`Self::bleats_pane`] is
     /// `Some`. There is nothing on this screen to move or edit: `Escape`
-    /// closes it, and everything else is inert.
+    /// drops the newest filter chip first, one axis at a time, and only
+    /// closes the pane once none are left.
     fn on_bleats_key(&mut self, key: KeyPress) -> Effect {
         match key {
             KeyPress::Quit => Effect::Quit,
             KeyPress::Escape => {
-                self.close_pane();
+                let dropped_a_chip = self
+                    .bleats_pane_mut()
+                    .is_some_and(BleatsPane::drop_newest_chip);
+                if !dropped_a_chip {
+                    self.close_pane();
+                }
                 Effect::None
             }
             KeyPress::SelectUp
@@ -4328,6 +4334,16 @@ impl App {
     #[must_use]
     pub fn bleats_pane(&self) -> Option<&BleatsPane> {
         match &self.body {
+            Body::Bleats(pane) => Some(pane),
+            Body::FlockTable | Body::Settings(_) | Body::ConfigPane(_) => None,
+        }
+    }
+
+    /// [`Self::bleats_pane`]'s mutable twin, for `Escape`'s chip-by-chip
+    /// backout and the filter-setting keys the reducer handles on
+    /// [`Body::Bleats`].
+    fn bleats_pane_mut(&mut self) -> Option<&mut BleatsPane> {
+        match &mut self.body {
             Body::Bleats(pane) => Some(pane),
             Body::FlockTable | Body::Settings(_) | Body::ConfigPane(_) => None,
         }
@@ -7112,6 +7128,18 @@ mod tests {
     /// preceded the pane. Same rule the config pane follows.
     #[test]
     fn esc_from_the_bleats_pane_lands_on_the_dashboard() {
+        let mut app =
+            fixtures::with_selection(ProcessInfo::builder(9, "web", ProcStatus::Online).build());
+        let _ = app.update(Msg::Key(KeyPress::Bleats));
+        let _ = app.update(Msg::Key(KeyPress::Escape));
+        assert!(matches!(app.body(), Body::FlockTable));
+    }
+
+    /// With no chips left, `Escape` closes the pane instead of dropping one.
+    /// A freshly opened pane has no filters set, so its very first `Escape`
+    /// already exercises this rather than the chip-dropping branch.
+    #[test]
+    fn esc_with_no_chips_closes_the_pane() {
         let mut app =
             fixtures::with_selection(ProcessInfo::builder(9, "web", ProcStatus::Online).build());
         let _ = app.update(Msg::Key(KeyPress::Bleats));

--- a/crates/shep-cli/src/lookout/app.rs
+++ b/crates/shep-cli/src/lookout/app.rs
@@ -1479,7 +1479,16 @@ impl App {
                 {
                     pane.cancel();
                 }
-                Effect::None
+                // The bleats pane has no timer of its own; it rides every
+                // tick instead of the dashboard's own cadence, which is
+                // fixed for the connection's lifetime (see `RefreshFeed`'s
+                // own doc). The dashboard raises nothing here, or every
+                // lookout would poll twice as often for nothing.
+                if matches!(self.body, Body::Bleats(_)) {
+                    Effect::RefreshFeed
+                } else {
+                    Effect::None
+                }
             }
             Msg::Resize => Effect::None,
             Msg::Key(key) => self.on_key(key),
@@ -4899,6 +4908,27 @@ mod tests {
             now: t0 + Duration::from_secs(10),
         });
         assert!(app.action().is_none(), "ten is not");
+    }
+
+    /// The pane asks for its own refreshes rather than changing the link's
+    /// interval, which is fixed for a connection's lifetime.
+    #[test]
+    fn a_tick_while_the_pane_is_open_asks_for_a_poll() {
+        let mut app =
+            fixtures::with_selection(ProcessInfo::builder(9, "web", ProcStatus::Online).build());
+        let _ = app.update(Msg::Key(KeyPress::Bleats));
+        let now = Instant::now();
+        assert_eq!(app.update(Msg::Tick { now }), Effect::RefreshFeed);
+    }
+
+    /// And does not on the dashboard, or every lookout would poll twice as
+    /// often for nothing.
+    #[test]
+    fn a_tick_on_the_dashboard_asks_for_nothing() {
+        let mut app =
+            fixtures::with_selection(ProcessInfo::builder(9, "web", ProcStatus::Online).build());
+        let now = Instant::now();
+        assert_eq!(app.update(Msg::Tick { now }), Effect::None);
     }
 
     #[test]

--- a/crates/shep-cli/src/lookout/app.rs
+++ b/crates/shep-cli/src/lookout/app.rs
@@ -7135,16 +7135,40 @@ mod tests {
         assert!(matches!(app.body(), Body::FlockTable));
     }
 
-    /// With no chips left, `Escape` closes the pane instead of dropping one.
-    /// A freshly opened pane has no filters set, so its very first `Escape`
-    /// already exercises this rather than the chip-dropping branch.
+    /// `Escape` with a chip set drops the chip and leaves the pane open; only
+    /// the next one closes it. Both halves in one test, because the guard in
+    /// `on_bleats_key` is invisible to a test that never sets a chip: with a
+    /// freshly opened pane `drop_newest_chip` returns `false` either way, so
+    /// removing the guard entirely still passes every other `esc` test in this
+    /// file. Measured, not assumed.
     #[test]
-    fn esc_with_no_chips_closes_the_pane() {
+    fn esc_drops_a_chip_before_it_closes_the_pane() {
         let mut app =
             fixtures::with_selection(ProcessInfo::builder(9, "web", ProcStatus::Online).build());
         let _ = app.update(Msg::Key(KeyPress::Bleats));
+        app.bleats_pane_mut()
+            .expect("the pane is open")
+            .set_min_level(Some(super::super::level::Level::Warn));
+
         let _ = app.update(Msg::Key(KeyPress::Escape));
-        assert!(matches!(app.body(), Body::FlockTable));
+        assert!(
+            matches!(app.body(), Body::Bleats(_)),
+            "the first Escape spends the chip and keeps the pane"
+        );
+        assert!(
+            app.bleats_pane()
+                .expect("still open")
+                .filters()
+                .min_level
+                .is_none(),
+            "the chip it spent was the level one"
+        );
+
+        let _ = app.update(Msg::Key(KeyPress::Escape));
+        assert!(
+            matches!(app.body(), Body::FlockTable),
+            "with no chips left the next Escape closes"
+        );
     }
 
     /// `b` with nothing selected asks for nothing, the way `e` does.

--- a/crates/shep-cli/src/lookout/app.rs
+++ b/crates/shep-cli/src/lookout/app.rs
@@ -2530,7 +2530,7 @@ impl App {
                 Effect::None
             }
             // `ctrl-u`: a page toward older lines. Sized through
-            // `page_amount` rather than `pane.body_rows()` directly: see
+            // `page_amount_up` rather than `pane.body_rows()` directly: see
             // that function's own doc for why a page is a line count under
             // wrap, not a raw row count.
             KeyPress::PageUp => {
@@ -4682,9 +4682,9 @@ impl App {
         }
     }
 
-    /// [`Self::bleats_pane_mut`], exposed past this module: the only route a
-    /// fixture has to stack filters onto a pane it opened, since setting one
-    /// is not yet reachable through any key.
+    /// [`Self::bleats_pane_mut`], exposed past this module so a fixture can
+    /// stack filters onto a pane it opened without walking `o` and `m`
+    /// through their cycles or typing into the match box.
     #[cfg(test)]
     pub(crate) fn bleats_pane_mut_for_tests(&mut self) -> Option<&mut BleatsPane> {
         self.bleats_pane_mut()

--- a/crates/shep-cli/src/lookout/app.rs
+++ b/crates/shep-cli/src/lookout/app.rs
@@ -23,8 +23,10 @@ use shep_core::protocol::{
 use shep_core::status::ProcStatus;
 
 use super::field::{FieldKind, FieldSet};
+use super::level::Level;
 use super::pane::{ConfigPane, FieldValue, Lock, PaneEdit, PanePending, PaneTarget, ReloadKind};
 use super::pane_bleats::BleatsPane;
+use super::tail::Stream;
 use super::theme::Palette;
 use super::viewport::Viewport;
 use crate::commands::settings::{SettingEdit, SettingField, SettingsSnapshot, settings_field_set};
@@ -118,6 +120,16 @@ pub enum KeyPress {
     /// `b`: opens the full-screen bleats pane on the selected sheep. Does
     /// nothing with no sheep selected, the way `e` does.
     Bleats,
+    /// `o`: cycles the bleats pane's stream axis, `None` (both) → `Out` →
+    /// `Err` → `None`. A global binding, so the dashboard sees it too, and
+    /// ignores it: there is no stream axis outside the pane.
+    StreamCycle,
+    /// `m`: cycles the bleats pane's minimum-level axis through every
+    /// [`super::level::Level`] in ascending order, then back to `None`.
+    /// Chosen over a design-named key because the status bar's own list
+    /// names none for this axis; a global binding, ignored on the
+    /// dashboard the same way [`Self::StreamCycle`] is.
+    LevelCycle,
 }
 
 /// Everything that can change the dashboard.
@@ -2390,6 +2402,11 @@ impl App {
             // Opens on the selected sheep, or does nothing without one, the
             // same shape `KeyPress::Edit` follows above.
             KeyPress::Bleats => self.ask_for_bleats(),
+            // Both cycle a bleats-pane filter axis, and the dashboard has no
+            // such axis; named here rather than left to fall through the
+            // arm above, the same way `KeyPress::Bleats` would be ignored
+            // on a screen with no bleats pane.
+            KeyPress::StreamCycle | KeyPress::LevelCycle => Effect::None,
         }
     }
 
@@ -2420,6 +2437,47 @@ impl App {
                 }
                 Effect::None
             }
+            // Opens the match box: `on_text_key` routes the keystrokes that
+            // follow to `on_bleats_text_key` once this pane owns
+            // `InputMode::Text`. `begin_match_edit` remembers what the axis
+            // held, so an abandoned edit restores it rather than losing it.
+            KeyPress::FilterStart => {
+                if let Some(pane) = self.bleats_pane_mut() {
+                    pane.begin_match_edit();
+                }
+                self.mode = InputMode::Text;
+                Effect::None
+            }
+            // `o`: `None` (both streams) -> `Out` -> `Err` -> `None`.
+            KeyPress::StreamCycle => {
+                if let Some(pane) = self.bleats_pane_mut() {
+                    let next = match pane.filters().stream {
+                        None => Some(Stream::Out),
+                        Some(Stream::Out) => Some(Stream::Err),
+                        Some(Stream::Err) => None,
+                    };
+                    pane.set_stream(next);
+                }
+                Effect::None
+            }
+            // `m`: every `Level` in ascending order, then back to `None`.
+            // The cycle must reach `None` again, or an operator who sets a
+            // minimum can never see an unclassifiable line again without
+            // closing the pane.
+            KeyPress::LevelCycle => {
+                if let Some(pane) = self.bleats_pane_mut() {
+                    let next = match pane.filters().min_level {
+                        None => Some(Level::Trace),
+                        Some(Level::Trace) => Some(Level::Debug),
+                        Some(Level::Debug) => Some(Level::Info),
+                        Some(Level::Info) => Some(Level::Warn),
+                        Some(Level::Warn) => Some(Level::Error),
+                        Some(Level::Error) => None,
+                    };
+                    pane.set_min_level(next);
+                }
+                Effect::None
+            }
             KeyPress::SelectUp
             | KeyPress::SelectDown
             | KeyPress::SelectFirst
@@ -2427,7 +2485,9 @@ impl App {
             | KeyPress::Refresh
             | KeyPress::Action(_)
             | KeyPress::Confirm
-            | KeyPress::FilterStart
+            // Reach here only from text mode, already branched above in
+            // `on_key`; listed so a new `KeyPress` variant cannot fall
+            // silently into an arm that ignores it.
             | KeyPress::TextChar(_)
             | KeyPress::TextBackspace
             | KeyPress::TextApply
@@ -2440,6 +2500,50 @@ impl App {
             | KeyPress::ListMoveUp
             | KeyPress::ListMoveDown
             | KeyPress::Bleats => Effect::None,
+        }
+    }
+
+    /// The bleats pane's match box, in force while it owns
+    /// [`InputMode::Text`]. Follows the flock table's own text keymap
+    /// ([`Self::on_filter_text_key`]) with one difference the design calls
+    /// for: typing narrows live through [`BleatsPane::set_match`], but
+    /// `TextAbandon` restores whatever [`BleatsPane::begin_match_edit`] saw
+    /// rather than clearing the axis outright, since the axis may already
+    /// have held a chip from an earlier edit.
+    fn on_bleats_text_key(&mut self, key: KeyPress) -> Effect {
+        match key {
+            KeyPress::Quit => Effect::Quit,
+            KeyPress::TextChar(typed) => {
+                if let Some(pane) = self.bleats_pane_mut() {
+                    let mut text = pane.filters().matcher.clone().unwrap_or_default();
+                    text.push(typed);
+                    pane.set_match(text);
+                }
+                Effect::None
+            }
+            KeyPress::TextBackspace => {
+                if let Some(pane) = self.bleats_pane_mut() {
+                    let mut text = pane.filters().matcher.clone().unwrap_or_default();
+                    text.pop();
+                    pane.set_match(text);
+                }
+                Effect::None
+            }
+            KeyPress::TextApply => {
+                self.mode = InputMode::Normal;
+                if let Some(pane) = self.bleats_pane_mut() {
+                    pane.commit_match_edit();
+                }
+                Effect::None
+            }
+            KeyPress::TextAbandon => {
+                self.mode = InputMode::Normal;
+                if let Some(pane) = self.bleats_pane_mut() {
+                    pane.abandon_match_edit();
+                }
+                Effect::None
+            }
+            _ => Effect::None,
         }
     }
 
@@ -2520,6 +2624,8 @@ impl App {
             | KeyPress::ListRemove
             | KeyPress::ListMoveUp
             | KeyPress::ListMoveDown
+            | KeyPress::StreamCycle
+            | KeyPress::LevelCycle
             | KeyPress::Bleats => {}
         }
         Effect::None
@@ -2703,6 +2809,8 @@ impl App {
             | KeyPress::ListRemove
             | KeyPress::ListMoveUp
             | KeyPress::ListMoveDown
+            | KeyPress::StreamCycle
+            | KeyPress::LevelCycle
             | KeyPress::Bleats => {}
         }
         Effect::None
@@ -2798,6 +2906,8 @@ impl App {
             | KeyPress::ListRemove
             | KeyPress::ListMoveUp
             | KeyPress::ListMoveDown
+            | KeyPress::StreamCycle
+            | KeyPress::LevelCycle
             | KeyPress::Bleats => Effect::None,
         }
     }
@@ -3176,6 +3286,8 @@ impl App {
             | KeyPress::TextApply
             | KeyPress::TextAbandon
             | KeyPress::Help
+            | KeyPress::StreamCycle
+            | KeyPress::LevelCycle
             | KeyPress::Bleats => {}
         }
         Effect::None
@@ -3257,6 +3369,8 @@ impl App {
             | KeyPress::ListRemove
             | KeyPress::ListMoveUp
             | KeyPress::ListMoveDown
+            | KeyPress::StreamCycle
+            | KeyPress::LevelCycle
             | KeyPress::Bleats => {}
         }
         Effect::None
@@ -3735,16 +3849,20 @@ impl App {
     /// closed, [`Self::on_settings_text_key`]'s editor while it is open. The
     /// two never both own [`InputMode::Text`].
     fn on_text_key(&mut self, key: KeyPress) -> Effect {
-        // Three now, and the split is still total: the config pane and the
-        // settings screen cannot both be open (`e` reaches the dashboard
-        // only from the dashboard, and `s` only from there too), and
-        // neither can coexist with the filter box, which `Msg::Settings`'s
-        // own arm closed the window on.
+        // Four now, and the split is still total: the config pane, the
+        // settings screen and the bleats pane cannot coexist with each
+        // other (`e` and `s` reach the dashboard only from the dashboard,
+        // and `b` only from there too), and none of them coexist with the
+        // dashboard's own filter box, which `Msg::Settings`'s own arm
+        // closed the window on.
         if self.config_pane().is_some() {
             return self.on_pane_text_key(key);
         }
         if self.settings().is_some() {
             return self.on_settings_text_key(key);
+        }
+        if self.bleats_pane().is_some() {
+            return self.on_bleats_text_key(key);
         }
         self.on_filter_text_key(key)
     }
@@ -7207,6 +7325,158 @@ mod tests {
             matches!(app.body(), Body::FlockTable),
             "with no chips left the next Escape closes"
         );
+    }
+
+    /// `o` cycles the stream axis through its three states and back. Three
+    /// presses return to where it began, which is what makes it a cycle
+    /// rather than a toggle that strands the operator on `err`.
+    #[test]
+    fn o_cycles_the_stream_axis_and_returns_to_both() {
+        let mut app =
+            fixtures::with_selection(ProcessInfo::builder(9, "web", ProcStatus::Online).build());
+        let _ = app.update(Msg::Key(KeyPress::Bleats));
+        assert!(app.bleats_pane().expect("open").filters().stream.is_none());
+        let _ = app.update(Msg::Key(KeyPress::StreamCycle));
+        let first = app.bleats_pane().expect("open").filters().stream;
+        assert!(first.is_some(), "one press sets an axis");
+        let _ = app.update(Msg::Key(KeyPress::StreamCycle));
+        let _ = app.update(Msg::Key(KeyPress::StreamCycle));
+        assert!(
+            app.bleats_pane().expect("open").filters().stream.is_none(),
+            "three presses land back on both"
+        );
+    }
+
+    /// `m` raises the minimum level and eventually clears it. The unset state
+    /// has to be reachable by key, or an operator who sets a minimum can never
+    /// see unlevelled output again without closing the pane.
+    #[test]
+    fn m_cycles_the_level_axis_back_to_unset() {
+        let mut app =
+            fixtures::with_selection(ProcessInfo::builder(9, "web", ProcStatus::Online).build());
+        let _ = app.update(Msg::Key(KeyPress::Bleats));
+        let mut seen_some = false;
+        for _ in 0..8 {
+            let _ = app.update(Msg::Key(KeyPress::LevelCycle));
+            if app
+                .bleats_pane()
+                .expect("open")
+                .filters()
+                .min_level
+                .is_some()
+            {
+                seen_some = true;
+            }
+        }
+        assert!(seen_some, "the cycle passes through a set minimum");
+        // Whatever the cycle length, it must return to unset within one lap.
+        let mut cleared = false;
+        for _ in 0..8 {
+            let _ = app.update(Msg::Key(KeyPress::LevelCycle));
+            if app
+                .bleats_pane()
+                .expect("open")
+                .filters()
+                .min_level
+                .is_none()
+            {
+                cleared = true;
+                break;
+            }
+        }
+        assert!(cleared, "the cycle returns to unset");
+    }
+
+    /// `/` opens the match input rather than doing nothing, which is what it
+    /// did when this pane first shipped.
+    #[test]
+    fn slash_opens_the_match_input_in_the_bleats_pane() {
+        let mut app =
+            fixtures::with_selection(ProcessInfo::builder(9, "web", ProcStatus::Online).build());
+        let _ = app.update(Msg::Key(KeyPress::Bleats));
+        let _ = app.update(Msg::Key(KeyPress::FilterStart));
+        assert_eq!(app.mode(), InputMode::Text, "typing goes to the pane");
+    }
+
+    /// Typing into the match box narrows live, the same as the flock
+    /// table's own `/` box: the operator sees the filter row react to every
+    /// keystroke rather than only after `Enter`.
+    #[test]
+    fn typing_in_the_match_box_narrows_live() {
+        let mut app =
+            fixtures::with_selection(ProcessInfo::builder(9, "web", ProcStatus::Online).build());
+        let _ = app.update(Msg::Key(KeyPress::Bleats));
+        let _ = app.update(Msg::Key(KeyPress::FilterStart));
+        let _ = app.update(Msg::Key(KeyPress::TextChar('p')));
+        let _ = app.update(Msg::Key(KeyPress::TextChar('o')));
+        assert_eq!(
+            app.bleats_pane()
+                .expect("open")
+                .filters()
+                .matcher
+                .as_deref(),
+            Some("po")
+        );
+        let _ = app.update(Msg::Key(KeyPress::TextApply));
+        assert_eq!(app.mode(), InputMode::Normal);
+        assert_eq!(
+            app.bleats_pane()
+                .expect("open")
+                .filters()
+                .matcher
+                .as_deref(),
+            Some("po"),
+            "TextApply keeps what was already applied live"
+        );
+    }
+
+    /// `TextAbandon` restores the match axis to what it held before the box
+    /// opened, discarding whatever was typed since, rather than clearing it
+    /// outright the way the flock table's own filter box does.
+    #[test]
+    fn abandoning_the_match_box_restores_the_axis_it_had_before() {
+        let mut app =
+            fixtures::with_selection(ProcessInfo::builder(9, "web", ProcStatus::Online).build());
+        let _ = app.update(Msg::Key(KeyPress::Bleats));
+        app.bleats_pane_mut()
+            .expect("open")
+            .set_match("pool".to_string());
+
+        let _ = app.update(Msg::Key(KeyPress::FilterStart));
+        let _ = app.update(Msg::Key(KeyPress::TextChar('x')));
+        assert_eq!(
+            app.bleats_pane()
+                .expect("open")
+                .filters()
+                .matcher
+                .as_deref(),
+            Some("poolx"),
+            "typing narrowed live"
+        );
+        let _ = app.update(Msg::Key(KeyPress::TextAbandon));
+        assert_eq!(app.mode(), InputMode::Normal);
+        assert_eq!(
+            app.bleats_pane()
+                .expect("open")
+                .filters()
+                .matcher
+                .as_deref(),
+            Some("pool"),
+            "abandon restores what the axis held before the edit"
+        );
+    }
+
+    /// `o` and `m` are global bindings, so the dashboard sees them too; with
+    /// no bleats pane open there is no stream or level axis to cycle, and
+    /// the reducer says so explicitly rather than falling through to a
+    /// wildcard, the same way it already does for `KeyPress::Bleats` here.
+    #[test]
+    fn stream_and_level_cycle_are_inert_on_the_dashboard() {
+        let mut app =
+            fixtures::with_selection(ProcessInfo::builder(9, "web", ProcStatus::Online).build());
+        assert_eq!(app.update(Msg::Key(KeyPress::StreamCycle)), Effect::None);
+        assert_eq!(app.update(Msg::Key(KeyPress::LevelCycle)), Effect::None);
+        assert!(matches!(app.body(), Body::FlockTable));
     }
 
     /// `b` with nothing selected asks for nothing, the way `e` does.

--- a/crates/shep-cli/src/lookout/app.rs
+++ b/crates/shep-cli/src/lookout/app.rs
@@ -4514,12 +4514,18 @@ impl App {
             }
         }
         if let Some(pane) = self.bleats_pane_mut() {
-            // One less than the whole body, the same discount the config
-            // pane takes above: the title band costs a line before any
-            // feed line is drawn. The filter row, when one is showing,
-            // costs a second; not deducted here, since `page_up`/`page_down`
-            // only need a page-sized jump, not an exact one.
-            pane.set_rows(usize::from(rows.saturating_sub(1)));
+            // Every row `view::bleats_full::lines` spends before the first
+            // feed line: the title band always, and the filter row whenever
+            // a chip is set.
+            //
+            // Both, not just the title. A page jump larger than the body it
+            // scrolls skips lines outright rather than merely overshooting:
+            // with a chip showing, a jump of `rows - 1` over a body of
+            // `rows - 2` leaves one line between consecutive pages that
+            // `ctrl-d` alone never renders. Paging down and back up is
+            // symmetric either way, which is why nothing noticed.
+            let chrome = 1 + usize::from(!pane.filters().is_empty());
+            pane.set_rows(usize::from(rows).saturating_sub(chrome));
         }
     }
 
@@ -7503,14 +7509,25 @@ mod tests {
         let mut app = fixtures::bleats_pane_with_lines(120);
         let _ = app.update(Msg::Key(KeyPress::PageUp));
         let _ = app.update(Msg::Key(KeyPress::PageUp));
+
+        // One survivor, far fewer than the offset two pages back. Without
+        // the clamp the skip underflows: it panics in debug and wraps in
+        // release, and a wrapped skip yields no feed lines at all.
         app.bleats_pane_mut_for_tests()
             .expect("open")
-            .set_match("a-string-no-line-contains".to_string());
+            .set_match("line-119".to_string());
         let text =
             fixtures::render_all(&super::super::view::bleats_full::draw_lines(&app, 160, 40));
+
+        // Asserts a rendered FEED line, tagged `out`, not merely that the
+        // text appears: the filter row echoes the matcher back as its own
+        // `match line-119` chip, so `contains("line-119")` passes even when
+        // every feed line was skipped away. `!text.is_empty()` was weaker
+        // still, and passed in release with the clamp removed because the
+        // title and the chip alone kept the buffer non-empty.
         assert!(
-            !text.is_empty(),
-            "the pane still draws rather than panicking"
+            text.contains("out  line-119"),
+            "the one surviving line is drawn in the body: {text}"
         );
     }
 
@@ -7552,6 +7569,43 @@ mod tests {
     /// `ctrl-u`/`ctrl-d` move by a body height rather than a line, and the
     /// body height is what `note_body_rows` last reported, not a hardcoded
     /// guess.
+    /// Two pages back leave no line unseen, with a filter chip on screen.
+    ///
+    /// The chip costs a row, so the body is two rows shorter than the pane,
+    /// not one. A jump sized to the pane rather than the body skips a line
+    /// between consecutive pages: it belongs to neither window and `ctrl-u`
+    /// alone never renders it. Paging back down is symmetric either way,
+    /// which is why the round trip looked fine and the gap did not.
+    ///
+    /// Asserts every line across the two windows, not the offset: an
+    /// operator reading history by paging silently misses the gap, so a
+    /// test that only watched the number move would too.
+    #[test]
+    fn consecutive_pages_leave_no_line_unseen_while_a_chip_is_showing() {
+        let mut app = fixtures::bleats_pane_with_lines(40);
+        app.bleats_pane_mut_for_tests()
+            .expect("open")
+            .set_match("line".to_string());
+        app.note_body_rows(6); // 1 title + 1 filter row + 4 body rows
+
+        let first = fixtures::render_all(&super::super::view::bleats_full::draw_lines(&app, 80, 6));
+        let _ = app.update(Msg::Key(KeyPress::PageUp));
+        let second =
+            fixtures::render_all(&super::super::view::bleats_full::draw_lines(&app, 80, 6));
+        let _ = app.update(Msg::Key(KeyPress::PageUp));
+        let third = fixtures::render_all(&super::super::view::bleats_full::draw_lines(&app, 80, 6));
+
+        let seen = format!("{first}{second}{third}");
+        // The three windows are contiguous, so every line from the oldest
+        // one drawn through the newest must appear in one of them.
+        for n in 28..=39 {
+            assert!(
+                seen.contains(&format!("line-{n}")),
+                "line-{n} fell between two pages: {seen}"
+            );
+        }
+    }
+
     #[test]
     fn page_up_and_down_move_by_a_body_height() {
         let mut app = fixtures::bleats_pane_with_lines(20);

--- a/crates/shep-cli/src/lookout/app.rs
+++ b/crates/shep-cli/src/lookout/app.rs
@@ -130,6 +130,17 @@ pub enum KeyPress {
     /// names none for this axis; a global binding, ignored on the
     /// dashboard the same way [`Self::StreamCycle`] is.
     LevelCycle,
+    /// `Ctrl-d`: scrolls the bleats pane forward (toward the newest line) by
+    /// a body height. A global binding, ignored on the dashboard the same
+    /// way [`Self::StreamCycle`] is.
+    PageDown,
+    /// `Ctrl-u`: scrolls the bleats pane backward (toward the oldest
+    /// surviving line) by a body height, and stops it following the tail,
+    /// the same way [`Self::SelectUp`] does. Ignored on the dashboard.
+    PageUp,
+    /// `f`: toggles whether the bleats pane follows the tail. Ignored on the
+    /// dashboard.
+    FollowToggle,
 }
 
 /// Everything that can change the dashboard.
@@ -2402,11 +2413,16 @@ impl App {
             // Opens on the selected sheep, or does nothing without one, the
             // same shape `KeyPress::Edit` follows above.
             KeyPress::Bleats => self.ask_for_bleats(),
-            // Both cycle a bleats-pane filter axis, and the dashboard has no
-            // such axis; named here rather than left to fall through the
-            // arm above, the same way `KeyPress::Bleats` would be ignored
-            // on a screen with no bleats pane.
-            KeyPress::StreamCycle | KeyPress::LevelCycle => Effect::None,
+            // All four scroll or cycle a bleats-pane axis, and the
+            // dashboard has neither a filter axis nor a feed to scroll;
+            // named here rather than left to fall through the arm above,
+            // the same way `KeyPress::Bleats` would be ignored on a screen
+            // with no bleats pane.
+            KeyPress::StreamCycle
+            | KeyPress::LevelCycle
+            | KeyPress::PageDown
+            | KeyPress::PageUp
+            | KeyPress::FollowToggle => Effect::None,
         }
     }
 
@@ -2422,9 +2438,10 @@ impl App {
     }
 
     /// The bleats pane's own keymap, in force while [`Self::bleats_pane`] is
-    /// `Some`. There is nothing on this screen to move or edit: `Escape`
-    /// drops the newest filter chip first, one axis at a time, and only
-    /// closes the pane once none are left.
+    /// `Some`. `Escape` drops the newest filter chip first, one axis at a
+    /// time, and only closes the pane once none are left. `j`/`k` scroll a
+    /// line, `ctrl-d`/`ctrl-u` a page, `G` jumps to the tail and resumes
+    /// following, and `f` toggles following explicitly.
     fn on_bleats_key(&mut self, key: KeyPress) -> Effect {
         match key {
             KeyPress::Quit => Effect::Quit,
@@ -2478,10 +2495,54 @@ impl App {
                 }
                 Effect::None
             }
-            KeyPress::SelectUp
-            | KeyPress::SelectDown
-            | KeyPress::SelectFirst
-            | KeyPress::SelectLast
+            // `k`/`Up`: one line toward older lines.
+            KeyPress::SelectUp => {
+                if let Some(pane) = self.bleats_pane_mut() {
+                    pane.scroll_up(1);
+                }
+                Effect::None
+            }
+            // `j`/`Down`: one line toward the newest.
+            KeyPress::SelectDown => {
+                if let Some(pane) = self.bleats_pane_mut() {
+                    pane.scroll_down(1);
+                }
+                Effect::None
+            }
+            // `G`/`End`: the tail, and following resumes — that is what an
+            // operator means by "go to the end".
+            KeyPress::SelectLast => {
+                if let Some(pane) = self.bleats_pane_mut() {
+                    pane.jump_to_end();
+                }
+                Effect::None
+            }
+            // `ctrl-u`: a page toward older lines.
+            KeyPress::PageUp => {
+                if let Some(pane) = self.bleats_pane_mut() {
+                    pane.page_up();
+                }
+                Effect::None
+            }
+            // `ctrl-d`: a page toward the newest line.
+            KeyPress::PageDown => {
+                if let Some(pane) = self.bleats_pane_mut() {
+                    pane.page_down();
+                }
+                Effect::None
+            }
+            // `f`: toggles following explicitly.
+            KeyPress::FollowToggle => {
+                if let Some(pane) = self.bleats_pane_mut() {
+                    pane.toggle_follow();
+                }
+                Effect::None
+            }
+            // There is nothing on this screen `g`/`Home` can move to: the
+            // window has no fixed start, only a tail. Left unbound rather
+            // than aliased to `ctrl-u`'s page, which would give one key two
+            // different meanings depending on how far a page happens to be.
+            KeyPress::SelectFirst
             | KeyPress::Refresh
             | KeyPress::Action(_)
             | KeyPress::Confirm
@@ -2626,6 +2687,9 @@ impl App {
             | KeyPress::ListMoveDown
             | KeyPress::StreamCycle
             | KeyPress::LevelCycle
+            | KeyPress::PageDown
+            | KeyPress::PageUp
+            | KeyPress::FollowToggle
             | KeyPress::Bleats => {}
         }
         Effect::None
@@ -2811,6 +2875,9 @@ impl App {
             | KeyPress::ListMoveDown
             | KeyPress::StreamCycle
             | KeyPress::LevelCycle
+            | KeyPress::PageDown
+            | KeyPress::PageUp
+            | KeyPress::FollowToggle
             | KeyPress::Bleats => {}
         }
         Effect::None
@@ -2908,6 +2975,9 @@ impl App {
             | KeyPress::ListMoveDown
             | KeyPress::StreamCycle
             | KeyPress::LevelCycle
+            | KeyPress::PageDown
+            | KeyPress::PageUp
+            | KeyPress::FollowToggle
             | KeyPress::Bleats => Effect::None,
         }
     }
@@ -3288,6 +3358,9 @@ impl App {
             | KeyPress::Help
             | KeyPress::StreamCycle
             | KeyPress::LevelCycle
+            | KeyPress::PageDown
+            | KeyPress::PageUp
+            | KeyPress::FollowToggle
             | KeyPress::Bleats => {}
         }
         Effect::None
@@ -3371,6 +3444,9 @@ impl App {
             | KeyPress::ListMoveDown
             | KeyPress::StreamCycle
             | KeyPress::LevelCycle
+            | KeyPress::PageDown
+            | KeyPress::PageUp
+            | KeyPress::FollowToggle
             | KeyPress::Bleats => {}
         }
         Effect::None
@@ -4436,6 +4512,14 @@ impl App {
             if let Some(list) = pane.list_mut() {
                 list.set_rows(body);
             }
+        }
+        if let Some(pane) = self.bleats_pane_mut() {
+            // One less than the whole body, the same discount the config
+            // pane takes above: the title band costs a line before any
+            // feed line is drawn. The filter row, when one is showing,
+            // costs a second; not deducted here, since `page_up`/`page_down`
+            // only need a page-sized jump, not an exact one.
+            pane.set_rows(usize::from(rows.saturating_sub(1)));
         }
     }
 
@@ -7385,6 +7469,135 @@ mod tests {
             }
         }
         assert!(cleared, "the cycle returns to unset");
+    }
+
+    /// Scrolling back stops the follow, or the next refresh undoes the
+    /// operator's keypress.
+    #[test]
+    fn scrolling_back_stops_following() {
+        let mut app = fixtures::bleats_pane_with_lines(120);
+        assert!(app.bleats_pane().expect("open").following());
+        let _ = app.update(Msg::Key(KeyPress::SelectUp));
+        assert!(
+            !app.bleats_pane().expect("open").following(),
+            "one line back is enough to mean the operator took over"
+        );
+    }
+
+    /// `G` is the way back to the live tail, so it restores following as well
+    /// as jumping.
+    #[test]
+    fn g_returns_to_the_end_and_resumes_following() {
+        let mut app = fixtures::bleats_pane_with_lines(120);
+        let _ = app.update(Msg::Key(KeyPress::SelectUp));
+        let _ = app.update(Msg::Key(KeyPress::SelectLast));
+        let pane = app.bleats_pane().expect("open");
+        assert!(pane.following(), "G resumes the follow");
+        assert_eq!(pane.scroll_offset(), 0, "and lands on the newest line");
+    }
+
+    /// A filter that hides most of the window must not leave the offset
+    /// pointing past the end of what survives.
+    #[test]
+    fn a_narrowing_filter_clamps_the_scroll_offset() {
+        let mut app = fixtures::bleats_pane_with_lines(120);
+        let _ = app.update(Msg::Key(KeyPress::PageUp));
+        let _ = app.update(Msg::Key(KeyPress::PageUp));
+        app.bleats_pane_mut_for_tests()
+            .expect("open")
+            .set_match("a-string-no-line-contains".to_string());
+        let text =
+            fixtures::render_all(&super::super::view::bleats_full::draw_lines(&app, 160, 40));
+        assert!(
+            !text.is_empty(),
+            "the pane still draws rather than panicking"
+        );
+    }
+
+    /// `SelectUp`/`SelectDown` actually move the window, not just the
+    /// `following` flag: pins which lines are on screen before and after,
+    /// so a wrong direction or an off-by-one is caught rather than passing
+    /// on the presence of any text at all.
+    #[test]
+    fn select_up_and_down_move_which_lines_are_on_screen() {
+        let mut app = fixtures::bleats_pane_with_lines(20);
+        app.note_body_rows(6); // 1 title row + 5 body rows
+        let before =
+            fixtures::render_all(&super::super::view::bleats_full::draw_lines(&app, 80, 6));
+        assert!(
+            before.contains("line-19"),
+            "starts pinned to the tail: {before}"
+        );
+        assert!(
+            !before.contains("line-14"),
+            "one line older than the window: {before}"
+        );
+
+        let _ = app.update(Msg::Key(KeyPress::SelectUp));
+        let after = fixtures::render_all(&super::super::view::bleats_full::draw_lines(&app, 80, 6));
+        assert!(
+            after.contains("line-14") && !after.contains("line-19"),
+            "one line back drops the newest line and reveals the one above the old window: {after}"
+        );
+
+        let _ = app.update(Msg::Key(KeyPress::SelectDown));
+        let restored =
+            fixtures::render_all(&super::super::view::bleats_full::draw_lines(&app, 80, 6));
+        assert_eq!(
+            restored, before,
+            "one line forward undoes the one line back"
+        );
+    }
+
+    /// `ctrl-u`/`ctrl-d` move by a body height rather than a line, and the
+    /// body height is what `note_body_rows` last reported, not a hardcoded
+    /// guess.
+    #[test]
+    fn page_up_and_down_move_by_a_body_height() {
+        let mut app = fixtures::bleats_pane_with_lines(20);
+        app.note_body_rows(6); // 1 title row + 5 body rows
+        let before =
+            fixtures::render_all(&super::super::view::bleats_full::draw_lines(&app, 80, 6));
+        assert!(
+            before.contains("line-19"),
+            "starts pinned to the tail: {before}"
+        );
+
+        let _ = app.update(Msg::Key(KeyPress::PageUp));
+        let after = fixtures::render_all(&super::super::view::bleats_full::draw_lines(&app, 80, 6));
+        assert!(
+            after.contains("line-10") && !after.contains("line-15"),
+            "a page is 5 body rows, so one page up lands on 10..=14, not 1 row back: {after}"
+        );
+        assert!(
+            !app.bleats_pane().expect("open").following(),
+            "ctrl-u is backward movement too"
+        );
+
+        let _ = app.update(Msg::Key(KeyPress::PageDown));
+        let restored =
+            fixtures::render_all(&super::super::view::bleats_full::draw_lines(&app, 80, 6));
+        assert_eq!(restored, before, "one page down undoes one page up");
+    }
+
+    /// `f` toggles following explicitly, and turning it back on snaps to the
+    /// tail rather than leaving the view wherever it was scrolled to.
+    #[test]
+    fn f_toggles_following_and_resuming_snaps_to_the_tail() {
+        let mut app = fixtures::bleats_pane_with_lines(120);
+        let _ = app.update(Msg::Key(KeyPress::SelectUp));
+        assert!(!app.bleats_pane().expect("open").following());
+
+        let _ = app.update(Msg::Key(KeyPress::FollowToggle));
+        let pane = app.bleats_pane().expect("open");
+        assert!(pane.following(), "f turned it back on");
+        assert_eq!(pane.scroll_offset(), 0, "and snapped to the tail");
+
+        let _ = app.update(Msg::Key(KeyPress::FollowToggle));
+        assert!(
+            !app.bleats_pane().expect("open").following(),
+            "f is a toggle, not a one-way switch"
+        );
     }
 
     /// `/` opens the match input rather than doing nothing, which is what it

--- a/crates/shep-cli/src/lookout/app.rs
+++ b/crates/shep-cli/src/lookout/app.rs
@@ -141,6 +141,16 @@ pub enum KeyPress {
     /// `f`: toggles whether the bleats pane follows the tail. Ignored on the
     /// dashboard.
     FollowToggle,
+    /// `w`: toggles whether the bleats pane wraps long lines rather than
+    /// truncating them. Ignored on the dashboard.
+    WrapToggle,
+    /// `n`: steps the bleats pane toward the newest line that matches the
+    /// match axis. Does nothing with no match axis set, rather than
+    /// quietly becoming a line-movement key. Ignored on the dashboard.
+    MatchNext,
+    /// `N`: the same, toward the oldest matching line. Ignored on the
+    /// dashboard.
+    MatchPrev,
 }
 
 /// Everything that can change the dashboard.
@@ -2422,7 +2432,10 @@ impl App {
             | KeyPress::LevelCycle
             | KeyPress::PageDown
             | KeyPress::PageUp
-            | KeyPress::FollowToggle => Effect::None,
+            | KeyPress::FollowToggle
+            | KeyPress::WrapToggle
+            | KeyPress::MatchNext
+            | KeyPress::MatchPrev => Effect::None,
         }
     }
 
@@ -2441,7 +2454,8 @@ impl App {
     /// `Some`. `Escape` drops the newest filter chip first, one axis at a
     /// time, and only closes the pane once none are left. `j`/`k` scroll a
     /// line, `ctrl-d`/`ctrl-u` a page, `G` jumps to the tail and resumes
-    /// following, and `f` toggles following explicitly.
+    /// following, `f` toggles following explicitly, `w` toggles wrapping,
+    /// and `n`/`N` step toward the newest or oldest matching line.
     fn on_bleats_key(&mut self, key: KeyPress) -> Effect {
         match key {
             KeyPress::Quit => Effect::Quit,
@@ -2517,17 +2531,26 @@ impl App {
                 }
                 Effect::None
             }
-            // `ctrl-u`: a page toward older lines.
+            // `ctrl-u`: a page toward older lines. Sized through
+            // `page_amount` rather than `pane.body_rows()` directly: see
+            // that function's own doc for why a page is a line count under
+            // wrap, not a raw row count.
             KeyPress::PageUp => {
+                let amount = self
+                    .bleats_pane()
+                    .map_or(1, |pane| super::view::bleats_full::page_amount(self, pane));
                 if let Some(pane) = self.bleats_pane_mut() {
-                    pane.page_up();
+                    pane.page_up(amount);
                 }
                 Effect::None
             }
-            // `ctrl-d`: a page toward the newest line.
+            // `ctrl-d`: the same, toward the newest line.
             KeyPress::PageDown => {
+                let amount = self
+                    .bleats_pane()
+                    .map_or(1, |pane| super::view::bleats_full::page_amount(self, pane));
                 if let Some(pane) = self.bleats_pane_mut() {
-                    pane.page_down();
+                    pane.page_down(amount);
                 }
                 Effect::None
             }
@@ -2535,6 +2558,28 @@ impl App {
             KeyPress::FollowToggle => {
                 if let Some(pane) = self.bleats_pane_mut() {
                     pane.toggle_follow();
+                }
+                Effect::None
+            }
+            // `w`: toggles whether a long line wraps or truncates.
+            KeyPress::WrapToggle => {
+                if let Some(pane) = self.bleats_pane_mut() {
+                    pane.toggle_wrap();
+                }
+                Effect::None
+            }
+            // `n`: one match toward the newest line. A no-op with no match
+            // axis set: see `BleatsPane::match_next`.
+            KeyPress::MatchNext => {
+                if let Some(pane) = self.bleats_pane_mut() {
+                    pane.match_next();
+                }
+                Effect::None
+            }
+            // `N`: the same, toward the oldest matching line.
+            KeyPress::MatchPrev => {
+                if let Some(pane) = self.bleats_pane_mut() {
+                    pane.match_prev();
                 }
                 Effect::None
             }
@@ -2690,6 +2735,9 @@ impl App {
             | KeyPress::PageDown
             | KeyPress::PageUp
             | KeyPress::FollowToggle
+            | KeyPress::WrapToggle
+            | KeyPress::MatchNext
+            | KeyPress::MatchPrev
             | KeyPress::Bleats => {}
         }
         Effect::None
@@ -2878,6 +2926,9 @@ impl App {
             | KeyPress::PageDown
             | KeyPress::PageUp
             | KeyPress::FollowToggle
+            | KeyPress::WrapToggle
+            | KeyPress::MatchNext
+            | KeyPress::MatchPrev
             | KeyPress::Bleats => {}
         }
         Effect::None
@@ -2978,6 +3029,9 @@ impl App {
             | KeyPress::PageDown
             | KeyPress::PageUp
             | KeyPress::FollowToggle
+            | KeyPress::WrapToggle
+            | KeyPress::MatchNext
+            | KeyPress::MatchPrev
             | KeyPress::Bleats => Effect::None,
         }
     }
@@ -3361,6 +3415,9 @@ impl App {
             | KeyPress::PageDown
             | KeyPress::PageUp
             | KeyPress::FollowToggle
+            | KeyPress::WrapToggle
+            | KeyPress::MatchNext
+            | KeyPress::MatchPrev
             | KeyPress::Bleats => {}
         }
         Effect::None
@@ -3447,6 +3504,9 @@ impl App {
             | KeyPress::PageDown
             | KeyPress::PageUp
             | KeyPress::FollowToggle
+            | KeyPress::WrapToggle
+            | KeyPress::MatchNext
+            | KeyPress::MatchPrev
             | KeyPress::Bleats => {}
         }
         Effect::None
@@ -4526,6 +4586,22 @@ impl App {
             // symmetric either way, which is why nothing noticed.
             let chrome = 1 + usize::from(!pane.filters().is_empty());
             pane.set_rows(usize::from(rows).saturating_sub(chrome));
+        }
+    }
+
+    /// Tells the bleats pane how many columns its own area draws into, so a
+    /// wrapped line's row cost can be measured against something.
+    ///
+    /// Its own method rather than a second parameter on
+    /// [`Self::note_body_rows`]: the settings screen and the config pane
+    /// never need a column count, and every existing caller of that method
+    /// — production and test alike — would otherwise have to invent one it
+    /// has no use for. Called by the event loop right alongside
+    /// [`Self::note_body_rows`], from the same `Rect` both figures come
+    /// from.
+    pub fn note_body_width(&mut self, width: u16) {
+        if let Some(pane) = self.bleats_pane_mut() {
+            pane.set_width(width);
         }
     }
 
@@ -7651,6 +7727,50 @@ mod tests {
         assert!(
             !app.bleats_pane().expect("open").following(),
             "f is a toggle, not a one-way switch"
+        );
+    }
+
+    /// `n` with no match axis set does nothing, rather than quietly becoming
+    /// a line-movement key.
+    #[test]
+    fn n_without_a_matcher_does_nothing() {
+        let mut app = fixtures::bleats_pane_with_lines(120);
+        let before = app.bleats_pane().expect("open").scroll_offset();
+        let _ = app.update(Msg::Key(KeyPress::MatchNext));
+        assert_eq!(app.bleats_pane().expect("open").scroll_offset(), before);
+        assert!(app.bleats_pane().expect("open").following());
+    }
+
+    /// Wrapping a long line makes it occupy more rows than one, which is the
+    /// whole point, and the pane must still draw inside its area.
+    #[test]
+    fn a_wrapped_line_occupies_more_rows_and_stays_in_the_area() {
+        let mut app = fixtures::bleats_pane_with_long_line();
+        let unwrapped = fixtures::draw_lines(&app, 80, 20).len();
+        let _ = app.update(Msg::Key(KeyPress::WrapToggle));
+        let wrapped = fixtures::draw_lines(&app, 80, 20);
+        assert!(wrapped.len() <= 20, "never draws past its own height");
+        assert!(
+            wrapped.iter().filter(|line| !line.spans.is_empty()).count() >= unwrapped,
+            "wrapping uses at least as many rows as not wrapping"
+        );
+    }
+
+    /// The brief's own test above (`a_wrapped_line_occupies_more_rows_and_stays_in_the_area`)
+    /// only asserts `>=`, which a `w` that did nothing at all would still
+    /// satisfy: the unwrapped and "wrapped" renders would be identical, and
+    /// identical passes `>=` too. This pins the number changing, not merely
+    /// never shrinking.
+    #[test]
+    fn toggling_wrap_actually_changes_how_many_rows_a_long_line_draws() {
+        let mut app = fixtures::bleats_pane_with_long_line();
+        let unwrapped = fixtures::draw_lines(&app, 80, 20).len();
+        let _ = app.update(Msg::Key(KeyPress::WrapToggle));
+        let wrapped = fixtures::draw_lines(&app, 80, 20).len();
+        assert!(
+            wrapped > unwrapped,
+            "wrap must add rows for a line too long for one, not just permit them: \
+             {unwrapped} unwrapped rows, {wrapped} wrapped: got the same window"
         );
     }
 

--- a/crates/shep-cli/src/lookout/app.rs
+++ b/crates/shep-cli/src/lookout/app.rs
@@ -2538,17 +2538,19 @@ impl App {
             KeyPress::PageUp => {
                 let amount = self
                     .bleats_pane()
-                    .map_or(1, |pane| super::view::bleats_full::page_amount(self, pane));
+                    .map_or(1, |pane| super::view::bleats_full::page_amount_up(self, pane));
                 if let Some(pane) = self.bleats_pane_mut() {
                     pane.page_up(amount);
                 }
                 Effect::None
             }
-            // `ctrl-d`: the same, toward the newest line.
+            // `ctrl-d`: toward the newest line, and sized by its own
+            // function. The backward count `ctrl-u` uses drops lines when
+            // applied forward; see `page_amount_up`'s doc.
             KeyPress::PageDown => {
                 let amount = self
                     .bleats_pane()
-                    .map_or(1, |pane| super::view::bleats_full::page_amount(self, pane));
+                    .map_or(1, |pane| super::view::bleats_full::page_amount_down(self, pane));
                 if let Some(pane) = self.bleats_pane_mut() {
                     pane.page_down(amount);
                 }
@@ -7676,12 +7678,11 @@ mod tests {
     ///
     /// Walks in one direction and asserts every line across the windows,
     /// because paging back is symmetric and would hide the gap.
-
     #[test]
     fn wrapped_pages_leave_no_line_unseen() {
         let mut app = fixtures::bleats_pane_with_mixed_line_lengths();
         let _ = app.update(Msg::Key(KeyPress::WrapToggle));
-        app.note_body_rows(13); // 1 title, no chip, so 12 body rows
+        app.note_body_rows(13);
         app.note_body_width(60);
 
         let mut seen = String::new();
@@ -7691,14 +7692,64 @@ mod tests {
             ));
             let _ = app.update(Msg::Key(KeyPress::PageUp));
         }
-
-        // Every `old-` line the walk passed over must have been drawn in one
-        // of the windows. A gap means a page stepped over lines that no
-        // screen ever showed.
         for n in 30..40 {
             assert!(
                 seen.contains(&format!("old-{n} ")),
                 "old-{n} fell between two wrapped pages"
+            );
+        }
+    }
+
+    /// The same, walking `ctrl-d` instead. Its own test because its own
+    /// arithmetic: a single shared page size drops lines in one direction
+    /// whichever way it is measured.
+    ///
+    /// This one was missing when the wrapped-page fix landed, and that is
+    /// exactly why the fix was half a fix. The sibling test above presses
+    /// only `PageUp`, so a `PageDown` that skipped eight lines a step passed
+    /// the whole suite.
+    #[test]
+    fn wrapped_pages_down_leave_no_line_unseen() {
+        /// The `old-N`/`new-N` ids the pane is drawing, in order.
+        fn shown(app: &App) -> Vec<String> {
+            fixtures::render_all(&super::super::view::bleats_full::draw_lines(app, 60, 13))
+                .split_whitespace()
+                .filter(|word| word.starts_with("old-") || word.starts_with("new-"))
+                .map(str::to_string)
+                .collect()
+        }
+
+        let mut app = fixtures::bleats_pane_with_mixed_line_lengths();
+        let _ = app.update(Msg::Key(KeyPress::WrapToggle));
+        app.note_body_rows(13);
+        app.note_body_width(60);
+
+        // Into the wrapped stretch, then forward one page at a time.
+        for _ in 0..6 {
+            let _ = app.update(Msg::Key(KeyPress::PageUp));
+        }
+
+        // Consecutive windows, not eventual coverage. A long enough walk
+        // sees every line whatever the step size, so the gap only shows in
+        // the join between one window and the next.
+        for step in 0..5 {
+            let before = shown(&app);
+            let _ = app.update(Msg::Key(KeyPress::PageDown));
+            let after = shown(&app);
+            let (Some(last), Some(first)) = (before.last(), after.first()) else {
+                continue;
+            };
+            // The feed is `old-0..old-39` then `new-0..new-39`, so this is
+            // each id's position in it.
+            let position = |id: &str| -> usize {
+                let (prefix, n) = id.split_once('-').expect("id-N");
+                let n: usize = n.parse().expect("a number");
+                if prefix == "old" { n } else { 40 + n }
+            };
+            assert!(
+                position(first) <= position(last) + 1,
+                "step {step} jumped from {last} to {first}, leaving a gap: \
+                 {before:?} then {after:?}"
             );
         }
     }
@@ -7779,6 +7830,63 @@ mod tests {
 
     /// `n` with no match axis set does nothing, rather than quietly becoming
     /// a line-movement key.
+    /// `n` and `N` step between matches, in opposite directions, and both
+    /// stop the follow.
+    ///
+    /// The no-matcher case below covers only the inert branch, so a swapped
+    /// direction, a wrong step, or a `following` regression would all have
+    /// shipped unseen.
+    /// A wrapped line's height is measured in display columns, not `char`s.
+    ///
+    /// Sixty full-width characters occupy 120 columns, so at this width they
+    /// wrap to about twice the rows sixty ASCII characters would. Every other
+    /// wrap test here is ASCII, where the two counts agree and a regression
+    /// to `chars().count()` would pass unnoticed. This repo has fixed that
+    /// same bug on two other branches.
+    #[test]
+    fn a_wide_character_line_wraps_by_columns_not_char_count() {
+        let mut wide = fixtures::bleats_pane_with_a_wide_line();
+        let _ = wide.update(Msg::Key(KeyPress::WrapToggle));
+        wide.note_body_rows(30);
+        wide.note_body_width(40);
+        let wide_rows = super::super::view::bleats_full::draw_lines(&wide, 40, 30).len();
+
+        // 60 double-width characters are 120 display columns. The body is
+        // 40 wide less the 5-column stream tag, so 35, and 120 columns need
+        // 4 rows. Counting `char`s instead gives 60 over 35, which is 2.
+        // The title takes one more row, so 5 total by columns and 3 by
+        // `char`s: the assertion separates the two.
+        assert!(
+            wide_rows >= 5,
+            "wrapped by columns that is 4 body rows plus a title; by \
+             `char`s it would be 2. Got {wide_rows}"
+        );
+    }
+
+    #[test]
+    fn n_and_shift_n_step_between_matches_in_opposite_directions() {
+        let mut app = fixtures::bleats_pane_with_lines(40);
+        app.note_body_rows(6);
+        app.bleats_pane_mut_for_tests()
+            .expect("open")
+            .set_match("line".to_string());
+        assert!(app.bleats_pane().expect("open").following());
+
+        let _ = app.update(Msg::Key(KeyPress::MatchPrev));
+        let back = app.bleats_pane().expect("open").scroll_offset();
+        assert!(back > 0, "N steps toward older matches");
+        assert!(
+            !app.bleats_pane().expect("open").following(),
+            "stepping back is backward movement, so the follow stops"
+        );
+
+        let _ = app.update(Msg::Key(KeyPress::MatchNext));
+        assert!(
+            app.bleats_pane().expect("open").scroll_offset() < back,
+            "n steps the other way"
+        );
+    }
+
     #[test]
     fn n_without_a_matcher_does_nothing() {
         let mut app = fixtures::bleats_pane_with_lines(120);

--- a/crates/shep-cli/src/lookout/app.rs
+++ b/crates/shep-cli/src/lookout/app.rs
@@ -4340,13 +4340,21 @@ impl App {
     }
 
     /// [`Self::bleats_pane`]'s mutable twin, for `Escape`'s chip-by-chip
-    /// backout and the filter-setting keys the reducer handles on
-    /// [`Body::Bleats`].
+    /// backout. No key sets a filter axis yet; whichever task wires one
+    /// needs this too.
     fn bleats_pane_mut(&mut self) -> Option<&mut BleatsPane> {
         match &mut self.body {
             Body::Bleats(pane) => Some(pane),
             Body::FlockTable | Body::Settings(_) | Body::ConfigPane(_) => None,
         }
+    }
+
+    /// [`Self::bleats_pane_mut`], exposed past this module: the only route a
+    /// fixture has to stack filters onto a pane it opened, since setting one
+    /// is not yet reachable through any key.
+    #[cfg(test)]
+    pub(crate) fn bleats_pane_mut_for_tests(&mut self) -> Option<&mut BleatsPane> {
+        self.bleats_pane_mut()
     }
 
     /// The apply offer over the open pane, or `None`.

--- a/crates/shep-cli/src/lookout/frames.rs
+++ b/crates/shep-cli/src/lookout/frames.rs
@@ -477,6 +477,13 @@ impl Scene {
             // would no longer pin that arithmetic. 14 rows, the same tier
             // `Confirm` and its siblings use: a title, a filter row and two
             // wrapped rows fit inside `body_rows`'s 12 with room to spare.
+            //
+            // The title truncates here and that is the honest render: two
+            // full log paths plus the window figures do not fit 100 columns,
+            // and `fit` cuts what a real terminal would. Widening to show
+            // them whole would unpin the wrap arithmetic above, which is what
+            // this scene exists for. `the_title_names_the_window_and_what_
+            // fell_below_it` covers the figures at a width that fits them.
             Self::Bleats => (100, 14),
             // HealthyWide, Errored, Grouped, WithDogs, Retrying, Frozen,
             // Refused, FeedGap, FeedMissing, HostUnknown, Lambs, LambsUnknown:

--- a/crates/shep-cli/src/lookout/frames.rs
+++ b/crates/shep-cli/src/lookout/frames.rs
@@ -1210,8 +1210,8 @@ fn scene_with(which: Scene, age: Duration, palette: Palette) -> Buffer {
 /// lines say what a log-rotate dog says rather than the default fixture's
 /// web-server lines.
 ///
-/// `Bleats`: sixteen lines, ten `out` and six `err`, six carrying a level
-/// word and ten carrying none, one of them 153 characters long. Built to
+/// `Bleats`: sixteen lines, ten `out` and six `err`, eight carrying a level
+/// word and eight carrying none, one of them 153 characters long. Built to
 /// be filtered and wrapped, not read raw: see [`scene_with`]'s own
 /// `Scene::Bleats` arm for the axes it stacks on top.
 fn feed_for(which: Scene) -> Tail {
@@ -1257,8 +1257,8 @@ fn feed_for(which: Scene) -> Tail {
             read_bytes: 0,
             note: Some("this sheep has not written a log in this $SHEP_HOME".to_string()),
         },
-        // Ten `out` lines and six `err`, six carrying a real level word
-        // (two of each: debug, info/warn's pair below, error) and ten
+        // Ten `out` lines and six `err`, eight carrying a real level word
+        // (three `WARN`, two `DEBUG`, two `ERROR`, one `INFO`) and eight
         // carrying none, so the level axis has both a floor to apply and
         // unclassifiable lines to exempt from it. One line, the `WARN
         // retrying...` one, is 153 characters: long enough that
@@ -1618,9 +1618,9 @@ These are real frames, rendered headlessly through ratatui's TestBackend by
 
 Nothing here is a mockup.
 
-frames.ansi renders all thirty-five scenes through the same coloured
+frames.ansi renders all thirty-six scenes through the same coloured
 palette the pinned `.snap` tests use; read it with `less -R`. frames.txt
-renders the same thirty-five scenes through the flattened NO_COLOR palette
+renders the same thirty-six scenes through the flattened NO_COLOR palette
 instead, the one an operator with $NO_COLOR set or a 16-colour terminal
 actually gets. The two files are deliberately different pictures of the
 same dashboard, not one file with the colour removed.
@@ -1642,7 +1642,8 @@ it read and dropped are counted exactly; bytes below its 64 KiB window were
 never read at all, so those are reported in bytes, because nothing counted the
 lines in them and guessing would be worse than saying so.
 
-The last seven frames are the settings screen, `s` from the dashboard. It owns
+The last frame is the full-screen bleats pane, `b` from the dashboard. The
+seven before it are the settings screen, `s` from the dashboard. It owns
 the whole body between the title and the status bar rather than sharing it
 with the flock table, so a fresh $SHEP_HOME, some scalars declared, an armed
 confirm, the socket editor mid-type, the dogs table's own drift, the same
@@ -1783,6 +1784,33 @@ mod tests {
     ///
     /// Each caption clause in [`Scene::caption`] is pinned by one
     /// assertion here.
+    /// The preamble's own scene count matches `Scene::ALL`.
+    ///
+    /// It said thirty-five twice while the gallery held thirty-six, and
+    /// nothing compared the two, so `write_the_gallery` committed a document
+    /// that miscounted itself into `docs/lookout/frames.txt` for an operator
+    /// to read. The sibling fold-view branch drifted the same way. Spelled
+    /// out rather than a digit, so this checks the words a reader sees.
+    #[test]
+    fn the_gallery_preamble_counts_the_scenes_it_has() {
+        const NUMBERS: [(usize, &str); 4] = [
+            (34, "thirty-four"),
+            (35, "thirty-five"),
+            (36, "thirty-six"),
+            (37, "thirty-seven"),
+        ];
+        let spelled = NUMBERS
+            .iter()
+            .find(|(n, _)| *n == Scene::ALL.len())
+            .map(|(_, word)| *word)
+            .expect("add the next number to NUMBERS when the gallery outgrows it");
+        assert!(
+            GALLERY_PREAMBLE.contains(spelled),
+            "the preamble says something other than {spelled}, and \
+             `write_the_gallery` commits it for an operator to read"
+        );
+    }
+
     #[test]
     /// `cfg(unix)`: one fixture carries a synthetic signalled exit, and
     /// `signal_label` resolves it against the running platform's table.
@@ -1791,7 +1819,7 @@ mod tests {
     /// artifacts under `docs/lookout/` are unix renderings for the same
     /// reason.
     #[cfg(unix)]
-    #[allow(clippy::too_many_lines)] // thirty-five captions, each pinned clause by clause
+    #[allow(clippy::too_many_lines)] // thirty-six captions, each pinned clause by clause
     fn every_scene_shows_the_thing_it_is_named_for() {
         // HealthyWide: all three panes at 120x30.
         let wide_buffer = scene(Scene::HealthyWide).1;

--- a/crates/shep-cli/src/lookout/frames.rs
+++ b/crates/shep-cli/src/lookout/frames.rs
@@ -1146,6 +1146,7 @@ fn scene_with(which: Scene, age: Duration, palette: Palette) -> Buffer {
     // `Viewport::rows` stays zero, which means unlimited, so a guard on a
     // scrolled screen never triggers.
     app.note_body_rows(body_rows(Rect::new(0, 0, width, height)));
+    app.note_body_width(width);
     let mut terminal = Terminal::new(TestBackend::new(width, height)).unwrap();
     terminal.draw(|frame| draw(&app, frame)).unwrap();
     terminal.backend().buffer().clone()

--- a/crates/shep-cli/src/lookout/frames.rs
+++ b/crates/shep-cli/src/lookout/frames.rs
@@ -247,6 +247,10 @@ pub enum Scene {
     /// The settings screen on a terminal too short to hold every row, with
     /// the cursor on the last one, so the view has scrolled.
     SettingsShort,
+    /// The full-screen bleats pane with all three filter axes stacked: a
+    /// stream, a minimum level and a regex, wrapping turned on so the one
+    /// surviving line's full text is on screen rather than truncated.
+    Bleats,
 }
 }
 
@@ -290,6 +294,7 @@ impl Scene {
             Self::SettingsDogs => "settings_dogs",
             Self::SettingsNarrow => "settings_narrow",
             Self::SettingsShort => "settings_short",
+            Self::Bleats => "bleats",
         }
     }
 
@@ -406,6 +411,9 @@ impl Scene {
             Self::SettingsShort => {
                 "The same screen at 14 rows, which is fewer than it has to draw. The cursor is on the last dog, so the view has scrolled to reach it and `... 5 above` says how much is off the top. The scroll is counted in LINES rather than in rows: a section header and the dogs caption cost the same height a row does."
             }
+            Self::Bleats => {
+                "The full-screen bleats pane, pinned to api, with a stream, a minimum level and a regex all stacked: only out, only warn and above, only a line mentioning retrying or jitter. The filter row states the composition and counts one surviving line out of sixteen, and that one line is also the longest in the fixture, so wrapping is on and its full text runs onto a second row instead of an ellipsis."
+            }
         }
     }
 
@@ -462,6 +470,14 @@ impl Scene {
             // reached without scrolling, tall enough that what survives is
             // a legible section rather than a single row.
             Self::SettingsShort => (120, 14),
+            // 100: `bleats_full`'s own text width is `width - TAG_PREFIX_WIDTH`
+            // (5), so 100 - 5 = 95. The fixture's one surviving line is 153
+            // characters, so it wraps onto exactly two rows at this width
+            // (153 / 95, rounded up); a wider frame would still wrap it but
+            // would no longer pin that arithmetic. 14 rows, the same tier
+            // `Confirm` and its siblings use: a title, a filter row and two
+            // wrapped rows fit inside `body_rows`'s 12 with room to spare.
+            Self::Bleats => (100, 14),
             // HealthyWide, Errored, Grouped, WithDogs, Retrying, Frozen,
             // Refused, FeedGap, FeedMissing, HostUnknown, Lambs, LambsUnknown:
             // every scene that carries all three optional panes at their
@@ -953,6 +969,25 @@ fn scene_with(which: Scene, age: Duration, palette: Palette) -> Buffer {
         tail: feed_for(which),
     });
 
+    // Opens the pane on `api` (already selected above) and stacks all
+    // three filter axes: `o` once for `out`, `m` four times for `None ->
+    // Trace -> Debug -> Info -> Warn`, then a regex typed into the match
+    // box. `w` last, since it toggles independently of the filters and
+    // this is the one fixture line worth wrapping.
+    if which == Scene::Bleats {
+        app.update(Msg::Key(KeyPress::Bleats));
+        app.update(Msg::Key(KeyPress::StreamCycle));
+        for _ in 0..4 {
+            app.update(Msg::Key(KeyPress::LevelCycle));
+        }
+        app.update(Msg::Key(KeyPress::FilterStart));
+        for typed in "/retry|jitter/".chars() {
+            app.update(Msg::Key(KeyPress::TextChar(typed)));
+        }
+        app.update(Msg::Key(KeyPress::TextApply));
+        app.update(Msg::Key(KeyPress::WrapToggle));
+    }
+
     // Applied while the link is still `Live`: `on_lambs` refuses once it
     // is `Lost`, the same guard `Msg::Bleats` carries.
     if matches!(which, Scene::Lambs | Scene::Frozen) {
@@ -1167,6 +1202,11 @@ fn scene_with(which: Scene, age: Duration, palette: Palette) -> Buffer {
 /// `WithDogs`: the selected row is the adopted `log-rotate` dog, so its
 /// lines say what a log-rotate dog says rather than the default fixture's
 /// web-server lines.
+///
+/// `Bleats`: sixteen lines, ten `out` and six `err`, six carrying a level
+/// word and ten carrying none, one of them 153 characters long. Built to
+/// be filtered and wrapped, not read raw: see [`scene_with`]'s own
+/// `Scene::Bleats` arm for the axes it stacks on top.
 fn feed_for(which: Scene) -> Tail {
     match which {
         // Mirrors `run_ui`: an empty flock has no selected row, so no
@@ -1209,6 +1249,62 @@ fn feed_for(which: Scene) -> Tail {
             missed_bytes: 0,
             read_bytes: 0,
             note: Some("this sheep has not written a log in this $SHEP_HOME".to_string()),
+        },
+        // Ten `out` lines and six `err`, six carrying a real level word
+        // (two of each: debug, info/warn's pair below, error) and ten
+        // carrying none, so the level axis has both a floor to apply and
+        // unclassifiable lines to exempt from it. One line, the `WARN
+        // retrying...` one, is 153 characters: long enough that
+        // `Scene::Bleats`'s 100-column frame wraps it onto two rows.
+        Scene::Bleats => Tail {
+            lines: [
+                (Stream::Out, "listening on 0.0.0.0:8080"),
+                (
+                    Stream::Err,
+                    "WARN connection pool nearing capacity: 47/50 in use",
+                ),
+                (Stream::Out, "GET /v1/orders 200 12ms"),
+                (
+                    Stream::Out,
+                    "WARN retrying upstream payment gateway after a timeout, backing off \
+                     500ms before trying again with jitter added so the whole fleet does \
+                     not retry at once",
+                ),
+                (
+                    Stream::Err,
+                    "INFO shutting down worker 2 for a rolling restart",
+                ),
+                (Stream::Out, "DEBUG cache warmed 128 keys in 4ms"),
+                (Stream::Out, "POST /v1/orders 201 88ms"),
+                (
+                    Stream::Err,
+                    "ERROR failed to write session cache: disk quota exceeded",
+                ),
+                (Stream::Out, "connection pool: 14/50 in use"),
+                (
+                    Stream::Out,
+                    "ERROR panic recovered in worker 3: index out of bounds",
+                ),
+                (Stream::Err, "GET /healthz 200 3ms"),
+                (Stream::Out, "GET /v1/orders/8821 200 9ms"),
+                (Stream::Err, "DEBUG flushing metrics buffer"),
+                (Stream::Out, "POST /v1/orders 500 210ms"),
+                (
+                    Stream::Err,
+                    "WARN queue depth crossed 200, backpressure engaged",
+                ),
+                (Stream::Out, "GET /v1/orders/9013 200 7ms"),
+            ]
+            .into_iter()
+            .map(|(stream, text)| TailLine {
+                stream,
+                text: text.to_string(),
+            })
+            .collect(),
+            missed_lines: 0,
+            missed_bytes: 0,
+            read_bytes: 2048,
+            note: None,
         },
         _ => Tail {
             lines: [
@@ -2283,6 +2379,36 @@ mod tests {
             short.contains("[style]") && short.contains("[dogs]"),
             "what survives is whole sections, headers and all: {short:?}"
         );
+
+        // Bleats: all three axes stacked, wrapping on.
+        let bleats = render_text(&scene(Scene::Bleats).1);
+        for chip in ["stream out", "level ≥ warn", "match /retry|jitter/ (regex)"] {
+            assert!(
+                bleats.contains(chip),
+                "the filter row names {chip}: {bleats:?}"
+            );
+        }
+        assert!(
+            // The sentence itself is longer than this 100-column frame, so
+            // it fits and truncates with an ellipsis: this is the prefix
+            // that survives the cut.
+            bleats.contains("1 of 16 lines in the window: all three m…"),
+            "the survivor count and the start of the composition sentence: {bleats:?}"
+        );
+        assert!(
+            bleats.contains("out  WARN retrying upstream payment gateway"),
+            "the one surviving line, tagged by its stream: {bleats:?}"
+        );
+        assert!(
+            bleats
+                .lines()
+                .any(|line| line.starts_with("     ith jitter")),
+            "wrapping is on, so the line's tail lands on its own row rather than truncating: {bleats:?}"
+        );
+        assert!(
+            bleats.contains("esc back") && bleats.contains("\u{2588} following"),
+            "the full key line, and the pane is still following the tail: {bleats:?}"
+        );
     }
 
     /// Two grouped apps, four sheep, six visible rows: a `0..=flock_len()`
@@ -2393,7 +2519,8 @@ mod tests {
             Scene::SettingsTyping => Some(Scene::SettingsDogs),
             Scene::SettingsDogs => Some(Scene::SettingsNarrow),
             Scene::SettingsNarrow => Some(Scene::SettingsShort),
-            Scene::SettingsShort => None,
+            Scene::SettingsShort => Some(Scene::Bleats),
+            Scene::Bleats => None,
         }
     }
 

--- a/crates/shep-cli/src/lookout/input.rs
+++ b/crates/shep-cli/src/lookout/input.rs
@@ -59,6 +59,7 @@ pub fn map_key(event: &Event, mode: InputMode) -> Option<KeyPress> {
         KeyCode::Char('d') => Some(KeyPress::ListRemove),
         KeyCode::Char('K') => Some(KeyPress::ListMoveUp),
         KeyCode::Char('J') => Some(KeyPress::ListMoveDown),
+        KeyCode::Char('b') => Some(KeyPress::Bleats),
         KeyCode::Enter => Some(KeyPress::Confirm),
         _ => None,
     }
@@ -157,6 +158,17 @@ mod tests {
             Some(KeyPress::ListMoveDown)
         );
         assert_eq!(map_key(&key(KeyCode::Char('z')), InputMode::Normal), None);
+    }
+
+    /// `b` opens the full-screen bleats pane. Pinned because `map_key`
+    /// dispatches on mode rather than pane, so a key taken here is taken
+    /// everywhere in `Normal`.
+    #[test]
+    fn b_opens_the_bleats_pane() {
+        assert_eq!(
+            map_key(&key(KeyCode::Char('b')), InputMode::Normal),
+            Some(KeyPress::Bleats)
+        );
     }
 
     #[test]

--- a/crates/shep-cli/src/lookout/input.rs
+++ b/crates/shep-cli/src/lookout/input.rs
@@ -73,6 +73,9 @@ pub fn map_key(event: &Event, mode: InputMode) -> Option<KeyPress> {
         KeyCode::Char('o') => Some(KeyPress::StreamCycle),
         KeyCode::Char('m') => Some(KeyPress::LevelCycle),
         KeyCode::Char('f') => Some(KeyPress::FollowToggle),
+        KeyCode::Char('w') => Some(KeyPress::WrapToggle),
+        KeyCode::Char('n') => Some(KeyPress::MatchNext),
+        KeyCode::Char('N') => Some(KeyPress::MatchPrev),
         KeyCode::Enter => Some(KeyPress::Confirm),
         _ => None,
     }
@@ -325,6 +328,25 @@ mod tests {
         assert_eq!(
             map_key(&key(KeyCode::Char('/')), InputMode::Normal),
             Some(KeyPress::FilterStart)
+        );
+    }
+
+    /// `w` toggles the bleats pane's wrap; `n`/`N` step between matches. All
+    /// three are global bindings, the same way `o`/`m`/`f` are: `map_key`
+    /// dispatches on mode alone, ignored on the dashboard.
+    #[test]
+    fn w_and_n_and_shift_n_are_bound() {
+        assert_eq!(
+            map_key(&key(KeyCode::Char('w')), InputMode::Normal),
+            Some(KeyPress::WrapToggle)
+        );
+        assert_eq!(
+            map_key(&key(KeyCode::Char('n')), InputMode::Normal),
+            Some(KeyPress::MatchNext)
+        );
+        assert_eq!(
+            map_key(&key(KeyCode::Char('N')), InputMode::Normal),
+            Some(KeyPress::MatchPrev)
         );
     }
 }

--- a/crates/shep-cli/src/lookout/input.rs
+++ b/crates/shep-cli/src/lookout/input.rs
@@ -12,7 +12,9 @@ use super::app::{ActionVerb, InputMode, KeyPress};
 /// Only `KeyEventKind::Press` counts: a terminal that reports repeats and
 /// releases would otherwise fire an action once per repeat of a held key.
 /// `Ctrl-C` is a binding in either mode, since raw mode delivers it as an
-/// ordinary key event and there is no `SIGINT` to catch.
+/// ordinary key event and there is no `SIGINT` to catch. `Ctrl-D`/`Ctrl-U`
+/// are `Normal`-only, so paging the bleats pane never fires behind an
+/// operator's back while they are typing a match.
 #[must_use]
 pub fn map_key(event: &Event, mode: InputMode) -> Option<KeyPress> {
     let Event::Key(key) = event else {
@@ -24,6 +26,14 @@ pub fn map_key(event: &Event, mode: InputMode) -> Option<KeyPress> {
     if key.modifiers.contains(KeyModifiers::CONTROL) {
         return match key.code {
             KeyCode::Char('c') => Some(KeyPress::Quit),
+            // Guarded on `mode` here, unlike every other binding in this
+            // branch: this CONTROL match runs ahead of the `InputMode::Text`
+            // check below, so an unguarded `ctrl-d`/`ctrl-u` would page the
+            // pane behind an operator's back while they are typing a match
+            // into the bleats box. `ctrl-c` stays unguarded on purpose — it
+            // quits from the box too, the same way it always has.
+            KeyCode::Char('d') if mode == InputMode::Normal => Some(KeyPress::PageDown),
+            KeyCode::Char('u') if mode == InputMode::Normal => Some(KeyPress::PageUp),
             _ => None,
         };
     }
@@ -62,6 +72,7 @@ pub fn map_key(event: &Event, mode: InputMode) -> Option<KeyPress> {
         KeyCode::Char('b') => Some(KeyPress::Bleats),
         KeyCode::Char('o') => Some(KeyPress::StreamCycle),
         KeyCode::Char('m') => Some(KeyPress::LevelCycle),
+        KeyCode::Char('f') => Some(KeyPress::FollowToggle),
         KeyCode::Enter => Some(KeyPress::Confirm),
         _ => None,
     }
@@ -281,6 +292,32 @@ mod tests {
             map_key(&key(KeyCode::Char('m')), InputMode::Normal),
             Some(KeyPress::LevelCycle)
         );
+    }
+
+    /// `f` cycles the bleats pane's follow flag; a global binding, ignored
+    /// on the dashboard the same way `o`/`m` are.
+    #[test]
+    fn f_toggles_follow() {
+        assert_eq!(
+            map_key(&key(KeyCode::Char('f')), InputMode::Normal),
+            Some(KeyPress::FollowToggle)
+        );
+    }
+
+    /// `ctrl-d`/`ctrl-u` page the bleats pane, and only fire in `Normal`:
+    /// unguarded, they would page the pane behind an operator's back while
+    /// the match box owns `InputMode::Text`.
+    #[test]
+    fn ctrl_d_and_ctrl_u_page_only_in_normal_mode() {
+        let ctrl_d = Event::Key(KeyEvent::new(KeyCode::Char('d'), KeyModifiers::CONTROL));
+        let ctrl_u = Event::Key(KeyEvent::new(KeyCode::Char('u'), KeyModifiers::CONTROL));
+        assert_eq!(
+            map_key(&ctrl_d, InputMode::Normal),
+            Some(KeyPress::PageDown)
+        );
+        assert_eq!(map_key(&ctrl_u, InputMode::Normal), Some(KeyPress::PageUp));
+        assert_eq!(map_key(&ctrl_d, InputMode::Text), None);
+        assert_eq!(map_key(&ctrl_u, InputMode::Text), None);
     }
 
     #[test]

--- a/crates/shep-cli/src/lookout/input.rs
+++ b/crates/shep-cli/src/lookout/input.rs
@@ -60,6 +60,8 @@ pub fn map_key(event: &Event, mode: InputMode) -> Option<KeyPress> {
         KeyCode::Char('K') => Some(KeyPress::ListMoveUp),
         KeyCode::Char('J') => Some(KeyPress::ListMoveDown),
         KeyCode::Char('b') => Some(KeyPress::Bleats),
+        KeyCode::Char('o') => Some(KeyPress::StreamCycle),
+        KeyCode::Char('m') => Some(KeyPress::LevelCycle),
         KeyCode::Enter => Some(KeyPress::Confirm),
         _ => None,
     }
@@ -262,6 +264,22 @@ mod tests {
         assert_eq!(
             map_key(&shifted, InputMode::Text),
             Some(KeyPress::TextChar('W'))
+        );
+    }
+
+    /// `o` and `m` are global bindings, taken here so the bleats pane can
+    /// cycle its stream and minimum-level axes; a key taken in `map_key` is
+    /// taken everywhere in `Normal`, the same note `b_opens_the_bleats_pane`
+    /// makes.
+    #[test]
+    fn o_and_m_cycle_the_stream_and_level_axes() {
+        assert_eq!(
+            map_key(&key(KeyCode::Char('o')), InputMode::Normal),
+            Some(KeyPress::StreamCycle)
+        );
+        assert_eq!(
+            map_key(&key(KeyCode::Char('m')), InputMode::Normal),
+            Some(KeyPress::LevelCycle)
         );
     }
 

--- a/crates/shep-cli/src/lookout/level.rs
+++ b/crates/shep-cli/src/lookout/level.rs
@@ -95,10 +95,14 @@ mod tests {
     /// The full extra-word variants of warn/error, not just the short
     /// forms. Dropping either from the match still passes every other
     /// test in this file, so each needs its own pin.
+    ///
+    /// Neither line may contain a second level word. `a fatal error
+    /// occurred` pins nothing: drop the `fatal` arm and `find_map` reaches
+    /// `error` on the next word for the same answer.
     #[test]
     fn the_long_forms_of_warn_and_error_are_recognised() {
         assert_eq!(level_of("a warning was logged"), Some(Level::Warn));
-        assert_eq!(level_of("a fatal error occurred"), Some(Level::Error));
+        assert_eq!(level_of("a fatal crash occurred"), Some(Level::Error));
     }
 
     /// A digit touching the word means it was never a level token: an

--- a/crates/shep-cli/src/lookout/level.rs
+++ b/crates/shep-cli/src/lookout/level.rs
@@ -3,12 +3,23 @@
 /// `Ord` is derived and the declaration order is the ordering: `Trace` is
 /// the lowest and `Error` the highest, so `level >= minimum` reads the way
 /// an operator setting `level >= warn` expects.
+///
+/// `Debug` is derived and is operator-facing rather than diagnostic: the
+/// bleats filter row renders the chip through `format!("{min:?}")`
+/// lowercased, so these variant names are the words on screen. Renaming one
+/// changes what an operator reads.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum Level {
+    /// The lowest, and the only one an app has to opt into emitting.
     Trace,
+    /// Below `Info`, and the usual floor for an app's own noise.
     Debug,
+    /// The default an operator reads when nothing is filtered.
     Info,
+    /// Something an operator should look at, without the sheep being broken.
     Warn,
+    /// The highest. `fatal` parses to this too, since a line saying it is
+    /// fatal is not saying something milder than one saying error.
     Error,
 }
 

--- a/crates/shep-cli/src/lookout/level.rs
+++ b/crates/shep-cli/src/lookout/level.rs
@@ -3,6 +3,9 @@
 /// `Ord` is derived and the declaration order is the ordering: `Trace` is
 /// the lowest and `Error` the highest, so `level >= minimum` reads the way
 /// an operator setting `level >= warn` expects.
+///
+/// No non-test caller yet: `#[allow(dead_code)]` says so rather than
+/// inventing one. Task 3 wires this into the bleats filter.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 #[allow(dead_code)]
 pub enum Level {
@@ -15,19 +18,30 @@ pub enum Level {
 
 /// The level a line announces, or `None` when it announces none.
 ///
-/// Scans the first few whitespace-separated words rather than only the
+/// Scans the first 4 whitespace-separated words rather than only the
 /// first, because a timestamp before the level is the common shape. A
-/// candidate matches only as a whole word, after trailing punctuation is
-/// stripped, so `information` is not `info`.
+/// level past the fourth word is not found; that is deliberate, not a
+/// bug, and a line whose level falls outside the window simply falls
+/// back to `None`, which is always safe under decision 3.
+///
+/// A candidate matches only as a whole word, after surrounding
+/// punctuation is stripped, so `information` is not `info`. Digits
+/// adjacent to the word are NOT stripped, only punctuation is: a digit
+/// touching the word means it was never a level token in the first
+/// place (`/error404`, `info2`), and trimming through it would invent a
+/// level the line never announced, which decision 3 forbids.
 ///
 /// `None` is the ordinary answer for app output. Callers must not treat it
 /// as "below the minimum": see the spec's decision 3.
+///
+/// No non-test caller yet: `#[allow(dead_code)]` says so rather than
+/// inventing one. Task 3 wires this into the bleats filter.
 #[must_use]
 #[allow(dead_code)]
 pub fn level_of(line: &str) -> Option<Level> {
     line.split_whitespace().take(4).find_map(|word| {
         match word
-            .trim_matches(|c: char| !c.is_ascii_alphabetic())
+            .trim_matches(|c: char| !c.is_ascii_alphabetic() && !c.is_ascii_digit())
             .to_ascii_lowercase()
             .as_str()
         {
@@ -76,6 +90,42 @@ mod tests {
     fn a_level_name_inside_a_longer_word_is_not_a_level() {
         assert_eq!(level_of("information about the pool"), None);
         assert_eq!(level_of("warnings are disabled"), None);
+    }
+
+    /// The full extra-word variants of warn/error, not just the short
+    /// forms. Dropping either from the match still passes every other
+    /// test in this file, so each needs its own pin.
+    #[test]
+    fn the_long_forms_of_warn_and_error_are_recognised() {
+        assert_eq!(level_of("a warning was logged"), Some(Level::Warn));
+        assert_eq!(level_of("a fatal error occurred"), Some(Level::Error));
+    }
+
+    /// A digit touching the word means it was never a level token: an
+    /// HTTP status glued onto a route, or a word that merely ends in a
+    /// digit. Stripping through the digit would invent a level the line
+    /// never announced (decision 3 forbids exactly this).
+    #[test]
+    fn a_digit_touching_the_word_blocks_the_match() {
+        assert_eq!(level_of("/error404 requested"), None);
+        assert_eq!(level_of("info2 and counting"), None);
+        assert_eq!(level_of("GET /info2 200"), None);
+    }
+
+    /// Punctuation still strips cleanly on both sides; only digits are
+    /// excluded from what trims.
+    #[test]
+    fn surrounding_punctuation_still_trims() {
+        assert_eq!(level_of("[WARN] pool exhausted"), Some(Level::Warn));
+        assert_eq!(level_of("Error: connection refused"), Some(Level::Error));
+    }
+
+    /// The scan window is exactly 4 words: a level at the fourth word is
+    /// found, one at the fifth is not.
+    #[test]
+    fn the_scan_window_is_exactly_four_words() {
+        assert_eq!(level_of("a b c warn"), Some(Level::Warn));
+        assert_eq!(level_of("a b c d warn"), None);
     }
 
     #[test]

--- a/crates/shep-cli/src/lookout/level.rs
+++ b/crates/shep-cli/src/lookout/level.rs
@@ -1,0 +1,88 @@
+/// A log level, ordered so a minimum can be compared against.
+///
+/// `Ord` is derived and the declaration order is the ordering: `Trace` is
+/// the lowest and `Error` the highest, so `level >= minimum` reads the way
+/// an operator setting `level >= warn` expects.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[allow(dead_code)]
+pub enum Level {
+    Trace,
+    Debug,
+    Info,
+    Warn,
+    Error,
+}
+
+/// The level a line announces, or `None` when it announces none.
+///
+/// Scans the first few whitespace-separated words rather than only the
+/// first, because a timestamp before the level is the common shape. A
+/// candidate matches only as a whole word, after trailing punctuation is
+/// stripped, so `information` is not `info`.
+///
+/// `None` is the ordinary answer for app output. Callers must not treat it
+/// as "below the minimum": see the spec's decision 3.
+#[must_use]
+#[allow(dead_code)]
+pub fn level_of(line: &str) -> Option<Level> {
+    line.split_whitespace().take(4).find_map(|word| {
+        match word
+            .trim_matches(|c: char| !c.is_ascii_alphabetic())
+            .to_ascii_lowercase()
+            .as_str()
+        {
+            "trace" => Some(Level::Trace),
+            "debug" => Some(Level::Debug),
+            "info" => Some(Level::Info),
+            "warn" | "warning" => Some(Level::Warn),
+            "error" | "fatal" => Some(Level::Error),
+            _ => None,
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_leading_level_word_is_found_whatever_its_case() {
+        assert_eq!(level_of("WARN pool exhausted"), Some(Level::Warn));
+        assert_eq!(level_of("warn pool exhausted"), Some(Level::Warn));
+        assert_eq!(level_of("Error: connection refused"), Some(Level::Error));
+    }
+
+    /// A timestamp before the level is the common shape, so the search looks
+    /// past a prefix rather than only at the first word.
+    #[test]
+    fn a_level_after_a_timestamp_is_still_found() {
+        assert_eq!(
+            level_of("2026-09-08T11:02:03Z INFO listening on 8080"),
+            Some(Level::Info)
+        );
+    }
+
+    /// The whole reason the filter shows unclassifiable lines: most app
+    /// output looks like this.
+    #[test]
+    fn a_line_with_no_level_word_has_no_level() {
+        assert_eq!(level_of("listening on 8080"), None);
+        assert_eq!(level_of(""), None);
+    }
+
+    /// A word that merely contains a level name is not a level. Without
+    /// this, "information" and "errors:" both read as levels.
+    #[test]
+    fn a_level_name_inside_a_longer_word_is_not_a_level() {
+        assert_eq!(level_of("information about the pool"), None);
+        assert_eq!(level_of("warnings are disabled"), None);
+    }
+
+    #[test]
+    fn levels_order_from_trace_up_to_error() {
+        assert!(Level::Trace < Level::Debug);
+        assert!(Level::Debug < Level::Info);
+        assert!(Level::Info < Level::Warn);
+        assert!(Level::Warn < Level::Error);
+    }
+}

--- a/crates/shep-cli/src/lookout/level.rs
+++ b/crates/shep-cli/src/lookout/level.rs
@@ -3,11 +3,7 @@
 /// `Ord` is derived and the declaration order is the ordering: `Trace` is
 /// the lowest and `Error` the highest, so `level >= minimum` reads the way
 /// an operator setting `level >= warn` expects.
-///
-/// No non-test caller yet: `#[allow(dead_code)]` says so rather than
-/// inventing one. Task 3 wires this into the bleats filter.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-#[allow(dead_code)]
 pub enum Level {
     Trace,
     Debug,
@@ -33,11 +29,7 @@ pub enum Level {
 ///
 /// `None` is the ordinary answer for app output. Callers must not treat it
 /// as "below the minimum": see the spec's decision 3.
-///
-/// No non-test caller yet: `#[allow(dead_code)]` says so rather than
-/// inventing one. Task 3 wires this into the bleats filter.
 #[must_use]
-#[allow(dead_code)]
 pub fn level_of(line: &str) -> Option<Level> {
     line.split_whitespace().take(4).find_map(|word| {
         match word

--- a/crates/shep-cli/src/lookout/mod.rs
+++ b/crates/shep-cli/src/lookout/mod.rs
@@ -316,6 +316,7 @@ where
             if let Ok(size) = terminal.size() {
                 let area = Rect::new(0, 0, size.width, size.height);
                 app.note_body_rows(view::body_rows(area));
+                app.note_body_width(area.width);
             }
             let _ = terminal.draw(|frame| view::draw(&app, frame));
             dirty = false;

--- a/crates/shep-cli/src/lookout/mod.rs
+++ b/crates/shep-cli/src/lookout/mod.rs
@@ -20,6 +20,7 @@ pub mod frames;
 pub mod input;
 pub mod link;
 pub mod pane;
+pub mod pane_bleats;
 pub mod source;
 pub mod tail;
 pub mod term;

--- a/crates/shep-cli/src/lookout/mod.rs
+++ b/crates/shep-cli/src/lookout/mod.rs
@@ -275,11 +275,16 @@ where
         // shows it and never on a frame that is not about to be drawn.
         let may_draw = last_draw.is_none_or(|at| at.elapsed() >= MIN_REDRAW);
         if feed_dirty && may_draw {
-            // Nothing selected means an empty flock, and the pane's header
-            // already says so. `tail::read`'s `(None, None)` early return is
-            // for a different case, a selected sheep whose shepherd predates
-            // the `out_file`/`err_file` fields.
-            let tail = match app.selected_row() {
+            // `feed_row`, not `selected_row`: the full-screen pane pins a
+            // sheep and the selection can move out from under it, so reading
+            // the selection would draw another sheep's lines under a title
+            // naming the pinned one.
+            //
+            // Nothing to read means an empty flock, or a pinned sheep that
+            // has left it, and the pane's header says which. `tail::read`'s
+            // `(None, None)` early return is for a different case, a sheep
+            // whose shepherd predates the `out_file`/`err_file` fields.
+            let tail = match app.feed_row() {
                 None => tail::Tail::default(),
                 Some(row) => {
                     // Cloned out before `app` is borrowed mutably.

--- a/crates/shep-cli/src/lookout/mod.rs
+++ b/crates/shep-cli/src/lookout/mod.rs
@@ -18,6 +18,7 @@ pub mod field;
 #[cfg(test)]
 pub mod frames;
 pub mod input;
+pub mod level;
 pub mod link;
 pub mod pane;
 pub mod pane_bleats;

--- a/crates/shep-cli/src/lookout/pane_bleats.rs
+++ b/crates/shep-cli/src/lookout/pane_bleats.rs
@@ -1,6 +1,8 @@
 //! The full-screen bleats pane's own state: which sheep it is pinned to, and
 //! the three filters an operator can stack over the feed it reads.
 
+use regex::Regex;
+
 use super::app::RowKey;
 use super::level::{Level, level_of};
 use super::tail::{Stream, TailLine};
@@ -13,9 +15,12 @@ use super::tail::{Stream, TailLine};
 /// [`BleatsPane::drop_newest_chip`] needs an explicit order to pop from.
 ///
 /// No non-test caller for the setters that construct a variant yet:
-/// `#[allow(dead_code)]` on them says so rather than inventing one. Task 4
-/// wires the filter row's keys into [`BleatsPane::set_stream`],
-/// [`BleatsPane::set_min_level`] and [`BleatsPane::set_match`].
+/// `#[allow(dead_code)]` on them says so rather than inventing one.
+/// [`BleatsPane::set_stream`], [`BleatsPane::set_min_level`] and
+/// [`BleatsPane::set_match`] each construct one, but no task in this plan
+/// binds a key to any of the three — the filter row (this task) only reads
+/// `Filters`, it does not set it. Whichever task wires the keys is the
+/// first production caller.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[allow(dead_code)]
 enum Axis {
@@ -25,6 +30,107 @@ enum Axis {
     Level,
     /// The text-match axis.
     Match,
+}
+
+/// What the match axis's typed text resolves to.
+///
+/// `/pattern/` (a leading and trailing slash, the same delimiter grep,
+/// sed and this pane's own `filters` chip agree to read) compiles as a
+/// regex; anything else is a plain substring. This is the deliberate
+/// choice for distinguishing the two, since the spec says only "text or
+/// regex" and not how an operator picks: trying to compile *every* typed
+/// string as a regex and falling back to literal on a parse error was
+/// rejected, because almost any short string a person types (`get
+/// index.html`, `(unset)`) is *already* valid regex syntax with a
+/// different meaning than its literal reading — `.` and `(` would
+/// silently stop meaning themselves. An explicit delimiter costs two
+/// characters and never reinterprets a search an operator meant literally.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MatchKind {
+    /// Plain substring search: `Filters::matcher`'s text, verbatim.
+    Literal,
+    /// `/…/`-delimited text that compiled.
+    Regex,
+    /// `/…/`-delimited text that did not compile. Matches no line rather
+    /// than every line or panicking; the filter row names this state so an
+    /// operator sees a typo rather than a feed that has gone silent for no
+    /// visible reason.
+    Invalid,
+}
+
+/// How `Filters::matcher`'s typed text is actually matched against a line.
+///
+/// Parsed fresh from [`Filters::matcher`] wherever it is needed
+/// ([`Filters::keeps`] through [`Filters::visible`], and the filter row's
+/// highlighting) rather than cached on `Filters` itself: `regex::Regex`
+/// implements neither `PartialEq` nor `Eq`, so storing a compiled one on
+/// `Filters` would force a hand-written `PartialEq` (or dropping it, which
+/// every existing test compares `Filters` by), and it implements `Debug` by
+/// printing its source pattern, which is a worse `Debug` for `Filters` than
+/// the plain string already there. Recompiling costs one small regex
+/// compile per redraw at most, against a window capped at
+/// [`super::tail::FEED_TAIL_LINES`] lines; nothing here is hot enough for
+/// that to matter.
+enum Matcher {
+    /// Plain substring search.
+    Literal(String),
+    /// A compiled `/…/`-delimited regex.
+    Regex(Regex),
+    /// A `/…/`-delimited pattern that failed to compile.
+    Invalid,
+}
+
+impl Matcher {
+    /// Parses `text` per [`MatchKind`]'s rule.
+    fn parse(text: &str) -> Self {
+        match delimited_regex(text) {
+            Some(pattern) => Regex::new(pattern).map_or(Self::Invalid, Self::Regex),
+            None => Self::Literal(text.to_string()),
+        }
+    }
+
+    /// This matcher's [`MatchKind`].
+    fn kind(&self) -> MatchKind {
+        match self {
+            Self::Literal(_) => MatchKind::Literal,
+            Self::Regex(_) => MatchKind::Regex,
+            Self::Invalid => MatchKind::Invalid,
+        }
+    }
+
+    /// Whether `haystack` matches at all.
+    fn is_match(&self, haystack: &str) -> bool {
+        match self {
+            Self::Literal(pattern) => haystack.contains(pattern.as_str()),
+            Self::Regex(re) => re.is_match(haystack),
+            Self::Invalid => false,
+        }
+    }
+
+    /// Every byte range in `haystack` this matcher hits, oldest first, for
+    /// highlighting. Empty for [`Self::Invalid`], which matches nothing, and
+    /// for an empty literal pattern, which `str::match_indices` would
+    /// otherwise report at every byte boundary.
+    fn ranges(&self, haystack: &str) -> Vec<(usize, usize)> {
+        match self {
+            Self::Literal(pattern) if !pattern.is_empty() => haystack
+                .match_indices(pattern.as_str())
+                .map(|(start, matched)| (start, start + matched.len()))
+                .collect(),
+            Self::Literal(_) | Self::Invalid => Vec::new(),
+            Self::Regex(re) => re
+                .find_iter(haystack)
+                .map(|m| (m.start(), m.end()))
+                .collect(),
+        }
+    }
+}
+
+/// `text` if it is `/`-delimited on both ends with at least one byte between
+/// them, stripped of both delimiters; `None` otherwise.
+fn delimited_regex(text: &str) -> Option<&str> {
+    let inner = text.strip_prefix('/')?.strip_suffix('/')?;
+    (!inner.is_empty()).then_some(inner)
 }
 
 /// The bleats pane's three filter axes, composed with AND.
@@ -40,7 +146,10 @@ pub struct Filters {
     /// A line with no detectable level always passes regardless of this
     /// field: see [`Filters::keeps`].
     pub min_level: Option<Level>,
-    /// Keep only lines whose text contains this substring.
+    /// Keep only lines this text matches: a plain substring, or a
+    /// `/…/`-delimited regex. See [`MatchKind`] for exactly how the two are
+    /// told apart, and [`Filters::match_kind`]/[`Filters::match_ranges`] for
+    /// reading the result back.
     pub matcher: Option<String>,
     /// The axes currently set, oldest first, so the newest is the last
     /// element.
@@ -51,9 +160,13 @@ impl Filters {
     /// Records that `axis` just turned on or off, keeping [`Self::order`] in
     /// sync without letting an axis appear in it twice.
     ///
-    /// No non-test caller yet: `#[allow(dead_code)]` says so rather than
-    /// inventing one. Task 4 wires the filter row's keys into the setters
-    /// that call this.
+    /// No non-test caller yet in this plan: `#[allow(dead_code)]` says so
+    /// rather than inventing one. `set_stream`, `set_min_level` and
+    /// `set_match` call this, and Task 4 (this task) exercises all three
+    /// from its own test fixture, but no task in this plan wires an actual
+    /// key to any of them — the filter row this task draws only *reads*
+    /// `Filters`. Whichever task ends up binding the keys is this method's
+    /// first production caller.
     #[allow(dead_code)]
     fn note_axis(&mut self, axis: Axis, now_set: bool) {
         let already_set = self.order.contains(&axis);
@@ -64,17 +177,44 @@ impl Filters {
         }
     }
 
+    /// Whether no axis is currently set.
+    ///
+    /// The filter row renders only when this is `false`: with nothing set,
+    /// a row stating "all three must hold" and a survivor count equal to
+    /// the total would say nothing an operator does not already see.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.stream.is_none() && self.min_level.is_none() && self.matcher.is_none()
+    }
+
+    /// What the match axis's typed text resolves to, or `None` when the
+    /// axis is not set.
+    #[must_use]
+    pub fn match_kind(&self) -> Option<MatchKind> {
+        self.matcher
+            .as_deref()
+            .map(|text| Matcher::parse(text).kind())
+    }
+
+    /// Every byte range in `haystack` the match axis hits, for highlighting
+    /// a rendered line. Empty when the axis is not set, and empty (never a
+    /// panic) for an invalid regex.
+    #[must_use]
+    pub fn match_ranges(&self, haystack: &str) -> Vec<(usize, usize)> {
+        self.matcher
+            .as_deref()
+            .map(|text| Matcher::parse(text).ranges(haystack))
+            .unwrap_or_default()
+    }
+
     /// Whether `line` survives every axis currently set.
     ///
     /// Each axis short-circuits the line out the moment it fails; an axis
     /// left `None` holds automatically, which is how the three compose
-    /// with AND rather than needing a combinator.
-    ///
-    /// No non-test caller yet: `#[allow(dead_code)]` says so rather than
-    /// inventing one. Task 5 reaches this through [`BleatsPane::visible`]
-    /// on every poll.
-    #[allow(dead_code)]
-    fn keeps(&self, line: &TailLine) -> bool {
+    /// with AND rather than needing a combinator. `matcher` is the match
+    /// axis's typed text, already parsed once by the caller
+    /// ([`Self::visible`]) rather than per line.
+    fn keeps(&self, line: &TailLine, matcher: Option<&Matcher>) -> bool {
         if let Some(stream) = self.stream
             && line.stream != stream
         {
@@ -93,8 +233,8 @@ impl Filters {
                 return false;
             }
         }
-        if let Some(text) = &self.matcher
-            && !line.text.contains(text.as_str())
+        if let Some(matcher) = matcher
+            && !matcher.is_match(&line.text)
         {
             return false;
         }
@@ -135,10 +275,9 @@ impl BleatsPane {
 
     /// The filters currently stacked on this pane's feed.
     ///
-    /// No non-test caller yet: `#[allow(dead_code)]` says so rather than
-    /// inventing one. Task 4 reads this to draw the filter row's chips.
+    /// Read by [`super::view::bleats_full::draw`] to draw the filter row's
+    /// chips.
     #[must_use]
-    #[allow(dead_code)]
     pub fn filters(&self) -> &Filters {
         &self.filters
     }
@@ -146,7 +285,9 @@ impl BleatsPane {
     /// Restricts the feed to one stream, or both when `stream` is `None`.
     ///
     /// No non-test caller yet: `#[allow(dead_code)]` says so rather than
-    /// inventing one. Task 4 calls this from the filter row's stream key.
+    /// inventing one. This plan's filter row (drawn by
+    /// [`super::view::bleats_full::draw`]) only reads [`Filters`]; no task
+    /// in it binds a key to this setter.
     #[allow(dead_code)]
     pub fn set_stream(&mut self, stream: Option<Stream>) {
         self.filters.note_axis(Axis::Stream, stream.is_some());
@@ -157,14 +298,15 @@ impl BleatsPane {
     /// when `level` is `None`.
     ///
     /// No non-test caller yet: `#[allow(dead_code)]` says so rather than
-    /// inventing one. Task 4 calls this from the filter row's level key.
+    /// inventing one. See [`Self::set_stream`]'s doc for why.
     #[allow(dead_code)]
     pub fn set_min_level(&mut self, level: Option<Level>) {
         self.filters.note_axis(Axis::Level, level.is_some());
         self.filters.min_level = level;
     }
 
-    /// Sets the text a line's body must contain to show.
+    /// Sets the text a line's body must match to show: a plain substring, or
+    /// a `/…/`-delimited regex (see [`MatchKind`]).
     ///
     /// An empty string clears the axis rather than matching every line:
     /// there is no chip an operator can point at for "match nothing
@@ -172,7 +314,7 @@ impl BleatsPane {
     /// never set.
     ///
     /// No non-test caller yet: `#[allow(dead_code)]` says so rather than
-    /// inventing one. Task 4 calls this from the filter row's match box.
+    /// inventing one. See [`Self::set_stream`]'s doc for why.
     #[allow(dead_code)]
     pub fn set_match(&mut self, text: String) {
         let matcher = (!text.is_empty()).then_some(text);
@@ -182,14 +324,15 @@ impl BleatsPane {
 
     /// The lines from `lines` that survive every filter axis currently set.
     ///
-    /// No non-test caller yet: `#[allow(dead_code)]` says so rather than
-    /// inventing one. Task 5 calls this on every poll to draw the feed.
+    /// Read by [`super::view::bleats_full::draw`], both to draw only the
+    /// lines that pass and to count how many did, out of how many were in
+    /// the window.
     #[must_use]
-    #[allow(dead_code)]
     pub fn visible<'a>(&self, lines: &'a [TailLine]) -> Vec<&'a TailLine> {
+        let matcher = self.filters.matcher.as_deref().map(Matcher::parse);
         lines
             .iter()
-            .filter(|line| self.filters.keeps(line))
+            .filter(|line| self.filters.keeps(line, matcher.as_ref()))
             .collect()
     }
 
@@ -272,5 +415,111 @@ mod tests {
 
         assert!(pane.drop_newest_chip(), "the stream chip goes next");
         assert!(!pane.drop_newest_chip(), "nothing left to drop");
+    }
+
+    /// `note_axis`'s "unset an axis already in `order`, and not the newest
+    /// one" branch. Without the `retain`, `order` would still list `Stream`
+    /// after this, and the second `drop_newest_chip` below would find it
+    /// there and report `true` instead of `false`.
+    #[test]
+    fn clearing_an_older_axis_directly_removes_it_from_the_drop_order() {
+        let mut pane = BleatsPane::new(RowKey::Sheep(9));
+        pane.set_stream(Some(Stream::Err));
+        pane.set_min_level(Some(Level::Warn));
+        pane.set_stream(None);
+
+        assert!(pane.drop_newest_chip(), "level is the only chip left");
+        assert!(pane.filters().min_level.is_none());
+        assert!(
+            !pane.drop_newest_chip(),
+            "stream was cleared directly, not through drop_newest_chip, and \
+             must not still be sitting in the order"
+        );
+    }
+
+    /// `note_axis`'s "re-set an axis already set" branch: it must not move
+    /// to the back of `order`. Without the `already_set` guard, `order`
+    /// would gain a second `Stream` entry and the first
+    /// `drop_newest_chip` below would pop that instead of `Level`.
+    #[test]
+    fn re_setting_an_already_set_axis_does_not_reorder_it() {
+        let mut pane = BleatsPane::new(RowKey::Sheep(9));
+        pane.set_stream(Some(Stream::Err));
+        pane.set_min_level(Some(Level::Warn));
+        pane.set_stream(Some(Stream::Out));
+
+        assert!(pane.drop_newest_chip(), "level is still the newest chip");
+        assert!(pane.filters().min_level.is_none());
+        assert!(
+            pane.filters().stream.is_some(),
+            "the re-set stream chip is still the older one"
+        );
+    }
+
+    /// `/…/` compiles as a regex rather than a literal search for those two
+    /// characters.
+    #[test]
+    fn a_slash_delimited_matcher_is_read_as_a_regex() {
+        let mut pane = BleatsPane::new(RowKey::Sheep(9));
+        pane.set_match("/poo+l/".to_string());
+        let lines = vec![
+            line(Stream::Out, "pool exhausted"),
+            line(Stream::Out, "pooool exhausted"),
+            line(Stream::Out, "pol exhausted"),
+            line(Stream::Out, "kennel"),
+        ];
+        let kept: Vec<&str> = pane
+            .visible(&lines)
+            .iter()
+            .map(|l| l.text.as_str())
+            .collect();
+        assert_eq!(kept, vec!["pool exhausted", "pooool exhausted"]);
+    }
+
+    /// A pattern that does not compile matches nothing rather than
+    /// panicking or matching every line, and the axis says so through
+    /// `match_kind` for the filter row to render.
+    #[test]
+    fn an_invalid_regex_matches_no_line_and_reports_itself_invalid() {
+        let mut pane = BleatsPane::new(RowKey::Sheep(9));
+        pane.set_match("/pool(/".to_string());
+        let lines = vec![line(Stream::Out, "pool exhausted")];
+        assert!(pane.visible(&lines).is_empty());
+        assert_eq!(pane.filters().match_kind(), Some(MatchKind::Invalid));
+    }
+
+    /// A plain string with no delimiters stays a literal search, even one
+    /// that would parse as a different regex if it were read as one.
+    #[test]
+    fn a_plain_matcher_is_read_literally_not_as_a_regex() {
+        let mut pane = BleatsPane::new(RowKey::Sheep(9));
+        // `.` would match any character as a regex; read literally it must
+        // only match a real dot.
+        pane.set_match("get index.html".to_string());
+        let lines = vec![
+            line(Stream::Out, "GET get index.html 200"),
+            line(Stream::Out, "GET get indexXhtml 200"),
+        ];
+        let kept: Vec<&str> = pane
+            .visible(&lines)
+            .iter()
+            .map(|l| l.text.as_str())
+            .collect();
+        assert_eq!(kept, vec!["GET get index.html 200"]);
+        assert_eq!(pane.filters().match_kind(), Some(MatchKind::Literal));
+    }
+
+    /// The ranges a regex matcher reports are what the filter row highlights;
+    /// pinned here directly rather than only through a render assertion.
+    #[test]
+    fn match_ranges_reports_every_hit_a_regex_matcher_finds() {
+        let mut pane = BleatsPane::new(RowKey::Sheep(9));
+        pane.set_match("/po+l/".to_string());
+        let ranges = pane.filters().match_ranges("pool then pol then pooool");
+        let hits: Vec<&str> = ranges
+            .iter()
+            .map(|&(start, end)| &"pool then pol then pooool"[start..end])
+            .collect();
+        assert_eq!(hits, vec!["pool", "pol", "pooool"]);
     }
 }

--- a/crates/shep-cli/src/lookout/pane_bleats.rs
+++ b/crates/shep-cli/src/lookout/pane_bleats.rs
@@ -1,30 +1,276 @@
-//! The full-screen bleats pane's own state: which sheep it is pinned to.
+//! The full-screen bleats pane's own state: which sheep it is pinned to, and
+//! the three filters an operator can stack over the feed it reads.
 
 use super::app::RowKey;
+use super::level::{Level, level_of};
+use super::tail::{Stream, TailLine};
+
+/// Which filter axis was most recently turned on.
+///
+/// Kept as its own small enum, in a `Vec` on [`Filters`], rather than
+/// deriving "newest" from the three fields directly: nothing about a
+/// `Stream`, a `Level` or a `String` says when it was set, so
+/// [`BleatsPane::drop_newest_chip`] needs an explicit order to pop from.
+///
+/// No non-test caller for the setters that construct a variant yet:
+/// `#[allow(dead_code)]` on them says so rather than inventing one. Task 4
+/// wires the filter row's keys into [`BleatsPane::set_stream`],
+/// [`BleatsPane::set_min_level`] and [`BleatsPane::set_match`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[allow(dead_code)]
+enum Axis {
+    /// The stream axis: `out`, `err`, or both.
+    Stream,
+    /// The minimum-level axis.
+    Level,
+    /// The text-match axis.
+    Match,
+}
+
+/// The bleats pane's three filter axes, composed with AND.
+///
+/// `Debug` is derived. A stream tag, a level and an operator-typed search
+/// string carry no env, no path and no argument vector.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct Filters {
+    /// Keep only lines from this stream, or both when `None`.
+    pub stream: Option<Stream>,
+    /// Keep a line whose level meets this floor, or every line when `None`.
+    ///
+    /// A line with no detectable level always passes regardless of this
+    /// field: see [`Filters::keeps`].
+    pub min_level: Option<Level>,
+    /// Keep only lines whose text contains this substring.
+    pub matcher: Option<String>,
+    /// The axes currently set, oldest first, so the newest is the last
+    /// element.
+    order: Vec<Axis>,
+}
+
+impl Filters {
+    /// Records that `axis` just turned on or off, keeping [`Self::order`] in
+    /// sync without letting an axis appear in it twice.
+    ///
+    /// No non-test caller yet: `#[allow(dead_code)]` says so rather than
+    /// inventing one. Task 4 wires the filter row's keys into the setters
+    /// that call this.
+    #[allow(dead_code)]
+    fn note_axis(&mut self, axis: Axis, now_set: bool) {
+        let already_set = self.order.contains(&axis);
+        if now_set && !already_set {
+            self.order.push(axis);
+        } else if !now_set && already_set {
+            self.order.retain(|set| *set != axis);
+        }
+    }
+
+    /// Whether `line` survives every axis currently set.
+    ///
+    /// Each axis short-circuits the line out the moment it fails; an axis
+    /// left `None` holds automatically, which is how the three compose
+    /// with AND rather than needing a combinator.
+    ///
+    /// No non-test caller yet: `#[allow(dead_code)]` says so rather than
+    /// inventing one. Task 5 reaches this through [`BleatsPane::visible`]
+    /// on every poll.
+    #[allow(dead_code)]
+    fn keeps(&self, line: &TailLine) -> bool {
+        if let Some(stream) = self.stream
+            && line.stream != stream
+        {
+            return false;
+        }
+        if let Some(min) = self.min_level {
+            // A line with no detectable level always passes: `level_of`
+            // returning `None` means "unclassifiable", the ordinary case
+            // for plain app output, not "below the minimum". Treating it
+            // as a miss would make a bare `println!` line vanish the
+            // moment an operator set any floor at all, which is exactly
+            // the line the pane was opened to find.
+            if let Some(level) = level_of(&line.text)
+                && level < min
+            {
+                return false;
+            }
+        }
+        if let Some(text) = &self.matcher
+            && !line.text.contains(text.as_str())
+        {
+            return false;
+        }
+        true
+    }
+}
 
 /// The full-screen bleats pane's own state.
 ///
 /// Holds the sheep it opened on rather than reading the dashboard's
 /// selection: full screen leaves no table on which to change one, so the
-/// pane describes a single sheep for as long as it is open.
+/// pane describes a single sheep for as long as it is open. Also holds the
+/// filters an operator has stacked on top of that sheep's feed.
 ///
-/// `Debug` is derived. A row key and a cursor position carry no env, no
-/// path and no argument vector.
+/// `Debug` is derived. A row key, a filter set and a cursor position carry
+/// no env, no path and no argument vector.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BleatsPane {
     sheep: RowKey,
+    filters: Filters,
 }
 
 impl BleatsPane {
-    /// Opens the pane on one sheep.
+    /// Opens the pane on one sheep, with no filters set.
     #[must_use]
     pub fn new(sheep: RowKey) -> Self {
-        Self { sheep }
+        Self {
+            sheep,
+            filters: Filters::default(),
+        }
     }
 
     /// The sheep this pane describes, fixed for its lifetime.
     #[must_use]
     pub fn sheep(&self) -> &RowKey {
         &self.sheep
+    }
+
+    /// The filters currently stacked on this pane's feed.
+    ///
+    /// No non-test caller yet: `#[allow(dead_code)]` says so rather than
+    /// inventing one. Task 4 reads this to draw the filter row's chips.
+    #[must_use]
+    #[allow(dead_code)]
+    pub fn filters(&self) -> &Filters {
+        &self.filters
+    }
+
+    /// Restricts the feed to one stream, or both when `stream` is `None`.
+    ///
+    /// No non-test caller yet: `#[allow(dead_code)]` says so rather than
+    /// inventing one. Task 4 calls this from the filter row's stream key.
+    #[allow(dead_code)]
+    pub fn set_stream(&mut self, stream: Option<Stream>) {
+        self.filters.note_axis(Axis::Stream, stream.is_some());
+        self.filters.stream = stream;
+    }
+
+    /// Sets the minimum level a line must meet to show, or clears the floor
+    /// when `level` is `None`.
+    ///
+    /// No non-test caller yet: `#[allow(dead_code)]` says so rather than
+    /// inventing one. Task 4 calls this from the filter row's level key.
+    #[allow(dead_code)]
+    pub fn set_min_level(&mut self, level: Option<Level>) {
+        self.filters.note_axis(Axis::Level, level.is_some());
+        self.filters.min_level = level;
+    }
+
+    /// Sets the text a line's body must contain to show.
+    ///
+    /// An empty string clears the axis rather than matching every line:
+    /// there is no chip an operator can point at for "match nothing
+    /// typed yet", so an empty search box behaves as if the axis were
+    /// never set.
+    ///
+    /// No non-test caller yet: `#[allow(dead_code)]` says so rather than
+    /// inventing one. Task 4 calls this from the filter row's match box.
+    #[allow(dead_code)]
+    pub fn set_match(&mut self, text: String) {
+        let matcher = (!text.is_empty()).then_some(text);
+        self.filters.note_axis(Axis::Match, matcher.is_some());
+        self.filters.matcher = matcher;
+    }
+
+    /// The lines from `lines` that survive every filter axis currently set.
+    ///
+    /// No non-test caller yet: `#[allow(dead_code)]` says so rather than
+    /// inventing one. Task 5 calls this on every poll to draw the feed.
+    #[must_use]
+    #[allow(dead_code)]
+    pub fn visible<'a>(&self, lines: &'a [TailLine]) -> Vec<&'a TailLine> {
+        lines
+            .iter()
+            .filter(|line| self.filters.keeps(line))
+            .collect()
+    }
+
+    /// Drops the most recently set filter axis, returning whether one was
+    /// there to drop.
+    ///
+    /// This is what `Escape` does while a chip is showing: backing out is
+    /// one axis at a time, oldest survives longest. `false` once every
+    /// axis is clear tells the caller there is nothing left to drop, which
+    /// is the reducer's signal to close the pane instead.
+    pub fn drop_newest_chip(&mut self) -> bool {
+        let Some(axis) = self.filters.order.pop() else {
+            return false;
+        };
+        match axis {
+            Axis::Stream => self.filters.stream = None,
+            Axis::Level => self.filters.min_level = None,
+            Axis::Match => self.filters.matcher = None,
+        }
+        true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn line(stream: Stream, text: &str) -> TailLine {
+        TailLine {
+            stream,
+            text: text.to_string(),
+        }
+    }
+
+    /// The decision most likely to be quietly reversed. An app printing bare
+    /// text must not vanish because somebody asked for warnings.
+    #[test]
+    fn a_line_with_no_level_survives_a_minimum() {
+        let mut pane = BleatsPane::new(RowKey::Sheep(9));
+        pane.set_min_level(Some(Level::Warn));
+        let lines = vec![
+            line(Stream::Out, "listening on 8080"),
+            line(Stream::Out, "INFO routine chatter"),
+            line(Stream::Out, "ERROR pool exhausted"),
+        ];
+        let kept: Vec<&str> = pane
+            .visible(&lines)
+            .iter()
+            .map(|l| l.text.as_str())
+            .collect();
+        assert_eq!(kept, vec!["listening on 8080", "ERROR pool exhausted"]);
+    }
+
+    #[test]
+    fn the_three_axes_compose_with_and() {
+        let mut pane = BleatsPane::new(RowKey::Sheep(9));
+        pane.set_stream(Some(Stream::Err));
+        pane.set_min_level(Some(Level::Warn));
+        pane.set_match("pool".to_string());
+        let lines = vec![
+            line(Stream::Err, "ERROR pool exhausted"), // all three hold
+            line(Stream::Out, "ERROR pool exhausted"), // wrong stream
+            line(Stream::Err, "INFO pool warming"),    // below the minimum
+            line(Stream::Err, "ERROR disk full"),      // no match
+        ];
+        assert_eq!(pane.visible(&lines).len(), 1);
+    }
+
+    /// esc removes the newest chip rather than clearing every filter, so
+    /// backing out of a filter is one key at a time.
+    #[test]
+    fn esc_drops_the_newest_chip_then_reports_there_are_none_left() {
+        let mut pane = BleatsPane::new(RowKey::Sheep(9));
+        pane.set_stream(Some(Stream::Err));
+        pane.set_min_level(Some(Level::Warn));
+
+        assert!(pane.drop_newest_chip(), "the level chip was newest");
+        assert!(pane.filters().min_level.is_none());
+        assert!(pane.filters().stream.is_some(), "the older chip stays");
+
+        assert!(pane.drop_newest_chip(), "the stream chip goes next");
+        assert!(!pane.drop_newest_chip(), "nothing left to drop");
     }
 }

--- a/crates/shep-cli/src/lookout/pane_bleats.rs
+++ b/crates/shep-cli/src/lookout/pane_bleats.rs
@@ -442,6 +442,15 @@ impl BleatsPane {
         self.following = false;
     }
 
+    /// Holds the offset at `ceiling`, the last value that changes the frame.
+    ///
+    /// Called by the reducer straight after a backward scroll, because the
+    /// ceiling depends on the surviving lines and their wrapped heights and
+    /// this type sees neither.
+    pub fn clamp_scroll(&mut self, ceiling: usize) {
+        self.scroll_offset = self.scroll_offset.min(ceiling);
+    }
+
     /// Scrolls toward the newest line by `amount`. Does not restore
     /// following on its own, even if it lands back on the tail: only
     /// [`Self::jump_to_end`] and turning [`Self::toggle_follow`] on do that,
@@ -449,16 +458,6 @@ impl BleatsPane {
     /// back, not the arithmetic.
     pub fn scroll_down(&mut self, amount: usize) {
         self.scroll_offset = self.scroll_offset.saturating_sub(amount);
-    }
-
-    /// `ctrl-u`: pages toward older lines by `amount`, which
-    /// [`super::app::App::on_bleats_key`] sizes through
-    /// [`super::view::bleats_full::page_amount`] rather than a raw body-row
-    /// count: unwrapped, a page is one line per row, the arithmetic this
-    /// method always did; wrapped, a tall line spends more than one row, so
-    /// the same row budget fits fewer lines.
-    pub fn page_up(&mut self, amount: usize) {
-        self.scroll_up(amount.max(1));
     }
 
     /// `ctrl-d`: the same, toward the newest line.

--- a/crates/shep-cli/src/lookout/pane_bleats.rs
+++ b/crates/shep-cli/src/lookout/pane_bleats.rs
@@ -13,16 +13,7 @@ use super::tail::{Stream, TailLine};
 /// deriving "newest" from the three fields directly: nothing about a
 /// `Stream`, a `Level` or a `String` says when it was set, so
 /// [`BleatsPane::drop_newest_chip`] needs an explicit order to pop from.
-///
-/// No non-test caller for the setters that construct a variant yet:
-/// `#[allow(dead_code)]` on them says so rather than inventing one.
-/// [`BleatsPane::set_stream`], [`BleatsPane::set_min_level`] and
-/// [`BleatsPane::set_match`] each construct one, but no task in this plan
-/// binds a key to any of the three — the filter row (this task) only reads
-/// `Filters`, it does not set it. Whichever task wires the keys is the
-/// first production caller.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[allow(dead_code)]
 enum Axis {
     /// The stream axis: `out`, `err`, or both.
     Stream,
@@ -159,15 +150,6 @@ pub struct Filters {
 impl Filters {
     /// Records that `axis` just turned on or off, keeping [`Self::order`] in
     /// sync without letting an axis appear in it twice.
-    ///
-    /// No non-test caller yet in this plan: `#[allow(dead_code)]` says so
-    /// rather than inventing one. `set_stream`, `set_min_level` and
-    /// `set_match` call this, and Task 4 (this task) exercises all three
-    /// from its own test fixture, but no task in this plan wires an actual
-    /// key to any of them — the filter row this task draws only *reads*
-    /// `Filters`. Whichever task ends up binding the keys is this method's
-    /// first production caller.
-    #[allow(dead_code)]
     fn note_axis(&mut self, axis: Axis, now_set: bool) {
         let already_set = self.order.contains(&axis);
         if now_set && !already_set {
@@ -247,14 +229,19 @@ impl Filters {
 /// Holds the sheep it opened on rather than reading the dashboard's
 /// selection: full screen leaves no table on which to change one, so the
 /// pane describes a single sheep for as long as it is open. Also holds the
-/// filters an operator has stacked on top of that sheep's feed.
+/// filters an operator has stacked on top of that sheep's feed, and, while
+/// the match box is open, what the match axis held before the edit began.
 ///
-/// `Debug` is derived. A row key, a filter set and a cursor position carry
-/// no env, no path and no argument vector.
+/// `Debug` is derived. A row key, a filter set and a snapshot of typed
+/// search text carry no env, no path and no argument vector.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BleatsPane {
     sheep: RowKey,
     filters: Filters,
+    /// `Some` while the match box owns `InputMode::Text`; the match axis's
+    /// text as it stood before this edit started, so [`Self::abandon_match_edit`]
+    /// can restore it. `None` the rest of the time.
+    match_snapshot: Option<Option<String>>,
 }
 
 impl BleatsPane {
@@ -264,6 +251,7 @@ impl BleatsPane {
         Self {
             sheep,
             filters: Filters::default(),
+            match_snapshot: None,
         }
     }
 
@@ -283,12 +271,6 @@ impl BleatsPane {
     }
 
     /// Restricts the feed to one stream, or both when `stream` is `None`.
-    ///
-    /// No non-test caller yet: `#[allow(dead_code)]` says so rather than
-    /// inventing one. This plan's filter row (drawn by
-    /// [`super::view::bleats_full::draw`]) only reads [`Filters`]; no task
-    /// in it binds a key to this setter.
-    #[allow(dead_code)]
     pub fn set_stream(&mut self, stream: Option<Stream>) {
         self.filters.note_axis(Axis::Stream, stream.is_some());
         self.filters.stream = stream;
@@ -296,10 +278,6 @@ impl BleatsPane {
 
     /// Sets the minimum level a line must meet to show, or clears the floor
     /// when `level` is `None`.
-    ///
-    /// No non-test caller yet: `#[allow(dead_code)]` says so rather than
-    /// inventing one. See [`Self::set_stream`]'s doc for why.
-    #[allow(dead_code)]
     pub fn set_min_level(&mut self, level: Option<Level>) {
         self.filters.note_axis(Axis::Level, level.is_some());
         self.filters.min_level = level;
@@ -312,14 +290,32 @@ impl BleatsPane {
     /// there is no chip an operator can point at for "match nothing
     /// typed yet", so an empty search box behaves as if the axis were
     /// never set.
-    ///
-    /// No non-test caller yet: `#[allow(dead_code)]` says so rather than
-    /// inventing one. See [`Self::set_stream`]'s doc for why.
-    #[allow(dead_code)]
     pub fn set_match(&mut self, text: String) {
         let matcher = (!text.is_empty()).then_some(text);
         self.filters.note_axis(Axis::Match, matcher.is_some());
         self.filters.matcher = matcher;
+    }
+
+    /// Opens the match box, remembering the match axis's current text so
+    /// [`Self::abandon_match_edit`] can restore it.
+    pub fn begin_match_edit(&mut self) {
+        self.match_snapshot = Some(self.filters.matcher.clone());
+    }
+
+    /// Ends the match box, keeping whatever [`Self::set_match`] already
+    /// applied on the way in: `TextChar` and `TextBackspace` narrow the
+    /// axis live, so there is nothing left for this to write.
+    pub fn commit_match_edit(&mut self) {
+        self.match_snapshot = None;
+    }
+
+    /// Restores the match axis to what [`Self::begin_match_edit`] saw,
+    /// discarding whatever was typed since. A no-op if the match box was
+    /// never opened.
+    pub fn abandon_match_edit(&mut self) {
+        if let Some(previous) = self.match_snapshot.take() {
+            self.set_match(previous.unwrap_or_default());
+        }
     }
 
     /// The lines from `lines` that survive every filter axis currently set.

--- a/crates/shep-cli/src/lookout/pane_bleats.rs
+++ b/crates/shep-cli/src/lookout/pane_bleats.rs
@@ -504,15 +504,6 @@ impl BleatsPane {
         self.following = false;
     }
 
-    /// `N`: the same, toward the oldest matching line. [`Self::scroll_up`]
-    /// already clears the follow flag.
-    pub fn match_prev(&mut self) {
-        if self.filters.matcher.is_none() {
-            return;
-        }
-        self.scroll_up(1);
-    }
-
     /// Drops the most recently set filter axis, returning whether one was
     /// there to drop.
     ///

--- a/crates/shep-cli/src/lookout/pane_bleats.rs
+++ b/crates/shep-cli/src/lookout/pane_bleats.rs
@@ -262,7 +262,7 @@ pub struct BleatsPane {
     body_rows: usize,
     /// The area's own column width, set from
     /// [`super::app::App::note_body_width`]. `0` until the first draw, which
-    /// [`super::view::bleats_full::page_amount`] reads as "no column count
+    /// [`super::view::bleats_full::page_amount_up`] reads as "no column count
     /// to wrap against" and falls back to [`Self::body_rows`] unmodified,
     /// the same amount a page always moved by before wrap existed.
     width: u16,
@@ -394,13 +394,13 @@ impl BleatsPane {
     }
 
     /// The body rows last recorded through [`Self::set_rows`], for
-    /// [`super::view::bleats_full::page_amount`] to size a page by.
+    /// [`super::view::bleats_full::page_amount_up`] to size a page by.
     #[must_use]
     pub(crate) fn body_rows(&self) -> usize {
         self.body_rows
     }
 
-    /// Records the body rows available, for [`super::view::bleats_full::page_amount`],
+    /// Records the body rows available, for [`super::view::bleats_full::page_amount_up`],
     /// which [`super::app::App::on_bleats_key`] reads before every
     /// `ctrl-u`/`ctrl-d`. Called from [`super::app::App::note_body_rows`]
     /// before every draw, the same way the config pane and settings screen
@@ -416,7 +416,7 @@ impl BleatsPane {
         self.width
     }
 
-    /// Records the area's column width, for [`super::view::bleats_full::page_amount`]
+    /// Records the area's column width, for [`super::view::bleats_full::page_amount_up`]
     /// to measure a wrapped line's row cost against. Called from
     /// [`super::app::App::note_body_width`] before every draw.
     pub fn set_width(&mut self, width: u16) {

--- a/crates/shep-cli/src/lookout/pane_bleats.rs
+++ b/crates/shep-cli/src/lookout/pane_bleats.rs
@@ -242,16 +242,37 @@ pub struct BleatsPane {
     /// text as it stood before this edit started, so [`Self::abandon_match_edit`]
     /// can restore it. `None` the rest of the time.
     match_snapshot: Option<Option<String>>,
+    /// How many surviving lines back from the newest one the view is
+    /// scrolled, counting **filtered** lines (what [`Self::visible`]
+    /// returns), not raw ones. `0` is the newest surviving line, the tail;
+    /// it grows as the operator scrolls toward older lines. A stored value
+    /// is never trusted past a filter change: [`super::view::bleats_full`]
+    /// recomputes the window from this and the current survivor count on
+    /// every draw, so a narrowing filter cannot leave it pointing past the
+    /// end.
+    scroll_offset: usize,
+    /// Whether the view stays pinned to the newest surviving line as new
+    /// ones arrive. `true` on open: an operator who has not scrolled wants
+    /// the live tail. Any backward movement clears it;
+    /// [`Self::jump_to_end`] and [`Self::toggle_follow`] (turning it on) both
+    /// restore it and reset [`Self::scroll_offset`] to `0`.
+    following: bool,
+    /// The body rows available to page by, set from
+    /// [`super::app::App::note_body_rows`]. `0` until the first draw.
+    body_rows: usize,
 }
 
 impl BleatsPane {
-    /// Opens the pane on one sheep, with no filters set.
+    /// Opens the pane on one sheep, with no filters set, following the tail.
     #[must_use]
     pub fn new(sheep: RowKey) -> Self {
         Self {
             sheep,
             filters: Filters::default(),
             match_snapshot: None,
+            scroll_offset: 0,
+            following: true,
+            body_rows: 0,
         }
     }
 
@@ -343,6 +364,73 @@ impl BleatsPane {
             .iter()
             .filter(|line| self.filters.keeps(line, matcher.as_ref()))
             .collect()
+    }
+
+    /// How many surviving lines back from the tail the view is scrolled.
+    /// `0` is the newest surviving line. See the field's own doc for what
+    /// this counts and why a stored value is never trusted on its own.
+    #[must_use]
+    pub fn scroll_offset(&self) -> usize {
+        self.scroll_offset
+    }
+
+    /// Whether the view is pinned to the newest surviving line.
+    #[must_use]
+    pub fn following(&self) -> bool {
+        self.following
+    }
+
+    /// Records the body rows available, for [`Self::page_up`]/[`Self::page_down`].
+    /// Called from [`super::app::App::note_body_rows`] before every draw, the
+    /// same way the config pane and settings screen already are.
+    pub fn set_rows(&mut self, rows: usize) {
+        self.body_rows = rows;
+    }
+
+    /// Scrolls toward older lines by `amount`, and stops following the
+    /// tail: any backward movement means the operator has taken over, or
+    /// the next refresh would undo the keypress.
+    pub fn scroll_up(&mut self, amount: usize) {
+        self.scroll_offset = self.scroll_offset.saturating_add(amount);
+        self.following = false;
+    }
+
+    /// Scrolls toward the newest line by `amount`. Does not restore
+    /// following on its own, even if it lands back on the tail: only
+    /// [`Self::jump_to_end`] and turning [`Self::toggle_follow`] on do that,
+    /// because an operator who has taken over decides when to hand the view
+    /// back, not the arithmetic.
+    pub fn scroll_down(&mut self, amount: usize) {
+        self.scroll_offset = self.scroll_offset.saturating_sub(amount);
+    }
+
+    /// `ctrl-u`: pages toward older lines by [`Self::body_rows`] set
+    /// through [`Self::set_rows`].
+    pub fn page_up(&mut self) {
+        self.scroll_up(self.body_rows.max(1));
+    }
+
+    /// `ctrl-d`: pages toward the newest line by [`Self::body_rows`].
+    pub fn page_down(&mut self) {
+        self.scroll_down(self.body_rows.max(1));
+    }
+
+    /// `G`: jumps to the newest surviving line and resumes following, since
+    /// that is what an operator means by "go to the end".
+    pub fn jump_to_end(&mut self) {
+        self.scroll_offset = 0;
+        self.following = true;
+    }
+
+    /// `f`: toggles following explicitly. Turning it on also jumps to the
+    /// tail, the same way [`Self::jump_to_end`] does, since "following"
+    /// means pinned to the newest line, not pinned wherever the view
+    /// happened to be.
+    pub fn toggle_follow(&mut self) {
+        self.following = !self.following;
+        if self.following {
+            self.scroll_offset = 0;
+        }
     }
 
     /// Drops the most recently set filter axis, returning whether one was

--- a/crates/shep-cli/src/lookout/pane_bleats.rs
+++ b/crates/shep-cli/src/lookout/pane_bleats.rs
@@ -1,0 +1,30 @@
+//! The full-screen bleats pane's own state: which sheep it is pinned to.
+
+use super::app::RowKey;
+
+/// The full-screen bleats pane's own state.
+///
+/// Holds the sheep it opened on rather than reading the dashboard's
+/// selection: full screen leaves no table on which to change one, so the
+/// pane describes a single sheep for as long as it is open.
+///
+/// `Debug` is derived. A row key and a cursor position carry no env, no
+/// path and no argument vector.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BleatsPane {
+    sheep: RowKey,
+}
+
+impl BleatsPane {
+    /// Opens the pane on one sheep.
+    #[must_use]
+    pub fn new(sheep: RowKey) -> Self {
+        Self { sheep }
+    }
+
+    /// The sheep this pane describes, fixed for its lifetime.
+    #[must_use]
+    pub fn sheep(&self) -> &RowKey {
+        &self.sheep
+    }
+}

--- a/crates/shep-cli/src/lookout/pane_bleats.rs
+++ b/crates/shep-cli/src/lookout/pane_bleats.rs
@@ -302,6 +302,19 @@ impl BleatsPane {
         self.match_snapshot = Some(self.filters.matcher.clone());
     }
 
+    /// The match box's live buffer while it is open, or `None` when it is
+    /// not.
+    ///
+    /// The status bar needs both facts and the buffer alone cannot carry
+    /// them: an empty box and a closed box both read as an empty matcher.
+    /// `Some("")` is a box open over nothing typed yet.
+    #[must_use]
+    pub fn match_editing(&self) -> Option<&str> {
+        self.match_snapshot
+            .as_ref()
+            .map(|_| self.filters.matcher.as_deref().unwrap_or(""))
+    }
+
     /// Ends the match box, keeping whatever [`Self::set_match`] already
     /// applied on the way in: `TextChar` and `TextBackspace` narrow the
     /// axis live, so there is nothing left for this to write.

--- a/crates/shep-cli/src/lookout/pane_bleats.rs
+++ b/crates/shep-cli/src/lookout/pane_bleats.rs
@@ -260,6 +260,17 @@ pub struct BleatsPane {
     /// The body rows available to page by, set from
     /// [`super::app::App::note_body_rows`]. `0` until the first draw.
     body_rows: usize,
+    /// The area's own column width, set from
+    /// [`super::app::App::note_body_width`]. `0` until the first draw, which
+    /// [`super::view::bleats_full::page_amount`] reads as "no column count
+    /// to wrap against" and falls back to [`Self::body_rows`] unmodified,
+    /// the same amount a page always moved by before wrap existed.
+    width: u16,
+    /// Whether a line too wide for the pane wraps onto extra rows instead
+    /// of truncating with an ellipsis. `false` on open: unwrapped is the
+    /// pane's original behavior, and every existing feed still reads that
+    /// way until an operator asks for the other one.
+    wrap: bool,
 }
 
 impl BleatsPane {
@@ -273,6 +284,8 @@ impl BleatsPane {
             scroll_offset: 0,
             following: true,
             body_rows: 0,
+            width: 0,
+            wrap: false,
         }
     }
 
@@ -380,11 +393,45 @@ impl BleatsPane {
         self.following
     }
 
-    /// Records the body rows available, for [`Self::page_up`]/[`Self::page_down`].
-    /// Called from [`super::app::App::note_body_rows`] before every draw, the
-    /// same way the config pane and settings screen already are.
+    /// The body rows last recorded through [`Self::set_rows`], for
+    /// [`super::view::bleats_full::page_amount`] to size a page by.
+    #[must_use]
+    pub(crate) fn body_rows(&self) -> usize {
+        self.body_rows
+    }
+
+    /// Records the body rows available, for [`super::view::bleats_full::page_amount`],
+    /// which [`super::app::App::on_bleats_key`] reads before every
+    /// `ctrl-u`/`ctrl-d`. Called from [`super::app::App::note_body_rows`]
+    /// before every draw, the same way the config pane and settings screen
+    /// already are.
     pub fn set_rows(&mut self, rows: usize) {
         self.body_rows = rows;
+    }
+
+    /// The area's own column width last recorded through [`Self::set_width`],
+    /// or `0` before the first draw.
+    #[must_use]
+    pub(crate) fn width(&self) -> u16 {
+        self.width
+    }
+
+    /// Records the area's column width, for [`super::view::bleats_full::page_amount`]
+    /// to measure a wrapped line's row cost against. Called from
+    /// [`super::app::App::note_body_width`] before every draw.
+    pub fn set_width(&mut self, width: u16) {
+        self.width = width;
+    }
+
+    /// Whether a long line wraps onto extra rows instead of truncating.
+    #[must_use]
+    pub fn wrapped(&self) -> bool {
+        self.wrap
+    }
+
+    /// `w`: toggles wrapping.
+    pub fn toggle_wrap(&mut self) {
+        self.wrap = !self.wrap;
     }
 
     /// Scrolls toward older lines by `amount`, and stops following the
@@ -404,15 +451,19 @@ impl BleatsPane {
         self.scroll_offset = self.scroll_offset.saturating_sub(amount);
     }
 
-    /// `ctrl-u`: pages toward older lines by [`Self::body_rows`] set
-    /// through [`Self::set_rows`].
-    pub fn page_up(&mut self) {
-        self.scroll_up(self.body_rows.max(1));
+    /// `ctrl-u`: pages toward older lines by `amount`, which
+    /// [`super::app::App::on_bleats_key`] sizes through
+    /// [`super::view::bleats_full::page_amount`] rather than a raw body-row
+    /// count: unwrapped, a page is one line per row, the arithmetic this
+    /// method always did; wrapped, a tall line spends more than one row, so
+    /// the same row budget fits fewer lines.
+    pub fn page_up(&mut self, amount: usize) {
+        self.scroll_up(amount.max(1));
     }
 
-    /// `ctrl-d`: pages toward the newest line by [`Self::body_rows`].
-    pub fn page_down(&mut self) {
-        self.scroll_down(self.body_rows.max(1));
+    /// `ctrl-d`: the same, toward the newest line.
+    pub fn page_down(&mut self, amount: usize) {
+        self.scroll_down(amount.max(1));
     }
 
     /// `G`: jumps to the newest surviving line and resumes following, since
@@ -431,6 +482,36 @@ impl BleatsPane {
         if self.following {
             self.scroll_offset = 0;
         }
+    }
+
+    /// `n`: steps one line toward the newest matching line. A no-op with no
+    /// match axis set, rather than quietly becoming a line-movement key:
+    /// with the axis off there is no "matching line" to step between at
+    /// all.
+    ///
+    /// Runs the matcher no second time: once the axis is set,
+    /// [`Filters::keeps`] already dropped every non-matching line out of
+    /// [`Self::visible`], so every surviving line *is* a match, and
+    /// stepping between matches is stepping between the lines already on
+    /// screen. Clears the follow flag either way, like any other backward
+    /// movement — `n` moves toward the newest line, not away from it, but
+    /// the design still calls it a deliberate jump the next refresh must
+    /// not undo.
+    pub fn match_next(&mut self) {
+        if self.filters.matcher.is_none() {
+            return;
+        }
+        self.scroll_down(1);
+        self.following = false;
+    }
+
+    /// `N`: the same, toward the oldest matching line. [`Self::scroll_up`]
+    /// already clears the follow flag.
+    pub fn match_prev(&mut self) {
+        if self.filters.matcher.is_none() {
+            return;
+        }
+        self.scroll_up(1);
     }
 
     /// Drops the most recently set filter axis, returning whether one was

--- a/crates/shep-cli/src/lookout/snapshots/shep__lookout__frames__tests__bleats.snap
+++ b/crates/shep-cli/src/lookout/snapshots/shep__lookout__frames__tests__bleats.snap
@@ -1,0 +1,18 @@
+---
+source: crates/shep-cli/src/lookout/frames.rs
+expression: render_text(&buffer)
+---
+shep lookout   /home/ada/.shep                                                        6 in the flock
+ ██ api  out /home/ada/.shep/logs/api-2-out.log  err /home/ada/.shep/logs/api-2-err.log             
+ stream out   level ≥ warn   match /retry|jitter/ (regex)  1 of 16 lines in the window: all three m…
+out  WARN retrying upstream payment gateway after a timeout, backing off 500ms before trying again w
+     ith jitter added so the whole fleet does not retry at once                                     
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+esc back   j/k line   ctrl-d/u page   G end   / search   n/N match   f follow   w wrap … █ following

--- a/crates/shep-cli/src/lookout/snapshots/shep__lookout__frames__tests__bleats.snap
+++ b/crates/shep-cli/src/lookout/snapshots/shep__lookout__frames__tests__bleats.snap
@@ -3,7 +3,7 @@ source: crates/shep-cli/src/lookout/frames.rs
 expression: render_text(&buffer)
 ---
 shep lookout   /home/ada/.shep                                                        6 in the flock
- ██ api  out /home/ada/.shep/logs/api-2-out.log  err /home/ada/.shep/logs/api-2-err.log             
+ ██ api  out /home/ada/.shep/logs/api-2-out.log  err /home/ada/.shep/logs/api-2-err.log  64.0K wind…
  stream out   level ≥ warn   match /retry|jitter/ (regex)  1 of 16 lines in the window: all three m…
 out  WARN retrying upstream payment gateway after a timeout, backing off 500ms before trying again w
      ith jitter added so the whole fleet does not retry at once                                     

--- a/crates/shep-cli/src/lookout/view/bleats_full.rs
+++ b/crates/shep-cli/src/lookout/view/bleats_full.rs
@@ -86,10 +86,16 @@ fn lines(app: &App, pane: &BleatsPane, width: u16, rows: usize) -> Vec<Line<'sta
     }
 
     let body_rows = rows.saturating_sub(out.len());
-    // The last surviving lines that fit, oldest first, so the newest one
-    // lands on the bottom row: the same order `view::bleats::feed_lines`
-    // renders in.
-    let skip = survivors.len().saturating_sub(body_rows);
+    // The window `pane.scroll_offset()` names, oldest first, so the newest
+    // one lands on the bottom row when the offset is `0`: the same order
+    // `view::bleats::feed_lines` renders in. `saturating_sub` is the clamp
+    // the offset itself is never trusted to carry on its own: a filter that
+    // just narrowed, or an offset a shrunk feed has outgrown, both fall
+    // out of view here rather than panicking or reading past the end.
+    let skip = survivors
+        .len()
+        .saturating_sub(body_rows)
+        .saturating_sub(pane.scroll_offset());
     for line in survivors.iter().skip(skip).take(body_rows) {
         out.push(feed_line(app, filters, line, width));
     }

--- a/crates/shep-cli/src/lookout/view/bleats_full.rs
+++ b/crates/shep-cli/src/lookout/view/bleats_full.rs
@@ -193,42 +193,17 @@ fn window_range(
 /// by, so a page under wrap moves by roughly the room `pane`'s own area
 /// draws rather than a raw row count that assumes one row per line.
 ///
-/// How many lines one `ctrl-u`/`ctrl-d` moves [`BleatsPane::scroll_offset`]
-/// by: exactly the lines the pane is showing right now.
+/// Lines one backward page covers: what fits ending at `start`.
 ///
-/// Measured from the current [`BleatsPane::scroll_offset`] through the same
-/// [`window_range`] the draw uses, so consecutive pages are contiguous by
-/// construction rather than by estimate. Unwrapped that is `body_rows`, the
-/// arithmetic this pane always used.
-///
-/// It has to be the current window rather than the feed's tail. Sizing a page
-/// once at the tail and reusing it is wrong the moment wrapped-line density
-/// differs anywhere else: a tail of one-row lines says "a page is twelve
-/// lines" while an older stretch draws four of them per screen, so a step
-/// would pass over eight lines no screen ever rendered. Clamping at render
-/// time does not help, because the lines are skipped rather than
-/// overshot. `wrapped_pages_leave_no_line_unseen` walks one direction and
-/// checks every line, since paging back is symmetric and hides the gap.
-#[must_use]
-pub(crate) fn page_amount(app: &App, pane: &BleatsPane) -> usize {
-    let body_rows = pane.body_rows();
-    if !pane.wrapped() || pane.width() == 0 {
-        return body_rows.max(1);
-    }
-    let survivors = pane.visible(&app.feed().lines);
-    let text_width = pane.width().saturating_sub(TAG_PREFIX_WIDTH);
-    let cost = |index: usize| row_height(&survivors[index].text, text_width, true);
-    let shown = window_range(survivors.len(), pane.scroll_offset(), body_rows, cost);
-
-    // Backward from where the view starts, not forward from where it ends.
-    // A page has to land the NEXT window's last line on this one's first, so
-    // it is sized by what fits going back from `shown.start`. Sizing it by
-    // the current window's own length is the same mistake one step later:
-    // when the older stretch wraps denser, fewer of its lines fill the same
-    // rows, and the difference is skipped.
+/// Pure, and separated from [`page_amount_up`] so the invariant that matters
+/// can be tested directly over cost profiles rather than hunted for through a
+/// fixture. A feed of uniform heights cannot expose a direction-mismatched
+/// page size at all, because a backward count and a window's own length agree
+/// there, which is how the `ctrl-d` gap survived its first fix.
+fn page_lines_back(start: usize, body_rows: usize, cost: impl Fn(usize) -> usize) -> usize {
     let mut used = 0usize;
     let mut count = 0usize;
-    let mut at = shown.start;
+    let mut at = start;
     while at > 0 {
         let row = cost(at - 1);
         if count > 0 && used + row > body_rows {
@@ -239,6 +214,60 @@ pub(crate) fn page_amount(app: &App, pane: &BleatsPane) -> usize {
         count += 1;
     }
     count.max(1)
+}
+
+/// How many lines one `ctrl-u` moves [`BleatsPane::scroll_offset`] by:
+/// what fits walking backward from the line the pane is currently showing
+/// first.
+///
+/// Unwrapped that is `body_rows`, the arithmetic this pane always used.
+///
+/// **The two page keys need different arithmetic and it is not obvious.** A
+/// page has to land the next window's last line on this one's first, so
+/// going backward the step is sized by what fits *ending* where the view
+/// starts. Sizing it from the feed's tail instead is wrong the moment
+/// wrapped-line density differs anywhere else, and sizing it by the current
+/// window's own length is wrong whenever the older stretch packs fewer lines
+/// into the same rows. Both skip lines rather than overshooting them, so
+/// [`window_range`]'s clamp does not save it.
+///
+/// [`page_amount_down`] is the mirror, and reusing this one for both
+/// directions leaves gaps: measured over 279,274 simulated steps, 48,476 of
+/// them dropped a line. `wrapped_pages_leave_no_line_unseen` and
+/// `wrapped_pages_down_leave_no_line_unseen` walk one direction each,
+/// because paging back is symmetric and hides the gap either way.
+#[must_use]
+pub(crate) fn page_amount_up(app: &App, pane: &BleatsPane) -> usize {
+    let body_rows = pane.body_rows();
+    if !pane.wrapped() || pane.width() == 0 {
+        return body_rows.max(1);
+    }
+    let survivors = pane.visible(&app.feed().lines);
+    let text_width = pane.width().saturating_sub(TAG_PREFIX_WIDTH);
+    let cost = |index: usize| row_height(&survivors[index].text, text_width, true);
+    let shown = window_range(survivors.len(), pane.scroll_offset(), body_rows, cost);
+    page_lines_back(shown.start, body_rows, cost)
+}
+
+/// How many lines one `ctrl-d` moves [`BleatsPane::scroll_offset`] by: the
+/// lines the pane is showing right now.
+///
+/// Going forward the next window should *begin* where this one ended, and
+/// stepping by the current window's own length puts it there exactly. That
+/// is the mirror of [`page_amount_up`]'s backward count, not the same
+/// number: see its doc for why one figure cannot serve both keys.
+#[must_use]
+pub(crate) fn page_amount_down(app: &App, pane: &BleatsPane) -> usize {
+    let body_rows = pane.body_rows();
+    if !pane.wrapped() || pane.width() == 0 {
+        return body_rows.max(1);
+    }
+    let survivors = pane.visible(&app.feed().lines);
+    let text_width = pane.width().saturating_sub(TAG_PREFIX_WIDTH);
+    let shown = window_range(survivors.len(), pane.scroll_offset(), body_rows, |index| {
+        row_height(&survivors[index].text, text_width, true)
+    });
+    shown.len().max(1)
 }
 
 /// One feed line, as the rows it actually draws: one row when
@@ -761,5 +790,60 @@ mod tests {
             plain.is_some(),
             "the rest of the line must stay unstyled, for contrast: {survivor:?}"
         );
+    }
+
+    /// Neither page direction ever steps over a line, across every cost
+    /// profile a wrapped feed can produce.
+    ///
+    /// Over the arithmetic rather than through a fixture, because a fixture
+    /// is the wrong instrument here. A feed of uniform row heights cannot
+    /// show this bug at all: a backward count and a window's own length are
+    /// the same number when every line is the same height, so the two
+    /// directions agree and a shared page size looks correct. Three separate
+    /// fixtures failed to reproduce a defect that a stress test finds in
+    /// roughly one step in six.
+    ///
+    /// The invariant: after a page, the next window must start no later than
+    /// one past where the last one ended, going forward, and end no earlier
+    /// than one before where it began, going back. Anything else is a line
+    /// no screen drew.
+    #[test]
+    fn neither_page_direction_steps_over_a_line() {
+        // A cheap deterministic spread of heights: no rng, and the profile
+        // is reproducible from the seed in a failure message.
+        let profile = |seed: usize, index: usize| -> usize {
+            1 + (seed.wrapping_mul(31).wrapping_add(index.wrapping_mul(17))) % 4
+        };
+
+        for seed in 0..200usize {
+            for len in [3usize, 7, 12, 25] {
+                for body_rows in [2usize, 3, 5, 8] {
+                    let cost = |index: usize| profile(seed, index);
+                    for offset in 0..len {
+                        let shown = window_range(len, offset, body_rows, cost);
+                        if shown.is_empty() {
+                            continue;
+                        }
+
+                        let back = page_lines_back(shown.start, body_rows, cost);
+                        let up = window_range(len, offset + back, body_rows, cost);
+                        assert!(
+                            up.end + 1 >= shown.start,
+                            "seed {seed} len {len} rows {body_rows} offset {offset}: \
+                             ctrl-u went from {shown:?} to {up:?}"
+                        );
+
+                        let forward = shown.len().max(1);
+                        let down =
+                            window_range(len, offset.saturating_sub(forward), body_rows, cost);
+                        assert!(
+                            down.start <= shown.end,
+                            "seed {seed} len {len} rows {body_rows} offset {offset}: \
+                             ctrl-d went from {shown:?} to {down:?}"
+                        );
+                    }
+                }
+            }
+        }
     }
 }

--- a/crates/shep-cli/src/lookout/view/bleats_full.rs
+++ b/crates/shep-cli/src/lookout/view/bleats_full.rs
@@ -111,7 +111,7 @@ fn feed_line(app: &App, filters: &Filters, line: &TailLine, width: u16) -> Line<
         Span::styled(format!("{tag}  "), palette.muted()),
     ];
     let text = fit(&line.text, width.saturating_sub(5));
-    spans.extend(highlighted(&text, filters, palette.attention()));
+    spans.extend(highlighted(&text, filters, palette.band(Role::Butter)));
     Line::from(spans)
 }
 
@@ -193,7 +193,7 @@ fn chip_labels(filters: &Filters) -> Vec<String> {
         chips.push(format!("stream {name}"));
     }
     if let Some(min) = filters.min_level {
-        chips.push(format!("level ≥{}", format!("{min:?}").to_lowercase()));
+        chips.push(format!("level ≥ {}", format!("{min:?}").to_lowercase()));
     }
     if let Some(text) = &filters.matcher {
         let suffix = match filters.match_kind() {
@@ -264,6 +264,7 @@ mod tests {
 
     use super::super::super::app::{KeyPress, Msg};
     use super::super::super::frames::render_text;
+    use super::super::super::level::Level;
     use super::super::super::pane_bleats::MatchKind;
     use super::super::super::tail::{Stream, Tail, TailLine};
     use super::super::fixtures::{
@@ -468,6 +469,27 @@ mod tests {
         // words.
         assert!(!text.contains("level ≥"), "got {text}");
         assert!(!text.contains("match "), "got {text}");
+    }
+
+    /// Each chip's literal text, exactly as the design draws it:
+    /// `stream err`, `level \u{2265} warn`, `match \u{2026}`. Pinned to the
+    /// character because nothing else asserts it and the spacing already
+    /// drifted once: the level chip shipped as `level \u{2265}warn` against a
+    /// design reading `level \u{2265} warn`, and every test passed.
+    #[test]
+    fn each_chip_reads_the_way_the_design_draws_it() {
+        let mut app = with_selection(ProcessInfo::builder(9, "web", ProcStatus::Online).build());
+        app.update(Msg::Key(KeyPress::Bleats));
+        let pane = app
+            .bleats_pane_mut_for_tests()
+            .expect("the key above opened the pane");
+        pane.set_stream(Some(Stream::Err));
+        pane.set_min_level(Some(Level::Warn));
+        pane.set_match("pool".to_string());
+        let text = render_all(&draw_lines(&app, 160, 40));
+        assert!(text.contains("stream err"), "got {text}");
+        assert!(text.contains("level \u{2265} warn"), "got {text}");
+        assert!(text.contains("match pool"), "got {text}");
     }
 
     /// A `/…/`-delimited matcher's chip says it is a regex.

--- a/crates/shep-cli/src/lookout/view/bleats_full.rs
+++ b/crates/shep-cli/src/lookout/view/bleats_full.rs
@@ -9,14 +9,15 @@ use ratatui::text::{Line, Span};
 
 use super::super::app::{App, RowKey};
 use super::super::pane_bleats::{BleatsPane, Filters, MatchKind};
-use super::super::tail::{Stream, TailLine};
+use super::super::tail::{FEED_WINDOW_BYTES, Stream, TailLine};
 use super::cell;
 use super::flock::fit;
+use crate::output::human_bytes;
 use crate::output::width::char_columns;
 use crate::vocabulary::Role;
 
 /// The stream tag's own width, shared by [`feed_line_rows`] (what it
-/// indents a wrapped line's continuation rows under) and [`page_amount`]
+/// indents a wrapped line's continuation rows under) and [`page_amount_up`]
 /// (what it reserves before measuring a line's row cost): `"out  "` and
 /// `"err  "` are both three letters and two trailing spaces.
 const TAG_PREFIX_WIDTH: u16 = 5;
@@ -54,7 +55,10 @@ pub fn draw(app: &App, pane: &BleatsPane, area: Rect, buffer: &mut Buffer) {
 /// Panics if `app`'s body is not the bleats pane. Every caller only reaches
 /// this after opening it.
 ///
-/// `#[cfg(test)]`: this module's own tests are the only caller today.
+/// `#[cfg(test)]`: reached from this module's tests, from
+/// `view::fixtures::draw_lines`, and from roughly a dozen tests in `app.rs`
+/// through that. It said "this module's own tests are the only caller" until
+/// the pane grew keys, and the tests that drive them live in `app.rs`.
 #[cfg(test)]
 #[must_use]
 pub(crate) fn draw_lines(app: &App, width: u16, rows: usize) -> Vec<Line<'static>> {
@@ -447,9 +451,12 @@ fn filter_row_line(
         spans.push(Span::raw(" "));
         used += 1;
     }
+    // Three clauses, the third of which the design states and this row used
+    // to omit: `esc` is the one non-obvious key in the pane, and nothing else
+    // on screen says it spends a chip rather than closing.
     let sentence = format!(
-        "{} of {} lines in the window: all three must hold, and a line with no \
-         detectable level always shows",
+        "{} of {} lines in the window: all three must hold, a line with no \
+         detectable level always shows, esc drops the newest chip",
         group_thousands(survivors),
         group_thousands(total),
     );
@@ -507,12 +514,31 @@ fn group_thousands(mut n: usize) -> String {
 /// [`Role::Meadow`].
 fn title_line(app: &App, pane: &BleatsPane, width: u16) -> Line<'static> {
     let text = match sheep_id(pane).and_then(|id| app.row(id)) {
-        Some(row) => format!(
-            "{}  out {}  err {}",
-            row.info.name,
-            row.info.out_file.as_deref().unwrap_or("-"),
-            row.info.err_file.as_deref().unwrap_or("-"),
-        ),
+        Some(row) => {
+            let feed = app.feed();
+            // The window that was read, and what fell below it. `rulings.md`
+            // dropped the whole-file line count, the absolute line numbers
+            // and the density gutter, all three of which need reading the
+            // file to say anything. Bytes below the window are not that:
+            // `tail.rs` already knows them exactly because it seeked past
+            // them, and the four-line corner strip this pane replaces
+            // already surfaces the same figures.
+            let window = format!(
+                "{} window, {} read",
+                human_bytes(FEED_WINDOW_BYTES),
+                human_bytes(feed.read_bytes),
+            );
+            let below = match feed.missed_bytes {
+                0 => String::new(),
+                bytes => format!("  {} below the window, unread", human_bytes(bytes)),
+            };
+            format!(
+                "{}  out {}  err {}  {window}{below}",
+                row.info.name,
+                row.info.out_file.as_deref().unwrap_or("-"),
+                row.info.err_file.as_deref().unwrap_or("-"),
+            )
+        }
         None => match sheep_id(pane) {
             Some(id) => format!("sheep {id}: it is no longer in the flock"),
             None => "no sheep is selected".to_string(),
@@ -833,6 +859,82 @@ mod tests {
         assert!(
             plain.is_some(),
             "the rest of the line must stay unstyled, for contrast: {survivor:?}"
+        );
+    }
+
+    /// `group_thousands` groups, pads and orders.
+    ///
+    /// Every survivor count in every other test is under a thousand, so the
+    /// separator branch never ran: dropping the `{:03}` pad passed, and so
+    /// did dropping the `reverse()`. The spec's own example is `2,847`, which
+    /// is exactly the untested path.
+    #[test]
+    fn group_thousands_pads_and_orders_its_groups() {
+        assert_eq!(group_thousands(0), "0");
+        assert_eq!(group_thousands(999), "999");
+        assert_eq!(group_thousands(2_847), "2,847");
+        // The pad: without `{:03}` this is `1,7`.
+        assert_eq!(group_thousands(1_007), "1,007");
+        // The order: reversed, this is `847,12`.
+        assert_eq!(group_thousands(12_847), "12,847");
+        assert_eq!(group_thousands(1_000_000), "1,000,000");
+    }
+
+    /// The filter row states all three clauses the design gives it.
+    ///
+    /// The third was missing: `esc` is the one non-obvious key in this pane,
+    /// and with it absent nothing on screen said the key spends a chip
+    /// rather than closing. The status bar says `esc back`, which is the
+    /// design's own wording and true of a pane with no chips set.
+    #[test]
+    fn the_filter_row_states_all_three_of_its_clauses() {
+        let mut app = with_selection(ProcessInfo::builder(9, "web", ProcStatus::Online).build());
+        app.update(Msg::Key(KeyPress::Bleats));
+        app.bleats_pane_mut_for_tests()
+            .expect("open")
+            .set_min_level(Some(Level::Warn));
+        let text = render_all(&draw_lines(&app, 200, 40));
+        assert!(text.contains("all three must hold"), "got {text}");
+        assert!(
+            text.contains("no detectable level always shows"),
+            "got {text}"
+        );
+        assert!(text.contains("esc drops the newest chip"), "got {text}");
+    }
+
+    /// The title names the window it read and what fell below it.
+    ///
+    /// `rulings.md` dropped the whole-file line count, the absolute line
+    /// numbers and the density gutter, all three of which need reading the
+    /// file. Bytes below the window are not in that set: `tail.rs` knows
+    /// them exactly because it seeked past them, and the design asks row 1
+    /// for them.
+    #[test]
+    fn the_title_names_the_window_and_what_fell_below_it() {
+        let mut app = with_selection(
+            ProcessInfo::builder(9, "web", ProcStatus::Online)
+                .out_file(Some("/logs/web-out.log".to_string()))
+                .build(),
+        );
+        app.update(Msg::Bleats {
+            tail: Tail {
+                lines: vec![TailLine {
+                    stream: Stream::Out,
+                    text: "listening".to_string(),
+                }],
+                missed_lines: 0,
+                missed_bytes: 831 * 1024,
+                read_bytes: 4096,
+                note: None,
+            },
+        });
+        app.update(Msg::Key(KeyPress::Bleats));
+        let text = render_all(&draw_lines(&app, 200, 40));
+        assert!(text.contains("64.0K window"), "the window it reads: {text}");
+        assert!(text.contains("4.0K read"), "and what it read: {text}");
+        assert!(
+            text.contains("below the window, unread"),
+            "and what it could not: {text}"
         );
     }
 

--- a/crates/shep-cli/src/lookout/view/bleats_full.rs
+++ b/crates/shep-cli/src/lookout/view/bleats_full.rs
@@ -375,7 +375,7 @@ fn filter_row_line(
         used += 1;
     }
     let sentence = format!(
-        "{} of {} lines in the window — all three must hold, and a line with no \
+        "{} of {} lines in the window: all three must hold, and a line with no \
          detectable level always shows",
         group_thousands(survivors),
         group_thousands(total),

--- a/crates/shep-cli/src/lookout/view/bleats_full.rs
+++ b/crates/shep-cli/src/lookout/view/bleats_full.rs
@@ -193,6 +193,40 @@ fn window_range(
 /// by, so a page under wrap moves by roughly the room `pane`'s own area
 /// draws rather than a raw row count that assumes one row per line.
 ///
+/// The largest scroll offset that still changes what the pane draws.
+///
+/// [`window_range`] floors its skip at zero, so an offset past the oldest
+/// surviving line renders the same frame as the one before it. Without a
+/// ceiling the stored offset keeps climbing: 40 `k` presses over a 20-line
+/// feed leave it at 39 where 15 is the most that does anything, and the
+/// operator then presses `j` 25 times before the window moves. `G` and `f`
+/// escape that, but `j` is the reflex and it would do nothing.
+#[must_use]
+pub(crate) fn max_scroll_offset(app: &App, pane: &BleatsPane) -> usize {
+    let survivors = pane.visible(&app.feed().lines);
+    let body_rows = pane.body_rows();
+    if body_rows == 0 || survivors.is_empty() {
+        return 0;
+    }
+    let text_width = pane.width().saturating_sub(TAG_PREFIX_WIDTH);
+    let wrap = pane.wrapped() && pane.width() > 0;
+    let cost = |index: usize| row_height(&survivors[index].text, text_width, wrap);
+
+    // Where the tail window starts. Scrolling past it only re-renders the
+    // oldest frame, so that index is the ceiling.
+    let mut base = survivors.len();
+    let mut used = 0usize;
+    while base > 0 {
+        let row = cost(base - 1);
+        if used > 0 && used + row > body_rows {
+            break;
+        }
+        base -= 1;
+        used += row;
+    }
+    base
+}
+
 /// Lines one backward page covers: what fits ending at `start`.
 ///
 /// Pure, and separated from [`page_amount_up`] so the invariant that matters
@@ -800,6 +834,31 @@ mod tests {
             plain.is_some(),
             "the rest of the line must stay unstyled, for contrast: {survivor:?}"
         );
+    }
+
+    /// `row_height` counts display columns, and `wrap_spans` has to agree
+    /// with it or the page arithmetic drifts from what is drawn.
+    ///
+    /// `row_height` feeds every page and window calculation while
+    /// `wrap_spans` produces the rows themselves, and `row_height`'s own doc
+    /// says the two "can never disagree on how many rows one line takes".
+    /// Only `wrap_spans` was held there: mutating `char_columns` to `1`
+    /// inside `row_height` passed the whole suite, because every test that
+    /// counted rows counted rendered ones.
+    #[test]
+    fn row_height_and_the_rendered_rows_agree_on_a_wide_line() {
+        // Ten double-width characters are 20 columns. At a text width of 8
+        // that is 3 rows; counting `char`s would say 2.
+        let wide = "\u{5e83}".repeat(10);
+        assert_eq!(row_height(&wide, 8, true), 3, "counted by columns");
+        assert_eq!(
+            row_height(&wide, 8, true),
+            wrap_spans(vec![Span::raw(wide.clone())], 8).len(),
+            "the counter and the renderer agree"
+        );
+
+        // And unwrapped it is always one row, whatever the width.
+        assert_eq!(row_height(&wide, 8, false), 1);
     }
 
     /// Neither page direction ever steps over a line, across every cost

--- a/crates/shep-cli/src/lookout/view/bleats_full.rs
+++ b/crates/shep-cli/src/lookout/view/bleats_full.rs
@@ -1,67 +1,226 @@
 //! The full-screen bleats pane: the same feed [`super::bleats`] draws in its
-//! five-line strip, given the whole body instead.
-//!
-//! No filters yet: this task draws the window plainly. Level parsing, a
-//! `Filters` type and the filter row all land in later tasks of the same
-//! plan.
+//! five-line strip, given the whole body instead, plus the filter row
+//! stacked on it once an operator has set an axis.
 
 use ratatui::buffer::Buffer;
 use ratatui::layout::Rect;
+use ratatui::style::Style;
 use ratatui::text::{Line, Span};
 
 use super::super::app::{App, RowKey};
-use super::super::pane_bleats::BleatsPane;
-use super::super::tail::Stream;
+use super::super::pane_bleats::{BleatsPane, Filters, MatchKind};
+use super::super::tail::{Stream, TailLine};
 use super::cell;
 use super::flock::fit;
 use crate::vocabulary::Role;
 
 /// Draws the pane over the whole body: a title band naming the sheep and
-/// both log paths, then either the window's newest lines, each tagged `out`
-/// or `err` with the newest at the bottom, or, when there are none yet,
-/// [`Tail::note`](super::super::tail::Tail::note) naming why.
+/// both log paths, then, once any filter axis is set, the filter row, then
+/// either the window's newest surviving lines, each tagged `out` or `err`
+/// with the newest at the bottom, or, when there are none, [`Tail::note`]
+/// naming why.
+///
+/// [`Tail::note`]: super::super::tail::Tail::note
 pub fn draw(app: &App, pane: &BleatsPane, area: Rect, buffer: &mut Buffer) {
     let width = area.width;
-    buffer.set_line(area.x, area.y, &title_line(app, pane, width), width);
+    let rows = usize::from(area.height);
+    for (offset, line) in lines(app, pane, width, rows).into_iter().enumerate() {
+        let Ok(offset) = u16::try_from(offset) else {
+            break;
+        };
+        let y = area.y + offset;
+        if y >= area.y + area.height {
+            break;
+        }
+        buffer.set_line(area.x, y, &line, width);
+    }
+}
 
+/// [`draw`]'s own lines, without a [`Buffer`] round trip: what
+/// [`super::frames::render_text`] would read back off the buffer `draw`
+/// writes, built directly instead. Reads the pane through
+/// [`App::bleats_pane`] rather than taking one as a parameter, the same
+/// shape [`super::detail::detail_lines`] uses for the pane it draws.
+///
+/// # Panics
+///
+/// Panics if `app`'s body is not the bleats pane. Every caller only reaches
+/// this after opening it.
+///
+/// `#[cfg(test)]`: this module's own tests are the only caller today.
+#[cfg(test)]
+#[must_use]
+pub(crate) fn draw_lines(app: &App, width: u16, rows: usize) -> Vec<Line<'static>> {
+    let pane = app
+        .bleats_pane()
+        .expect("draw_lines is only called while the bleats pane is open");
+    lines(app, pane, width, rows)
+}
+
+/// Shared by [`draw`] and [`draw_lines`], so the two never drift.
+fn lines(app: &App, pane: &BleatsPane, width: u16, rows: usize) -> Vec<Line<'static>> {
+    let mut out = Vec::with_capacity(rows);
+    out.push(title_line(app, pane, width));
+
+    let filters = pane.filters();
     let feed = app.feed();
+    let survivors = pane.visible(&feed.lines);
+
+    if let Some(row) = filter_row_line(app, filters, survivors.len(), feed.lines.len(), width) {
+        out.push(row);
+    }
 
     if feed.lines.is_empty() {
         // The same rule `view::bleats::feed_lines` follows: the note names
         // why there is nothing, and only shows when there is nothing to
-        // show instead of it.
-        if area.height > 1
+        // show instead of it, and only when a row remains for it.
+        if rows > out.len()
             && let Some(note) = feed.note.as_deref()
         {
-            let rendered = Line::from(Span::styled(fit(note, width), app.palette().muted()));
-            buffer.set_line(area.x, area.y + 1, &rendered, width);
+            out.push(Line::from(Span::styled(
+                fit(note, width),
+                app.palette().muted(),
+            )));
         }
-        return;
+        return out;
     }
 
-    let rows = usize::from(area.height.saturating_sub(1));
-    // The last lines that fit, oldest first, so the newest one lands on the
-    // bottom row: the same order `view::bleats::feed_lines` renders in.
-    let skip = feed.lines.len().saturating_sub(rows);
-    for (offset, line) in feed.lines.iter().skip(skip).enumerate() {
-        let offset = u16::try_from(offset).unwrap_or(0);
-        let y = area.y + 1 + offset;
-        if y >= area.y + area.height {
-            break;
+    let body_rows = rows.saturating_sub(out.len());
+    // The last surviving lines that fit, oldest first, so the newest one
+    // lands on the bottom row: the same order `view::bleats::feed_lines`
+    // renders in.
+    let skip = survivors.len().saturating_sub(body_rows);
+    for line in survivors.iter().skip(skip).take(body_rows) {
+        out.push(feed_line(app, filters, line, width));
+    }
+    out
+}
+
+/// One feed line: its stream tag, then its text with every match-axis hit
+/// highlighted.
+fn feed_line(app: &App, filters: &Filters, line: &TailLine, width: u16) -> Line<'static> {
+    let palette = app.palette();
+    let tag = match line.stream {
+        Stream::Out => "out",
+        Stream::Err => "err",
+    };
+    let mut spans = vec![
+        // Muted, both of them: the word carries the meaning, and a red
+        // `err` would say a stderr line is damage. See
+        // `view::bleats::feed_lines` for the same choice.
+        Span::styled(format!("{tag}  "), palette.muted()),
+    ];
+    let text = fit(&line.text, width.saturating_sub(5));
+    spans.extend(highlighted(&text, filters, palette.attention()));
+    Line::from(spans)
+}
+
+/// Splits `text` into spans, styling every byte range [`Filters::match_ranges`]
+/// reports in `highlight` and leaving the rest at the default style.
+///
+/// A test asserting only that the line renders (its text is present) cannot
+/// tell this function apart from one that never highlights anything: see
+/// `bleats_full::tests::a_match_axis_highlights_its_hit_and_only_its_hit`,
+/// which inspects the spans themselves.
+fn highlighted(text: &str, filters: &Filters, highlight: Style) -> Vec<Span<'static>> {
+    let ranges = filters.match_ranges(text);
+    if ranges.is_empty() {
+        return vec![Span::raw(text.to_string())];
+    }
+    let mut spans = Vec::with_capacity(ranges.len() * 2 + 1);
+    let mut cursor = 0;
+    for (start, end) in ranges {
+        if start > cursor {
+            spans.push(Span::raw(text[cursor..start].to_string()));
         }
-        let tag = match line.stream {
+        spans.push(Span::styled(text[start..end].to_string(), highlight));
+        cursor = end;
+    }
+    if cursor < text.len() {
+        spans.push(Span::raw(text[cursor..].to_string()));
+    }
+    spans
+}
+
+/// The row under the title once any filter axis is set: a chip per set
+/// axis, then the sentence naming how many of the window's lines survived
+/// and how the axes compose. `None` while every axis is clear: with nothing
+/// set, a row saying so would repeat what the plain feed already shows.
+fn filter_row_line(
+    app: &App,
+    filters: &Filters,
+    survivors: usize,
+    total: usize,
+    width: u16,
+) -> Option<Line<'static>> {
+    if filters.is_empty() {
+        return None;
+    }
+    let palette = app.palette();
+    let ground = palette.ground();
+    let mut spans: Vec<Span<'static>> = Vec::new();
+    let mut used: u16 = 0;
+    for chip in chip_labels(filters) {
+        let text = format!(" {chip} ");
+        used += u16::try_from(text.chars().count()).unwrap_or(width);
+        spans.push(Span::styled(text, ground));
+        spans.push(Span::raw(" "));
+        used += 1;
+    }
+    let sentence = format!(
+        "{} of {} lines in the window — all three must hold, and a line with no \
+         detectable level always shows",
+        group_thousands(survivors),
+        group_thousands(total),
+    );
+    spans.push(Span::styled(
+        fit(&sentence, width.saturating_sub(used)),
+        palette.muted(),
+    ));
+    Some(Line::from(spans))
+}
+
+/// One chip's text per axis currently set, in field order (not
+/// [`Filters`]'s own newest-last `order`: the row is a snapshot, not a
+/// history).
+fn chip_labels(filters: &Filters) -> Vec<String> {
+    let mut chips = Vec::new();
+    if let Some(stream) = filters.stream {
+        let name = match stream {
             Stream::Out => "out",
             Stream::Err => "err",
         };
-        let rendered = Line::from(vec![
-            // Muted, both of them: the word carries the meaning, and a red
-            // `err` would say a stderr line is damage. See
-            // `view::bleats::feed_lines` for the same choice.
-            Span::styled(format!("{tag}  "), app.palette().muted()),
-            Span::raw(fit(&line.text, width.saturating_sub(5))),
-        ]);
-        buffer.set_line(area.x, y, &rendered, width);
+        chips.push(format!("stream {name}"));
     }
+    if let Some(min) = filters.min_level {
+        chips.push(format!("level ≥{}", format!("{min:?}").to_lowercase()));
+    }
+    if let Some(text) = &filters.matcher {
+        let suffix = match filters.match_kind() {
+            Some(MatchKind::Literal) | None => String::new(),
+            Some(MatchKind::Regex) => " (regex)".to_string(),
+            Some(MatchKind::Invalid) => " (invalid regex, matches nothing)".to_string(),
+        };
+        chips.push(format!("match {text}{suffix}"));
+    }
+    chips
+}
+
+/// `2847` as `2,847`. Grouped from the right in threes; a count in this pane
+/// never carries a fractional part or a sign.
+fn group_thousands(mut n: usize) -> String {
+    let mut groups = Vec::new();
+    loop {
+        let rest = n / 1000;
+        if rest == 0 {
+            groups.push(n.to_string());
+            break;
+        }
+        groups.push(format!("{:03}", n % 1000));
+        n = rest;
+    }
+    groups.reverse();
+    groups.join(",")
 }
 
 /// The pane's title: the sheep's name and both log paths, banded in
@@ -103,9 +262,14 @@ mod tests {
     use shep_core::protocol::ProcessInfo;
     use shep_core::status::ProcStatus;
 
+    use super::super::super::app::{KeyPress, Msg};
     use super::super::super::frames::render_text;
+    use super::super::super::pane_bleats::MatchKind;
     use super::super::super::tail::{Stream, Tail, TailLine};
-    use super::super::fixtures::{full_app, with_feed, with_no_selection, with_selection};
+    use super::super::fixtures::{
+        bleats_pane_with_filters, full_app, render_all, rendered, with_feed, with_no_selection,
+        with_selection,
+    };
     use super::*;
 
     /// Draws `pane` over `app` at `width`x`height` and renders it back to
@@ -244,6 +408,129 @@ mod tests {
         assert!(
             lines.last().is_some_and(|line| line.contains("line-9")),
             "the newest line is on the bottom row: {text:?}"
+        );
+    }
+
+    /// No axis set, no filter row at all: `draw_keeps_the_newest_lines_...`
+    /// above depends on this, since it counts on three whole body rows.
+    #[test]
+    fn no_axis_set_draws_no_filter_row() {
+        let mut app = full_app();
+        app.update(Msg::Key(KeyPress::Bleats));
+        let text = render_all(&draw_lines(&app, 80, 6));
+        assert!(!text.contains("must hold"), "got {text:?}");
+        assert!(!text.contains("lines in the window"), "got {text:?}");
+    }
+
+    /// The row states the composition rule, because three chips with no
+    /// stated relationship read as alternatives.
+    #[test]
+    fn the_filter_row_says_the_axes_compose_with_and() {
+        let app = bleats_pane_with_filters();
+        let text = render_all(&draw_lines(&app, 160, 40));
+        assert!(text.contains("all three must hold"), "got {text}");
+    }
+
+    /// Scoped to the window, because nothing counted the whole file.
+    #[test]
+    fn the_survivor_count_is_scoped_to_the_window() {
+        let app = bleats_pane_with_filters();
+        let text = render_all(&draw_lines(&app, 160, 40));
+        assert!(
+            text.contains("lines in the window"),
+            "the count must not claim a whole-file total: {text}"
+        );
+    }
+
+    /// One survivor out of four lines in the window: pins the actual
+    /// numbers, not just the presence of the sentence.
+    #[test]
+    fn the_survivor_count_matches_what_visible_reports() {
+        let app = bleats_pane_with_filters();
+        let text = render_all(&draw_lines(&app, 160, 40));
+        assert!(text.contains("1 of 4 lines in the window"), "got {text}");
+    }
+
+    /// Only a set axis gets a chip: with just `stream` set, `level` and
+    /// `match` never appear on the row.
+    #[test]
+    fn only_the_set_axes_get_a_chip() {
+        let mut app = with_selection(ProcessInfo::builder(9, "web", ProcStatus::Online).build());
+        app.update(Msg::Key(KeyPress::Bleats));
+        app.bleats_pane_mut_for_tests()
+            .expect("the key above opened the pane")
+            .set_stream(Some(Stream::Err));
+        let text = render_all(&draw_lines(&app, 160, 40));
+        assert!(text.contains("stream err"), "got {text}");
+        // The row's own composition sentence always says "level" and
+        // "match" (an unclassifiable line's level, and the AND rule), so
+        // this checks for the chips specifically rather than the bare
+        // words.
+        assert!(!text.contains("level ≥"), "got {text}");
+        assert!(!text.contains("match "), "got {text}");
+    }
+
+    /// A `/…/`-delimited matcher's chip says it is a regex.
+    #[test]
+    fn a_regex_matcher_chip_names_itself_a_regex() {
+        let mut app = with_selection(ProcessInfo::builder(9, "web", ProcStatus::Online).build());
+        app.update(Msg::Key(KeyPress::Bleats));
+        app.bleats_pane_mut_for_tests()
+            .expect("the key above opened the pane")
+            .set_match("/po+l/".to_string());
+        let text = render_all(&draw_lines(&app, 160, 40));
+        assert!(text.contains("match /po+l/ (regex)"), "got {text}");
+    }
+
+    /// A pattern that fails to compile says so on the chip, rather than the
+    /// feed just going quiet with no explanation.
+    #[test]
+    fn an_invalid_regex_chip_names_itself_invalid() {
+        let mut app = with_selection(ProcessInfo::builder(9, "web", ProcStatus::Online).build());
+        app.update(Msg::Key(KeyPress::Bleats));
+        app.bleats_pane_mut_for_tests()
+            .expect("the key above opened the pane")
+            .set_match("/pool(/".to_string());
+        assert_eq!(
+            app.bleats_pane().unwrap().filters().match_kind(),
+            Some(MatchKind::Invalid)
+        );
+        let text = render_all(&draw_lines(&app, 160, 40));
+        assert!(text.contains("invalid regex"), "got {text}");
+    }
+
+    /// The matched text is its own span, styled apart from the rest of the
+    /// line. A test asserting only that the line's text renders (as every
+    /// other test in this module does) cannot tell a highlighted match from
+    /// a plain one: this reads the spans themselves instead.
+    #[test]
+    fn a_match_axis_highlights_its_hit_and_only_its_hit() {
+        let app = bleats_pane_with_filters();
+        let lines = draw_lines(&app, 160, 40);
+        // Not `.contains("pool")`: the filter row's own `match pool` chip
+        // contains that substring too, and sits before the feed in `lines`.
+        // `"exhausted"` only ever appears in the surviving log line itself.
+        let survivor = lines
+            .iter()
+            .find(|line| rendered(line).contains("exhausted"))
+            .expect("the one surviving line contains \"exhausted\"");
+        let hit = survivor
+            .spans
+            .iter()
+            .find(|span| span.content.as_ref() == "pool")
+            .expect("the matched text is its own span, not merged into a longer one");
+        assert_ne!(
+            hit.style,
+            Style::default(),
+            "the match must carry a style distinct from plain text"
+        );
+        let plain = survivor
+            .spans
+            .iter()
+            .find(|span| span.style == Style::default() && span.content.as_ref() != "pool");
+        assert!(
+            plain.is_some(),
+            "the rest of the line must stay unstyled, for contrast: {survivor:?}"
         );
     }
 }

--- a/crates/shep-cli/src/lookout/view/bleats_full.rs
+++ b/crates/shep-cli/src/lookout/view/bleats_full.rs
@@ -193,22 +193,22 @@ fn window_range(
 /// by, so a page under wrap moves by roughly the room `pane`'s own area
 /// draws rather than a raw row count that assumes one row per line.
 ///
-/// Falls back to [`BleatsPane::body_rows`] outright when wrap is off or
-/// [`BleatsPane::width`] is `0` (no draw has ever reported a column count):
-/// with one row per line, the row count and the line count are the same
-/// number, which is the arithmetic [`BleatsPane::page_up`]/[`BleatsPane::page_down`]
-/// always used before this task, and every test built against that pane
-/// already assumes it.
+/// How many lines one `ctrl-u`/`ctrl-d` moves [`BleatsPane::scroll_offset`]
+/// by: exactly the lines the pane is showing right now.
 ///
-/// Wrapped, walks backward from the tail — not from the current
-/// [`BleatsPane::scroll_offset`] — so a page is sized once from the feed's
-/// own newest lines rather than re-measured from wherever the view happens
-/// to be. A feed whose wrapped-line density varies sharply between its tail
-/// and an older stretch can still under- or overshoot a screen's worth of
-/// rows once scrolled into that stretch, the same way an unwrapped page
-/// already could undershoot the very first or last page of a feed shorter
-/// than one page: the fix in either case is [`window_range`]'s own clamp at
-/// render time, not a perfectly-sized step.
+/// Measured from the current [`BleatsPane::scroll_offset`] through the same
+/// [`window_range`] the draw uses, so consecutive pages are contiguous by
+/// construction rather than by estimate. Unwrapped that is `body_rows`, the
+/// arithmetic this pane always used.
+///
+/// It has to be the current window rather than the feed's tail. Sizing a page
+/// once at the tail and reusing it is wrong the moment wrapped-line density
+/// differs anywhere else: a tail of one-row lines says "a page is twelve
+/// lines" while an older stretch draws four of them per screen, so a step
+/// would pass over eight lines no screen ever rendered. Clamping at render
+/// time does not help, because the lines are skipped rather than
+/// overshot. `wrapped_pages_leave_no_line_unseen` walks one direction and
+/// checks every line, since paging back is symmetric and hides the gap.
 #[must_use]
 pub(crate) fn page_amount(app: &App, pane: &BleatsPane) -> usize {
     let body_rows = pane.body_rows();
@@ -217,14 +217,25 @@ pub(crate) fn page_amount(app: &App, pane: &BleatsPane) -> usize {
     }
     let survivors = pane.visible(&app.feed().lines);
     let text_width = pane.width().saturating_sub(TAG_PREFIX_WIDTH);
+    let cost = |index: usize| row_height(&survivors[index].text, text_width, true);
+    let shown = window_range(survivors.len(), pane.scroll_offset(), body_rows, cost);
+
+    // Backward from where the view starts, not forward from where it ends.
+    // A page has to land the NEXT window's last line on this one's first, so
+    // it is sized by what fits going back from `shown.start`. Sizing it by
+    // the current window's own length is the same mistake one step later:
+    // when the older stretch wraps denser, fewer of its lines fill the same
+    // rows, and the difference is skipped.
     let mut used = 0usize;
     let mut count = 0usize;
-    for line in survivors.iter().rev() {
-        let cost = row_height(&line.text, text_width, true);
-        if count > 0 && used + cost > body_rows {
+    let mut at = shown.start;
+    while at > 0 {
+        let row = cost(at - 1);
+        if count > 0 && used + row > body_rows {
             break;
         }
-        used += cost;
+        at -= 1;
+        used += row;
         count += 1;
     }
     count.max(1)

--- a/crates/shep-cli/src/lookout/view/bleats_full.rs
+++ b/crates/shep-cli/src/lookout/view/bleats_full.rs
@@ -160,6 +160,28 @@ fn row_height(text: &str, text_width: u16, wrap: bool) -> usize {
 /// include at least one line once `len > 0`, even one whose own cost alone
 /// exceeds `body_rows`: a body of one very long wrapped line is still one
 /// line to show, not zero.
+/// Where the tail window starts: walks back from `len` spending each line's
+/// row cost until `body_rows` is gone, and always keeps one line once `len`
+/// is non-zero.
+///
+/// Shared by [`window_range`] and [`max_scroll_offset`] because the ceiling
+/// is defined as the window's own start index. Two copies of this walk would
+/// have to be kept in step by hand, and the day they drifted the pane would
+/// let an operator scroll somewhere it never draws.
+fn tail_window_start(len: usize, body_rows: usize, cost: impl Fn(usize) -> usize) -> usize {
+    let mut base = len;
+    let mut used = 0usize;
+    while base > 0 {
+        let row = cost(base - 1);
+        if used > 0 && used + row > body_rows {
+            break;
+        }
+        base -= 1;
+        used += row;
+    }
+    base
+}
+
 fn window_range(
     len: usize,
     scroll_offset: usize,
@@ -169,16 +191,7 @@ fn window_range(
     if len == 0 || body_rows == 0 {
         return 0..0;
     }
-    let mut base = len;
-    let mut used = 0usize;
-    while base > 0 {
-        let cost = row_height(base - 1);
-        if used > 0 && used + cost > body_rows {
-            break;
-        }
-        base -= 1;
-        used += cost;
-    }
+    let base = tail_window_start(len, body_rows, &row_height);
     let skip = base.saturating_sub(scroll_offset);
     let mut end = skip;
     let mut used = 0usize;
@@ -218,17 +231,7 @@ pub(crate) fn max_scroll_offset(app: &App, pane: &BleatsPane) -> usize {
 
     // Where the tail window starts. Scrolling past it only re-renders the
     // oldest frame, so that index is the ceiling.
-    let mut base = survivors.len();
-    let mut used = 0usize;
-    while base > 0 {
-        let row = cost(base - 1);
-        if used > 0 && used + row > body_rows {
-            break;
-        }
-        base -= 1;
-        used += row;
-    }
-    base
+    tail_window_start(survivors.len(), body_rows, cost)
 }
 
 /// Lines one backward page covers: what fits ending at `start`.
@@ -446,10 +449,16 @@ fn filter_row_line(
     let mut used: u16 = 0;
     for chip in chip_labels(filters) {
         let text = format!(" {chip} ");
-        used += u16::try_from(text.chars().count()).unwrap_or(width);
+        // Columns, not `char`s, because `fit` below budgets columns: a match
+        // chip carrying wide characters would otherwise under-reserve and
+        // the sentence would overrun the line. Saturating, because the match
+        // text is whatever an operator typed and three capped chips plus
+        // their separators can still overflow a `u16`.
+        let chip_columns = text.chars().map(char_columns).sum::<usize>();
+        used = used.saturating_add(u16::try_from(chip_columns).unwrap_or(width));
         spans.push(Span::styled(text, ground));
         spans.push(Span::raw(" "));
-        used += 1;
+        used = used.saturating_add(1);
     }
     // Three clauses, the third of which the design states and this row used
     // to omit: `esc` is the one non-obvious key in the pane, and nothing else

--- a/crates/shep-cli/src/lookout/view/bleats_full.rs
+++ b/crates/shep-cli/src/lookout/view/bleats_full.rs
@@ -1,0 +1,82 @@
+//! The full-screen bleats pane: the same feed [`super::bleats`] draws in its
+//! five-line strip, given the whole body instead.
+//!
+//! No filters yet: this task draws the window plainly. Level parsing, a
+//! `Filters` type and the filter row all land in later tasks of the same
+//! plan.
+
+use ratatui::buffer::Buffer;
+use ratatui::layout::Rect;
+use ratatui::text::{Line, Span};
+
+use super::super::app::{App, RowKey};
+use super::super::pane_bleats::BleatsPane;
+use super::super::tail::Stream;
+use super::cell;
+use super::flock::fit;
+use crate::vocabulary::Role;
+
+/// Draws the pane over the whole body: a title band naming the sheep and
+/// both log paths, then the window's newest lines, each tagged `out` or
+/// `err`, newest at the bottom.
+pub fn draw(app: &App, pane: &BleatsPane, area: Rect, buffer: &mut Buffer) {
+    let width = area.width;
+    buffer.set_line(area.x, area.y, &title_line(app, pane, width), width);
+
+    let feed = app.feed();
+    let rows = usize::from(area.height.saturating_sub(1));
+    // The last lines that fit, oldest first, so the newest one lands on the
+    // bottom row: the same order `view::bleats::feed_lines` renders in.
+    let skip = feed.lines.len().saturating_sub(rows);
+    for (offset, line) in feed.lines.iter().skip(skip).enumerate() {
+        let offset = u16::try_from(offset).unwrap_or(0);
+        let y = area.y + 1 + offset;
+        if y >= area.y + area.height {
+            break;
+        }
+        let tag = match line.stream {
+            Stream::Out => "out",
+            Stream::Err => "err",
+        };
+        let rendered = Line::from(vec![
+            // Muted, both of them: the word carries the meaning, and a red
+            // `err` would say a stderr line is damage. See
+            // `view::bleats::feed_lines` for the same choice.
+            Span::styled(format!("{tag}  "), app.palette().muted()),
+            Span::raw(fit(&line.text, width.saturating_sub(5))),
+        ]);
+        buffer.set_line(area.x, y, &rendered, width);
+    }
+}
+
+/// The pane's title: the sheep's name and both log paths, banded in
+/// [`Role::Meadow`].
+fn title_line(app: &App, pane: &BleatsPane, width: u16) -> Line<'static> {
+    let text = match sheep_id(pane).and_then(|id| app.row(id)) {
+        Some(row) => format!(
+            "{}  out {}  err {}",
+            row.info.name,
+            row.info.out_file.as_deref().unwrap_or("-"),
+            row.info.err_file.as_deref().unwrap_or("-"),
+        ),
+        None => match sheep_id(pane) {
+            Some(id) => format!("sheep {id}: it is no longer in the flock"),
+            None => "no sheep is selected".to_string(),
+        },
+    };
+    Line::from(Span::styled(
+        cell::band(&text, usize::from(width)),
+        app.palette().band(Role::Meadow),
+    ))
+}
+
+/// The sheep id a [`BleatsPane`] describes, or `None` for the two `RowKey`
+/// variants it is never opened on. `ask_for_bleats` only ever builds one on
+/// a [`RowKey::Sheep`]; this stays exhaustive rather than assuming that
+/// holds forever.
+fn sheep_id(pane: &BleatsPane) -> Option<u32> {
+    match pane.sheep() {
+        RowKey::Sheep(id) => Some(*id),
+        RowKey::Group(_) | RowKey::Section(_) => None,
+    }
+}

--- a/crates/shep-cli/src/lookout/view/bleats_full.rs
+++ b/crates/shep-cli/src/lookout/view/bleats_full.rs
@@ -12,7 +12,14 @@ use super::super::pane_bleats::{BleatsPane, Filters, MatchKind};
 use super::super::tail::{Stream, TailLine};
 use super::cell;
 use super::flock::fit;
+use crate::output::width::char_columns;
 use crate::vocabulary::Role;
+
+/// The stream tag's own width, shared by [`feed_line_rows`] (what it
+/// indents a wrapped line's continuation rows under) and [`page_amount`]
+/// (what it reserves before measuring a line's row cost): `"out  "` and
+/// `"err  "` are both three letters and two trailing spaces.
+const TAG_PREFIX_WIDTH: u16 = 5;
 
 /// Draws the pane over the whole body: a title band naming the sheep and
 /// both log paths, then, once any filter axis is set, the filter row, then
@@ -86,39 +93,222 @@ fn lines(app: &App, pane: &BleatsPane, width: u16, rows: usize) -> Vec<Line<'sta
     }
 
     let body_rows = rows.saturating_sub(out.len());
-    // The window `pane.scroll_offset()` names, oldest first, so the newest
-    // one lands on the bottom row when the offset is `0`: the same order
-    // `view::bleats::feed_lines` renders in. `saturating_sub` is the clamp
-    // the offset itself is never trusted to carry on its own: a filter that
-    // just narrowed, or an offset a shrunk feed has outgrown, both fall
-    // out of view here rather than panicking or reading past the end.
-    let skip = survivors
-        .len()
-        .saturating_sub(body_rows)
-        .saturating_sub(pane.scroll_offset());
-    for line in survivors.iter().skip(skip).take(body_rows) {
-        out.push(feed_line(app, filters, line, width));
+    let wrap = pane.wrapped();
+    let text_width = width.saturating_sub(TAG_PREFIX_WIDTH);
+    let window = window_range(survivors.len(), pane.scroll_offset(), body_rows, |i| {
+        row_height(&survivors[i].text, text_width, wrap)
+    });
+    for line in &survivors[window] {
+        out.extend(feed_line_rows(app, filters, line, width, wrap));
     }
+    // A single line taller than the whole body (an extreme wrapped case, or
+    // a body of zero rows) can still push `out` past `rows`: `window_range`
+    // always includes at least one line so the pane never renders nothing,
+    // even when that one line does not fit. This is the actual guarantee
+    // `draw`'s own bounds check backs up for the terminal; `draw_lines`'s
+    // tests call this directly, with no such check downstream.
+    out.truncate(rows);
     out
 }
 
-/// One feed line: its stream tag, then its text with every match-axis hit
-/// highlighted.
-fn feed_line(app: &App, filters: &Filters, line: &TailLine, width: u16) -> Line<'static> {
+/// How many rows rendering `text` at `text_width` columns costs. `1`
+/// outright when `wrap` is off or there is no column count yet: one line,
+/// one row, the pane's whole behavior before this task. Wrapped, walks
+/// `text`'s own characters with [`char_columns`], not [`str::chars`]'s
+/// count: a double-width character that would overflow the current row
+/// starts a new one instead of being charged half a column, the same
+/// walk [`wrap_spans`] draws by, so the two can never disagree on how many
+/// rows one line takes.
+fn row_height(text: &str, text_width: u16, wrap: bool) -> usize {
+    if !wrap || text_width == 0 {
+        return 1;
+    }
+    let width = usize::from(text_width);
+    let mut rows = 1usize;
+    let mut col = 0usize;
+    for c in text.chars() {
+        let w = char_columns(c);
+        if col > 0 && col + w > width {
+            rows += 1;
+            col = 0;
+        }
+        col += w;
+    }
+    rows
+}
+
+/// The half-open range of `survivors`' indices [`lines`] draws, oldest
+/// first, for a window of `body_rows` rows ending on the line
+/// `scroll_offset` counts back from the tail, `row_height` naming each
+/// index's own row cost.
+///
+/// Generalizes the single formula this pane always used before wrap
+/// existed (`skip = len - body_rows - offset`, `take = body_rows`) to a
+/// line that may cost more than one row: walks backward from the tail
+/// accumulating each line's cost until the budget is spent, which is
+/// exactly that formula's arithmetic once every line costs one row (wrap
+/// off). `scroll_offset` then shifts the far edge of that walk toward the
+/// tail by `scroll_offset` *lines*, not rows — an offset counts filtered
+/// lines regardless of how tall any of them draws — saturating at the
+/// oldest survivor exactly the way the original subtraction did, so a
+/// stale offset a shrunk feed or a narrowing filter has outgrown still
+/// clamps rather than panicking or reading past the end. Both walks always
+/// include at least one line once `len > 0`, even one whose own cost alone
+/// exceeds `body_rows`: a body of one very long wrapped line is still one
+/// line to show, not zero.
+fn window_range(
+    len: usize,
+    scroll_offset: usize,
+    body_rows: usize,
+    row_height: impl Fn(usize) -> usize,
+) -> std::ops::Range<usize> {
+    if len == 0 || body_rows == 0 {
+        return 0..0;
+    }
+    let mut base = len;
+    let mut used = 0usize;
+    while base > 0 {
+        let cost = row_height(base - 1);
+        if used > 0 && used + cost > body_rows {
+            break;
+        }
+        base -= 1;
+        used += cost;
+    }
+    let skip = base.saturating_sub(scroll_offset);
+    let mut end = skip;
+    let mut used = 0usize;
+    while end < len {
+        let cost = row_height(end);
+        if used > 0 && used + cost > body_rows {
+            break;
+        }
+        end += 1;
+        used += cost;
+    }
+    skip..end
+}
+
+/// How many lines one `ctrl-u`/`ctrl-d` should move [`BleatsPane::scroll_offset`]
+/// by, so a page under wrap moves by roughly the room `pane`'s own area
+/// draws rather than a raw row count that assumes one row per line.
+///
+/// Falls back to [`BleatsPane::body_rows`] outright when wrap is off or
+/// [`BleatsPane::width`] is `0` (no draw has ever reported a column count):
+/// with one row per line, the row count and the line count are the same
+/// number, which is the arithmetic [`BleatsPane::page_up`]/[`BleatsPane::page_down`]
+/// always used before this task, and every test built against that pane
+/// already assumes it.
+///
+/// Wrapped, walks backward from the tail — not from the current
+/// [`BleatsPane::scroll_offset`] — so a page is sized once from the feed's
+/// own newest lines rather than re-measured from wherever the view happens
+/// to be. A feed whose wrapped-line density varies sharply between its tail
+/// and an older stretch can still under- or overshoot a screen's worth of
+/// rows once scrolled into that stretch, the same way an unwrapped page
+/// already could undershoot the very first or last page of a feed shorter
+/// than one page: the fix in either case is [`window_range`]'s own clamp at
+/// render time, not a perfectly-sized step.
+#[must_use]
+pub(crate) fn page_amount(app: &App, pane: &BleatsPane) -> usize {
+    let body_rows = pane.body_rows();
+    if !pane.wrapped() || pane.width() == 0 {
+        return body_rows.max(1);
+    }
+    let survivors = pane.visible(&app.feed().lines);
+    let text_width = pane.width().saturating_sub(TAG_PREFIX_WIDTH);
+    let mut used = 0usize;
+    let mut count = 0usize;
+    for line in survivors.iter().rev() {
+        let cost = row_height(&line.text, text_width, true);
+        if count > 0 && used + cost > body_rows {
+            break;
+        }
+        used += cost;
+        count += 1;
+    }
+    count.max(1)
+}
+
+/// One feed line, as the rows it actually draws: one row when
+/// [`BleatsPane::wrapped`] is off, unchanged from before this task, or as
+/// many as `text_width` columns force otherwise. Every row after the first
+/// carries a blank indent the width of the stream tag rather than repeating
+/// it, so a wrapped line's continuation reads as one entry, not several.
+fn feed_line_rows(
+    app: &App,
+    filters: &Filters,
+    line: &TailLine,
+    width: u16,
+    wrap: bool,
+) -> Vec<Line<'static>> {
     let palette = app.palette();
     let tag = match line.stream {
         Stream::Out => "out",
         Stream::Err => "err",
     };
-    let mut spans = vec![
-        // Muted, both of them: the word carries the meaning, and a red
-        // `err` would say a stderr line is damage. See
-        // `view::bleats::feed_lines` for the same choice.
-        Span::styled(format!("{tag}  "), palette.muted()),
-    ];
-    let text = fit(&line.text, width.saturating_sub(5));
-    spans.extend(highlighted(&text, filters, palette.band(Role::Butter)));
-    Line::from(spans)
+    // Muted, both of them: the word carries the meaning, and a red `err`
+    // would say a stderr line is damage. See `view::bleats::feed_lines` for
+    // the same choice.
+    let prefix = format!("{tag}  ");
+    let text_width = width.saturating_sub(TAG_PREFIX_WIDTH);
+    if !wrap {
+        let text = fit(&line.text, text_width);
+        let mut spans = vec![Span::styled(prefix, palette.muted())];
+        spans.extend(highlighted(&text, filters, palette.band(Role::Butter)));
+        return vec![Line::from(spans)];
+    }
+    let spans = highlighted(&line.text, filters, palette.band(Role::Butter));
+    let indent = " ".repeat(usize::from(TAG_PREFIX_WIDTH));
+    wrap_spans(spans, usize::from(text_width))
+        .into_iter()
+        .enumerate()
+        .map(|(i, row_spans)| {
+            let lead = if i == 0 { &prefix } else { &indent };
+            let mut all = vec![Span::styled(lead.clone(), palette.muted())];
+            all.extend(row_spans);
+            Line::from(all)
+        })
+        .collect()
+}
+
+/// Splits `spans` into rows of at most `width` columns, breaking mid-span
+/// where a span crosses the boundary rather than moving the whole span to
+/// the next row: a match highlighted across a wrap point keeps its style on
+/// both halves instead of jumping there whole. Measures with
+/// [`char_columns`], the same walk [`row_height`] counts rows by, so the
+/// two never disagree on how many rows one line takes. `width == 0` returns
+/// every span on one row, since there is no boundary to wrap against.
+fn wrap_spans(spans: Vec<Span<'static>>, width: usize) -> Vec<Vec<Span<'static>>> {
+    if width == 0 {
+        return vec![spans];
+    }
+    let mut rows: Vec<Vec<Span<'static>>> = vec![Vec::new()];
+    let mut col = 0usize;
+    for span in spans {
+        let style = span.style;
+        let mut buf = String::new();
+        for c in span.content.chars() {
+            let w = char_columns(c);
+            if col > 0 && col + w > width {
+                if !buf.is_empty() {
+                    rows.last_mut()
+                        .expect("rows always has a current row")
+                        .push(Span::styled(std::mem::take(&mut buf), style));
+                }
+                rows.push(Vec::new());
+                col = 0;
+            }
+            buf.push(c);
+            col += w;
+        }
+        if !buf.is_empty() {
+            rows.last_mut()
+                .expect("rows always has a current row")
+                .push(Span::styled(buf, style));
+        }
+    }
+    rows
 }
 
 /// Splits `text` into spans, styling every byte range [`Filters::match_ranges`]

--- a/crates/shep-cli/src/lookout/view/bleats_full.rs
+++ b/crates/shep-cli/src/lookout/view/bleats_full.rs
@@ -17,13 +17,28 @@ use super::flock::fit;
 use crate::vocabulary::Role;
 
 /// Draws the pane over the whole body: a title band naming the sheep and
-/// both log paths, then the window's newest lines, each tagged `out` or
-/// `err`, newest at the bottom.
+/// both log paths, then either the window's newest lines, each tagged `out`
+/// or `err` with the newest at the bottom, or, when there are none yet,
+/// [`Tail::note`](super::super::tail::Tail::note) naming why.
 pub fn draw(app: &App, pane: &BleatsPane, area: Rect, buffer: &mut Buffer) {
     let width = area.width;
     buffer.set_line(area.x, area.y, &title_line(app, pane, width), width);
 
     let feed = app.feed();
+
+    if feed.lines.is_empty() {
+        // The same rule `view::bleats::feed_lines` follows: the note names
+        // why there is nothing, and only shows when there is nothing to
+        // show instead of it.
+        if area.height > 1
+            && let Some(note) = feed.note.as_deref()
+        {
+            let rendered = Line::from(Span::styled(fit(note, width), app.palette().muted()));
+            buffer.set_line(area.x, area.y + 1, &rendered, width);
+        }
+        return;
+    }
+
     let rows = usize::from(area.height.saturating_sub(1));
     // The last lines that fit, oldest first, so the newest one lands on the
     // bottom row: the same order `view::bleats::feed_lines` renders in.
@@ -78,5 +93,157 @@ fn sheep_id(pane: &BleatsPane) -> Option<u32> {
     match pane.sheep() {
         RowKey::Sheep(id) => Some(*id),
         RowKey::Group(_) | RowKey::Section(_) => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use ratatui::buffer::Buffer;
+    use ratatui::layout::Rect;
+    use shep_core::protocol::ProcessInfo;
+    use shep_core::status::ProcStatus;
+
+    use super::super::super::frames::render_text;
+    use super::super::super::tail::{Stream, Tail, TailLine};
+    use super::super::fixtures::{full_app, with_feed, with_no_selection, with_selection};
+    use super::*;
+
+    /// Draws `pane` over `app` at `width`x`height` and renders it back to
+    /// plain text, styles dropped: the same round trip `frames.rs`'s own
+    /// tests use.
+    fn drawn(app: &App, pane: &BleatsPane, width: u16, height: u16) -> String {
+        let area = Rect::new(0, 0, width, height);
+        let mut buffer = Buffer::empty(area);
+        draw(app, pane, area, &mut buffer);
+        render_text(&buffer)
+    }
+
+    /// Mirrors `view::bleats::tests::an_empty_feed_prints_the_reason_rather_than_nothing`:
+    /// the full-screen pane owes the operator the same explanation the
+    /// five-line strip already gives.
+    #[test]
+    fn an_empty_feed_shows_the_note_in_the_body() {
+        let app = with_feed(Tail {
+            lines: Vec::new(),
+            missed_lines: 0,
+            missed_bytes: 0,
+            read_bytes: 0,
+            note: Some("no log path is configured for this sheep".to_string()),
+        });
+        let pane = BleatsPane::new(app.selected().expect("with_feed selects a sheep"));
+        let text = drawn(&app, &pane, 80, 6);
+        assert!(
+            text.contains("no log path is configured for this sheep"),
+            "got {text:?}"
+        );
+    }
+
+    /// The note names why there is nothing to show; once there is something,
+    /// it has to go, not sit above the lines.
+    #[test]
+    fn a_feed_with_lines_never_shows_the_note() {
+        let app = with_feed(Tail {
+            lines: vec![TailLine {
+                stream: Stream::Out,
+                text: "listening".to_string(),
+            }],
+            missed_lines: 0,
+            missed_bytes: 0,
+            read_bytes: 9,
+            note: Some("should never reach the screen".to_string()),
+        });
+        let pane = BleatsPane::new(app.selected().expect("with_feed selects a sheep"));
+        let text = drawn(&app, &pane, 80, 6);
+        assert!(
+            !text.contains("should never reach the screen"),
+            "got {text:?}"
+        );
+        assert!(text.contains("listening"), "got {text:?}");
+    }
+
+    /// The ordinary case: a sheep still in the flock names itself and both
+    /// its log paths.
+    #[test]
+    fn the_title_names_the_sheep_and_both_log_paths() {
+        let info = ProcessInfo::builder(3, "catcher", ProcStatus::Online)
+            .out_file(Some("/home/ada/.shep/logs/catcher-out.log".to_string()))
+            .err_file(Some("/home/ada/.shep/logs/catcher-err.log".to_string()))
+            .build();
+        let app = with_selection(info);
+        let pane = BleatsPane::new(RowKey::Sheep(3));
+        let text = title_line(&app, &pane, 120);
+        let rendered: String = text
+            .spans
+            .iter()
+            .map(|span| span.content.as_ref())
+            .collect();
+        assert!(rendered.contains("catcher"), "got {rendered:?}");
+        assert!(
+            rendered.contains("/home/ada/.shep/logs/catcher-out.log"),
+            "got {rendered:?}"
+        );
+        assert!(
+            rendered.contains("/home/ada/.shep/logs/catcher-err.log"),
+            "got {rendered:?}"
+        );
+    }
+
+    /// A pane pinned to a sheep that has since left the flock says so,
+    /// rather than drawing a title with nothing behind it.
+    #[test]
+    fn the_title_says_when_the_pinned_sheep_left_the_flock() {
+        let info = ProcessInfo::builder(3, "catcher", ProcStatus::Online).build();
+        let app = with_selection(info);
+        let pane = BleatsPane::new(RowKey::Sheep(404));
+        let text = title_line(&app, &pane, 120);
+        let rendered: String = text
+            .spans
+            .iter()
+            .map(|span| span.content.as_ref())
+            .collect();
+        assert!(
+            rendered.contains("sheep 404: it is no longer in the flock"),
+            "got {rendered:?}"
+        );
+    }
+
+    /// A group row can never own this pane ([`ask_for_bleats`] refuses one),
+    /// but `sheep_id` stays exhaustive, and the title has to say something
+    /// sane if it is ever handed one anyway.
+    #[test]
+    fn the_title_says_no_sheep_is_selected_for_a_non_sheep_row() {
+        let app = with_no_selection();
+        let pane = BleatsPane::new(RowKey::Group("web".to_string()));
+        let text = title_line(&app, &pane, 120);
+        let rendered: String = text
+            .spans
+            .iter()
+            .map(|span| span.content.as_ref())
+            .collect();
+        assert!(
+            rendered.contains("no sheep is selected"),
+            "got {rendered:?}"
+        );
+    }
+
+    /// Ten lines over a three-row window: the newest three land on screen,
+    /// oldest first, so the newest sits on the bottom row.
+    #[test]
+    fn draw_keeps_the_newest_lines_when_more_exist_than_fit() {
+        let app = full_app();
+        let pane = BleatsPane::new(app.selected().expect("full_app selects a sheep"));
+        // height 4: one title row plus three body rows.
+        let text = drawn(&app, &pane, 80, 4);
+        for n in 7..10 {
+            assert!(text.contains(&format!("line-{n}")), "got {text:?}");
+        }
+        for n in 0..7 {
+            assert!(!text.contains(&format!("line-{n} ")), "got {text:?}");
+        }
+        let lines: Vec<&str> = text.lines().collect();
+        assert!(
+            lines.last().is_some_and(|line| line.contains("line-9")),
+            "the newest line is on the bottom row: {text:?}"
+        );
     }
 }

--- a/crates/shep-cli/src/lookout/view/bleats_full.rs
+++ b/crates/shep-cli/src/lookout/view/bleats_full.rs
@@ -216,6 +216,16 @@ fn page_lines_back(start: usize, body_rows: usize, cost: impl Fn(usize) -> usize
     count.max(1)
 }
 
+/// Lines one forward page covers: the lines the window is showing.
+///
+/// Pure and named, mirroring [`page_lines_back`], so the property test can
+/// call the same code the key does. Its first version re-implemented this
+/// expression inline, which pinned the arithmetic and left the wiring free:
+/// `page_amount_down` could return a constant and every test still passed.
+fn page_lines_forward(shown: &std::ops::Range<usize>) -> usize {
+    shown.len().max(1)
+}
+
 /// How many lines one `ctrl-u` moves [`BleatsPane::scroll_offset`] by:
 /// what fits walking backward from the line the pane is currently showing
 /// first.
@@ -267,7 +277,7 @@ pub(crate) fn page_amount_down(app: &App, pane: &BleatsPane) -> usize {
     let shown = window_range(survivors.len(), pane.scroll_offset(), body_rows, |index| {
         row_height(&survivors[index].text, text_width, true)
     });
-    shown.len().max(1)
+    page_lines_forward(&shown)
 }
 
 /// One feed line, as the rows it actually draws: one row when
@@ -833,7 +843,7 @@ mod tests {
                              ctrl-u went from {shown:?} to {up:?}"
                         );
 
-                        let forward = shown.len().max(1);
+                        let forward = page_lines_forward(&shown);
                         let down =
                             window_range(len, offset.saturating_sub(forward), body_rows, cost);
                         assert!(

--- a/crates/shep-cli/src/lookout/view/fixtures.rs
+++ b/crates/shep-cli/src/lookout/view/fixtures.rs
@@ -313,7 +313,8 @@ pub fn full_app() -> App {
 /// the filter row's own tests.
 ///
 /// Filters are stacked through [`App::bleats_pane_mut_for_tests`] rather
-/// than a key: no key sets one yet (see that method's own doc).
+/// than through `o`, `m` and `/`, so a test naming the axes it wants does not
+/// have to walk each cycle to reach them.
 pub fn bleats_pane_with_filters() -> App {
     let mut app = with_selection(ProcessInfo::builder(9, "web", ProcStatus::Online).build());
     app.update(Msg::Bleats {
@@ -366,7 +367,7 @@ pub fn bleats_pane_with_lines(n: u32) -> App {
 /// page sized from the tail is far too many lines once the view is scrolled
 /// back into the long stretch.
 ///
-/// The shape a wrap-aware page step has to survive: `page_amount` measures
+/// The shape a wrap-aware page step has to survive: `page_amount_up` measures
 /// from the tail, and a tail of one-row lines says "a page is N lines" while
 /// the older region draws each of those lines as three rows.
 #[must_use]

--- a/crates/shep-cli/src/lookout/view/fixtures.rs
+++ b/crates/shep-cli/src/lookout/view/fixtures.rs
@@ -360,6 +360,37 @@ pub fn bleats_pane_with_lines(n: u32) -> App {
     app
 }
 
+/// The full-screen bleats pane, open on `web`, over a feed with one line
+/// comfortably wider than 80 columns, for the wrap tests.
+pub fn bleats_pane_with_long_line() -> App {
+    let mut app = with_selection(ProcessInfo::builder(9, "web", ProcStatus::Online).build());
+    app.update(Msg::Bleats {
+        tail: Tail {
+            lines: vec![
+                line(Stream::Out, "short line"),
+                line(Stream::Out, &"x".repeat(200)),
+            ],
+            missed_lines: 0,
+            missed_bytes: 0,
+            read_bytes: 1_024,
+            note: None,
+        },
+    });
+    app.update(Msg::Key(KeyPress::Bleats));
+    app
+}
+
+/// [`super::bleats_full::draw`]'s own lines, for a test that needs the
+/// bleats pane's rendered rows without a [`Buffer`] round trip. Thin
+/// wrapper: [`super::bleats_full::draw_lines`] is `pub(crate)` for exactly
+/// this, but lives in a sibling module the top-level fixture callers in
+/// `app.rs` do not otherwise reach.
+///
+/// [`Buffer`]: ratatui::buffer::Buffer
+pub fn draw_lines(app: &App, width: u16, rows: usize) -> Vec<Line<'static>> {
+    super::bleats_full::draw_lines(app, width, rows)
+}
+
 /// One sheep, `catcher`, selected, with a two-line feed applied and its log
 /// paths pointing at real files in a leaked tempdir, so `fs::metadata` in
 /// [`super::detail::log_row`] succeeds the way it would against a live

--- a/crates/shep-cli/src/lookout/view/fixtures.rs
+++ b/crates/shep-cli/src/lookout/view/fixtures.rs
@@ -372,13 +372,44 @@ pub fn bleats_pane_with_lines(n: u32) -> App {
 #[must_use]
 pub fn bleats_pane_with_mixed_line_lengths() -> App {
     let mut app = with_selection(ProcessInfo::builder(9, "web", ProcStatus::Online).build());
+    // Heights cycling 1, 2, 3, 4 rows rather than a uniform block. Uniform
+    // costs make a backward count and a window's own length agree, which is
+    // exactly the case that hides a direction-mismatched page size; the gap
+    // only appears where consecutive lines wrap to different heights.
     let mut lines: Vec<TailLine> = (0..40)
-        .map(|i| line(Stream::Out, &format!("old-{i} {}", "y".repeat(150))))
+        .map(|i| {
+            let padding = "y".repeat(50 * (i % 4));
+            line(Stream::Out, &format!("old-{i} {padding}"))
+        })
         .collect();
     lines.extend((0..40).map(|i| line(Stream::Out, &format!("new-{i}"))));
     app.update(Msg::Bleats {
         tail: Tail {
             lines,
+            missed_lines: 0,
+            missed_bytes: 0,
+            read_bytes: 1_024,
+            note: None,
+        },
+    });
+    app.update(Msg::Key(KeyPress::Bleats));
+    app
+}
+
+/// A feed whose long line is double-width characters, so its wrapped height
+/// depends on display columns rather than `char` count.
+///
+/// Every other wrap fixture here is single-width ASCII, where `char_columns`
+/// and a naive per-`char` count agree. That makes them blind to the exact
+/// regression this repo has already fixed on two other branches: a
+/// full-width character occupies two columns, so 60 of them wrap to twice
+/// the rows 60 ASCII characters would.
+#[must_use]
+pub fn bleats_pane_with_a_wide_line() -> App {
+    let mut app = with_selection(ProcessInfo::builder(9, "web", ProcStatus::Online).build());
+    app.update(Msg::Bleats {
+        tail: Tail {
+            lines: vec![line(Stream::Out, &"\u{5e83}".repeat(60))],
             missed_lines: 0,
             missed_bytes: 0,
             read_bytes: 1_024,

--- a/crates/shep-cli/src/lookout/view/fixtures.rs
+++ b/crates/shep-cli/src/lookout/view/fixtures.rs
@@ -361,8 +361,6 @@ pub fn bleats_pane_with_lines(n: u32) -> App {
     app
 }
 
-/// The full-screen bleats pane, open on `web`, over a feed with one line
-/// comfortably wider than 80 columns, for the wrap tests.
 /// A feed whose newest lines are short and whose older ones are long, so a
 /// page sized from the tail is far too many lines once the view is scrolled
 /// back into the long stretch.
@@ -421,6 +419,8 @@ pub fn bleats_pane_with_a_wide_line() -> App {
     app
 }
 
+/// The full-screen bleats pane, open on `web`, over a feed with one line
+/// comfortably wider than 80 columns, for the wrap tests.
 pub fn bleats_pane_with_long_line() -> App {
     let mut app = with_selection(ProcessInfo::builder(9, "web", ProcStatus::Online).build());
     app.update(Msg::Bleats {

--- a/crates/shep-cli/src/lookout/view/fixtures.rs
+++ b/crates/shep-cli/src/lookout/view/fixtures.rs
@@ -362,6 +362,33 @@ pub fn bleats_pane_with_lines(n: u32) -> App {
 
 /// The full-screen bleats pane, open on `web`, over a feed with one line
 /// comfortably wider than 80 columns, for the wrap tests.
+/// A feed whose newest lines are short and whose older ones are long, so a
+/// page sized from the tail is far too many lines once the view is scrolled
+/// back into the long stretch.
+///
+/// The shape a wrap-aware page step has to survive: `page_amount` measures
+/// from the tail, and a tail of one-row lines says "a page is N lines" while
+/// the older region draws each of those lines as three rows.
+#[must_use]
+pub fn bleats_pane_with_mixed_line_lengths() -> App {
+    let mut app = with_selection(ProcessInfo::builder(9, "web", ProcStatus::Online).build());
+    let mut lines: Vec<TailLine> = (0..40)
+        .map(|i| line(Stream::Out, &format!("old-{i} {}", "y".repeat(150))))
+        .collect();
+    lines.extend((0..40).map(|i| line(Stream::Out, &format!("new-{i}"))));
+    app.update(Msg::Bleats {
+        tail: Tail {
+            lines,
+            missed_lines: 0,
+            missed_bytes: 0,
+            read_bytes: 1_024,
+            note: None,
+        },
+    });
+    app.update(Msg::Key(KeyPress::Bleats));
+    app
+}
+
 pub fn bleats_pane_with_long_line() -> App {
     let mut app = with_selection(ProcessInfo::builder(9, "web", ProcStatus::Online).build());
     app.update(Msg::Bleats {

--- a/crates/shep-cli/src/lookout/view/fixtures.rs
+++ b/crates/shep-cli/src/lookout/view/fixtures.rs
@@ -13,6 +13,7 @@ use shep_core::status::ProcStatus;
 use super::super::app::{
     ActionVerb, App, Control, KeyPress, LambWalk, Msg, RowKey, Sent, SettingsRow,
 };
+use super::super::level::Level;
 use super::super::source::HostSample;
 use super::super::tail::{Stream, Tail, TailLine};
 use super::super::theme::Palette;
@@ -303,6 +304,39 @@ pub fn full_app() -> App {
             note: None,
         },
     });
+    app
+}
+
+/// The full-screen bleats pane, open on `web`, with all three filter axes
+/// set (stream `err`, level `warn`, match `pool`) over a feed mixing one
+/// line that survives every axis with three that each fail exactly one, for
+/// the filter row's own tests.
+///
+/// Filters are stacked through [`App::bleats_pane_mut_for_tests`] rather
+/// than a key: no key sets one yet (see that method's own doc).
+pub fn bleats_pane_with_filters() -> App {
+    let mut app = with_selection(ProcessInfo::builder(9, "web", ProcStatus::Online).build());
+    app.update(Msg::Bleats {
+        tail: Tail {
+            lines: vec![
+                line(Stream::Err, "ERROR pool exhausted"), // all three hold
+                line(Stream::Out, "ERROR pool exhausted"), // wrong stream
+                line(Stream::Err, "INFO pool warming"),    // below the minimum
+                line(Stream::Err, "ERROR disk full"),      // no match
+            ],
+            missed_lines: 0,
+            missed_bytes: 0,
+            read_bytes: 128,
+            note: None,
+        },
+    });
+    app.update(Msg::Key(KeyPress::Bleats));
+    let pane = app
+        .bleats_pane_mut_for_tests()
+        .expect("Msg::Key(KeyPress::Bleats) opened the pane on the sheep selected above");
+    pane.set_stream(Some(Stream::Err));
+    pane.set_min_level(Some(Level::Warn));
+    pane.set_match("pool".to_string());
     app
 }
 

--- a/crates/shep-cli/src/lookout/view/fixtures.rs
+++ b/crates/shep-cli/src/lookout/view/fixtures.rs
@@ -340,6 +340,26 @@ pub fn bleats_pane_with_filters() -> App {
     app
 }
 
+/// The full-screen bleats pane, open on `web`, over a feed of `n` lines
+/// numbered `line-0`..`line-{n-1}`, oldest first — enough to exceed any
+/// test's body height, for the scrolling and follow tests.
+pub fn bleats_pane_with_lines(n: u32) -> App {
+    let mut app = with_selection(ProcessInfo::builder(9, "web", ProcStatus::Online).build());
+    app.update(Msg::Bleats {
+        tail: Tail {
+            lines: (0..n)
+                .map(|i| line(Stream::Out, &format!("line-{i}")))
+                .collect(),
+            missed_lines: 0,
+            missed_bytes: 0,
+            read_bytes: 1_024,
+            note: None,
+        },
+    });
+    app.update(Msg::Key(KeyPress::Bleats));
+    app
+}
+
 /// One sheep, `catcher`, selected, with a two-line feed applied and its log
 /// paths pointing at real files in a leaked tempdir, so `fs::metadata` in
 /// [`super::detail::log_row`] succeeds the way it would against a live

--- a/crates/shep-cli/src/lookout/view/mod.rs
+++ b/crates/shep-cli/src/lookout/view/mod.rs
@@ -6,6 +6,7 @@
 //! both testable and cheap to keep working across a ratatui release.
 
 pub mod bleats;
+pub mod bleats_full;
 pub mod cell;
 pub mod detail;
 pub mod flock;
@@ -243,6 +244,17 @@ pub fn draw(app: &App, frame: &mut Frame<'_>) {
                 height: body_rows(area),
             };
             settings::draw_settings(app, settings, body, buffer);
+            buffer.set_line(area.x, bottom, &status::status_line(app, width), width);
+            return;
+        }
+        Body::Bleats(pane) => {
+            let body = Rect {
+                x: area.x,
+                y,
+                width,
+                height: body_rows(area),
+            };
+            bleats_full::draw(app, pane, body, buffer);
             buffer.set_line(area.x, bottom, &status::status_line(app, width), width);
             return;
         }

--- a/crates/shep-cli/src/lookout/view/status.rs
+++ b/crates/shep-cli/src/lookout/view/status.rs
@@ -169,10 +169,17 @@ pub fn status_line(app: &App, width: u16) -> Line<'static> {
     };
     // Always rendered, in both states. An operator who does not know whether
     // their dashboard can act is one keystroke from finding out the wrong
-    // way.
-    let right = match app.control() {
-        Control::ReadOnly => "read-only",
-        Control::Allowed => "control enabled",
+    // way. The bleats pane borrows this slot while it is following the
+    // tail: control state means nothing on a screen with no action keys of
+    // its own, and whether the view is pinned to the newest line is the
+    // fact this screen's own operator needs a keystroke away from.
+    let right = if app.bleats_pane().is_some_and(BleatsPane::following) {
+        "\u{2588} following"
+    } else {
+        match app.control() {
+            Control::ReadOnly => "read-only",
+            Control::Allowed => "control enabled",
+        }
     };
     let right_len = u16::try_from(right.chars().count()).unwrap_or(0);
     // `+ 1` reserves one column of gap so a truncated left side's `…` never
@@ -886,5 +893,28 @@ mod tests {
         let bar = rendered(&status_line(&app, 160));
         assert!(bar.contains("match  pool"), "got {bar}");
         assert!(!bar.contains("filter"), "not the dashboard's box: {bar}");
+    }
+
+    /// The right-aligned `█ following` indicator replaces the control-state
+    /// label while the bleats pane is pinned to the tail, and only then:
+    /// the design names it for this screen alone.
+    #[test]
+    fn the_following_indicator_replaces_control_state_while_pinned_to_the_tail() {
+        use shep_core::protocol::ProcessInfo;
+        use shep_core::status::ProcStatus;
+
+        let mut app = with_selection(ProcessInfo::builder(9, "web", ProcStatus::Online).build());
+        let _ = app.update(Msg::Key(KeyPress::Bleats));
+        let bar = rendered(&status_line(&app, 160));
+        assert!(bar.contains("\u{2588} following"), "got {bar}");
+        assert!(!bar.contains("read-only"), "got {bar}");
+
+        let _ = app.update(Msg::Key(KeyPress::SelectUp));
+        let scrolled = rendered(&status_line(&app, 160));
+        assert!(
+            !scrolled.contains("\u{2588} following"),
+            "scrolled back, no longer following: {scrolled}"
+        );
+        assert!(scrolled.contains("read-only"), "got {scrolled}");
     }
 }

--- a/crates/shep-cli/src/lookout/view/status.rs
+++ b/crates/shep-cli/src/lookout/view/status.rs
@@ -10,6 +10,7 @@ use super::super::app::{
     ActionState, App, Control, InputMode, Link, RowKey, Settings, SettingsPrompt, retrying_sentence,
 };
 use super::super::pane::{ConfigPane, PanePending};
+use super::super::pane_bleats::BleatsPane;
 use super::cell;
 use super::flock::fit;
 use super::settings::field_label;
@@ -71,6 +72,15 @@ pub fn status_line(app: &App, width: u16) -> Line<'static> {
             format!("{}  enter confirms, any other key cancels", prompt.text)
         };
         (text, palette.attention())
+    } else if let Some(buffer) = app.bleats_pane().and_then(BleatsPane::match_editing) {
+        // Ahead of the filter branch for the reason the comment below gives:
+        // the bleats pane's match box shares `InputMode::Text` with the
+        // dashboard's name filter, and falling through would label the
+        // dashboard's own untouched query as this pane's match.
+        (
+            format!("match  {buffer}\u{258f}   enter applies   esc cancels"),
+            palette.attention(),
+        )
     } else if let Some((label, buffer)) = app.config_pane().and_then(pane_editor) {
         // The pane's own free-text editor, and the env sub-screen's, ahead
         // of the filter branch: all three share `InputMode::Text`, and a
@@ -374,6 +384,7 @@ mod tests {
     use super::super::fixtures::{
         acting_app, allowed_app, app_in_settings, app_in_settings_on, app_in_settings_with_control,
         armed_app, armed_app_with_a_filter_and_a_notice, editing_app, filtered_app, rendered,
+        with_selection,
     };
     use super::*;
     use crate::commands::settings::SettingField;
@@ -852,5 +863,28 @@ mod tests {
         app.update(Msg::Key(KeyPress::Escape));
         app.update(Msg::Key(KeyPress::ListMoveDown));
         assert!(app.config_pane().unwrap().is_armed(), "J arms a move");
+    }
+
+    /// The bleats pane's match box gets the status bar, not the dashboard's
+    /// name filter.
+    ///
+    /// Both own `InputMode::Text`, and the filter branch is a catch-all, so
+    /// without a branch of its own the bar labels the dashboard's untouched
+    /// query as this pane's match. The same trap the config pane's editor
+    /// sits ahead of the filter branch to avoid.
+    #[test]
+    fn the_bleats_match_box_owns_the_status_bar_while_it_is_open() {
+        use shep_core::protocol::ProcessInfo;
+        use shep_core::status::ProcStatus;
+
+        let mut app = with_selection(ProcessInfo::builder(9, "web", ProcStatus::Online).build());
+        let _ = app.update(Msg::Key(KeyPress::Bleats));
+        let _ = app.update(Msg::Key(KeyPress::FilterStart));
+        for typed in "pool".chars() {
+            let _ = app.update(Msg::Key(KeyPress::TextChar(typed)));
+        }
+        let bar = rendered(&status_line(&app, 160));
+        assert!(bar.contains("match  pool"), "got {bar}");
+        assert!(!bar.contains("filter"), "not the dashboard's box: {bar}");
     }
 }

--- a/crates/shep-cli/src/lookout/view/status.rs
+++ b/crates/shep-cli/src/lookout/view/status.rs
@@ -151,6 +151,14 @@ pub fn status_line(app: &App, width: u16) -> Line<'static> {
             pane_hint(app.control(), pane_screen(pane)).to_string(),
             palette.attention(),
         )
+    } else if app.bleats_pane().is_some() {
+        // Checked below the match box's own branch above, which owns this
+        // slot instead while it is open. The design's own status-bar line
+        // (docs/lookout/design-files/README.md:274) names every key here
+        // but the minimum-level axis's own `m`: that line lists no key for
+        // it at all, so it is appended rather than inserted, the same rule
+        // `hint_for`'s own doc gives for its dashboard forms.
+        (BLEATS_HINT.to_string(), palette.attention())
     } else if app.settings().is_none() && !app.filter().is_empty() {
         // Gated on the screen being closed: the filter survives the swap
         // into settings (`App::on_settings_key` never touches it), but `/`
@@ -278,6 +286,14 @@ fn pane_editor(pane: &ConfigPane) -> Option<(String, &str)> {
         PanePending::Armed { .. } | PanePending::Sent { .. } => None,
     }
 }
+
+/// The bleats pane's key hint: the design's own status-bar line, plus `m`
+/// for the minimum-level axis. The design names a key for every other axis
+/// (`o` for the stream) but none for this one, so `m` is this crate's own
+/// addition, appended after the design's own list rather than sorted into
+/// it.
+const BLEATS_HINT: &str = "esc back   j/k line   ctrl-d/u page   G end   \
+    / search   n/N match   f follow   w wrap   o out/err/both   m level";
 
 /// The config pane's own key hint.
 ///
@@ -893,6 +909,35 @@ mod tests {
         let bar = rendered(&status_line(&app, 160));
         assert!(bar.contains("match  pool"), "got {bar}");
         assert!(!bar.contains("filter"), "not the dashboard's box: {bar}");
+    }
+
+    /// The bleats pane's own hint carries the design's full line, plus `m`
+    /// for the minimum-level axis the design names no key for at all. Every
+    /// other key hint test in this module checks for its own screen's
+    /// keys the same way; a bare "the bar is non-empty" would pass for the
+    /// dashboard's hint too, since the title alone already renders.
+    #[test]
+    fn the_bleats_pane_gets_its_own_status_line() {
+        use shep_core::protocol::ProcessInfo;
+        use shep_core::status::ProcStatus;
+
+        let mut app = with_selection(ProcessInfo::builder(9, "web", ProcStatus::Online).build());
+        let _ = app.update(Msg::Key(KeyPress::Bleats));
+        let bar = rendered(&status_line(&app, 200));
+        for key in [
+            "esc back",
+            "j/k line",
+            "ctrl-d/u page",
+            "G end",
+            "/ search",
+            "n/N match",
+            "f follow",
+            "w wrap",
+            "o out/err/both",
+            "m level",
+        ] {
+            assert!(bar.contains(key), "missing {key:?}: got {bar}");
+        }
     }
 
     /// The right-aligned `█ following` indicator replaces the control-state

--- a/docs/brainstorming/specs/2026-09-08-lookout-1i-1j-design.md
+++ b/docs/brainstorming/specs/2026-09-08-lookout-1i-1j-design.md
@@ -1,0 +1,191 @@
+# Lookout panes 1i and 1j: bleats full screen, and the fold view
+
+**Status:** approved 2026-09-08. Not yet implemented.
+
+Two panes from the redesign bundle, built on what 1a landed. They share no code
+with each other and can be built in parallel; they share this document because
+both borrow the same foundations and both were ruled on together.
+
+`docs/lookout/design-files/rulings.md` is the authority on which of the bundle's
+claims survive contact with shipped shep. Where a frame and a ruling disagree,
+the ruling wins.
+
+## 1i: bleats, full screen
+
+The dashboard's bleats feed is four lines in a corner. This is the same log,
+given the screen, with filters.
+
+### Shape
+
+A new `Body` variant and `Scene`, full screen over the dashboard. It opens on
+whichever sheep was selected and pins it: there is no table on screen to change
+the selection with, so the pane describes one sheep for as long as it is open.
+
+### Where the lines come from
+
+`tail.rs`'s existing bounded window, polled faster while the pane has focus.
+
+**Not the bus, and the reason is worth recording because it looks wrong at first
+glance.** A dedicated viewer for one sheep sounds like exactly the case where a
+subscription beats a poll. It is not, because the bus cannot scope logs to one
+sheep. The topics are `log.out` and `log.err`, and a subscription's globs match
+the topic rather than the sheep, so subscribing means taking every sheep's
+output and discarding almost all of it. `source.rs` already prices that:
+
+> Subscribing would make lookout the bus's highest-volume subscriber, and
+> `super::link::run_connected` answers a lag with an immediate `ListFlock`, so
+> log traffic would turn into shepherd request load exactly when the shepherd is
+> busiest.
+
+Two alternatives were considered and rejected. A second connection dedicated to
+the pane would stop a lag amplifying into the dashboard's `ListFlock`, but the
+daemon still fans every sheep's lines at this client. Per-sheep topics
+(`log.out.<id>`) would fix it properly and are newly cheap, since the
+compatibility work merged in #173 makes a new topic additive and needs no
+version bump. That is a protocol change to serve a view, and it is not this
+pane's job. It stays available if the poll proves inadequate.
+
+### The three filter axes
+
+They compose with AND, and the filter row says so.
+
+| Axis | How it decides |
+|---|---|
+| stream | out, err, or both. Exact: shep writes the two files separately, so a line's stream is known rather than inferred |
+| level | a level word parsed from near the start of the line, case insensitive |
+| match | text or regex, with matches highlighted |
+
+**A line with no detectable level is always shown, whatever the minimum is, and
+the filter row states that.** An app's stdout is arbitrary text, and most of it
+carries no level at all. Hiding what could not be classified is how a log viewer
+loses the thing it was opened to find, and a sheep printing bare lines would
+vanish entirely the moment a minimum was set.
+
+`esc` drops the newest chip rather than clearing every filter, so backing out is
+one key at a time. With no chips left, `esc` closes the pane.
+
+### What the ruling dropped, and what that leaves
+
+`rulings.md` drops the whole-file line count, absolute line numbers, and the
+density gutter. All three require reading the whole file to say anything, and
+this pane reads a window. Counting lines means reading them.
+
+That leaves the frame's 8-cell line-number column with nothing true to put in
+it. A window-relative number counts from wherever the window happens to begin,
+which moves as the window slides, so it would look meaningful and not be.
+**Drop the column and give its 8 cells to the line text.**
+
+The filter row still states a survivor count, scoped honestly to what was read:
+`211 of 2,847 lines in the window`, not the frame's count against a whole file
+nobody has counted.
+
+## 1j: the fold view
+
+### Shape
+
+A grouping mode on the flock table, not a separate pane. `App` gains a grouping
+state with two values, flat and by fold, and `F` toggles it.
+
+The table already carries a two-level row model for multi-instance apps, where
+`web ×3` is a group row with instance rows beneath it. A fold header is that
+same shape with a different key, so selection, scrolling, the action confirms
+and the detail pane below all keep working. The frame supports this reading: the
+meadow band and host strip are unchanged, and `F` toggles back rather than
+closing anything.
+
+### Rows
+
+One header per fold, plus `no fold` for sheep whose `AppConfig::fold` is `None`,
+plus `dogs`, which the header names explicitly because a dog is never in a fold.
+
+A header sums its members' restarts, CPU and memory, and takes the **shortest**
+of their uptimes. That matches the existing group-row rollup rule rather than
+inventing a second one.
+
+Header rows render in ink, member rows in ink-2.
+
+### Two levels of grouping, not three
+
+A three-instance app inside a fold shows as one member row and keeps its own
+`×3` rollup. Instances stay behind the app's row. Without this, `edge ×4` is
+ambiguous about whether four counts apps or processes, and the answer would
+change as somebody scaled an app.
+
+### The share bar
+
+A 20-cell gauge of that fold's share of total flock memory, with the percentage
+stated in `NOTES`. It reuses 1a's `cell::gauge`.
+
+### Actions
+
+Selecting a fold header and pressing `x`, `R` or `L` acts on every member, each
+still arming a confirm that names the count.
+
+Nothing new is needed on the wire. `SelectorSpec::Fold` already means
+`shep stop fold:api` runs today, so this is a view over a capability that ships.
+
+### A fold header needs a detail branch
+
+`detail.rs` already has one for `RowKey::Group`: rollup figures, no lamb line,
+no log paths, because a group has no single process to walk or tail. A fold
+header is the same situation one level up and reuses that shape rather than
+inventing a fourth.
+
+### Columns
+
+2 gutter, 24 `FOLD / NAME`, 12 `STATUS`, 22 `SHARE OF FLOCK MEM`, 10 `MEM`,
+9 `CPU`, 10 `UPTIME`, 8 `RST`, 63 `NOTES`.
+
+Eight columns against the dashboard's fourteen, so fold view needs its own drop
+ladder for narrow terminals. Same `columns_for` mechanism, separate table:
+`SHARE OF FLOCK MEM` at 22 cells is the first thing that should go, and it does
+not exist in flat view at all.
+
+`z` collapses a fold. `F` returns to the flat list.
+
+## What both panes reuse from 1a
+
+- `cell::gauge`, `cell::sparkline`, `cell::rule`, `cell::band`
+- `Palette::band`, `Palette::ground`, and the sky and meadow roles
+- `fit` and `columns`, which measure display columns rather than `char`s
+- the group-row rollup in `app.rs` and its detail branch in `detail.rs`
+
+## Testing
+
+Both panes are rendered output, so the tests that matter assert what a frame
+actually draws.
+
+- Every new scene joins the `frames.rs` gallery, so a rendering change shows up
+  as a diff somebody reads.
+- Width sweep: both panes land inside their own rows at every width the existing
+  sweep covers. 1j's ladder gets the same treatment 1a's did, including the
+  invariant that a chosen tier fits.
+- 1i's level filter: a line with no level survives a minimum, which is the
+  decision most likely to be quietly reversed by someone tidying up.
+- 1i's `esc`: drops one chip, then closes. Not one or the other.
+- 1j's rollup takes the shortest uptime, not the first or the longest.
+- 1j's fold actions reach every member, and the confirm names the count.
+
+## What this does not do
+
+- No per-sheep log topics. Recorded above as the fix if polling proves
+  inadequate, deliberately not built here.
+- No whole-file anything in 1i: no line count, no absolute numbers, no density
+  gutter. The pane reads a window and says so.
+- No third grouping level in 1j.
+
+## Decisions
+
+1. **1i pins the sheep it opened on.** Full screen leaves no table to change a
+   selection with.
+2. **1i polls the file rather than subscribing.** The bus cannot scope to one
+   sheep, so a subscription costs every sheep's output. This reverses a call
+   made earlier in the design conversation on a premise that turned out false.
+3. **An unclassifiable line survives the level filter.** The alternative hides
+   exactly the output a bare-printing app produces.
+4. **1i drops the line-number column** rather than filling it with a
+   window-relative count that would look meaningful and not be.
+5. **1j is a grouping mode, not a pane.** The table's existing two-level row
+   model already fits, and `F` toggles rather than opens.
+6. **1j groups two levels deep.** An app inside a fold stays one row with its
+   own instance rollup.

--- a/docs/lookout/README.md
+++ b/docs/lookout/README.md
@@ -16,10 +16,10 @@ phase before deciding what came next.
 
 ## Reading the frames
 
-- `frames.txt`, thirty-five scenes rendered through the flattened `NO_COLOR`
+- `frames.txt`, thirty-six scenes rendered through the flattened `NO_COLOR`
   palette, the one an operator with `$NO_COLOR` set or a 16-colour terminal
   actually gets. Open it in any editor.
-- `frames.ansi`, the same thirty-five scenes rendered through the coloured
+- `frames.ansi`, the same thirty-six scenes rendered through the coloured
   palette the pinned snapshot tests use. Read it with `less -R` so the
   escape codes render instead of printing literally.
 
@@ -174,3 +174,24 @@ debt.
   share a single row with a divider between them and the pair's combined
   size on disk after it, and the pane gained a `cfg !N pending` cell for a
   sheep still carrying an unapplied config change.
+
+## What 1i settled
+
+- **`b` opens the bleats feed full screen on the selected sheep, and pins
+  it.** There is no table on screen to change the selection with, so the
+  pane describes that one sheep for as long as it stays open. It reads the
+  same log files the corner feed does, not the bus, just polled faster
+  while the pane has focus.
+- **Three filter axes, and they compose with AND.** `o` cycles the stream
+  (out, err, or both), `m` cycles a minimum level, and `/` opens a box for
+  a text or regex match, with matches highlighted. A line with no
+  detectable level always shows, whatever the minimum is set to: most app
+  output carries no level at all, and hiding it would make the pane worse
+  at the job it was opened for. The filter row states the composition and
+  a survivor count scoped to the current window.
+- **`esc` drops the newest filter chip before it closes the pane.** One
+  axis at a time, newest first, and only once none are left does `esc`
+  close the pane and return to the table.
+- **`j`/`k` scroll a line, `ctrl-d`/`ctrl-u` a page, `G` jumps to the end
+  and resumes following, `f` toggles following, `w` wraps long lines
+  instead of truncating them, and `n`/`N` step between matches.**

--- a/docs/lookout/frames.ansi
+++ b/docs/lookout/frames.ansi
@@ -1046,7 +1046,7 @@ The same screen at 14 rows, which is fewer than it has to draw. The cursor is on
 The full-screen bleats pane, pinned to api, with a stream, a minimum level and a regex all stacked: only out, only warn and above, only a line mentioning retrying or jitter. The filter row states the composition and counts one surviving line out of sixteen, and that one line is also the longest in the fixture, so wrapping is on and its full text runs onto a second row instead of an ellipsis.
 
 [0m[7m[38;5;29mshep lookout   /home/ada/.shep                                                        6 in the flock[0m
-[0m[7m[38;5;29m ██ api  out /home/ada/.shep/logs/api-2-out.log  err /home/ada/.shep/logs/api-2-err.log             [0m
+[0m[7m[38;5;29m ██ api  out /home/ada/.shep/logs/api-2-out.log  err /home/ada/.shep/logs/api-2-err.log  64.0K wind…[0m
 [0m[48;5;235m stream out [0m [0m[48;5;235m level ≥ warn [0m [0m[48;5;235m match /retry|jitter/ (regex) [0m [0m[38;5;245m1 of 16 lines in the window: all three m…[0m
 [0m[38;5;245mout  [0mWARN [0m[7m[38;5;221mretry[0ming upstream payment gateway after a timeout, backing off 500ms before trying again w[0m
 [0m[38;5;245m     [0mith [0m[7m[38;5;221mjitter[0m added so the whole fleet does not [0m[7m[38;5;221mretry[0m at once                                     [0m

--- a/docs/lookout/frames.ansi
+++ b/docs/lookout/frames.ansi
@@ -7,9 +7,9 @@ These are real frames, rendered headlessly through ratatui's TestBackend by
 
 Nothing here is a mockup.
 
-frames.ansi renders all thirty-five scenes through the same coloured
+frames.ansi renders all thirty-six scenes through the same coloured
 palette the pinned `.snap` tests use; read it with `less -R`. frames.txt
-renders the same thirty-five scenes through the flattened NO_COLOR palette
+renders the same thirty-six scenes through the flattened NO_COLOR palette
 instead, the one an operator with $NO_COLOR set or a 16-colour terminal
 actually gets. The two files are deliberately different pictures of the
 same dashboard, not one file with the colour removed.
@@ -31,7 +31,8 @@ it read and dropped are counted exactly; bytes below its 64 KiB window were
 never read at all, so those are reported in bytes, because nothing counted the
 lines in them and guessing would be worse than saying so.
 
-The last seven frames are the settings screen, `s` from the dashboard. It owns
+The last frame is the full-screen bleats pane, `b` from the dashboard. The
+seven before it are the settings screen, `s` from the dashboard. It owns
 the whole body between the title and the status bar rather than sharing it
 with the flock table, so a fresh $SHEP_HOME, some scalars declared, an armed
 confirm, the socket editor mid-type, the dogs table's own drift, the same

--- a/docs/lookout/frames.ansi
+++ b/docs/lookout/frames.ansi
@@ -1040,3 +1040,22 @@ The same screen at 14 rows, which is fewer than it has to draw. The cursor is on
 > bark                                                                yes      built-in                  silent         [0m
                                                                                                                         [0m
 [0m[38;5;221m[48;5;235mesc/s close   j/k select   g/G first/last   r refresh   space cycle   enter apply   q quit              [0m[38;5;245m[48;5;235m control enabled[0m
+
+
+=== bleats  (100x14) ===
+The full-screen bleats pane, pinned to api, with a stream, a minimum level and a regex all stacked: only out, only warn and above, only a line mentioning retrying or jitter. The filter row states the composition and counts one surviving line out of sixteen, and that one line is also the longest in the fixture, so wrapping is on and its full text runs onto a second row instead of an ellipsis.
+
+[0m[7m[38;5;29mshep lookout   /home/ada/.shep                                                        6 in the flock[0m
+[0m[7m[38;5;29m ██ api  out /home/ada/.shep/logs/api-2-out.log  err /home/ada/.shep/logs/api-2-err.log             [0m
+[0m[48;5;235m stream out [0m [0m[48;5;235m level ≥ warn [0m [0m[48;5;235m match /retry|jitter/ (regex) [0m [0m[38;5;245m1 of 16 lines in the window: all three m…[0m
+[0m[38;5;245mout  [0mWARN [0m[7m[38;5;221mretry[0ming upstream payment gateway after a timeout, backing off 500ms before trying again w[0m
+[0m[38;5;245m     [0mith [0m[7m[38;5;221mjitter[0m added so the whole fleet does not [0m[7m[38;5;221mretry[0m at once                                     [0m
+                                                                                                    [0m
+                                                                                                    [0m
+                                                                                                    [0m
+                                                                                                    [0m
+                                                                                                    [0m
+                                                                                                    [0m
+                                                                                                    [0m
+                                                                                                    [0m
+[0m[38;5;221m[48;5;235mesc back   j/k line   ctrl-d/u page   G end   / search   n/N match   f follow   w wrap …[0m[38;5;245m[48;5;235m █ following[0m

--- a/docs/lookout/frames.txt
+++ b/docs/lookout/frames.txt
@@ -1011,7 +1011,7 @@ esc/s close   j/k select   g/G first/last   r refresh   space cycle   enter appl
 The full-screen bleats pane, pinned to api, with a stream, a minimum level and a regex all stacked: only out, only warn and above, only a line mentioning retrying or jitter. The filter row states the composition and counts one surviving line out of sixteen, and that one line is also the longest in the fixture, so wrapping is on and its full text runs onto a second row instead of an ellipsis.
 
 shep lookout   /home/ada/.shep                                                        6 in the flock
- ██ api  out /home/ada/.shep/logs/api-2-out.log  err /home/ada/.shep/logs/api-2-err.log             
+ ██ api  out /home/ada/.shep/logs/api-2-out.log  err /home/ada/.shep/logs/api-2-err.log  64.0K wind…
  stream out   level ≥ warn   match /retry|jitter/ (regex)  1 of 16 lines in the window: all three m…
 out  WARN retrying upstream payment gateway after a timeout, backing off 500ms before trying again w
      ith jitter added so the whole fleet does not retry at once                                     

--- a/docs/lookout/frames.txt
+++ b/docs/lookout/frames.txt
@@ -1006,3 +1006,21 @@ shep lookout   /home/ada/.shep                                                  
 > bark                                                                yes      built-in                  silent         
                                                                                                                         
 esc/s close   j/k select   g/G first/last   r refresh   space cycle   enter apply   q quit               control enabled
+
+=== bleats  (100x14) ===
+The full-screen bleats pane, pinned to api, with a stream, a minimum level and a regex all stacked: only out, only warn and above, only a line mentioning retrying or jitter. The filter row states the composition and counts one surviving line out of sixteen, and that one line is also the longest in the fixture, so wrapping is on and its full text runs onto a second row instead of an ellipsis.
+
+shep lookout   /home/ada/.shep                                                        6 in the flock
+ ██ api  out /home/ada/.shep/logs/api-2-out.log  err /home/ada/.shep/logs/api-2-err.log             
+ stream out   level ≥ warn   match /retry|jitter/ (regex)  1 of 16 lines in the window: all three m…
+out  WARN retrying upstream payment gateway after a timeout, backing off 500ms before trying again w
+     ith jitter added so the whole fleet does not retry at once                                     
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+esc back   j/k line   ctrl-d/u page   G end   / search   n/N match   f follow   w wrap … █ following

--- a/docs/lookout/frames.txt
+++ b/docs/lookout/frames.txt
@@ -7,9 +7,9 @@ These are real frames, rendered headlessly through ratatui's TestBackend by
 
 Nothing here is a mockup.
 
-frames.ansi renders all thirty-five scenes through the same coloured
+frames.ansi renders all thirty-six scenes through the same coloured
 palette the pinned `.snap` tests use; read it with `less -R`. frames.txt
-renders the same thirty-five scenes through the flattened NO_COLOR palette
+renders the same thirty-six scenes through the flattened NO_COLOR palette
 instead, the one an operator with $NO_COLOR set or a 16-colour terminal
 actually gets. The two files are deliberately different pictures of the
 same dashboard, not one file with the colour removed.
@@ -31,7 +31,8 @@ it read and dropped are counted exactly; bytes below its 64 KiB window were
 never read at all, so those are reported in bytes, because nothing counted the
 lines in them and guessing would be worse than saying so.
 
-The last seven frames are the settings screen, `s` from the dashboard. It owns
+The last frame is the full-screen bleats pane, `b` from the dashboard. The
+seven before it are the settings screen, `s` from the dashboard. It owns
 the whole body between the title and the status bar rather than sharing it
 with the flock table, so a fresh $SHEP_HOME, some scalars declared, an armed
 confirm, the socket editor mid-type, the dogs table's own drift, the same

--- a/docs/writing-plans/plans/2026-09-08-lookout-1i-bleats-pane.md
+++ b/docs/writing-plans/plans/2026-09-08-lookout-1i-bleats-pane.md
@@ -223,6 +223,16 @@ git commit -m "feat(lookout): open the bleats feed full screen on b"
 
 A pure function with no dependencies, so it lands on its own and is tested exhaustively before anything filters with it.
 
+**Correction, 2026-09-08, after this task's review.** The trimming rule below
+was written as `trim_matches(|c: char| !c.is_ascii_alphabetic())`, which
+strips digits as well as punctuation from both ends of a word. That turns
+`/error404` into `error` and `info2` into `info`, so `level_of` announces a
+level on an ordinary access-log token that announced none. Spec decision 3
+forbids exactly that. The trim must not swallow digits: a level word is the
+whole word once surrounding punctuation is gone, and a digit next to it means
+it was never a level word. The tests below cover only the alphabetic
+continuation case (`information`, `warnings`), which is why this got through.
+
 - [ ] **Step 1: Write the failing tests**
 
 ```rust
@@ -302,7 +312,7 @@ pub enum Level {
 #[must_use]
 pub fn level_of(line: &str) -> Option<Level> {
     line.split_whitespace().take(4).find_map(|word| {
-        match word.trim_matches(|c: char| !c.is_ascii_alphabetic()).to_ascii_lowercase().as_str() {
+        match word.trim_matches(|c: char| !c.is_ascii_alphanumeric())  // see the correction note below.to_ascii_lowercase().as_str() {
             "trace" => Some(Level::Trace),
             "debug" => Some(Level::Debug),
             "info" => Some(Level::Info),
@@ -685,7 +695,20 @@ git commit -m "docs(lookout): describe the full-screen bleats pane"
 
 ## Self-review
 
-**Spec coverage.** Pane shape and pinned sheep: Task 1. Source and the no-bus rule: Task 1, with the constraint stated globally. The three axes: Tasks 2 and 3. The unclassifiable-line rule: Task 2 defines it, Task 3 tests it. `esc` semantics: Task 3. Dropped line-number column: Task 4. Window-scoped survivor count: Task 4. Faster polling: Task 5. Scene, gallery and docs: Task 6.
+**Correction, 2026-09-08, found during Task 3's review.** The coverage claim
+below said "The three axes: Tasks 2 and 3" and that was false for half of one
+axis. The spec's match row reads "text **or regex**, with matches
+**highlighted**". Neither `regex` nor `highlight` appeared anywhere in this
+plan, so a spec requirement had no task at all and the self-review passed it
+anyway.
+
+Ruled into Task 4, which renders the filter row and is where highlighting
+belongs. The cost is small and was checked rather than assumed: `regex` is
+already a workspace dependency (`Cargo.toml:89`), already used by shep-core,
+and already in shep-cli's dependency graph, so honouring the spec row adds one
+`regex.workspace = true` line and no new crate to the tree.
+
+**Spec coverage.** Pane shape and pinned sheep: Task 1. Source and the no-bus rule: Task 1, with the constraint stated globally. The three axes: Tasks 2 and 3, with the match axis's regex and highlighting in Task 4 (see the correction above). The unclassifiable-line rule: Task 2 defines it, Task 3 tests it. `esc` semantics: Task 3. Dropped line-number column: Task 4. Window-scoped survivor count: Task 4. Faster polling: Task 5. Scene, gallery and docs: Task 6.
 
 **One spec item deliberately has no task.** The spec's "no per-sheep log topics" is a decision not to build something, recorded so a later reader knows it was considered. Nothing to implement.
 

--- a/docs/writing-plans/plans/2026-09-08-lookout-1i-bleats-pane.md
+++ b/docs/writing-plans/plans/2026-09-08-lookout-1i-bleats-pane.md
@@ -607,7 +607,389 @@ git commit -m "feat(lookout): refresh the bleats pane on its own ticks"
 
 ---
 
-## Task 6: The scene, the gallery and the docs
+## Task 6: The filter keys
+
+**Added 2026-09-08.** The plan shipped three filter axes that no key could
+set. `KeyPress::FilterStart`, which is `/`, sat in `on_bleats_key`'s inert arm,
+while `docs/lookout/design-files/README.md:321` says plainly "In 1i, `/` adds a
+match chip". `rulings.md` calls the three axes "the point of it". They were
+built, tested, rendered and unreachable. The maintainer chose to build the
+pane's full status bar rather than the filter keys alone, so this task and the
+two after it exist.
+
+**Files:**
+- Modify: `crates/shep-cli/src/lookout/input.rs`
+- Modify: `crates/shep-cli/src/lookout/app.rs` (`on_bleats_key`)
+- Modify: `crates/shep-cli/src/lookout/pane_bleats.rs`
+
+**Interfaces:**
+- Consumes: `Filters`, `BleatsPane::{set_stream, set_min_level, set_match}`,
+  `Level`, `Stream` — all built in Tasks 2 and 3.
+- Produces: `KeyPress::StreamCycle`, `KeyPress::LevelCycle`; `/` reaching the
+  pane's match input.
+
+**Three keys, and only two of them come from the design.**
+
+| key | axis | source |
+|---|---|---|
+| `/` | match | `README.md:321` and the status bar's `/ search` |
+| `o` | stream, out/err/both | the status bar's `o out/err/both` |
+| `m` | minimum level | **invented here.** The design's status bar names no key for the level axis, though the filter row draws its chip. `m` for minimum, chosen because every better mnemonic is taken: `l` reads as line, `L` is Reload, `v` means nothing here. Flag it to the maintainer rather than burying it. |
+
+**`/` reuses `InputMode::Text`, and does not add a mode.** The dashboard's name
+filter already does exactly this: `/` starts text entry, typing narrows, `↵`
+applies, `esc` abandons the edit. Read how `KeyPress::FilterStart` and the
+`TextChar`/`TextApply`/`TextAbandon` family are handled for the flock table
+before writing the pane's version, and follow it. The global constraint stands:
+there are two modes, `Normal` and `Text`, and a new pane does not get a third.
+
+**`esc` while typing abandons the edit; `esc` with the input closed drops the
+newest chip.** Those are different actions on the same key and the existing
+flock-table filter draws the same distinction. Task 3's chip-dropping behaviour
+must keep working, and it has a test.
+
+- [ ] **Step 1: Write the failing tests**
+
+```rust
+/// `o` cycles the stream axis through its three states and back. Three
+/// presses return to where it began, which is what makes it a cycle
+/// rather than a toggle that strands the operator on `err`.
+#[test]
+fn o_cycles_the_stream_axis_and_returns_to_both() {
+    let mut app =
+        fixtures::with_selection(ProcessInfo::builder(9, "web", ProcStatus::Online).build());
+    let _ = app.update(Msg::Key(KeyPress::Bleats));
+    assert!(app.bleats_pane().expect("open").filters().stream.is_none());
+    let _ = app.update(Msg::Key(KeyPress::StreamCycle));
+    let first = app.bleats_pane().expect("open").filters().stream;
+    assert!(first.is_some(), "one press sets an axis");
+    let _ = app.update(Msg::Key(KeyPress::StreamCycle));
+    let _ = app.update(Msg::Key(KeyPress::StreamCycle));
+    assert!(
+        app.bleats_pane().expect("open").filters().stream.is_none(),
+        "three presses land back on both"
+    );
+}
+
+/// `m` raises the minimum level and eventually clears it. The unset state
+/// has to be reachable by key, or an operator who sets a minimum can never
+/// see unlevelled output again without closing the pane.
+#[test]
+fn m_cycles_the_level_axis_back_to_unset() {
+    let mut app =
+        fixtures::with_selection(ProcessInfo::builder(9, "web", ProcStatus::Online).build());
+    let _ = app.update(Msg::Key(KeyPress::Bleats));
+    let mut seen_some = false;
+    for _ in 0..8 {
+        let _ = app.update(Msg::Key(KeyPress::LevelCycle));
+        if app.bleats_pane().expect("open").filters().min_level.is_some() {
+            seen_some = true;
+        }
+    }
+    assert!(seen_some, "the cycle passes through a set minimum");
+    // Whatever the cycle length, it must return to unset within one lap.
+    let mut cleared = false;
+    for _ in 0..8 {
+        let _ = app.update(Msg::Key(KeyPress::LevelCycle));
+        if app.bleats_pane().expect("open").filters().min_level.is_none() {
+            cleared = true;
+            break;
+        }
+    }
+    assert!(cleared, "the cycle returns to unset");
+}
+
+/// `/` opens the match input rather than doing nothing, which is what it
+/// did when this pane first shipped.
+#[test]
+fn slash_opens_the_match_input_in_the_bleats_pane() {
+    let mut app =
+        fixtures::with_selection(ProcessInfo::builder(9, "web", ProcStatus::Online).build());
+    let _ = app.update(Msg::Key(KeyPress::Bleats));
+    let _ = app.update(Msg::Key(KeyPress::FilterStart));
+    assert_eq!(app.input_mode(), InputMode::Text, "typing goes to the pane");
+}
+```
+
+Read the existing flock-table filter tests before writing these: the accessor
+for the current mode is named from a survey rather than read in place, so
+confirm `input_mode` exists and is reachable from the test module, and use
+whatever the neighbouring tests use if it is not.
+
+- [ ] **Step 2: Run them to verify they fail**
+
+Run: `cargo test --workspace --all-features --lib --bins -- o_cycles_the_stream m_cycles_the_level slash_opens_the_match`
+Expected: FAIL, no `KeyPress::StreamCycle` and no `KeyPress::LevelCycle`.
+
+- [ ] **Step 3: Add the two keys**
+
+`o` and `m` are both unbound; confirm with
+`rg "'o' =>|'m' =>" crates/shep-cli/src/lookout/input.rs` before adding. Add
+`KeyPress::StreamCycle` and `KeyPress::LevelCycle` to the enum and bind them in
+the `Normal` arm, following the shape of the neighbouring bindings.
+
+They are global bindings, so they reach the dashboard too. The dashboard's
+reducer must ignore them explicitly rather than by falling through, the same
+way it ignores `KeyPress::Bleats` on screens that have no bleats pane.
+
+- [ ] **Step 4: Cycle the axes**
+
+In `on_bleats_key`, move `KeyPress::FilterStart` out of the inert arm and add
+the two new keys. The stream cycle runs `None` → `Out` → `Err` → `None`. The
+level cycle walks `Level`'s variants in order and then returns to `None`, which
+is the state the "unclassifiable lines always show" rule depends on staying
+reachable.
+
+Both go through `set_stream` and `set_min_level` rather than writing
+`filters.stream` directly, because those setters maintain the chip order that
+`drop_newest_chip` reads. Setting an axis to `None` through them must remove it
+from that order; `note_axis` already has the branch for it and Task 3 left it
+untested, so this is where it earns a test.
+
+- [ ] **Step 5: Wire the match input**
+
+`/` puts the pane in `InputMode::Text` and routes `TextChar`, `TextBackspace`,
+`TextApply` and `TextAbandon` to the match axis. `TextApply` calls `set_match`;
+`TextAbandon` leaves the axis as it was. Follow the flock table's handling
+rather than inventing one.
+
+- [ ] **Step 6: Remove the dead-code allows this task retires**
+
+`set_stream`, `set_min_level`, `set_match`, `note_axis` and `Axis` carry
+`#[allow(dead_code)]` with a reason naming the task that would give them a
+caller. This is that task for the first three, and `note_axis` and `Axis` are
+reached through them. Remove every attribute this task retires, and its
+sentence with it.
+
+- [ ] **Step 7: Gate and commit**
+
+`cargo fmt --all --check`, then
+`cargo clippy --workspace --all-targets --all-features -- -D warnings`, then
+`cargo test --workspace --all-features`. One command at a time.
+
+---
+
+## Task 7: Scrolling, and following the tail
+
+**Added 2026-09-08.** The pane auto-tails and cannot be scrolled: `j`, `k`,
+`G` and the page keys all sit in `on_bleats_key`'s inert arm. The design's
+status bar names `j/k line`, `ctrl-d/u page`, `G end` and `f follow`.
+
+**Files:**
+- Modify: `crates/shep-cli/src/lookout/input.rs`
+- Modify: `crates/shep-cli/src/lookout/app.rs` (`on_bleats_key`)
+- Modify: `crates/shep-cli/src/lookout/pane_bleats.rs`
+- Modify: `crates/shep-cli/src/lookout/view/bleats_full.rs`
+
+**Interfaces:**
+- Consumes: `BleatsPane`, `BleatsPane::visible`.
+- Produces: a scroll offset and a follow flag on `BleatsPane`;
+  `KeyPress::PageDown`, `KeyPress::PageUp`, `KeyPress::FollowToggle`.
+
+**Follow is the state that makes scrolling coherent, so build it in the same
+task.** The pane is a live feed: new lines arrive every refresh. While
+following, the view stays pinned to the newest line and an arriving line
+scrolls the old ones up. The moment the operator scrolls back, following stops,
+or every keypress is undone two seconds later. `G` jumps to the end **and**
+re-enables following, because that is what an operator means by it. `f` toggles
+following explicitly, and the status bar's right-aligned `█ following`
+indicator says which state the pane is in.
+
+The scroll offset counts **filtered** lines, not raw ones. `visible` is what
+the body renders, so a changed filter changes what a given offset means;
+clamp the offset against the survivor count on every draw rather than trusting
+it to still be valid.
+
+`j`, `k` and `G` already map to `KeyPress::SelectDown`, `SelectUp` and
+`SelectLast`. Reuse them rather than adding pane-specific twins — the reducer
+already dispatches on `Body`, which is what makes one `KeyPress` mean two
+things on two screens. `ctrl-d` and `ctrl-u` are new and go in `map_key`'s
+CONTROL branch at `input.rs:24`, which currently handles only `ctrl-c`.
+
+**That CONTROL branch returns before the `InputMode::Text` check**, so
+`ctrl-d` will fire while the operator is typing a match. Decide deliberately
+whether that is acceptable and say which you chose: either move the check, or
+accept it and note why. Do not leave it unconsidered.
+
+- [ ] **Step 1: Write the failing tests**
+
+```rust
+/// Scrolling back stops the follow, or the next refresh undoes the
+/// operator's keypress.
+#[test]
+fn scrolling_back_stops_following() {
+    let mut app = fixtures::bleats_pane_with_lines(120);
+    assert!(app.bleats_pane().expect("open").following());
+    let _ = app.update(Msg::Key(KeyPress::SelectUp));
+    assert!(
+        !app.bleats_pane().expect("open").following(),
+        "one line back is enough to mean the operator took over"
+    );
+}
+
+/// `G` is the way back to the live tail, so it restores following as well
+/// as jumping.
+#[test]
+fn g_returns_to_the_end_and_resumes_following() {
+    let mut app = fixtures::bleats_pane_with_lines(120);
+    let _ = app.update(Msg::Key(KeyPress::SelectUp));
+    let _ = app.update(Msg::Key(KeyPress::SelectLast));
+    let pane = app.bleats_pane().expect("open");
+    assert!(pane.following(), "G resumes the follow");
+    assert_eq!(pane.scroll_offset(), 0, "and lands on the newest line");
+}
+
+/// A filter that hides most of the window must not leave the offset
+/// pointing past the end of what survives.
+#[test]
+fn a_narrowing_filter_clamps_the_scroll_offset() {
+    let mut app = fixtures::bleats_pane_with_lines(120);
+    let _ = app.update(Msg::Key(KeyPress::PageUp));
+    let _ = app.update(Msg::Key(KeyPress::PageUp));
+    app.bleats_pane_mut_for_tests()
+        .expect("open")
+        .set_match("a-string-no-line-contains".to_string());
+    let text = fixtures::render_all(&fixtures::draw_lines(&app, 160, 40));
+    assert!(!text.is_empty(), "the pane still draws rather than panicking");
+}
+```
+
+`fixtures::bleats_pane_with_lines` does not exist. Build it beside the
+existing bleats fixtures: an open pane over a feed of `n` lines, enough to
+exceed any test's body height.
+
+- [ ] **Step 2: Run them to verify they fail**
+
+Run: `cargo test --workspace --all-features --lib --bins -- scrolling_back_stops g_returns_to_the_end a_narrowing_filter_clamps`
+Expected: FAIL, no `following` and no `scroll_offset`.
+
+- [ ] **Step 3: Add the state**
+
+`BleatsPane` gains a scroll offset counted back from the newest surviving line,
+and a follow flag defaulting to true. Both need doc comments saying what the
+offset counts, because "0 is the newest" and "0 is the oldest" are equally
+plausible to the next reader and only one is right.
+
+- [ ] **Step 4: Handle the keys**
+
+`j`/`k` move by a line, `ctrl-d`/`ctrl-u` by a body height, `G` to the end.
+Any backward movement clears the follow flag; `G` and `f` restore it. Clamp
+against the survivor count.
+
+- [ ] **Step 5: Draw from the offset, and show the indicator**
+
+`view/bleats_full.rs` currently takes the last `body_rows` survivors. It now
+takes the window the offset names, still oldest-first with the newest at the
+bottom. The right-aligned `█ following` indicator appears only while following.
+
+- [ ] **Step 6: Gate and commit**
+
+The four commands, one at a time.
+
+---
+
+## Task 8: Wrap, and stepping between matches
+
+**Added 2026-09-08.** The last two keys in the design's status bar: `w wrap`
+and `n/N match`.
+
+**Files:**
+- Modify: `crates/shep-cli/src/lookout/input.rs`
+- Modify: `crates/shep-cli/src/lookout/app.rs` (`on_bleats_key`)
+- Modify: `crates/shep-cli/src/lookout/pane_bleats.rs`
+- Modify: `crates/shep-cli/src/lookout/view/bleats_full.rs`
+
+**Interfaces:**
+- Consumes: the scroll offset and follow flag from Task 7, the match axis and
+  its highlighting from Tasks 3 and 4.
+- Produces: `KeyPress::WrapToggle`, `KeyPress::MatchNext`,
+  `KeyPress::MatchPrev`.
+
+**Wrap changes how many rows a line occupies, so it changes what the scroll
+offset means.** A wrapped line takes as many rows as it needs; the offset
+counts lines, and the draw has to turn lines into rows. Get this wrong and
+scrolling near the end of a wrapped feed walks off the bottom. Task 7's clamp
+is the thing to extend, not to duplicate.
+
+**`n` and `N` step between lines that match the match axis**, which is only
+meaningful while that axis is set. With no matcher they do nothing rather than
+moving by one line, since a silent fallback to line movement is worse than an
+inert key. Stepping sets the offset and clears the follow flag, the same as any
+other backward movement.
+
+The highlighting from Task 4 already finds the match positions. Use what it
+computes rather than running the matcher a second time with a different
+implementation, which is how the two drift apart.
+
+- [ ] **Step 1: Write the failing tests**
+
+```rust
+/// `n` with no match axis set does nothing, rather than quietly becoming
+/// a line-movement key.
+#[test]
+fn n_without_a_matcher_does_nothing() {
+    let mut app = fixtures::bleats_pane_with_lines(120);
+    let before = app.bleats_pane().expect("open").scroll_offset();
+    let _ = app.update(Msg::Key(KeyPress::MatchNext));
+    assert_eq!(app.bleats_pane().expect("open").scroll_offset(), before);
+    assert!(app.bleats_pane().expect("open").following());
+}
+
+/// Wrapping a long line makes it occupy more rows than one, which is the
+/// whole point, and the pane must still draw inside its area.
+#[test]
+fn a_wrapped_line_occupies_more_rows_and_stays_in_the_area() {
+    let mut app = fixtures::bleats_pane_with_long_line();
+    let unwrapped = fixtures::draw_lines(&app, 80, 20).len();
+    let _ = app.update(Msg::Key(KeyPress::WrapToggle));
+    let wrapped = fixtures::draw_lines(&app, 80, 20);
+    assert!(wrapped.len() <= 20, "never draws past its own height");
+    assert!(
+        wrapped.iter().filter(|line| !line.spans.is_empty()).count() >= unwrapped,
+        "wrapping uses at least as many rows as not wrapping"
+    );
+}
+```
+
+`fixtures::bleats_pane_with_long_line` does not exist; build it, with a line
+comfortably wider than 80 columns.
+
+- [ ] **Step 2: Run them to verify they fail**
+
+Run: `cargo test --workspace --all-features --lib --bins -- n_without_a_matcher a_wrapped_line_occupies`
+Expected: FAIL, no `KeyPress::MatchNext` and no `KeyPress::WrapToggle`.
+
+- [ ] **Step 3: Add the three keys**
+
+`w`, `n` and `N` are unbound; confirm before adding.
+
+- [ ] **Step 4: Wrap**
+
+A flag on `BleatsPane`, and a draw that turns one line into as many rows as it
+needs. Use `columns` from the width module rather than `chars().count()`: this
+repo has fixed that same bug in two other branches and a third would reintroduce
+it.
+
+- [ ] **Step 5: Step between matches**
+
+`n` forward, `N` back, both clamped, both clearing the follow flag, both inert
+with no matcher set.
+
+- [ ] **Step 6: Update the status bar**
+
+The pane's status bar now carries the design's full line: `esc back`,
+`j/k line`, `ctrl-d/u page`, `G end`, `/ search`, `n/N match`, `f follow`,
+`w wrap`, `o out/err/both`, and right-aligned `█ following`. Add `m` for the
+level axis, which the design's own status bar omits, and say in the report that
+it was added.
+
+- [ ] **Step 7: Gate and commit**
+
+The four commands, one at a time.
+
+---
+
+## Task 9: The scene, the gallery and the docs
 
 **Files:**
 - Modify: `crates/shep-cli/src/lookout/frames.rs`
@@ -708,7 +1090,9 @@ already a workspace dependency (`Cargo.toml:89`), already used by shep-core,
 and already in shep-cli's dependency graph, so honouring the spec row adds one
 `regex.workspace = true` line and no new crate to the tree.
 
-**Spec coverage.** Pane shape and pinned sheep: Task 1. Source and the no-bus rule: Task 1, with the constraint stated globally. The three axes: Tasks 2 and 3, with the match axis's regex and highlighting in Task 4 (see the correction above). The unclassifiable-line rule: Task 2 defines it, Task 3 tests it. `esc` semantics: Task 3. Dropped line-number column: Task 4. Window-scoped survivor count: Task 4. Faster polling: Task 5. Scene, gallery and docs: Task 6.
+**Spec coverage.** Pane shape and pinned sheep: Task 1. Source and the no-bus rule: Task 1, with the constraint stated globally. The three axes: Tasks 2 and 3, with the match axis's regex and highlighting in Task 4 (see the correction above). The unclassifiable-line rule: Task 2 defines it, Task 3 tests it. `esc` semantics: Task 3. Dropped line-number column: Task 4. Window-scoped survivor count: Task 4. Faster polling: Task 5. The filter keys: Task 6. Scrolling and follow: Task 7. Wrap and match stepping: Task 8. Scene, gallery and docs: Task 9.
+
+**Second correction, 2026-09-08.** The coverage claim above accounted for the filter axes and never asked whether an operator could reach them. They could not: `KeyPress::FilterStart` sat in `on_bleats_key`'s inert arm, and no key touched stream or level. `docs/lookout/design-files/README.md:274` gives this pane a nine-key status bar and the plan implemented one key of it, `esc`. The maintainer chose the full status bar over the filter keys alone, which is Tasks 6 through 8.
 
 **One spec item deliberately has no task.** The spec's "no per-sheep log topics" is a decision not to build something, recorded so a later reader knows it was considered. Nothing to implement.
 

--- a/docs/writing-plans/plans/2026-09-08-lookout-1i-bleats-pane.md
+++ b/docs/writing-plans/plans/2026-09-08-lookout-1i-bleats-pane.md
@@ -1,0 +1,690 @@
+# Lookout 1i: bleats full screen Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give the bleats feed the whole screen, with three composable filters over the window it already reads.
+
+**Architecture:** A fourth `Body` variant holding the pane's own state, opened with `b` from the dashboard and closed with `esc`. It reads through `tail.rs`'s existing bounded window rather than the bus, and asks for extra polls through the channel `r` already uses rather than changing any interval.
+
+**Tech Stack:** Rust 1.88, edition 2024, ratatui 0.30.2, insta snapshots.
+
+**Spec:** [docs/brainstorming/specs/2026-09-08-lookout-1i-1j-design.md](../../brainstorming/specs/2026-09-08-lookout-1i-1j-design.md)
+
+## Global Constraints
+
+- No protocol change. No `PROTOCOL_VERSION`, `MIN_SUPPORTED` or `SCHEMA_VERSION` movement. This pane is a view.
+- **Do not subscribe to the bus.** Topics are `log.out` and `log.err` and globs match the topic rather than the sheep, so a subscription takes every sheep's output. `source.rs`'s comment explains the cost; leave `TOPICS` alone.
+- A log line with no detectable level is **always shown**, whatever the minimum is. This is the decision most likely to be reversed by someone tidying up, so it gets its own test.
+- Nothing whole-file: no line count, no absolute line numbers, no density gutter. The pane reads a window and every count it states is scoped to that window.
+- Invoke the `shep-idiomatic-rust` skill before writing Rust. Cite `IR-<n>` where a rule applies.
+- Every new public item needs a doc comment and a deliberate `Debug` decision.
+- Conventional commit subjects. Nothing here breaks, so no `!`.
+- ONE cargo shape: `--workspace`. Do not alternate with `-p <crate>`; this repo's cache churns badly when a brief names two shapes.
+- Iterate with `cargo test --workspace --all-features --lib --bins`. Run the full `cargo test --workspace --all-features` once per task before committing.
+- `map_key` dispatches on `InputMode`, not on which `Body` is showing. There are only two modes, `Normal` and `Text`. A new pane does **not** get a third; its keys are handled by the reducer matching on `Body`.
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `crates/shep-cli/src/lookout/pane_bleats.rs` (new) | the pane's own state: filters, cursor, and the pure filter application |
+| `crates/shep-cli/src/lookout/level.rs` (new) | parsing a level word out of an arbitrary log line |
+| `crates/shep-cli/src/lookout/view/bleats_full.rs` (new) | rendering the full-screen pane |
+| `crates/shep-cli/src/lookout/app.rs` | the `Body::Bleats` variant, open and close, key handling |
+| `crates/shep-cli/src/lookout/input.rs` | binding `b` |
+| `crates/shep-cli/src/lookout/view/mod.rs` | the `draw` arm |
+| `crates/shep-cli/src/lookout/frames.rs` | the scene, its label and caption |
+
+New files rather than growing `app.rs`, which is already past 8,000 lines.
+
+---
+
+## Task 1: The pane opens, shows the window, and closes
+
+**Files:**
+- Create: `crates/shep-cli/src/lookout/pane_bleats.rs`
+- Create: `crates/shep-cli/src/lookout/view/bleats_full.rs`
+- Modify: `crates/shep-cli/src/lookout/app.rs` (`Body` at :1251, `close_pane` at :2668, the reducer)
+- Modify: `crates/shep-cli/src/lookout/input.rs` (:43-64)
+- Modify: `crates/shep-cli/src/lookout/view/mod.rs` (`draw`)
+
+**Interfaces:**
+- Consumes: `tail::Tail`, `tail::TailLine`, `tail::Stream` from `crates/shep-cli/src/lookout/tail.rs:34-61`; `App::feed(&self) -> &Tail` at `app.rs:4145`.
+- Produces: `Body::Bleats(BleatsPane)`; `BleatsPane::new(sheep: RowKey) -> Self`; `BleatsPane::sheep(&self) -> &RowKey`; `view::bleats_full::draw(app, frame, area)`.
+
+- [ ] **Step 1: Write the failing tests**
+
+In `crates/shep-cli/src/lookout/input.rs`'s `mod tests`, beside the existing test that pins `z` as unbound at `input.rs:159`:
+
+```rust
+/// `b` opens the full-screen bleats pane. Pinned because `map_key`
+/// dispatches on mode rather than pane, so a key taken here is taken
+/// everywhere in `Normal`.
+#[test]
+fn b_opens_the_bleats_pane() {
+    assert_eq!(
+        map_key(&key('b'), InputMode::Normal),
+        Some(KeyPress::Bleats)
+    );
+}
+```
+
+Use whatever helper the neighbouring tests use to build the event; read two of them first rather than inventing one.
+
+In `crates/shep-cli/src/lookout/app.rs`'s `mod tests`:
+
+```rust
+/// The pane opens on whatever was selected and pins it: full screen
+/// leaves no table to change a selection with.
+#[test]
+fn b_opens_the_pane_on_the_selected_sheep() {
+    let mut app =
+        fixtures::with_selection(ProcessInfo::builder(9, "web", ProcStatus::Online).build());
+    let _ = app.update(Msg::Key(KeyPress::Bleats));
+    let pane = app.bleats_pane().expect("the pane is open");
+    assert!(matches!(pane.sheep(), RowKey::Sheep(id) if *id == 9));
+}
+
+/// `close_pane` always lands on the dashboard, never on whatever screen
+/// preceded the pane. Same rule the config pane follows.
+#[test]
+fn esc_from_the_bleats_pane_lands_on_the_dashboard() {
+    let mut app =
+        fixtures::with_selection(ProcessInfo::builder(9, "web", ProcStatus::Online).build());
+    let _ = app.update(Msg::Key(KeyPress::Bleats));
+    let _ = app.update(Msg::Key(KeyPress::Escape));
+    assert!(matches!(app.body(), Body::FlockTable));
+}
+
+/// `b` with nothing selected asks for nothing, the way `e` does.
+#[test]
+fn b_with_nothing_selected_opens_no_pane() {
+    let mut app = fixtures::app_with(Vec::new(), fixtures::plain());
+    let _ = app.update(Msg::Key(KeyPress::Bleats));
+    assert!(app.bleats_pane().is_none());
+}
+```
+
+- [ ] **Step 2: Run them to verify they fail**
+
+Run: `cargo test --workspace --all-features --lib --bins -- b_opens_the esc_from_the_bleats b_with_nothing_selected`
+Expected: FAIL, no `KeyPress::Bleats` and no `bleats_pane`.
+
+- [ ] **Step 3: Add the key**
+
+`b` is currently unbound; confirm with `rg "'b' =>" crates/shep-cli/src/lookout/input.rs` before adding. Add `KeyPress::Bleats` and bind `b` in the `Normal` arm at `input.rs:43-64`, following the shape of the neighbouring bindings.
+
+- [ ] **Step 4: Add the pane's state**
+
+`crates/shep-cli/src/lookout/pane_bleats.rs`:
+
+```rust
+/// The full-screen bleats pane's own state.
+///
+/// Holds the sheep it opened on rather than reading the dashboard's
+/// selection: full screen leaves no table on which to change one, so the
+/// pane describes a single sheep for as long as it is open.
+///
+/// `Debug` is derived. A row key and a cursor position carry no env, no
+/// path and no argument vector.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BleatsPane {
+    sheep: RowKey,
+}
+
+impl BleatsPane {
+    /// Opens the pane on one sheep.
+    #[must_use]
+    pub fn new(sheep: RowKey) -> Self {
+        Self { sheep }
+    }
+
+    /// The sheep this pane describes, fixed for its lifetime.
+    #[must_use]
+    pub fn sheep(&self) -> &RowKey {
+        &self.sheep
+    }
+}
+```
+
+- [ ] **Step 5: Add the `Body` variant and its accessor**
+
+In `app.rs`, extend `Body` at `:1251`:
+
+```rust
+    /// The bleats feed given the whole screen, opened by
+    /// [`KeyPress::Bleats`].
+    Bleats(BleatsPane),
+```
+
+Add the accessor beside `config_pane` at `app.rs:4247`, matching its shape exactly:
+
+```rust
+    /// The open bleats pane, or `None` on any other screen.
+    #[must_use]
+    pub fn bleats_pane(&self) -> Option<&BleatsPane> {
+        match &self.body {
+            Body::Bleats(pane) => Some(pane),
+            Body::FlockTable | Body::Settings(_) | Body::ConfigPane(_) => None,
+        }
+    }
+```
+
+The compiler will name every other `match` on `Body` that needs the new arm. Fix each; `settings()` and `config_pane()` list their non-matching variants explicitly rather than using a wildcard, so follow that.
+
+`close_pane` at `app.rs:2668` already sets `Body::FlockTable` and clears the pane fields. `BleatsPane` carries no state outside itself, so nothing new needs clearing there.
+
+- [ ] **Step 6: Handle the keys in the reducer**
+
+`KeyPress::Bleats` opens the pane when a sheep is selected and does nothing otherwise, mirroring how `KeyPress::Edit` behaves with nothing selected. `KeyPress::Escape` while `Body::Bleats` calls `close_pane()`.
+
+Remember the constraint: there is no new `InputMode`. The reducer matches on `Body` to decide what a key means.
+
+- [ ] **Step 7: Render it**
+
+`view/bleats_full.rs` draws the whole area: a title band naming the sheep and both log paths, then the window's lines, newest at the bottom, each tagged `out` or `err`. Reuse `cell::band` and `Palette::band(Role::Meadow)` for the title, and follow `view/bleats.rs:88-98` for how a line is tagged.
+
+Add the `Body::Bleats` arm to `view::draw` in `view/mod.rs`, following the arms already there.
+
+- [ ] **Step 8: Run to verify they pass**
+
+Run: `cargo test --workspace --all-features --lib --bins -- b_opens_the esc_from_the_bleats b_with_nothing_selected`
+Expected: PASS.
+
+- [ ] **Step 9: Full gate and commit**
+
+```bash
+cargo fmt --all --check
+```
+```bash
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+```
+```bash
+cargo test --workspace --all-features
+```
+
+```bash
+git add crates/shep-cli/src/lookout/
+git commit -m "feat(lookout): open the bleats feed full screen on b"
+```
+
+---
+
+## Task 2: Parsing a level out of an arbitrary line
+
+**Files:**
+- Create: `crates/shep-cli/src/lookout/level.rs`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `pub enum Level { Trace, Debug, Info, Warn, Error }` with `Ord`; `pub fn level_of(line: &str) -> Option<Level>`.
+
+A pure function with no dependencies, so it lands on its own and is tested exhaustively before anything filters with it.
+
+- [ ] **Step 1: Write the failing tests**
+
+```rust
+#[test]
+fn a_leading_level_word_is_found_whatever_its_case() {
+    assert_eq!(level_of("WARN pool exhausted"), Some(Level::Warn));
+    assert_eq!(level_of("warn pool exhausted"), Some(Level::Warn));
+    assert_eq!(level_of("Error: connection refused"), Some(Level::Error));
+}
+
+/// A timestamp before the level is the common shape, so the search looks
+/// past a prefix rather than only at the first word.
+#[test]
+fn a_level_after_a_timestamp_is_still_found() {
+    assert_eq!(
+        level_of("2026-09-08T11:02:03Z INFO listening on 8080"),
+        Some(Level::Info)
+    );
+}
+
+/// The whole reason the filter shows unclassifiable lines: most app
+/// output looks like this.
+#[test]
+fn a_line_with_no_level_word_has_no_level() {
+    assert_eq!(level_of("listening on 8080"), None);
+    assert_eq!(level_of(""), None);
+}
+
+/// A word that merely contains a level name is not a level. Without
+/// this, "information" and "errors:" both read as levels.
+#[test]
+fn a_level_name_inside_a_longer_word_is_not_a_level() {
+    assert_eq!(level_of("information about the pool"), None);
+    assert_eq!(level_of("warnings are disabled"), None);
+}
+
+#[test]
+fn levels_order_from_trace_up_to_error() {
+    assert!(Level::Trace < Level::Debug);
+    assert!(Level::Debug < Level::Info);
+    assert!(Level::Info < Level::Warn);
+    assert!(Level::Warn < Level::Error);
+}
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `cargo test --workspace --all-features --lib --bins -- level_of levels_order`
+Expected: FAIL, module does not exist.
+
+- [ ] **Step 3: Implement**
+
+```rust
+/// A log level, ordered so a minimum can be compared against.
+///
+/// `Ord` is derived and the declaration order is the ordering: `Trace` is
+/// the lowest and `Error` the highest, so `level >= minimum` reads the way
+/// an operator setting `level >= warn` expects.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum Level {
+    Trace,
+    Debug,
+    Info,
+    Warn,
+    Error,
+}
+
+/// The level a line announces, or `None` when it announces none.
+///
+/// Scans the first few whitespace-separated words rather than only the
+/// first, because a timestamp before the level is the common shape. A
+/// candidate matches only as a whole word, after trailing punctuation is
+/// stripped, so `information` is not `info`.
+///
+/// `None` is the ordinary answer for app output. Callers must not treat it
+/// as "below the minimum": see the spec's decision 3.
+#[must_use]
+pub fn level_of(line: &str) -> Option<Level> {
+    line.split_whitespace().take(4).find_map(|word| {
+        match word.trim_matches(|c: char| !c.is_ascii_alphabetic()).to_ascii_lowercase().as_str() {
+            "trace" => Some(Level::Trace),
+            "debug" => Some(Level::Debug),
+            "info" => Some(Level::Info),
+            "warn" | "warning" => Some(Level::Warn),
+            "error" | "fatal" => Some(Level::Error),
+            _ => None,
+        }
+    })
+}
+```
+
+- [ ] **Step 4: Run to verify they pass**
+
+Run: `cargo test --workspace --all-features --lib --bins -- level_of levels_order`
+Expected: PASS, five tests.
+
+- [ ] **Step 5: Full gate and commit**
+
+```bash
+cargo fmt --all --check
+```
+```bash
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+```
+```bash
+cargo test --workspace --all-features
+```
+
+```bash
+git add crates/shep-cli/src/lookout/level.rs crates/shep-cli/src/lookout/mod.rs
+git commit -m "feat(lookout): read a log level out of an arbitrary line"
+```
+
+---
+
+## Task 3: The three filters, and what esc does
+
+**Files:**
+- Modify: `crates/shep-cli/src/lookout/pane_bleats.rs`
+- Modify: `crates/shep-cli/src/lookout/app.rs` (reducer)
+
+**Interfaces:**
+- Consumes: `Level` and `level_of` from Task 2; `TailLine` and `Stream` from `tail.rs`.
+- Produces: `Filters { stream, min_level, matcher }`; `BleatsPane::filters(&self) -> &Filters`; `BleatsPane::visible<'a>(&self, lines: &'a [TailLine]) -> Vec<&'a TailLine>`; `BleatsPane::drop_newest_chip(&mut self) -> bool`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```rust
+/// The decision most likely to be quietly reversed. An app printing bare
+/// text must not vanish because somebody asked for warnings.
+#[test]
+fn a_line_with_no_level_survives_a_minimum() {
+    let mut pane = BleatsPane::new(RowKey::Sheep(9));
+    pane.set_min_level(Some(Level::Warn));
+    let lines = vec![
+        line(Stream::Out, "listening on 8080"),
+        line(Stream::Out, "INFO routine chatter"),
+        line(Stream::Out, "ERROR pool exhausted"),
+    ];
+    let kept: Vec<&str> = pane.visible(&lines).iter().map(|l| l.text.as_str()).collect();
+    assert_eq!(kept, vec!["listening on 8080", "ERROR pool exhausted"]);
+}
+
+#[test]
+fn the_three_axes_compose_with_and() {
+    let mut pane = BleatsPane::new(RowKey::Sheep(9));
+    pane.set_stream(Some(Stream::Err));
+    pane.set_min_level(Some(Level::Warn));
+    pane.set_match("pool".to_string());
+    let lines = vec![
+        line(Stream::Err, "ERROR pool exhausted"),   // all three hold
+        line(Stream::Out, "ERROR pool exhausted"),   // wrong stream
+        line(Stream::Err, "INFO pool warming"),      // below the minimum
+        line(Stream::Err, "ERROR disk full"),        // no match
+    ];
+    assert_eq!(pane.visible(&lines).len(), 1);
+}
+
+/// esc removes the newest chip rather than clearing every filter, so
+/// backing out of a filter is one key at a time.
+#[test]
+fn esc_drops_the_newest_chip_then_reports_there_are_none_left() {
+    let mut pane = BleatsPane::new(RowKey::Sheep(9));
+    pane.set_stream(Some(Stream::Err));
+    pane.set_min_level(Some(Level::Warn));
+
+    assert!(pane.drop_newest_chip(), "the level chip was newest");
+    assert!(pane.filters().min_level.is_none());
+    assert!(pane.filters().stream.is_some(), "the older chip stays");
+
+    assert!(pane.drop_newest_chip(), "the stream chip goes next");
+    assert!(!pane.drop_newest_chip(), "nothing left to drop");
+}
+
+/// With no chips left, esc closes the pane instead of dropping one.
+#[test]
+fn esc_with_no_chips_closes_the_pane() {
+    let mut app =
+        fixtures::with_selection(ProcessInfo::builder(9, "web", ProcStatus::Online).build());
+    let _ = app.update(Msg::Key(KeyPress::Bleats));
+    let _ = app.update(Msg::Key(KeyPress::Escape));
+    assert!(matches!(app.body(), Body::FlockTable));
+}
+```
+
+Write the `line` helper beside the tests; it builds a `TailLine` from a stream and a `&str`.
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `cargo test --workspace --all-features --lib --bins -- survives_a_minimum compose_with_and drops_the_newest_chip no_chips_closes`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement the filter state**
+
+`Filters` holds `stream: Option<Stream>`, `min_level: Option<Level>` and `matcher: Option<String>`, plus the order the chips were added so `drop_newest_chip` knows which is newest. A small `Vec<Axis>` of the axes currently set, pushed on set and removed on drop, is enough; do not reach for anything cleverer.
+
+`visible` keeps a line when every set axis holds. The level axis holds when the line has no detectable level **or** its level meets the minimum, and that arm carries a comment saying why.
+
+- [ ] **Step 4: Wire esc in the reducer**
+
+While `Body::Bleats`, `KeyPress::Escape` calls `drop_newest_chip()` first and only calls `close_pane()` when that returns `false`.
+
+- [ ] **Step 5: Run to verify they pass**
+
+Run: `cargo test --workspace --all-features --lib --bins -- survives_a_minimum compose_with_and drops_the_newest_chip no_chips_closes`
+Expected: PASS.
+
+- [ ] **Step 6: Full gate and commit**
+
+```bash
+cargo fmt --all --check
+```
+```bash
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+```
+```bash
+cargo test --workspace --all-features
+```
+
+```bash
+git add crates/shep-cli/src/lookout/
+git commit -m "feat(lookout): filter the bleats pane by stream, level and match"
+```
+
+---
+
+## Task 4: The filter row
+
+**Files:**
+- Modify: `crates/shep-cli/src/lookout/view/bleats_full.rs`
+
+**Interfaces:**
+- Consumes: `Filters` and `visible` from Task 3.
+- Produces: nothing later tasks depend on.
+
+- [ ] **Step 1: Write the failing tests**
+
+```rust
+/// The row states the composition rule, because three chips with no
+/// stated relationship read as alternatives.
+#[test]
+fn the_filter_row_says_the_axes_compose_with_and() {
+    let app = fixtures::bleats_pane_with_filters();
+    let text = render_all(&draw_lines(&app, 160, 40));
+    assert!(text.contains("all three must hold"), "got {text}");
+}
+
+/// Scoped to the window, because nothing counted the whole file.
+#[test]
+fn the_survivor_count_is_scoped_to_the_window() {
+    let app = fixtures::bleats_pane_with_filters();
+    let text = render_all(&draw_lines(&app, 160, 40));
+    assert!(
+        text.contains("lines in the window"),
+        "the count must not claim a whole-file total: {text}"
+    );
+}
+```
+
+Add `bleats_pane_with_filters()` to `view/fixtures.rs` beside the existing helpers, building an app with the pane open and all three axes set.
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `cargo test --workspace --all-features --lib --bins -- filter_row_says survivor_count_is_scoped`
+Expected: FAIL.
+
+- [ ] **Step 3: Render the row**
+
+One row under the title: a chip per set axis on `Palette::ground()`, then the sentence naming how many survived, of how many were read, in the window. Only set axes get a chip.
+
+The frame's 8-cell line-number column is not rendered: the ruling dropped absolute numbers and a window-relative one would move as the window slides. Those 8 cells go to the line text.
+
+- [ ] **Step 4: Run to verify they pass**
+
+Run: `cargo test --workspace --all-features --lib --bins -- filter_row_says survivor_count_is_scoped`
+Expected: PASS.
+
+- [ ] **Step 5: Full gate and commit**
+
+```bash
+cargo fmt --all --check
+```
+```bash
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+```
+```bash
+cargo test --workspace --all-features
+```
+
+```bash
+git add crates/shep-cli/src/lookout/view/
+git commit -m "feat(lookout): state the filter composition and the window's survivor count"
+```
+
+---
+
+## Task 5: Poll faster while the pane is open
+
+**Files:**
+- Modify: `crates/shep-cli/src/lookout/app.rs`
+- Modify: `crates/shep-cli/src/lookout/mod.rs` if the effect needs wiring
+
+**Interfaces:**
+- Consumes: the pane from Task 1.
+- Produces: nothing later tasks depend on.
+
+**Read this before starting.** `link::FLOCK_POLL` is a `const` passed once into `run_link` (`link.rs:29`, `mod.rs:172`) and the ticker is built once per connection at `link.rs:165`. **There is no way to change the interval at runtime, and you must not add one.** What exists is an out-of-band channel: `channels.polls` at `link.rs:173`, which `Effect::PollNow` and the `r` key already use to ask for an immediate reconcile.
+
+Drive extra polls through that channel while the pane is open. The dashboard's own cadence is untouched.
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+/// The pane asks for its own refreshes rather than changing the link's
+/// interval, which is fixed for a connection's lifetime.
+#[test]
+fn a_tick_while_the_pane_is_open_asks_for_a_poll() {
+    let mut app =
+        fixtures::with_selection(ProcessInfo::builder(9, "web", ProcStatus::Online).build());
+    let _ = app.update(Msg::Key(KeyPress::Bleats));
+    assert_eq!(app.update(Msg::Tick(fixtures::later())), Effect::PollNow);
+}
+
+/// And does not on the dashboard, or every lookout would poll twice as
+/// often for nothing.
+#[test]
+fn a_tick_on_the_dashboard_asks_for_nothing() {
+    let mut app =
+        fixtures::with_selection(ProcessInfo::builder(9, "web", ProcStatus::Online).build());
+    assert_eq!(app.update(Msg::Tick(fixtures::later())), Effect::None);
+}
+```
+
+Read the existing `Msg::Tick` tests first: the clock fixture and the `Effect` variant names must match what is really there, and `Effect::PollNow` is the name to confirm rather than assume.
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `cargo test --workspace --all-features --lib --bins -- tick_while_the_pane tick_on_the_dashboard`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement**
+
+In the `Msg::Tick` arm, return the poll effect when `body` is `Body::Bleats` and the existing effect otherwise.
+
+- [ ] **Step 4: Run to verify they pass**
+
+Run: `cargo test --workspace --all-features --lib --bins -- tick_while_the_pane tick_on_the_dashboard`
+Expected: PASS.
+
+- [ ] **Step 5: Full gate and commit**
+
+```bash
+cargo fmt --all --check
+```
+```bash
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+```
+```bash
+cargo test --workspace --all-features
+```
+
+```bash
+git add crates/shep-cli/src/lookout/
+git commit -m "feat(lookout): refresh the bleats pane on its own ticks"
+```
+
+---
+
+## Task 6: The scene, the gallery and the docs
+
+**Files:**
+- Modify: `crates/shep-cli/src/lookout/frames.rs`
+- Create: a snapshot under `crates/shep-cli/src/lookout/snapshots/`
+- Modify: `docs/lookout/frames.txt`, `docs/lookout/frames.ansi` (generated)
+- Modify: `web/src/pages/docs/lookout.astro`, `docs/lookout/README.md`
+
+**Interfaces:**
+- Consumes: everything above.
+- Produces: nothing.
+
+**Adding a scene touches more places than it looks.** All of these, and the first four fail to compile if missed:
+
+- the variant inside the `scenes!` block, with a doc comment (`frames.rs:164-250`)
+- `label()` (`frames.rs:256`), exhaustive, no wildcard
+- `caption()` (`frames.rs:302`), exhaustive; a test asserts the caption is a real sentence over 30 characters
+- `scene_after()` (`frames.rs:2359`), test-only and exhaustive, and `scene_all_lists_every_variant_the_compiler_can_see` walks the chain and compares it to `Scene::ALL` in order
+- `scene_with()`'s construction matches (`frames.rs:568` and the others listed at 916, 989, 1025, 1077)
+- `control()` (`frames.rs:418`) and `size()` (`frames.rs:427`) both have wildcard arms, so they compile without a new arm. Add one anyway if the pane needs a non-default size.
+
+- [ ] **Step 1: Add the scene**
+
+Add the variant, its label, its caption, its `scene_after` arm and its construction. Build a scene showing the pane with all three filters set, since an unfiltered pane looks like the dashboard feed and pins nothing interesting.
+
+- [ ] **Step 2: Run the scene tests**
+
+Run: `cargo test --workspace --all-features --lib --bins -- scene_all_lists every_scene_shows_the_thing`
+Expected: PASS.
+
+- [ ] **Step 3: Accept the snapshot**
+
+Run: `cargo test --workspace --all-features -- frames_are_pinned`
+Read the generated `.snap` before accepting it. A snapshot accepted without being read pins whatever bug was rendered.
+
+- [ ] **Step 4: Regenerate the gallery**
+
+```bash
+cargo test --workspace --all-features -- write_the_gallery --ignored
+```
+
+`docs/lookout/frames.txt` and `docs/lookout/frames.ansi` are generated. Confirm the diff shows the new scene and nothing else moved.
+
+- [ ] **Step 5: Update the prose**
+
+`docs/lookout/README.md` and `web/src/pages/docs/lookout.astro` describe what lookout's screens are. Add the pane: the key that opens it, the three axes, that they compose with AND, that `esc` drops the newest chip before closing, and that a line with no level is always shown.
+
+**This is prose a person reads. Run the `humanizer` skill, then `rin-voice`, before committing.** No em dashes.
+
+- [ ] **Step 6: Build the site**
+
+```bash
+cd web && npx astro build
+```
+```bash
+cd web && npx astro check
+```
+
+`check` is the one that catches a wrong component prop; `build` passes with those.
+
+- [ ] **Step 7: Full gate and commit**
+
+```bash
+cargo fmt --all --check
+```
+```bash
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+```
+```bash
+cargo test --workspace --all-features
+```
+```bash
+RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features
+```
+
+Two commits, since the scene and the published docs are separate concerns:
+
+```bash
+git add crates/shep-cli/src/lookout/ docs/lookout/frames.txt docs/lookout/frames.ansi
+git commit -m "test(lookout): pin the bleats pane in the frame gallery"
+git add docs/lookout/README.md web/src/pages/docs/lookout.astro
+git commit -m "docs(lookout): describe the full-screen bleats pane"
+```
+
+---
+
+## Self-review
+
+**Spec coverage.** Pane shape and pinned sheep: Task 1. Source and the no-bus rule: Task 1, with the constraint stated globally. The three axes: Tasks 2 and 3. The unclassifiable-line rule: Task 2 defines it, Task 3 tests it. `esc` semantics: Task 3. Dropped line-number column: Task 4. Window-scoped survivor count: Task 4. Faster polling: Task 5. Scene, gallery and docs: Task 6.
+
+**One spec item deliberately has no task.** The spec's "no per-sheep log topics" is a decision not to build something, recorded so a later reader knows it was considered. Nothing to implement.
+
+**Ordering.** Task 2 is independent and could run first. Task 3 consumes it. Task 4 consumes Task 3. Tasks 5 and 6 consume Task 1. Task 6 last, so the scene pins the finished pane rather than being re-accepted after every task.
+
+**Names checked against the tree, not carried from the spec.** `Body` (`app.rs:1251`), `close_pane` (`:2668`), `config_pane` (`:4247`), `App::feed` (`:4145`), `tail::Tail`/`TailLine`/`Stream` (`tail.rs:34-61`), `tail::read` (`tail.rs:104`), `link::FLOCK_POLL` (`link.rs:29`), the `polls` channel (`link.rs:173`), `cell::*` (`cell.rs:24-101`), `Palette::band`/`ground` (`theme.rs:194`, `:208`), the width sweep (`view/mod.rs:957`).
+
+**Two names the implementer must confirm rather than trust.** `Effect::PollNow` in Task 5 and the key-event helper in Task 1's input test: both are named from a survey rather than read in place, and the plan says to check them.

--- a/docs/writing-plans/plans/2026-09-08-lookout-1i-bleats-pane.md
+++ b/docs/writing-plans/plans/2026-09-08-lookout-1i-bleats-pane.md
@@ -312,7 +312,13 @@ pub enum Level {
 #[must_use]
 pub fn level_of(line: &str) -> Option<Level> {
     line.split_whitespace().take(4).find_map(|word| {
-        match word.trim_matches(|c: char| !c.is_ascii_alphanumeric())  // see the correction note below.to_ascii_lowercase().as_str() {
+        // The predicate keeps digits: see the correction note above for why
+        // stripping them made `/error404` read as `Error`.
+        match word
+            .trim_matches(|c: char| !c.is_ascii_alphanumeric())
+            .to_ascii_lowercase()
+            .as_str()
+        {
             "trace" => Some(Level::Trace),
             "debug" => Some(Level::Debug),
             "info" => Some(Level::Info),

--- a/docs/writing-plans/plans/2026-09-08-lookout-1i-bleats-pane.md
+++ b/docs/writing-plans/plans/2026-09-08-lookout-1i-bleats-pane.md
@@ -523,15 +523,21 @@ git commit -m "feat(lookout): state the filter composition and the window's surv
 
 **Files:**
 - Modify: `crates/shep-cli/src/lookout/app.rs`
-- Modify: `crates/shep-cli/src/lookout/mod.rs` if the effect needs wiring
+- Nothing in `crates/shep-cli/src/lookout/mod.rs`. `Effect::RefreshFeed` is already handled there (`mod.rs:392`); the pre-flight scan confirmed it, so this task is `app.rs` only.
 
 **Interfaces:**
 - Consumes: the pane from Task 1.
 - Produces: nothing later tasks depend on.
 
-**Read this before starting.** `link::FLOCK_POLL` is a `const` passed once into `run_link` (`link.rs:29`, `mod.rs:172`) and the ticker is built once per connection at `link.rs:165`. **There is no way to change the interval at runtime, and you must not add one.** What exists is an out-of-band channel: `channels.polls` at `link.rs:173`, which `Effect::PollNow` and the `r` key already use to ask for an immediate reconcile.
+**Read this before starting.** `link::FLOCK_POLL` is a `const` passed once into `run_link` (`link.rs:29`, `mod.rs:172`) and the ticker is built once per connection at `link.rs:165`. **There is no way to change the interval at runtime, and you must not add one.** Nor is the answer the out-of-band `channels.polls` at `link.rs:173`: that is the reconcile route, and `Effect::PollNow` and `r` own it.
 
-Drive extra polls through that channel while the pane is open. The dashboard's own cadence is untouched.
+The feed has a separate route already. `Effect::RefreshFeed` sets `feed_dirty` at `mod.rs:392` and the read is coalesced onto `MIN_REDRAW`, for the reason the comment above it gives: a held `j` reaches the terminal as twenty to thirty events a second, and an uncoalesced synchronous 128 KiB read would sit behind every repeat on the task that also owns the redraw. Raising `RefreshFeed` more often is therefore cheap by construction. Nothing in `mod.rs` changes.
+
+**Corrected during the pre-flight scan.** This task first said to raise `Effect::PollNow`. That is the wrong effect: it asks the link task for a `ListFlock`, the whole flock listing, which a log viewer does not want and which would re-fetch every sheep every tick while the pane is open.
+
+`Effect::RefreshFeed` (`app.rs:273`) is the right one, and its own doc says why: "Re-read the selected sheep's log files and hand the result back as `Msg::Bleats`. The feed has no timer of its own; it rides this." The read is coalesced at `mod.rs:257`, so repeated effects do not stack up reads.
+
+Raise `RefreshFeed` on each tick while the pane is open. The dashboard's own cadence is untouched.
 
 - [ ] **Step 1: Write the failing test**
 
@@ -543,7 +549,7 @@ fn a_tick_while_the_pane_is_open_asks_for_a_poll() {
     let mut app =
         fixtures::with_selection(ProcessInfo::builder(9, "web", ProcStatus::Online).build());
     let _ = app.update(Msg::Key(KeyPress::Bleats));
-    assert_eq!(app.update(Msg::Tick(fixtures::later())), Effect::PollNow);
+    assert_eq!(app.update(Msg::Tick(now)), Effect::RefreshFeed);
 }
 
 /// And does not on the dashboard, or every lookout would poll twice as
@@ -552,11 +558,11 @@ fn a_tick_while_the_pane_is_open_asks_for_a_poll() {
 fn a_tick_on_the_dashboard_asks_for_nothing() {
     let mut app =
         fixtures::with_selection(ProcessInfo::builder(9, "web", ProcStatus::Online).build());
-    assert_eq!(app.update(Msg::Tick(fixtures::later())), Effect::None);
+    assert_eq!(app.update(Msg::Tick(now)), Effect::None);
 }
 ```
 
-Read the existing `Msg::Tick` tests first: the clock fixture and the `Effect` variant names must match what is really there, and `Effect::PollNow` is the name to confirm rather than assume.
+Read the existing `Msg::Tick` tests first and build `now` the way they do; `fixtures::later()` does not exist. `Effect::RefreshFeed` does, at `app.rs:273`.
 
 - [ ] **Step 2: Run to verify they fail**
 
@@ -687,4 +693,4 @@ git commit -m "docs(lookout): describe the full-screen bleats pane"
 
 **Names checked against the tree, not carried from the spec.** `Body` (`app.rs:1251`), `close_pane` (`:2668`), `config_pane` (`:4247`), `App::feed` (`:4145`), `tail::Tail`/`TailLine`/`Stream` (`tail.rs:34-61`), `tail::read` (`tail.rs:104`), `link::FLOCK_POLL` (`link.rs:29`), the `polls` channel (`link.rs:173`), `cell::*` (`cell.rs:24-101`), `Palette::band`/`ground` (`theme.rs:194`, `:208`), the width sweep (`view/mod.rs:957`).
 
-**Two names the implementer must confirm rather than trust.** `Effect::PollNow` in Task 5 and the key-event helper in Task 1's input test: both are named from a survey rather than read in place, and the plan says to check them.
+**Helpers this plan invents, marked so the implementer builds rather than hunts.** `fixtures::draw_lines` in Task 4 and the clock value in Task 5's tick tests. `fixtures::with_selection`, `app_with`, `plain`, `render_all` and `rendered` were all confirmed to exist. `Effect::RefreshFeed` and `Effect::PollNow` both exist; the pre-flight scan established that this pane wants the first.

--- a/web/src/pages/docs/logs.astro
+++ b/web/src/pages/docs/logs.astro
@@ -144,6 +144,11 @@ stderr  /tmp/shepdocs/home/logs/shepd.err.log  emptied`;
       behaviour.
     </p>
     <CodeBlock>{bleatsDemo}</CodeBlock>
+    <p class="fine">
+      <a href="/docs/lookout">lookout</a> reads the same files.{" "}
+      <code>b</code> opens one sheep's feed full screen, with a stream, a
+      minimum level and a text or regex filter stacked on top.
+    </p>
     <p>
       A sheep's own output always goes to stdout, both streams of it, because
       both are the data you asked for. Only shep's own diagnostics, the

--- a/web/src/pages/docs/lookout.astro
+++ b/web/src/pages/docs/lookout.astro
@@ -139,6 +139,13 @@ out  GET /v1/orders/8821 200 9ms
 out  connection pool: 14/50 in use
 q quit   j/k select   / filter   x stop   R restart   L reload   s settings   e edit   * yours   ! park… control enabled`;
 
+const bleatsFull = `shep lookout   /home/ada/.shep                                                        6 in the flock
+ ██ api  out /home/ada/.shep/logs/api-2-out.log  err /home/ada/.shep/logs/api-2-err.log
+ stream out   level ≥ warn   match /retry|jitter/ (regex)  1 of 16 lines in the window: all three m…
+out  WARN retrying upstream payment gateway after a timeout, backing off 500ms before trying again w
+     ith jitter added so the whole fleet does not retry at once
+esc back   j/k line   ctrl-d/u page   G end   / search   n/N match   f follow   w wrap … █ following`;
+
 const filterActive = `shep lookout   /home/ada/.shep                                                   2 of 6 in the flock
 host  load  ██░░░░░░░░ 2.31 4.10 3.88 / 10 cores     host mem  ████░░░░░░ 12.4G / 32.0G     0 error…
 ────────────────────────────────────────────────────────────────────────────────────────────────────
@@ -367,6 +374,35 @@ esc/s close   j/k select   g… control enabled`;
       counted the lines inside them:
     </p>
     <CodeBlock>{feedExcerpt}</CodeBlock>
+
+    <h2>The bleats pane, full screen</h2>
+    <p>
+      <code>b</code> opens the selected sheep's feed full screen and pins it
+      there. There's no table on screen anymore to change the selection
+      with, so the pane keeps describing that one sheep until it closes. It
+      reads the same log files the corner feed does, just polled faster
+      while it has focus.
+    </p>
+    <p>
+      Three filters stack on top of the feed, and a line has to pass all
+      three to show. <code>o</code> cycles the stream (out, err, or both),{" "}
+      <code>m</code> cycles a minimum level, and <code>/</code> opens a box
+      for a text or regex match, with matches highlighted. A line with no
+      detectable level always shows, whatever the minimum is: most app
+      output carries no level word at all, and hiding it would defeat the
+      reason the pane exists. The filter row names which axes are set and
+      counts how many lines in the current window survive them.
+    </p>
+    <CodeBlock label="100×14, filtered and wrapped">{bleatsFull}</CodeBlock>
+    <p>
+      <code>esc</code> drops the newest filter first, one at a time, and
+      only closes the pane once none are left. <code>j</code>/<code>k</code>{" "}
+      scroll a line, <code>ctrl-d</code>/<code>ctrl-u</code> a page,{" "}
+      <code>G</code> jumps to the end and starts following again,{" "}
+      <code>f</code> toggles following, <code>w</code> wraps long lines
+      instead of truncating them, and <code>n</code>/<code>N</code> step
+      between matches.
+    </p>
 
     <h2>Filtering the table</h2>
     <p>


### PR DESCRIPTION
`b` opens the bleats feed full screen on the selected sheep and pins it. Frame 1i of the lookout redesign.

- Three filter axes, composed with AND: `o` cycles the stream, `m` the minimum level, `/` opens a text or regex match
- A `/…/` matcher is a regex. An invalid one matches nothing and the chip says so
- `esc` drops the newest chip, and only closes the pane once none are left
- `j`/`k` scroll, `ctrl-d`/`ctrl-u` page, `G` jumps to the end and resumes following, `f` toggles it, `w` wraps, `n`/`N` step between matches
- Filter row states the survivor count against the window that was read, never a whole file

A line with no detectable level is always shown, whatever the minimum. Most app output carries no level, and hiding it is how a log viewer loses the thing it was opened to find.

No bus subscription. Topics are `log.out` and `log.err` and a subscription's globs match the topic, not the sheep, so it would take every sheep's output. The pane polls its own file instead.

Nothing whole-file: no line count, no absolute line numbers, no density gutter. All three need reading the file to say anything. The title does state the window it read and the bytes below it, which `tail.rs` knows exactly.

Adds `regex` to shep-cli as `regex.workspace = true`. No new crate in the tree.

Docs, gallery scene and snapshots regenerated. `astro build` and `astro check` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a full-screen Bleats pane, opened with `b` for the selected sheep.
  - View live output with stream, minimum-level, and text or regex filters.
  - Added scrolling, paging, follow mode, line wrapping, match highlighting, and next/previous match navigation.
  - Feed remains pinned to the sheep while the pane is open.

- **Documentation**
  - Added Bleats pane guidance, keybindings, and example screenshots to the Lookout documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->