### PR TITLE
fix(cli): resolve a home on Windows, which sets no HOME

### DIFF
--- a/crates/shep-cli/src/commands/dev.rs
+++ b/crates/shep-cli/src/commands/dev.rs
@@ -6,7 +6,7 @@
 use std::path::{Path, PathBuf};
 
 use shep_core::config::AppConfig;
-use shep_core::paths::ShepPaths;
+use shep_core::paths::{ShepPaths, user_home};
 
 use crate::cli::DevArgs;
 use crate::commands::foreground::{self, ForegroundOptions};
@@ -14,6 +14,19 @@ use crate::commands::lifecycle::{resolve_target, target_exit_code};
 use crate::commands::runtime::discovered_target;
 use crate::exit::ExitCode;
 use crate::output::Streams;
+
+/// What `shep dev` reports when nothing resolves a root for its own home.
+#[cfg(not(windows))]
+const UNRESOLVED_DEV_HOME: &str =
+    "neither $SHEP_DEV_HOME nor $HOME resolves a root directory for shep dev";
+
+/// What `shep dev` reports when nothing resolves a root for its own home.
+///
+/// Names `%USERPROFILE%` for the same reason the shared refusal in `lib.rs`
+/// does: Windows sets no `HOME`.
+#[cfg(windows)]
+const UNRESOLVED_DEV_HOME: &str =
+    "neither %SHEP_DEV_HOME% nor %USERPROFILE% resolves a root directory for shep dev";
 
 /// Where a dev flock lives: `$SHEP_DEV_HOME`, else `~/.shep-dev`.
 ///
@@ -109,7 +122,8 @@ pub async fn dev(
     );
 
     // `env` only recognizes `SHEP_DEV_HOME`, so a real flock's env can't leak
-    // in here. `$HOME` is read separately below, only for the fallback parent.
+    // in here. The home directory is read separately below, only for the
+    // fallback parent.
     let env = |key: &str| {
         if key == "SHEP_DEV_HOME" {
             std::env::var("SHEP_DEV_HOME").ok()
@@ -117,13 +131,13 @@ pub async fn dev(
             None
         }
     };
-    let home_dir = match (std::env::var_os("HOME"), env("SHEP_DEV_HOME")) {
-        (Some(dir), _) => PathBuf::from(dir),
+    let home_dir = match (
+        user_home(&|key| std::env::var_os(key)),
+        env("SHEP_DEV_HOME"),
+    ) {
+        (Some(dir), _) => dir,
         (None, Some(_)) => PathBuf::new(),
-        (None, None) => {
-            let message = "neither $SHEP_DEV_HOME nor $HOME resolves a root directory for shep dev";
-            return streams.fail(ExitCode::Usage, message);
-        }
+        (None, None) => return streams.fail(ExitCode::Usage, UNRESOLVED_DEV_HOME),
     };
     let paths = dev_home(&env, &home_dir);
 

--- a/crates/shep-cli/src/commands/dogs.rs
+++ b/crates/shep-cli/src/commands/dogs.rs
@@ -20,7 +20,7 @@ use std::time::{Duration, Instant};
 use shep_client::{Client, ConnectError};
 use shep_core::barks;
 use shep_core::dogs::{DogVersion, SCHEMA_FLAG, VERSION_FLAG, parse_version_answer};
-use shep_core::paths::ShepPaths;
+use shep_core::paths::{ShepPaths, user_home};
 use shep_core::protocol::{DogSource, MIN_SUPPORTED, Request, Response, SelectorSpec};
 
 use crate::cli::{AdoptArgs, BarksArgs};
@@ -1052,7 +1052,7 @@ pub fn warn_of_a_dog_a_restart_would_break(
 /// defaulted name goes through the same [`collides_with_a_verb`] refusal an
 /// explicit `--name` would.
 pub async fn adopt(streams: &mut Streams<'_>, paths: &ShepPaths, args: &AdoptArgs) -> ExitCode {
-    let home = std::env::var_os("HOME").map(PathBuf::from);
+    let home = user_home(&|key| std::env::var_os(key));
     let path_var = std::env::var_os("PATH");
     let candidate = resolve_adopt_path(&args.path, home.as_deref(), path_var.as_deref());
     // Before vetting: `vet_binary` spawns the candidate, and a refusal

--- a/crates/shep-cli/src/commands/import/pm2/mod.rs
+++ b/crates/shep-cli/src/commands/import/pm2/mod.rs
@@ -144,22 +144,29 @@ pub fn import(streams: &mut Streams<'_>, args: &ImportPm2Args) -> ExitCode {
     ))
 }
 
-/// `args.from`, or `$HOME/.pm2/dump.pm2` if it names nothing.
+/// `args.from`, or `~/.pm2/dump.pm2` if it names nothing.
+///
+/// Which variables name that `~` is [`shep_core::paths::user_home`]'s
+/// question, and differs by platform.
 ///
 /// # Errors
-/// A message naming both `--from` and `$HOME` when neither resolves a path.
-/// `--home`/`$SHEP_HOME` can resolve `ShepPaths` while `$HOME` is unset.
+/// A message naming both `--from` and the home variable when neither
+/// resolves a path. `--home`/`$SHEP_HOME` can resolve `ShepPaths` while no
+/// home directory resolves at all.
 fn resolve_source(args: &ImportPm2Args) -> Result<PathBuf, String> {
+    #[cfg(not(windows))]
+    const NO_DUMP: &str = "neither --from nor $HOME names a dump to read; pass --from, or set \
+                           $HOME so ~/.pm2/dump.pm2 resolves";
+    #[cfg(windows)]
+    const NO_DUMP: &str = "neither --from nor %USERPROFILE% names a dump to read; pass --from, \
+                           or set %USERPROFILE% so ~/.pm2/dump.pm2 resolves";
+
     if let Some(from) = &args.from {
         return Ok(from.clone());
     }
-    std::env::var_os("HOME")
-        .map(|home| PathBuf::from(home).join(".pm2").join("dump.pm2"))
-        .ok_or_else(|| {
-            "neither --from nor $HOME names a dump to read; pass --from, or set $HOME so \
-             ~/.pm2/dump.pm2 resolves"
-                .to_string()
-        })
+    shep_core::paths::user_home(&|key| std::env::var_os(key))
+        .map(|home| home.join(".pm2").join("dump.pm2"))
+        .ok_or_else(|| NO_DUMP.to_string())
 }
 
 /// [`ImportNote`]'s stderr rendering: a stable code for `--format json`'s

--- a/crates/shep-cli/src/lib.rs
+++ b/crates/shep-cli/src/lib.rs
@@ -66,7 +66,7 @@ use launch::launch_daemon;
 use output::Streams;
 use shep_client::Client;
 use shep_client::spawn::{SpawnOutcome, connect_or_spawn};
-use shep_core::paths::ShepPaths;
+use shep_core::paths::{ShepPaths, user_home};
 
 use crate::commands::init;
 
@@ -310,16 +310,19 @@ async fn print_shepherd_status(argv: &[OsString]) {
     let _ = writeln!(err, "{}", status::one_line(&status));
 }
 
-/// Turns `--home`/`$SHEP_HOME`/`$HOME` into a resolved [`ShepPaths`].
+/// Turns `--home`/`$SHEP_HOME`/the user's home directory into a resolved
+/// [`ShepPaths`].
 ///
 /// Bridges clap's already-folded `GlobalArgs::home` back into the closure
-/// shape `ShepPaths::resolve` reads the environment through.
+/// shape `ShepPaths::resolve` reads the environment through. Which variables
+/// name a home directory is [`user_home`]'s question, and differs by
+/// platform.
 ///
 /// # Errors
 ///
-/// [`ExitCode::Usage`] if neither `--home`/`$SHEP_HOME` nor `$HOME` names a
-/// root to resolve against. `$HOME` is read only as that fallback, so a
-/// `--home` invocation still works with no `$HOME` at all.
+/// [`ExitCode::Usage`] if neither `--home`/`$SHEP_HOME` nor a home directory
+/// resolves a root. The home directory is read only as that fallback, so a
+/// `--home` invocation still works with none at all.
 fn resolve_paths(global: &GlobalArgs) -> Result<ShepPaths, ExitCode> {
     let env = |key: &str| match key {
         "SHEP_HOME" => global
@@ -328,8 +331,8 @@ fn resolve_paths(global: &GlobalArgs) -> Result<ShepPaths, ExitCode> {
             .map(|p| p.to_string_lossy().into_owned()),
         other => std::env::var(other).ok(),
     };
-    let home_dir = match (std::env::var_os("HOME"), env("SHEP_HOME")) {
-        (Some(dir), _) => PathBuf::from(dir),
+    let home_dir = match (user_home(&|key| std::env::var_os(key)), env("SHEP_HOME")) {
+        (Some(dir), _) => dir,
         (None, Some(_)) => PathBuf::new(),
         (None, None) => return Err(ExitCode::Usage),
     };
@@ -420,7 +423,8 @@ fn must_render_bare(stdout_is_terminal: bool, fmt: cli::Format) -> bool {
 /// they are about, and an operator cannot act on a refusal that omits it.
 #[derive(Debug)]
 pub(crate) enum HomeRefusal {
-    /// None of `--home`, `$SHEP_HOME` or `$HOME` resolved a root directory.
+    /// None of `--home`, `$SHEP_HOME` or the user's home directory
+    /// resolved a root directory.
     Unresolved,
     /// `--home`/`$SHEP_HOME` named a directory that is not there. Never
     /// created: a named path is not a path shep may invent.
@@ -1053,7 +1057,17 @@ async fn run(
 }
 
 /// What both [`resolve_paths`] call sites report when nothing resolves a root.
+#[cfg(not(windows))]
 const UNRESOLVED_HOME: &str = "none of --home, $SHEP_HOME, or $HOME resolves a root directory";
+
+/// What both [`resolve_paths`] call sites report when nothing resolves a root.
+///
+/// Names `%USERPROFILE%`, not `$HOME`: a Windows session sets no `HOME`, so
+/// naming it sends an operator looking for a variable that was never going
+/// to be there.
+#[cfg(windows)]
+const UNRESOLVED_HOME: &str =
+    "none of --home, %SHEP_HOME%, or %USERPROFILE% resolves a root directory";
 
 /// Emits one error envelope to stderr under a lock taken for just that write.
 ///

--- a/crates/shep-cli/tests/cli_e2e.rs
+++ b/crates/shep-cli/tests/cli_e2e.rs
@@ -2418,6 +2418,43 @@ fn home_reaches_the_spawned_daemon() {
     graceful_kill(dir.path());
 }
 
+/// The default home resolves from whichever variable the platform actually
+/// sets: `$HOME` on unix, `%USERPROFILE%` on Windows, which sets no `HOME` at
+/// all. Both are cleared first, so an ambient value cannot be what passes it.
+///
+/// Spawned rather than unit-tested: the lookup reads this process's real
+/// environment, and a test cannot unset a variable for one thread of it.
+/// Asserted on the directory `ensure_home` creates, not on exit 0 alone, so a
+/// shepherd that came up under some other root still fails.
+#[test]
+fn the_default_home_resolves_from_the_platform_s_own_variable() {
+    let dir = tempfile::tempdir().unwrap();
+    let mut guard = DaemonGuard::default();
+
+    let mut cmd = Command::cargo_bin("shep").unwrap();
+    cmd.arg("start")
+        .env_remove("SHEP_HOME")
+        .env_remove("HOME")
+        .env_remove("USERPROFILE");
+    #[cfg(unix)]
+    cmd.env("HOME", dir.path());
+    #[cfg(windows)]
+    cmd.env("USERPROFILE", dir.path());
+    let output = cmd.timeout(CMD_TIMEOUT).output().unwrap();
+
+    let home = dir.path().join(".shep");
+    guard.adopt_home(&home);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(output.status.success(), "{stderr}");
+    assert!(
+        home.is_dir(),
+        "the shepherd came up under a root that is not {}",
+        home.display()
+    );
+
+    graceful_kill(&home);
+}
+
 // --- Case 9 --------------------------------------------------------------
 
 #[cfg(unix)]

--- a/crates/shep-core/src/paths.rs
+++ b/crates/shep-core/src/paths.rs
@@ -3,6 +3,7 @@
 //! One resolver, no hidden `std::env` reads: the environment comes in as a
 //! closure so tests and the daemon share one code path.
 
+use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 
 /// Drops the `\\?\` extended-length prefix Windows' `canonicalize` adds
@@ -40,6 +41,42 @@ pub fn strip_verbatim_prefix(path: &Path) -> std::borrow::Cow<'_, Path> {
 #[must_use]
 pub fn strip_verbatim_prefix(path: &Path) -> std::borrow::Cow<'_, Path> {
     std::borrow::Cow::Borrowed(path)
+}
+
+/// The user's home directory, read through `var` rather than the process
+/// environment
+///
+/// The base [`ShepPaths::resolve`] joins `.shep` onto when nothing names a
+/// `$SHEP_HOME`. A variable set to the empty string counts as unset.
+///
+/// # Platform
+///
+/// Unix reads `HOME` alone. Windows reads `HOME`, then `USERPROFILE`, then
+/// `HOMEDRIVE` and `HOMEPATH` concatenated. Windows sets none of the first:
+/// PowerShell's `$HOME` is a shell variable no child process inherits, and
+/// `cmd.exe` has no such variable at all, so a `HOME`-only lookup resolves
+/// nothing on a stock Windows session.
+#[must_use]
+pub fn user_home(var: &dyn Fn(&str) -> Option<OsString>) -> Option<PathBuf> {
+    let named = |key: &str| var(key).filter(|value| !value.is_empty());
+    #[cfg(not(windows))]
+    {
+        named("HOME").map(PathBuf::from)
+    }
+    #[cfg(windows)]
+    {
+        // `HOMEDRIVE` is `C:` and `HOMEPATH` is `\Users\name`: two halves of
+        // one string, not a directory and a child inside it.
+        let split = || {
+            let mut joined = named("HOMEDRIVE")?;
+            joined.push(named("HOMEPATH")?);
+            Some(joined)
+        };
+        named("HOME")
+            .or_else(|| named("USERPROFILE"))
+            .or_else(split)
+            .map(PathBuf::from)
+    }
 }
 
 /// Resolved filesystem layout for one shep home
@@ -329,6 +366,76 @@ mod tests {
             n.pipe_name(),
             d.pipe_name(),
             "only the digest keeps two homes that sanitize alike off one pipe"
+        );
+    }
+
+    /// A fake environment, so nothing here touches the process's own.
+    fn os_env(pairs: &[(&str, &str)]) -> impl Fn(&str) -> Option<OsString> + use<> {
+        let owned: Vec<(String, OsString)> = pairs
+            .iter()
+            .map(|(k, v)| ((*k).to_string(), OsString::from(*v)))
+            .collect();
+        move |key: &str| owned.iter().find(|(k, _)| k == key).map(|(_, v)| v.clone())
+    }
+
+    #[test]
+    fn home_is_read_first_on_every_platform() {
+        assert_eq!(
+            user_home(&os_env(&[
+                ("HOME", "/home/ada"),
+                ("USERPROFILE", r"C:\Users\Ada")
+            ])),
+            Some(PathBuf::from("/home/ada"))
+        );
+    }
+
+    #[test]
+    fn nothing_named_resolves_nothing() {
+        assert_eq!(user_home(&os_env(&[])), None);
+    }
+
+    /// An exported-but-empty `HOME` would otherwise resolve `.shep` relative
+    /// to the working directory, which is a different flock per `cd`.
+    #[test]
+    fn an_empty_value_counts_as_unset() {
+        assert_eq!(user_home(&os_env(&[("HOME", "")])), None);
+    }
+
+    /// The bug this fallback exists for: a stock Windows session exports
+    /// `USERPROFILE` and no `HOME` at all, so `shep` refused every command
+    /// with "none of --home, %SHEP_HOME%, or %USERPROFILE% resolves a root
+    /// directory" until 0.7.1.
+    #[cfg(windows)]
+    #[test]
+    fn windows_falls_back_to_userprofile_then_to_the_homedrive_pair() {
+        assert_eq!(
+            user_home(&os_env(&[("USERPROFILE", r"C:\Users\Ada")])),
+            Some(PathBuf::from(r"C:\Users\Ada"))
+        );
+        assert_eq!(
+            user_home(&os_env(&[("HOMEDRIVE", "C:"), ("HOMEPATH", r"\Users\Ada")])),
+            Some(PathBuf::from(r"C:\Users\Ada")),
+            "the two halves concatenate into one path, they do not nest"
+        );
+        assert_eq!(
+            user_home(&os_env(&[("HOMEDRIVE", "C:")])),
+            None,
+            "half the pair names no directory"
+        );
+    }
+
+    /// Unix reads `HOME` alone: a Windows-only fallback firing there would
+    /// resolve a home on a host that deliberately unset one.
+    #[cfg(not(windows))]
+    #[test]
+    fn unix_ignores_the_windows_variables() {
+        assert_eq!(
+            user_home(&os_env(&[
+                ("USERPROFILE", r"C:\Users\Ada"),
+                ("HOMEDRIVE", "C:"),
+                ("HOMEPATH", r"\Users\Ada"),
+            ])),
+            None
         );
     }
 }

--- a/web/src/pages/docs/cli.astro
+++ b/web/src/pages/docs/cli.astro
@@ -133,9 +133,13 @@ if (coveredCount !== cliReference.verbs.length) {
       "Every verb, at a glance" for exactly how they render on each one.
     </Callout>
 
-    <Callout variant="careful">
-      Windows isn't supported yet. Every verb here prints an error naming that
-      and exits 1 on that platform. There's no partial subset that works.
+    <Callout variant="note">
+      Windows runs every verb on this page, with two exceptions.{" "}
+      <code>shep startup</code> is not built there, and <code>shep stop</code>{" "}
+      has no graceful signal to send unless your app reads the shepherd
+      channel. Windows sets no <code>HOME</code>, so the default flock home
+      comes from <code>%USERPROFILE%</code>, then{" "}
+      <code>%HOMEDRIVE%%HOMEPATH%</code>.
     </Callout>
 
     <h2>Aliases at a glance</h2>

--- a/web/src/pages/docs/getting-started.astro
+++ b/web/src/pages/docs/getting-started.astro
@@ -31,7 +31,9 @@ import CodeBlock from "../../components/docs/CodeBlock.astro";
       Windows all work; the Windows tier is newer, and two limits are worth
       knowing before you rely on it — <code>shep stop</code> has no graceful
       signal to send unless your app reads the shepherd channel, and{" "}
-      <code>shep startup</code> is not built there.
+      <code>shep startup</code> is not built there. Your flock lives in{" "}
+      <code>%USERPROFILE%\.shep</code> on Windows, since it sets no{" "}
+      <code>HOME</code>.
     </Callout>
 
     <h2>1. Install it</h2>


### PR DESCRIPTION
Every verb refused on a stock Windows session, because `resolve_paths` read `HOME` and Windows sets no `HOME`. PowerShell's `$HOME` is a shell variable no child process inherits, and `cmd.exe` has none at all.

```
PS C:\Users\Derick> shep flock
error[usage]: none of --home, $SHEP_HOME, or $HOME resolves a root directory
```

- new `shep_core::paths::user_home`: `HOME` on unix, and `HOME`, then `USERPROFILE`, then `HOMEDRIVE` + `HOMEPATH` on Windows. An empty value counts as unset
- `HOME` stays first on Windows deliberately, so Git Bash and every end-to-end fixture keep working with no second spelling to learn
- all four `HOME` reads go through it: `resolve_paths`, `shep dev`, `shep adopt`'s leading `~`, and `shep import pm2`'s `~/.pm2/dump.pm2` default
- the three refusals are spelled per platform. Windows names `%SHEP_HOME%` and `%USERPROFILE%`, since a message naming `$HOME` sends an operator after a variable that was never going to be there
- the CLI reference page still said Windows was unsupported and every verb exits 1, untrue since the Windows tier landed on 2026-08-26. Both docs pages now name where the default home comes from

Nothing caught this: the Windows tier is checked with `cargo check`, and the end-to-end suite sets `HOME` explicitly, which is exactly the case that already worked. The new case clears `HOME` and `USERPROFILE` both, sets whichever the platform uses, and asserts on the directory `ensure_home` creates rather than on exit 0.

Verified by hand on Windows 10 in PowerShell with no `HOME` set: `shep start` brings a shepherd up in `C:\Users\<user>\.shep`, and a sheep restarts under supervision.

`cargo test --workspace --all-features`: 2721 passed, 0 failed. `cargo fmt`, clippy and the rustdoc gate clean. `astro check` 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
