### PR TITLE
feat(lookout): read a level out of a logfmt key=value pair

### DIFF
--- a/crates/shep-cli/src/lookout/level.rs
+++ b/crates/shep-cli/src/lookout/level.rs
@@ -23,27 +23,27 @@ pub enum Level {
     Error,
 }
 
+/// The keys a `key=value` pair may announce a level under.
+///
+/// A closed set. `level` is Go's `log/slog` text handler and most logfmt
+/// writers, `lvl` is log15 and its descendants, `severity` the syslog
+/// spelling.
+const LEVEL_KEYS: [&str; 3] = ["level", "lvl", "severity"];
+
 /// The level a line announces, or `None` when it announces none.
 ///
-/// Scans the first 4 whitespace-separated words rather than only the
-/// first, because a timestamp before the level is the common shape. A
-/// level past the fourth word is not found; that is deliberate, not a
-/// bug, and a line whose level falls outside the window simply falls
-/// back to `None`, which is always safe under decision 3.
-///
-/// A candidate matches only as a whole word, after surrounding
-/// punctuation is stripped, so `information` is not `info`. Digits
-/// adjacent to the word are NOT stripped, only punctuation is: a digit
-/// touching the word means it was never a level token in the first
-/// place (`/error404`, `info2`), and trimming through it would invent a
-/// level the line never announced, which decision 3 forbids.
+/// Scans the first 4 whitespace-separated words, since a timestamp before
+/// the level is the common shape. A word counts as a bare level, or as a
+/// `key=value` pair keyed by `LEVEL_KEYS`. Either way the level must be a
+/// whole word once surrounding punctuation is stripped. A touching digit
+/// blocks it, so `/error404` and `info2` announce nothing.
 ///
 /// `None` is the ordinary answer for app output. Callers must not treat it
 /// as "below the minimum": see the spec's decision 3.
 #[must_use]
 pub fn level_of(line: &str) -> Option<Level> {
     line.split_whitespace().take(4).find_map(|word| {
-        match word
+        match level_word(word)
             .trim_matches(|c: char| !c.is_ascii_alphabetic() && !c.is_ascii_digit())
             .to_ascii_lowercase()
             .as_str()
@@ -56,6 +56,18 @@ pub fn level_of(line: &str) -> Option<Level> {
             _ => None,
         }
     })
+}
+
+/// The part of `word` that may name a level: a pair's value when its key
+/// is in `LEVEL_KEYS`, the whole word otherwise.
+///
+/// The key is matched whole, with no punctuation trimmed, so an access
+/// log's `GET /search?level=error` is not read as a pair.
+fn level_word(word: &str) -> &str {
+    match word.split_once('=') {
+        Some((key, value)) if LEVEL_KEYS.iter().any(|k| k.eq_ignore_ascii_case(key)) => value,
+        _ => word,
+    }
 }
 
 #[cfg(test)]
@@ -108,6 +120,14 @@ mod tests {
         assert_eq!(level_of("a fatal crash occurred"), Some(Level::Error));
     }
 
+    /// The two arms nothing else reaches. Delete either and every other
+    /// test in this file still passes.
+    #[test]
+    fn the_lowest_two_levels_are_recognised() {
+        assert_eq!(level_of("TRACE entering the pool"), Some(Level::Trace));
+        assert_eq!(level_of("debug pool has 4 idle"), Some(Level::Debug));
+    }
+
     /// A digit touching the word means it was never a level token: an
     /// HTTP status glued onto a route, or a word that merely ends in a
     /// digit. Stripping through the digit would invent a level the line
@@ -133,6 +153,62 @@ mod tests {
     fn the_scan_window_is_exactly_four_words() {
         assert_eq!(level_of("a b c warn"), Some(Level::Warn));
         assert_eq!(level_of("a b c d warn"), None);
+    }
+
+    /// The shape this reads for: `log/slog`'s text handler, and the many
+    /// Go and Rust services writing the same pairs.
+    #[test]
+    fn a_logfmt_line_announces_its_level() {
+        assert_eq!(
+            level_of(r#"time=2026-09-08T11:02:03.000Z level=ERROR msg="connection refused""#),
+            Some(Level::Error)
+        );
+        assert_eq!(
+            level_of("ts=2026-09-08T11:02:03Z caller=main.go:42 level=info msg=listening"),
+            Some(Level::Info)
+        );
+    }
+
+    /// Each accepted key, since each is the only thing pinning itself.
+    #[test]
+    fn every_accepted_key_is_read() {
+        assert_eq!(level_of("level=warn pool exhausted"), Some(Level::Warn));
+        assert_eq!(level_of("lvl=warn pool exhausted"), Some(Level::Warn));
+        assert_eq!(level_of("severity=warn pool exhausted"), Some(Level::Warn));
+    }
+
+    #[test]
+    fn a_key_matches_whatever_its_case() {
+        assert_eq!(
+            level_of("LEVEL=Error connection refused"),
+            Some(Level::Error)
+        );
+        assert_eq!(level_of("Lvl=FATAL connection refused"), Some(Level::Error));
+    }
+
+    /// A pair's value goes through the same rules as a bare word: quotes
+    /// strip, a touching digit blocks, an empty value announces nothing.
+    #[test]
+    fn a_pair_value_follows_the_bare_word_rules() {
+        assert_eq!(level_of(r#"level="error" msg=x"#), Some(Level::Error));
+        assert_eq!(level_of("level=error404 msg=x"), None);
+        assert_eq!(level_of("level= msg=x"), None);
+    }
+
+    /// The key set is closed rather than "anything before an `=`". Each of
+    /// these announces a level to a reader and none to the filter.
+    #[test]
+    fn a_key_outside_the_set_announces_nothing() {
+        assert_eq!(level_of("l=error connection refused"), None);
+        assert_eq!(level_of("loglevel=error connection refused"), None);
+        assert_eq!(level_of("status=error connection refused"), None);
+    }
+
+    /// The key is matched whole, which is what stops an access log's query
+    /// string from reading as a pair.
+    #[test]
+    fn a_query_string_is_not_a_level_pair() {
+        assert_eq!(level_of("GET /search?level=error 200"), None);
     }
 
     #[test]

--- a/web/src/pages/docs/lookout.astro
+++ b/web/src/pages/docs/lookout.astro
@@ -459,7 +459,9 @@ esc/s close   j/k select   g… control enabled`;
       Three filters stack on top of the feed, and a line has to pass all
       three to show. <code>o</code> cycles the stream (out, err, or both),{" "}
       <code>m</code> cycles a minimum level, and <code>/</code> opens a box
-      for a text or regex match, with matches highlighted. A line with no
+      for a text or regex match, with matches highlighted. A level is a
+      bare word like <code>WARN</code>, or a <code>level=warn</code> pair,
+      so the filter works on logfmt output too. A line with no
       detectable level always shows, whatever the minimum is: most app
       output carries no level word at all, and hiding it would defeat the
       reason the pane exists. The filter row names which axes are set and


### PR DESCRIPTION
`shep lookout`'s bleats level filter could not read logfmt, so `m` did nothing for a service writing `level=error`. That was safe rather than broken, since decision 3 always shows an unclassifiable line, but the filter was dead for anything on Go's `log/slog` text handler, logrus's text formatter, or log15. Found reviewing #191 and kept out of that fix round, since a grammar change wants its own test surface.

- A word counts as a level bare, as before, or as a `key=value` pair's value
- Accepted keys: `level`, `lvl`, `severity`. Closed set, matched case insensitively
- `l=` is not accepted: no producer was found writing it, and a single letter is where a closed set stops paying for itself
- The key is matched whole with no punctuation trimmed, so an access log's `GET /search?level=error 200` still reads as nothing
- A pair's value follows the bare word rules: quotes strip, a touching digit blocks, an empty value announces nothing
- `trace` and `debug` were accepted and never tested. Both have pins now
- `web/src/pages/docs/lookout.astro` now says what counts as a level

Known gap: the value vocabulary did not change, so syslog's own spellings still announce nothing and `severity=err` reads as no level. Separate call if it is wanted.

Gate green: fmt, clippy, `cargo test --workspace --all-features`, rustdoc, plus `astro check` and `astro build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
