### PR TITLE
feat(core): fold the durable-write sequence into shep-core

### DIFF
--- a/crates/shep-cli/src/commands/dog_migration.rs
+++ b/crates/shep-cli/src/commands/dog_migration.rs
@@ -289,15 +289,7 @@ fn write_dogs_config(path: &Path, rendered: &str) -> std::io::Result<()> {
     let parent = path.parent().unwrap_or_else(|| Path::new("."));
     let mut tmp = create_config_file(parent)?;
     tmp.write_all(rendered.as_bytes())?;
-    tmp.as_file().sync_all()?;
-    // `persist` is `rename(2)`. On failure the `NamedTempFile` comes back in
-    // the error and its `Drop` removes the staging file.
-    tmp.persist(path).map_err(|err| err.error)?;
-
-    // The `sync_all` above made the contents durable; this makes the rename
-    // that published them durable.
-    shep_core::atomic_file::sync_dir(parent)?;
-    Ok(())
+    shep_core::atomic_file::publish(tmp, path)
 }
 
 /// Why `[dog.<name>]` could not be moved into `dogs.toml`

--- a/crates/shep-cli/src/commands/shep_toml.rs
+++ b/crates/shep-cli/src/commands/shep_toml.rs
@@ -587,18 +587,7 @@ impl ShepToml {
         let mut tmp = create_config_file(parent).map_err(|source| self.io_error(source))?;
         tmp.write_all(self.doc.to_string().as_bytes())
             .map_err(|source| self.io_error(source))?;
-        tmp.as_file()
-            .sync_all()
-            .map_err(|source| self.io_error(source))?;
-        // `persist` is `rename(2)`. On failure the `NamedTempFile` comes back
-        // inside the error and its `Drop` removes the staging file.
-        tmp.persist(&self.path)
-            .map_err(|err| self.io_error(err.error))?;
-
-        // `sync_all` above made the contents durable; this makes the rename
-        // that published them durable.
-        shep_core::atomic_file::sync_dir(parent).map_err(|source| self.io_error(source))?;
-        Ok(())
+        shep_core::atomic_file::publish(tmp, &self.path).map_err(|source| self.io_error(source))
     }
 
     fn io_error(&self, source: std::io::Error) -> ShepTomlError {

--- a/crates/shep-core/src/atomic_file.rs
+++ b/crates/shep-core/src/atomic_file.rs
@@ -100,8 +100,7 @@ pub fn sync_dir(dir: &Path) -> std::io::Result<()> {
 /// Installs `tmp` at `path`, replacing whatever was there.
 ///
 /// Returns only once both the contents and the rename that published them
-/// have reached disk. The directory flushed is `path`'s own, or the current
-/// one when `path` names no parent.
+/// have reached disk.
 ///
 /// # Errors
 /// - [`std::io::Error`] if the `fsync`, the rename, or the directory flush
@@ -113,9 +112,6 @@ pub fn publish(tmp: tempfile::NamedTempFile, path: &Path) -> std::io::Result<()>
     // inside the error and its `Drop` removes the staging file, so a failed
     // replace does not leave one behind.
     tmp.persist(path).map_err(|err| err.error)?;
-
-    // `sync_all` above made the contents durable; this makes the rename
-    // that published them durable.
     sync_dir(path.parent().unwrap_or_else(|| Path::new(".")))
 }
 
@@ -192,24 +188,6 @@ mod tests {
                 "{prefix:?} {suffix:?}: {err:?}"
             );
         }
-    }
-
-    /// fails if `publish` leaves the staging file behind, or installs
-    /// anything but the bytes written to it.
-    #[test]
-    fn publish_installs_the_staged_bytes_and_leaves_no_staging_file() {
-        use std::io::Write as _;
-
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("store.json");
-        std::fs::write(&path, "old").unwrap();
-
-        let mut tmp = create_staging_file(dir.path(), "kv", ".tmp").unwrap();
-        tmp.write_all(b"new").unwrap();
-        publish(tmp, &path).unwrap();
-
-        assert_eq!(std::fs::read_to_string(&path).unwrap(), "new");
-        assert_eq!(entry_names(dir.path()), vec!["store.json"]);
     }
 
     /// fails if a refused rename leaves a staging file in `$SHEP_HOME`, the

--- a/crates/shep-core/src/atomic_file.rs
+++ b/crates/shep-core/src/atomic_file.rs
@@ -1,14 +1,15 @@
-//! The atomic file replace: its first step and its last.
+//! The atomic file replace.
 //!
 //! Stage a fresh file beside the real one, write it, `fsync` it, `rename`
 //! it over the target, then `fsync` the directory the rename landed in. A
 //! reader sees the whole old file or the whole new one, never a fragment.
-//! [`create_staging_file`] is the first step, [`sync_dir`] the last; the
-//! middle stays with each store.
+//! [`write_json`] is all of it for a store holding one serializable value;
+//! a store that writes its own bytes stages with [`create_staging_file`]
+//! and finishes with [`publish`].
 //!
-//! [`sync_dir`] makes the rename durable, which the temp file's own
-//! `fsync` does not, on unix only, and only where the filesystem
-//! implements the flush.
+//! [`sync_dir`], which [`publish`] calls last, makes the rename durable,
+//! where the temp file's own `fsync` does not, on unix only, and only
+//! where the filesystem implements the flush.
 
 use std::path::Path;
 
@@ -96,6 +97,55 @@ pub fn sync_dir(dir: &Path) -> std::io::Result<()> {
     }
 }
 
+/// Installs `tmp` at `path`, replacing whatever was there.
+///
+/// Returns only once both the contents and the rename that published them
+/// have reached disk. The directory flushed is `path`'s own, or the current
+/// one when `path` names no parent.
+///
+/// # Errors
+/// - [`std::io::Error`] if the `fsync`, the rename, or the directory flush
+///   failed. `path` keeps its old contents unless the rename succeeded.
+pub fn publish(tmp: tempfile::NamedTempFile, path: &Path) -> std::io::Result<()> {
+    tmp.as_file().sync_all()?;
+
+    // `persist` is `rename(2)`. On failure the `NamedTempFile` comes back
+    // inside the error and its `Drop` removes the staging file, so a failed
+    // replace does not leave one behind.
+    tmp.persist(path).map_err(|err| err.error)?;
+
+    // `sync_all` above made the contents durable; this makes the rename
+    // that published them durable.
+    sync_dir(path.parent().unwrap_or_else(|| Path::new(".")))
+}
+
+/// Replaces `path` with `value` as pretty-printed JSON and one trailing
+/// newline, atomically and durably.
+///
+/// The staging file lands beside `path` under `prefix`; see
+/// [`create_staging_file`] for what a prefix may hold. `path` is left as it
+/// was unless the whole value serialized and reached disk.
+///
+/// # Errors
+/// - [`std::io::ErrorKind::InvalidInput`] if `prefix` holds `/` or `\`.
+/// - [`std::io::Error`] carrying a `serde_json::Error` if `value` would not
+///   serialize, or reporting a failed stage, write, `fsync` or rename.
+pub fn write_json<T>(path: &Path, prefix: &str, value: &T) -> std::io::Result<()>
+where
+    T: serde::Serialize + ?Sized,
+{
+    use std::io::Write as _;
+
+    let parent = path.parent().unwrap_or_else(|| Path::new("."));
+    let mut tmp = create_staging_file(parent, prefix, ".tmp")?;
+
+    let json = serde_json::to_string_pretty(value).map_err(std::io::Error::other)?;
+    tmp.write_all(json.as_bytes())?;
+    tmp.write_all(b"\n")?;
+
+    publish(tmp, path)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -142,6 +192,77 @@ mod tests {
                 "{prefix:?} {suffix:?}: {err:?}"
             );
         }
+    }
+
+    /// fails if `publish` leaves the staging file behind, or installs
+    /// anything but the bytes written to it.
+    #[test]
+    fn publish_installs_the_staged_bytes_and_leaves_no_staging_file() {
+        use std::io::Write as _;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("store.json");
+        std::fs::write(&path, "old").unwrap();
+
+        let mut tmp = create_staging_file(dir.path(), "kv", ".tmp").unwrap();
+        tmp.write_all(b"new").unwrap();
+        publish(tmp, &path).unwrap();
+
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), "new");
+        assert_eq!(entry_names(dir.path()), vec!["store.json"]);
+    }
+
+    /// fails if a refused rename leaves a staging file in `$SHEP_HOME`, the
+    /// claim `publish`'s own comment makes about `persist`.
+    #[test]
+    fn a_refused_rename_takes_the_staging_file_with_it() {
+        let dir = tempfile::tempdir().unwrap();
+        let occupied = dir.path().join("a-directory");
+        std::fs::create_dir(&occupied).unwrap();
+
+        let tmp = create_staging_file(dir.path(), "kv", ".tmp").unwrap();
+        publish(tmp, &occupied).expect_err("a rename over a directory must fail");
+
+        assert!(occupied.is_dir(), "the target was replaced anyway");
+        assert_eq!(entry_names(dir.path()), vec!["a-directory"]);
+    }
+
+    /// fails if the trailing newline or the pretty printing is dropped: four
+    /// stores' on-disk bytes are this exact shape.
+    #[test]
+    fn write_json_writes_pretty_json_under_one_trailing_newline() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("store.json");
+        let value = std::collections::BTreeMap::from([("one", 1), ("two", 2)]);
+
+        write_json(&path, "kv", &value).unwrap();
+
+        assert_eq!(
+            std::fs::read_to_string(&path).unwrap(),
+            "{\n  \"one\": 1,\n  \"two\": 2\n}\n"
+        );
+        assert_eq!(entry_names(dir.path()), vec!["store.json"]);
+    }
+
+    /// fails if `write_json` stops routing its prefix through
+    /// `create_staging_file`, where the separator check lives.
+    #[test]
+    fn write_json_refuses_a_prefix_holding_a_separator() {
+        let dir = tempfile::tempdir().unwrap();
+        let err = write_json(&dir.path().join("store.json"), "../escape", &1)
+            .expect_err("a separator must not reach tempfile");
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput, "{err:?}");
+    }
+
+    /// Every entry in `dir`, sorted, so a leftover staging file shows up as a
+    /// mismatch naming itself.
+    fn entry_names(dir: &Path) -> Vec<String> {
+        let mut names: Vec<String> = std::fs::read_dir(dir)
+            .unwrap()
+            .map(|entry| entry.unwrap().file_name().to_string_lossy().into_owned())
+            .collect();
+        names.sort();
+        names
     }
 
     #[test]

--- a/crates/shep-core/src/barks.rs
+++ b/crates/shep-core/src/barks.rs
@@ -201,17 +201,7 @@ fn write_ring(path: &Path, lines: &[String]) -> Result<(), BarkError> {
         tmp.write_all(line.as_bytes())?;
         tmp.write_all(b"\n")?;
     }
-    tmp.as_file().sync_all()?;
-
-    // `persist` is `rename(2)`. On failure the `NamedTempFile` comes back
-    // inside the error and its `Drop` removes the staging file, so a
-    // failed replace does not leave one behind.
-    tmp.persist(path).map_err(|err| BarkError::Io(err.error))?;
-
-    // `sync_all` made the contents durable; this makes the rename that
-    // published them durable.
-    crate::atomic_file::sync_dir(parent)?;
-    Ok(())
+    crate::atomic_file::publish(tmp, path).map_err(BarkError::Io)
 }
 
 #[cfg(test)]

--- a/crates/shep-core/src/kv.rs
+++ b/crates/shep-core/src/kv.rs
@@ -14,7 +14,6 @@
 // `atomic_file` rather than open-coding another copy here.
 use core::fmt;
 use std::collections::BTreeMap;
-use std::io::Write as _;
 use std::path::Path;
 
 use serde::{Deserialize, Serialize};
@@ -160,26 +159,9 @@ fn read_file(path: &Path) -> Result<KvFile, KvError> {
     Ok(file)
 }
 
-/// Rewrites `path` to hold exactly `file`, atomically: staged through a
-/// temp file, then renamed over the original.
+/// Rewrites `path` to hold exactly `file`.
 fn write_file(path: &Path, file: &KvFile) -> Result<(), KvError> {
-    let parent = path.parent().unwrap_or_else(|| Path::new("."));
-    let mut tmp = crate::atomic_file::create_staging_file(parent, "kv", ".tmp")?;
-
-    let json = serde_json::to_string_pretty(file)?;
-    tmp.write_all(json.as_bytes())?;
-    tmp.write_all(b"\n")?;
-    tmp.as_file().sync_all()?;
-
-    // `persist` is `rename(2)`. On failure the `NamedTempFile` comes back
-    // inside the error and its `Drop` removes the staging file, so a failed
-    // replace does not leave one behind.
-    tmp.persist(path).map_err(|err| KvError::Io(err.error))?;
-
-    // `sync_all` above made the contents durable; this makes the rename
-    // that published them durable too.
-    crate::atomic_file::sync_dir(parent)?;
-    Ok(())
+    crate::atomic_file::write_json(path, "kv", file).map_err(KvError::Io)
 }
 
 /// Every key/value pair in the store, in key order.

--- a/crates/shep-core/src/overrides.rs
+++ b/crates/shep-core/src/overrides.rs
@@ -12,7 +12,6 @@
 
 use core::fmt;
 use std::collections::{BTreeMap, BTreeSet};
-use std::io::Write as _;
 use std::path::Path;
 
 use serde::{Deserialize, Serialize};
@@ -149,27 +148,9 @@ fn read_file(path: &Path) -> Result<OverridesFile, OverridesError> {
     Ok(file)
 }
 
-/// Rewrites `path` to hold exactly `file`, atomically: staged through a
-/// temp file, then renamed over the original.
+/// Rewrites `path` to hold exactly `file`.
 fn write_file(path: &Path, file: &OverridesFile) -> Result<(), OverridesError> {
-    let parent = path.parent().unwrap_or_else(|| Path::new("."));
-    let mut tmp = crate::atomic_file::create_staging_file(parent, "overrides", ".tmp")?;
-
-    let json = serde_json::to_string_pretty(file)?;
-    tmp.write_all(json.as_bytes())?;
-    tmp.write_all(b"\n")?;
-    tmp.as_file().sync_all()?;
-
-    // `persist` is `rename(2)`. On failure the `NamedTempFile` comes back
-    // inside the error and its `Drop` removes the staging file, so a failed
-    // replace does not leave one behind.
-    tmp.persist(path)
-        .map_err(|err| OverridesError::Io(err.error))?;
-
-    // `sync_all` above made the contents durable; this makes the rename
-    // that published them durable too.
-    crate::atomic_file::sync_dir(parent)?;
-    Ok(())
+    crate::atomic_file::write_json(path, "overrides", file).map_err(OverridesError::Io)
 }
 
 /// Every sheep's overrides, in name order.

--- a/crates/shep-core/src/secrets.rs
+++ b/crates/shep-core/src/secrets.rs
@@ -10,7 +10,6 @@
 
 use core::fmt;
 use std::collections::{BTreeMap, BTreeSet};
-use std::io::Write as _;
 use std::path::Path;
 
 use serde::{Deserialize, Serialize};
@@ -210,27 +209,9 @@ fn read_file(path: &Path) -> Result<SecretFile, SecretError> {
     Ok(file)
 }
 
-/// Rewrites `path` to hold exactly `file`, atomically: staged through a
-/// temp file, then renamed over the original.
+/// Rewrites `path` to hold exactly `file`.
 fn write_file(path: &Path, file: &SecretFile) -> Result<(), SecretError> {
-    let parent = path.parent().unwrap_or_else(|| Path::new("."));
-    let mut tmp = crate::atomic_file::create_staging_file(parent, "secrets", ".tmp")?;
-
-    let json = serde_json::to_string_pretty(file)?;
-    tmp.write_all(json.as_bytes())?;
-    tmp.write_all(b"\n")?;
-    tmp.as_file().sync_all()?;
-
-    // `persist` is `rename(2)`. On failure the `NamedTempFile` comes back
-    // inside the error and its `Drop` removes the staging file, so a failed
-    // replace does not leave one behind.
-    tmp.persist(path)
-        .map_err(|err| SecretError::Io(err.error))?;
-
-    // `sync_all` above made the contents durable; this makes the rename
-    // that published them durable too.
-    crate::atomic_file::sync_dir(parent)?;
-    Ok(())
+    crate::atomic_file::write_json(path, "secrets", file).map_err(SecretError::Io)
 }
 
 /// Every key in the store with its per-environment values, in key order.

--- a/crates/shep-daemon/src/boot.rs
+++ b/crates/shep-daemon/src/boot.rs
@@ -110,7 +110,8 @@ pub fn pidfile(paths: &ShepPaths) -> PathBuf {
     paths.pids.join("shepd.pid")
 }
 
-/// Writes the pidfile atomically: temp file in `pids/`, `fsync`, `rename`.
+/// Writes the pidfile atomically and durably, through
+/// [`shep_core::atomic_file::publish`].
 ///
 /// Fixture seeding only. [`boot`] records its pid through
 /// `PidfileLock::record` instead: a rename over the locked path swaps in an
@@ -135,15 +136,7 @@ fn write_pidfile(paths: &ShepPaths, pid: u32) -> Result<(), BootError> {
             path: path.clone(),
             source,
         })?;
-    tmp.as_file().sync_all().map_err(|source| BootError::Io {
-        path: path.clone(),
-        source,
-    })?;
-    tmp.persist(&path).map_err(|err| BootError::Io {
-        path,
-        source: err.error,
-    })?;
-    Ok(())
+    shep_core::atomic_file::publish(tmp, &path).map_err(|source| BootError::Io { path, source })
 }
 
 /// Reads the recorded daemon pid, if any

--- a/crates/shep-daemon/src/dogs.rs
+++ b/crates/shep-daemon/src/dogs.rs
@@ -348,15 +348,7 @@ pub fn set_dog_section(path: &Path, name: &str, section: &str) -> Result<(), Dog
     let parent = path.parent().unwrap_or_else(|| Path::new("."));
     let mut tmp = shep_core::config_lock::create_config_file(parent).map_err(DogError::Io)?;
     tmp.write_all(rendered.as_bytes()).map_err(DogError::Io)?;
-    tmp.as_file().sync_all().map_err(DogError::Io)?;
-    // `persist` is `rename(2)`. On failure the staging file comes back
-    // inside the error and its `Drop` removes it, so a failed replace
-    // leaves nothing behind in `$SHEP_HOME`.
-    tmp.persist(path).map_err(|err| DogError::Io(err.error))?;
-    // `sync_all` made the contents durable; this makes the rename that
-    // published them durable. A no-op on Windows.
-    shep_core::atomic_file::sync_dir(parent).map_err(DogError::Io)?;
-    Ok(())
+    shep_core::atomic_file::publish(tmp, path).map_err(DogError::Io)
 }
 
 /// What a refused handshake costs the dog that sent it.

--- a/crates/shep-daemon/src/secrets.rs
+++ b/crates/shep-daemon/src/secrets.rs
@@ -12,7 +12,6 @@
 
 use core::fmt;
 use std::collections::{BTreeMap, BTreeSet};
-use std::io::Write as _;
 use std::path::{Path, PathBuf};
 use std::sync::{Mutex, MutexGuard, PoisonError};
 
@@ -253,16 +252,7 @@ fn read_cache(path: &Path) -> ProviderCache {
 /// the `rename`. A failed rename leaves `path` as it was and removes the
 /// staging file.
 fn write_cache(path: &Path, file: &CacheFile) -> std::io::Result<()> {
-    let parent = path.parent().unwrap_or_else(|| Path::new("."));
-    let mut tmp = shep_core::atomic_file::create_staging_file(parent, "secrets-cache", ".tmp")?;
-
-    let json = serde_json::to_string_pretty(file).map_err(std::io::Error::other)?;
-    tmp.write_all(json.as_bytes())?;
-    tmp.write_all(b"\n")?;
-    tmp.as_file().sync_all()?;
-
-    tmp.persist(path).map_err(|err| err.error)?;
-    shep_core::atomic_file::sync_dir(parent)
+    shep_core::atomic_file::write_json(path, "secrets-cache", file)
 }
 
 #[cfg(test)]

--- a/crates/shep-daemon/src/snapshot.rs
+++ b/crates/shep-daemon/src/snapshot.rs
@@ -292,14 +292,7 @@ pub(crate) fn write_atomic(path: &Path, snapshot: &FlockSnapshot) -> Result<(), 
 
     let mut tmp = NamedTempFile::new_in(parent)?;
     tmp.write_all(&json)?;
-    tmp.as_file().sync_all()?;
-    tmp.persist(path)
-        .map_err(|err| SnapshotError::Io(err.error))?;
-
-    // The `sync_all` above made the CONTENTS durable; this makes the rename
-    // that published them durable. See `shep_core::atomic_file`.
-    shep_core::atomic_file::sync_dir(parent)?;
-    Ok(())
+    shep_core::atomic_file::publish(tmp, path).map_err(SnapshotError::Io)
 }
 
 /// Reads and validates a muster roll written by `write_atomic`.


### PR DESCRIPTION
Ten sites wrote a file the same way: stage a sibling temp file, write it, `sync_all`, `persist`, then `sync_dir` on the parent so the rename itself is durable.

Two functions in `shep_core::atomic_file` now hold that:

- `publish(tmp, path)` is the shared tail. Six callers that write their own bytes stage as before and finish here: the bark ring, three TOML documents, the muster roll, and a test-only pidfile
- `write_json(path, prefix, value)`, generic over `T: Serialize`, is the whole sequence for a store holding one value. Four callers: the kv, secret and overrides stores, plus the daemon's provider cache
- Callers keep their own error type and `map_err` at the call site

Two things that were easy to lose in the fold, now stated once instead of nine times. `persist` hands the `NamedTempFile` back inside its error, so a failed replace unlinks the staging file. `sync_all` makes the contents durable, the directory fsync makes the rename durable. Both have tests, including one asserting a refused rename leaves nothing behind.

`feat` rather than `refactor` because `atomic_file` is a public module, so two new public functions ship with this.

Notes:

- The four JSON stores now report a serialize failure as `Io` rather than `Decode`. Unreachable in practice, every one of them is a string-keyed `BTreeMap` and a `u32`
- `write_pidfile` in boot.rs had no directory fsync and gains one. It's `#[cfg(test)]` fixture seeding, so no test can see it
- `snapshot.rs` keeps `to_vec_pretty` and its own staging call. It writes no trailing newline, so `write_json` would change the roll's bytes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
