### PR TITLE
chore: release v0.7.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2068,7 +2068,7 @@ dependencies = [
 
 [[package]]
 name = "shep"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "anstyle",
  "assert_cmd",
@@ -2108,7 +2108,7 @@ dependencies = [
 
 [[package]]
 name = "shep-channel"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "command-fds",
  "serde",
@@ -2119,11 +2119,11 @@ dependencies = [
 
 [[package]]
 name = "shep-cli"
-version = "0.7.1"
+version = "0.7.2"
 
 [[package]]
 name = "shep-client"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "futures-util",
  "nix 0.29.0",
@@ -2139,7 +2139,7 @@ dependencies = [
 
 [[package]]
 name = "shep-core"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "annotate-snippets",
  "anstyle",
@@ -2172,7 +2172,7 @@ dependencies = [
 
 [[package]]
 name = "shep-daemon"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "bytes",
  "chrono",
@@ -2202,14 +2202,14 @@ dependencies = [
 
 [[package]]
 name = "shep-examples"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "nix 0.29.0",
 ]
 
 [[package]]
 name = "shep-macros"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "proc-macro2",
  "quote 1.0.47",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.7.1"
+version = "0.7.2"
 edition = "2024"
 # 1.88: serde-saphyr's let-chains need it; also the floor ratatui, sysinfo
 # and rmcp require.
@@ -33,11 +33,11 @@ license = "MIT OR Apache-2.0"
 # turn an inherited dependency's default features back on but never off, so the
 # floor is set off here. shep-core wants the wire types without the client
 # feature; a future consumer that wants the client opts back in.
-shep-channel = { path = "crates/shep-channel", version = "0.7.1", default-features = false }
-shep-core = { path = "crates/shep-core", version = "0.7.1" }
-shep-daemon = { path = "crates/shep-daemon", version = "0.7.1" }
-shep-client = { path = "crates/shep-client", version = "0.7.1" }
-shep-macros = { path = "crates/shep-macros", version = "0.7.1" }
+shep-channel = { path = "crates/shep-channel", version = "0.7.2", default-features = false }
+shep-core = { path = "crates/shep-core", version = "0.7.2" }
+shep-daemon = { path = "crates/shep-daemon", version = "0.7.2" }
+shep-client = { path = "crates/shep-client", version = "0.7.2" }
+shep-macros = { path = "crates/shep-macros", version = "0.7.2" }
 serde = { version = "1", default-features = false, features = ["derive"] }
 serde_json = { version = "1", default-features = false, features = ["std"] }
 toml = { version = "0.8", default-features = false, features = ["parse", "display"] }

--- a/crates/shep-channel/CHANGELOG.md
+++ b/crates/shep-channel/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this crate are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.2] - 2026-09-08
+
+
 ## [0.7.1] - 2026-09-08
 
 

--- a/crates/shep-cli/CHANGELOG.md
+++ b/crates/shep-cli/CHANGELOG.md
@@ -13,6 +13,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.2] - 2026-09-08
+
+### Added
+
+- Fold the durable-write sequence into shep-core
+- Read a level out of a logfmt key=value pair ([#194](https://github.com/shep-pm/shep/pull/194))
+
+
 ## [0.7.1] - 2026-09-08
 
 ### Added

--- a/crates/shep-client/CHANGELOG.md
+++ b/crates/shep-client/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.2] - 2026-09-08
+
+
 ## [0.7.1] - 2026-09-08
 
 

--- a/crates/shep-core/CHANGELOG.md
+++ b/crates/shep-core/CHANGELOG.md
@@ -10,6 +10,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.2] - 2026-09-08
+
+### Added
+
+- Fold the durable-write sequence into shep-core
+
+### Changed
+
+- Drop a redundant test and a thrice-stated comment
+
+
 ## [0.7.1] - 2026-09-08
 
 ### Added

--- a/crates/shep-daemon/CHANGELOG.md
+++ b/crates/shep-daemon/CHANGELOG.md
@@ -10,6 +10,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.2] - 2026-09-08
+
+### Added
+
+- Fold the durable-write sequence into shep-core
+
+
 ## [0.7.1] - 2026-09-08
 
 

--- a/crates/shep-macros/CHANGELOG.md
+++ b/crates/shep-macros/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.2] - 2026-09-08
+
+
 ## [0.7.1] - 2026-09-08
 
 


### PR DESCRIPTION



## 🤖 New release

* `shep-channel`: 0.7.1 -> 0.7.2
* `shep-core`: 0.7.1 -> 0.7.2 (✓ API compatible changes)
* `shep-daemon`: 0.7.1 -> 0.7.2 (✓ API compatible changes)
* `shep-macros`: 0.7.1 -> 0.7.2
* `shep-client`: 0.7.1 -> 0.7.2
* `shep`: 0.7.1 -> 0.7.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>


## `shep-core`

<blockquote>

## [0.7.2] - 2026-09-08

### Added

- Fold the durable-write sequence into shep-core

### Changed

- Drop a redundant test and a thrice-stated comment
</blockquote>

## `shep-daemon`

<blockquote>

## [0.7.2] - 2026-09-08

### Added

- Fold the durable-write sequence into shep-core
</blockquote>



## `shep`

<blockquote>

## [0.7.2] - 2026-09-08

### Added

- Fold the durable-write sequence into shep-core
- Read a level out of a logfmt key=value pair ([#194](https://github.com/shep-pm/shep/pull/194))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).