### PR TITLE
feat(cli)!: draw frame 1l, the frozen lookout dashboard

### DIFF
--- a/crates/shep-cli/src/lookout/app.rs
+++ b/crates/shep-cli/src/lookout/app.rs
@@ -191,6 +191,10 @@ pub enum Msg {
     Frozen {
         /// When the link was declared lost, already rendered for display.
         at_local: String,
+        /// The last dial's own words, from [`super::source::LinkError`]'s
+        /// `Display`. Carried rather than re-derived so the link panel
+        /// quotes the failure instead of guessing at one.
+        why: String,
     },
     /// One key.
     Key(KeyPress),
@@ -379,6 +383,8 @@ pub enum Link {
     Lost {
         /// When it was declared lost, already rendered for display.
         at_local: String,
+        /// Why the last dial failed, in the error's own words.
+        why: String,
     },
 }
 
@@ -1358,6 +1364,16 @@ pub struct App {
     /// The clock the view reads. Advanced by [`Msg::Tick`], and never once the
     /// link is [`Link::Lost`], so a frozen dashboard's uptime column stops.
     now: Instant,
+    /// When the link was declared lost, on [`Self::now`]'s clock. `None`
+    /// while it is still up.
+    froze_at: Option<Instant>,
+    /// How long ago that was, as of the last [`Msg::Tick`].
+    ///
+    /// The one number on a frozen dashboard that still moves. [`Self::now`]
+    /// stops, so every uptime stops with it; this rides the tick separately,
+    /// because how long the shepherd has been gone is a fact about now
+    /// rather than a value the shepherd reported.
+    frozen_for: Duration,
     /// The last host reading, or `None` before the first heartbeat and on a
     /// platform `sysinfo` does not support. [`Self::host_unsupported`] tells
     /// the strip which of the two it is looking at.
@@ -1485,6 +1501,8 @@ impl App {
             control,
             home,
             now,
+            froze_at: None,
+            frozen_for: Duration::ZERO,
             host: None,
             host_unsupported: false,
             feed: super::tail::Tail::default(),
@@ -1546,8 +1564,10 @@ impl App {
                 }
                 Effect::None
             }
-            Msg::Frozen { at_local } => {
-                self.link = Link::Lost { at_local };
+            Msg::Frozen { at_local, why } => {
+                self.link = Link::Lost { at_local, why };
+                self.froze_at = Some(self.now);
+                self.frozen_for = Duration::ZERO;
                 self.disarm_on_link_change();
                 Effect::None
             }
@@ -1567,6 +1587,12 @@ impl App {
                     if stale {
                         self.pane_menu = None;
                     }
+                }
+                // The tick's own `now` again, for the same reason: how long
+                // the shepherd has been gone is the one number a frozen
+                // dashboard keeps counting.
+                if let Some(at) = self.froze_at {
+                    self.frozen_for = now.saturating_duration_since(at);
                 }
                 // Against the tick's own `now`, not `self.now`, which stops on
                 // a dead link: a settings edit describes a local file that is
@@ -4769,6 +4795,28 @@ impl App {
         &self.link
     }
 
+    /// How long the link has been [`Link::Lost`], as of the last
+    /// [`Msg::Tick`]. Zero while it is up.
+    #[must_use]
+    pub fn frozen_for(&self) -> Duration {
+        self.frozen_for
+    }
+
+    /// The palette every cell of data renders through.
+    ///
+    /// [`Palette::frozen`] once the link is [`Link::Lost`], so the table and
+    /// the host strip go to one muted ink and no cell can be read as live.
+    /// The chrome keeps [`Self::palette`]: the band still names the mode in
+    /// bark and the status bar still paints its keys.
+    #[must_use]
+    pub fn data_palette(&self) -> Palette {
+        if matches!(self.link, Link::Lost { .. }) {
+            self.palette.frozen()
+        } else {
+            self.palette
+        }
+    }
+
     /// The current notice, if the last message left one.
     #[must_use]
     pub fn notice(&self) -> Option<&Notice> {
@@ -5682,6 +5730,7 @@ mod tests {
             Msg::Retrying { attempt: 2 },
             Msg::Frozen {
                 at_local: "2026-08-16 09:00:00".to_string(),
+                why: fixtures::FROZEN_WHY.to_string(),
             },
         ] {
             let mut app = allowed_with_instances();
@@ -5860,6 +5909,7 @@ mod tests {
             Msg::Retrying { attempt: 2 },
             Msg::Frozen {
                 at_local: "2026-08-16 09:00:00".to_string(),
+                why: fixtures::FROZEN_WHY.to_string(),
             },
         ] {
             let mut app = allowed();
@@ -5939,6 +5989,7 @@ mod tests {
             Msg::Retrying { attempt: 2 },
             Msg::Frozen {
                 at_local: "2026-08-16 09:00:00".to_string(),
+                why: fixtures::FROZEN_WHY.to_string(),
             },
         ] {
             let mut app = allowed();
@@ -6120,6 +6171,7 @@ mod tests {
         let (mut app, _t0) = started();
         app.update(Msg::Frozen {
             at_local: "2026-08-16 09:00:00".to_string(),
+            why: fixtures::FROZEN_WHY.to_string(),
         });
         assert_eq!(app.update(Msg::Key(KeyPress::SelectDown)), Effect::None);
     }
@@ -6136,6 +6188,7 @@ mod tests {
         );
         app.update(Msg::Frozen {
             at_local: "2026-08-14 14:32:07".to_string(),
+            why: fixtures::FROZEN_WHY.to_string(),
         });
         assert_eq!(
             app.update(Msg::Snapshot {
@@ -6154,6 +6207,7 @@ mod tests {
         let (mut app, _) = started();
         app.update(Msg::Frozen {
             at_local: "2026-08-14 14:32:07".to_string(),
+            why: fixtures::FROZEN_WHY.to_string(),
         });
 
         assert_eq!(
@@ -6221,6 +6275,7 @@ mod tests {
         });
         app.update(Msg::Frozen {
             at_local: "2026-08-14 14:32:07".to_string(),
+            why: fixtures::FROZEN_WHY.to_string(),
         });
         let at_freeze = app.uptime_ms(1);
         app.update(Msg::Tick {
@@ -6282,6 +6337,7 @@ mod tests {
             Msg::Retrying { attempt: 5 },
             Msg::Frozen {
                 at_local: "2026-08-14 14:32:07".to_string(),
+                why: fixtures::FROZEN_WHY.to_string(),
             },
         ] {
             assert_ne!(app.update(msg), Effect::Quit);
@@ -6386,11 +6442,13 @@ mod tests {
         app.update(Msg::Retrying { attempt: 5 });
         app.update(Msg::Frozen {
             at_local: "2026-08-14 14:32:07".to_string(),
+            why: fixtures::FROZEN_WHY.to_string(),
         });
         assert_eq!(
             app.link(),
             &Link::Lost {
-                at_local: "2026-08-14 14:32:07".to_string()
+                at_local: "2026-08-14 14:32:07".to_string(),
+                why: fixtures::FROZEN_WHY.to_string(),
             }
         );
 
@@ -6434,6 +6492,7 @@ mod tests {
 
         app.update(Msg::Frozen {
             at_local: "2026-08-14 14:32:07".to_string(),
+            why: fixtures::FROZEN_WHY.to_string(),
         });
         assert_eq!(
             app.update(Msg::Key(KeyPress::Refresh)),
@@ -6473,6 +6532,7 @@ mod tests {
 
         app.update(Msg::Frozen {
             at_local: "2026-08-14 14:32:07".to_string(),
+            why: fixtures::FROZEN_WHY.to_string(),
         });
         let frozen = app.host();
         assert_eq!(app.update(Msg::Host { sample: None }), Effect::None);
@@ -6513,6 +6573,7 @@ mod tests {
 
         app.update(Msg::Frozen {
             at_local: "2026-08-14 14:32:07".to_string(),
+            why: fixtures::FROZEN_WHY.to_string(),
         });
 
         let in_flight_tail = super::super::tail::Tail {
@@ -6792,6 +6853,7 @@ mod tests {
         let (mut app, _t0) = started();
         app.update(Msg::Frozen {
             at_local: "2026-08-16 09:00:00".to_string(),
+            why: fixtures::FROZEN_WHY.to_string(),
         });
         app.update(Msg::Replied {
             sent: Sent::Lambs { id: 1 },
@@ -7425,6 +7487,7 @@ mod tests {
         let _ = app.update(Msg::Key(KeyPress::Cycle));
         let _ = app.update(Msg::Frozen {
             at_local: "12:00:00".into(),
+            why: fixtures::FROZEN_WHY.to_string(),
         });
         assert!(
             app.settings().unwrap().pending().is_some(),
@@ -7440,6 +7503,7 @@ mod tests {
         let _ = app.update(Msg::Key(KeyPress::Cycle));
         let _ = app.update(Msg::Frozen {
             at_local: "12:00:00".into(),
+            why: fixtures::FROZEN_WHY.to_string(),
         });
         let _ = app.update(Msg::Tick {
             now: start + CONFIRM_EXPIRY,
@@ -7756,6 +7820,7 @@ mod tests {
         let mut app = fixtures::app_in_settings_on_dog("metrics");
         let _ = app.update(Msg::Frozen {
             at_local: "12:00:00".into(),
+            why: fixtures::FROZEN_WHY.to_string(),
         });
         let effect = app.update(Msg::Key(KeyPress::Cycle));
         assert_eq!(effect, Effect::None);
@@ -7768,6 +7833,7 @@ mod tests {
         let mut app = fixtures::app_in_settings_with_control(); // on log_level
         let _ = app.update(Msg::Frozen {
             at_local: "12:00:00".into(),
+            why: fixtures::FROZEN_WHY.to_string(),
         });
         let _ = app.update(Msg::Key(KeyPress::Cycle));
         assert!(
@@ -8408,6 +8474,7 @@ mod tests {
 
         let _ = app.update(Msg::Frozen {
             at_local: "2026-09-08 09:00:00".to_string(),
+            why: fixtures::FROZEN_WHY.to_string(),
         });
         assert_eq!(
             app.update(Msg::Tick { now }),

--- a/crates/shep-cli/src/lookout/app.rs
+++ b/crates/shep-cli/src/lookout/app.rs
@@ -1569,6 +1569,16 @@ impl App {
                 self.froze_at = Some(self.now);
                 self.frozen_for = Duration::ZERO;
                 self.disarm_on_link_change();
+                // Every notice is about a shepherd that no longer exists,
+                // and none of them can be acted on. Left standing, the last
+                // one outranks the key hint for the rest of the session
+                // (`view::status::status_line`'s own ordering), so an
+                // operator reads `the shepherd is shutting down` where the
+                // bar should be telling them `r` still dials. Whether the
+                // shutdown was clean is on the screen either way: the link
+                // panel quotes an error that says the socket was removed
+                // rather than refusing.
+                self.notice = None;
                 Effect::None
             }
             Msg::Tick { now } => {

--- a/crates/shep-cli/src/lookout/app.rs
+++ b/crates/shep-cli/src/lookout/app.rs
@@ -1574,7 +1574,7 @@ impl App {
                 // one outranks the key hint for the rest of the session
                 // (`view::status::status_line`'s own ordering), so an
                 // operator reads `the shepherd is shutting down` where the
-                // bar should be telling them `r` still dials. Whether the
+                // bar should be naming the keys that still work. Whether the
                 // shutdown was clean is on the screen either way: the link
                 // panel quotes an error that says the socket was removed
                 // rather than refusing.

--- a/crates/shep-cli/src/lookout/frames.rs
+++ b/crates/shep-cli/src/lookout/frames.rs
@@ -466,20 +466,24 @@ impl Scene {
             // is exactly `FOLD_ALL`'s threshold: the one scene that needs the
             // full column set, SHARE and NOTES included.
             Self::Folds => (160, 30),
-            // 160 because this is the one scene whose point is that every
-            // column is muted, and the widest column set starts at 148.
+            // The design target, and comfortably past the floor this
+            // scene actually needs. `columns_for` runs on `width - GUTTER`,
+            // and `ALL`'s own threshold is the sum of what it draws:
             //
-            //   160 - GUTTER (2)          = 158 cells of table
             //   ALL's fixed widths        = 112
             //   13 two-cell separators    =  26
-            //   NAME takes the remainder  =  20, inside NAME_MIN..=NAME_MAX
-            //   112 + 26 + 20             = 158, exactly the table's width
+            //   NAME at its floor         =   8  (NAME_MIN)
+            //   112 + 26 + 8              = 146, `TIERS`'s widest entry
+            //
+            // So 148 columns is the floor and 160 leaves NAME 20 cells,
+            // which is what the frame drew. `the_frozen_scene_draws_every_
+            // column` pins the floor; the extra twelve are the design's.
             //
             // At the 120 this used to inherit from the default arm, the
             // table renders the NO_SPARK tier: no CPU sparkline and no
             // MEM/CEIL gauge, which is two of the cells the frame exists to
             // show frozen. 30 rows, not the design's 48: the link panel is
-            // five rows where the two panes it replaces were twelve, so
+            // six rows where the two panes it replaces were twelve, so
             // nothing here needs the taller frame.
             Self::Frozen => (160, 30),
             Self::Confirm
@@ -2264,7 +2268,7 @@ mod tests {
         );
         assert!(
             frozen.contains(
-                "refused   the shepherd did not answer: could not connect to `/tmp/shep-lookout-tests/run/shep.sock`: Connection refused (os error 61)"
+                "refused   the shepherd did not answer: could not connect to `/home/ada/.shep/run/shep.sock`: Connection refused (os error 61)"
             ),
             "the link panel quotes the last dial's own error, whole"
         );
@@ -2770,13 +2774,19 @@ mod tests {
     /// A pinned width whose own arithmetic no longer holds drops a column
     /// in silence, and this is the scene whose whole point is what the
     /// columns look like once the shepherd is gone.
+    ///
+    /// The floor is `ALL`'s own tier threshold plus the gutter, not the
+    /// design's 160: the frame is drawn twelve columns wider than it has
+    /// to be, and pinning the wider number would fail for a scene that was
+    /// still drawing everything.
     #[test]
-    fn the_frozen_scene_is_wide_enough_for_every_column() {
+    fn the_frozen_scene_draws_every_column() {
+        use super::super::view::flock::{GUTTER, columns_for};
+
         let (width, _) = Scene::Frozen.size();
-        let table = width - super::super::view::flock::GUTTER;
         assert_eq!(
-            super::super::view::flock::columns_for(table).len(),
-            super::super::view::flock::columns_for(u16::MAX).len(),
+            columns_for(width - GUTTER).len(),
+            columns_for(u16::MAX).len(),
             "the frozen scene is {width} columns, which drops a column from the widest set"
         );
     }

--- a/crates/shep-cli/src/lookout/frames.rs
+++ b/crates/shep-cli/src/lookout/frames.rs
@@ -346,7 +346,7 @@ impl Scene {
                 "The shepherd stopped answering. Five attempts over about eight seconds before this becomes the next frame. Every pane below the table keeps describing the selected sheep from the last listing."
             }
             Self::Frozen => {
-                "The ladder ran out. Last known values stay, the uptime clock has stopped, and so has the host strip: one line ticking over on a frozen screen is a contradiction on the same frame."
+                "The ladder ran out. The band says so in bark, the whole table and the host strip go to one muted ink so no cell reads as live, and UPTIME becomes FROZEN over a duration that has stopped advancing. The detail band and the feed give their rows to the link panel: they describe a shepherd that is gone, and it describes what happened."
             }
             Self::Refused => {
                 "`x` with actions gated off. The refusal is literal, nothing about damage gets charming, and the panes below carry on."
@@ -466,6 +466,22 @@ impl Scene {
             // is exactly `FOLD_ALL`'s threshold: the one scene that needs the
             // full column set, SHARE and NOTES included.
             Self::Folds => (160, 30),
+            // 160 because this is the one scene whose point is that every
+            // column is muted, and the widest column set starts at 148.
+            //
+            //   160 - GUTTER (2)          = 158 cells of table
+            //   ALL's fixed widths        = 112
+            //   13 two-cell separators    =  26
+            //   NAME takes the remainder  =  20, inside NAME_MIN..=NAME_MAX
+            //   112 + 26 + 20             = 158, exactly the table's width
+            //
+            // At the 120 this used to inherit from the default arm, the
+            // table renders the NO_SPARK tier: no CPU sparkline and no
+            // MEM/CEIL gauge, which is two of the cells the frame exists to
+            // show frozen. 30 rows, not the design's 48: the link panel is
+            // five rows where the two panes it replaces were twelve, so
+            // nothing here needs the taller frame.
+            Self::Frozen => (160, 30),
             Self::Confirm
             | Self::Acting
             | Self::ActionRefused
@@ -498,10 +514,10 @@ impl Scene {
             // this scene exists for. `the_title_names_the_window_and_what_
             // fell_below_it` covers the figures at a width that fits them.
             Self::Bleats => (100, 14),
-            // HealthyWide, Errored, Grouped, WithDogs, Retrying, Frozen,
-            // Refused, FeedGap, FeedMissing, HostUnknown, Lambs, LambsUnknown:
-            // every scene that carries all three optional panes at their
-            // ordinary rows.
+            // HealthyWide, Errored, Grouped, WithDogs, Retrying, Refused,
+            // FeedGap, FeedMissing, HostUnknown, Lambs, LambsUnknown: every
+            // scene that carries all three optional panes at their ordinary
+            // rows.
             _ => (120, 30),
         }
     }
@@ -1159,6 +1175,7 @@ fn scene_with(which: Scene, age: Duration, palette: Palette) -> Buffer {
         Scene::Frozen => {
             app.update(Msg::Frozen {
                 at_local: "2026-08-14 14:32:07".to_string(),
+                why: super::view::fixtures::FROZEN_WHY.to_string(),
             });
             // Sent after `Msg::Frozen`, with a load average that varies
             // with `age`: the guard's refusal keeps
@@ -2233,12 +2250,27 @@ mod tests {
         );
         assert!(retrying.contains("host  load"), "and so is the strip");
 
-        // Frozen: last known values stay, nothing keeps ticking.
+        // Frozen: last known values stay, nothing keeps ticking, and the
+        // panel that replaced the two lower panes says what happened.
         let frozen = render_text(&scene(Scene::Frozen).1);
-        assert!(frozen.contains("the shepherd has died"));
+        assert!(frozen.contains("THE SHEPHERD HAS DIED"));
         assert!(
             frozen.contains("host  load  ██░░░░░░░░ 2.31 4.10 3.88 / 10 cores"),
             "the strip kept its LAST values rather than blanking"
+        );
+        assert!(
+            frozen.contains("FROZEN"),
+            "UPTIME renamed over a column that stopped advancing"
+        );
+        assert!(
+            frozen.contains(
+                "refused   the shepherd did not answer: could not connect to `/tmp/shep-lookout-tests/run/shep.sock`: Connection refused (os error 61)"
+            ),
+            "the link panel quotes the last dial's own error, whole"
+        );
+        assert!(
+            frozen.contains("█ 250ms  █ 500ms  █ 1s  █ 2s  █ 4s"),
+            "and draws every rung the ladder climbed"
         );
 
         // Errored: selection parked on the errored sheep.
@@ -2735,12 +2767,64 @@ mod tests {
         }
     }
 
+    /// A pinned width whose own arithmetic no longer holds drops a column
+    /// in silence, and this is the scene whose whole point is what the
+    /// columns look like once the shepherd is gone.
+    #[test]
+    fn the_frozen_scene_is_wide_enough_for_every_column() {
+        let (width, _) = Scene::Frozen.size();
+        let table = width - super::super::view::flock::GUTTER;
+        assert_eq!(
+            super::super::view::flock::columns_for(table).len(),
+            super::super::view::flock::columns_for(u16::MAX).len(),
+            "the frozen scene is {width} columns, which drops a column from the widest set"
+        );
+    }
+
+    /// Rule 3 of the design system: strip every colour and the frame still
+    /// reads. Its corollary on this one frame is stronger — no cell above
+    /// the link panel may carry a colour at all, since a meadow `online`
+    /// two seconds after the shepherd died is the one lie this screen can
+    /// tell.
+    #[test]
+    fn no_cell_above_the_link_panel_is_painted_live() {
+        let palette = coloured_palette();
+        let buffer = scene(Scene::Frozen).1;
+        let muted = palette.muted().fg;
+        let line = palette.line().fg;
+        // Row 0 is the band, which is bark and says so; the link panel
+        // below carries the ladder's own bark blocks and a butter `r`.
+        let panel_at = render_text(&buffer)
+            .lines()
+            .position(|row| row.contains("THE LINK"))
+            .expect("the link panel is on a frozen frame");
+        let panel_at = u16::try_from(panel_at).expect("a row index fits");
+        for y in 1..panel_at {
+            for x in 0..buffer.area.width {
+                let cell = &buffer[(buffer.area.x + x, buffer.area.y + y)];
+                assert!(
+                    cell.fg == Color::Reset || Some(cell.fg) == muted || Some(cell.fg) == line,
+                    "a live-looking cell at {x},{y}: {:?} in {:?}",
+                    cell.symbol(),
+                    cell.fg
+                );
+            }
+        }
+    }
+
     /// Rendered twice at two different ages and compared to each other,
     /// not to the healthy scene, since a live-versus-frozen diff would
     /// pass either way. The live pair at the bottom catches a renderer
     /// that drops the uptime column entirely.
+    ///
+    /// Split at the link panel's own chip rather than at a row index. Every
+    /// value above it came from the shepherd and stopped when the shepherd
+    /// did; the panel below it describes the link, and how long ago the
+    /// link died is a fact about now. One half must not move and the other
+    /// must, so the test asserts both rather than narrowing to the half
+    /// that is easier to pin.
     #[test]
-    fn the_frozen_frame_does_not_move_however_long_the_link_stays_gone() {
+    fn a_frozen_frame_moves_only_in_the_link_panel() {
         let ten_minutes = render_text(&scene_with(
             Scene::Frozen,
             Duration::from_secs(600),
@@ -2751,13 +2835,38 @@ mod tests {
             Duration::from_secs(60_000),
             coloured_palette(),
         ));
+        let above_the_panel = |frame: &str| {
+            frame
+                .split("THE LINK")
+                .next()
+                .expect("split yields at least one part")
+                .to_string()
+        };
         assert_eq!(
-            ten_minutes, sixteen_hours,
+            above_the_panel(&ten_minutes),
+            above_the_panel(&sixteen_hours),
             "the frozen frame's uptime column advanced after the link was lost"
         );
+        assert_ne!(
+            ten_minutes, sixteen_hours,
+            "the link panel's age is the one number a frozen frame still counts"
+        );
+        // Seven seconds short of each age, and deliberately: `scene_with`
+        // ticks the clock forward by that much before it freezes anything,
+        // so the freeze happens at `t0 + 7s` and the panel counts from
+        // there. `9m 53s`, not `593s` — the same two-unit shape every other
+        // duration on the screen uses.
         assert!(
-            ten_minutes.lines().any(|line| line.starts_with("lambs  ")),
-            "the frozen frame has a lamb line for the comparison above to cover"
+            ten_minutes.contains("2026-08-14 14:32:07, 9m 53s ago"),
+            "and it counts in the same words every other duration uses"
+        );
+        assert!(
+            sixteen_hours.contains("2026-08-14 14:32:07, 16h 39m ago"),
+            "at both ends of the sweep"
+        );
+        assert!(
+            above_the_panel(&ten_minutes).contains("1h 18m"),
+            "the frozen frame has an uptime cell for the comparison above to cover"
         );
 
         let live_ten = render_text(&scene_with(

--- a/crates/shep-cli/src/lookout/frames.rs
+++ b/crates/shep-cli/src/lookout/frames.rs
@@ -2276,6 +2276,17 @@ mod tests {
             frozen.contains("█ 250ms  █ 500ms  █ 1s  █ 2s  █ 4s"),
             "and draws every rung the ladder climbed"
         );
+        // The design's own copy offers `r` in both places. `r` is refused
+        // once the link is lost, and `run_link` has already returned, so
+        // the frame must not name it anywhere.
+        assert!(
+            frozen.contains("shep muster, from another shell"),
+            "the panel sends the operator somewhere that works"
+        );
+        assert!(
+            !frozen.contains("dials again") && !frozen.contains("retry the link"),
+            "and offers no key a freeze has already refused"
+        );
 
         // Errored: selection parked on the errored sheep.
         let errored_buffer = scene(Scene::Errored).1;

--- a/crates/shep-cli/src/lookout/link.rs
+++ b/crates/shep-cli/src/lookout/link.rs
@@ -98,15 +98,17 @@ pub async fn run_link<S: Shepherd>(
             None => match shepherd.link().await {
                 Ok(pair) => pair,
                 Err(err) => {
-                    // Not surfaced as its own Msg: the reducer's `Retrying`
-                    // state is what the banner reads, and a per-attempt error
-                    // string would change the sentence every 250ms.
-                    let _ = err;
+                    // Kept for the freeze below and nothing else: the
+                    // reducer's `Retrying` state is what the banner reads,
+                    // and a per-attempt error string would change that
+                    // sentence every 250ms. The frozen link panel quotes one
+                    // error that never changes again, so it gets the words.
                     attempt += 1;
                     if attempt > RECONNECT_ATTEMPTS {
                         let _ = msgs
                             .send(Msg::Frozen {
                                 at_local: local_now(),
+                                why: err.to_string(),
                             })
                             .await;
                         return;

--- a/crates/shep-cli/src/lookout/snapshots/shep__lookout__frames__tests__frozen.snap
+++ b/crates/shep-cli/src/lookout/snapshots/shep__lookout__frames__tests__frozen.snap
@@ -30,5 +30,5 @@ host  load  ██░░░░░░░░ 2.31 4.10 3.88 / 10 cores     host me
   ladder    █ 250ms  █ 500ms  █ 1s  █ 2s  █ 4s                                                                                                                  
   refused   the shepherd did not answer: could not connect to `/home/ada/.shep/run/shep.sock`: Connection refused (os error 61)                                 
   since     2026-08-14 14:32:07, 9m 53s ago      the sheep themselves may well still be running; lookout cannot see them to say                                 
-  try       r dials again now      or start the shepherd from another shell: shep muster                                                                        
-q quit   r retry the link   j/k still moves   every other key is refused while the link is down                                                         █ frozen
+  try       shep muster, from another shell      then reopen lookout: it does not reconnect on its own                                                          
+q quit   j/k still moves   every other key is refused while the link is down                                                                            █ frozen

--- a/crates/shep-cli/src/lookout/snapshots/shep__lookout__frames__tests__frozen.snap
+++ b/crates/shep-cli/src/lookout/snapshots/shep__lookout__frames__tests__frozen.snap
@@ -2,33 +2,33 @@
 source: crates/shep-cli/src/lookout/frames.rs
 expression: render_text(&buffer)
 ---
-shep lookout   /home/ada/.shep                                                                            6 in the flock
-                                                                                                                        
-the shepherd has died: these values are frozen as of 2026-08-14 14:32:07                                                
-host  load  ██░░░░░░░░ 2.31 4.10 3.88 / 10 cores     host mem  ████░░░░░░ 12.4G / 32.0G     1 errored · 0 parked   floc…
-────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-                                                                                                                        
-  ID    NAME        STATUS           PID      RESTARTS  EXIT       CPU     MEM       UPTIME    FOLD        SMIT         
-   ██ FLOCK                                                                                                             
-  2     api         errored          -        14        1          -       -         1h 18m    edge        -            
-  3     billing-r…  waiting-restart  -        3         1          -       -         1h 19m    -           -            
-  4     cron        stopped          -        0         SIGTERM    -       -         1h 21m    -           -            
-  5     metrics     online           48240    0         -          0.4%    11.0M     1h 22m    -           -            
-  0     web         online           48211    0         -          3.4%    182.0M    1h 15m    edge        -            
-  1     web         online           48212    0         -          2.9%    178.0M    1h 16m    edge        -            
-                                                                                                                        
-                                                                                                                        
-                                                                                                                        
-────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
- ██ SHEEP 2  api   errored   pid -   restarts 14   uptime 1h 18m   cpu -   mem -   fold edge                            
-lambs  3 parent-pid descendants, read 0s ago   48220 node   48221 node   48222 node                                     
-out  /home/ada/.shep/logs/api-2-out.log   │   err  /home/ada/.shep/logs/api-2-err.log                                   
-                                                                                                                        
-────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
- ██ BLEATS api  … 1 earlier line not shown                                                                              
-out  GET /healthz 200 3ms                                                                                               
-out  GET /v1/orders 200 44ms                                                                                            
-out  POST /v1/orders 201 88ms                                                                                           
-out  GET /v1/orders/8821 200 9ms                                                                                        
-out  connection pool: 14/50 in use                                                                                      
-q quit   j/k select   / filter   F folds   x stop   R restart   L reload   s settings   e edit   * your… control enabled
+ THE SHEPHERD HAS DIED  ▖  these values are frozen as of 2026-08-14 14:32:07                                                 nothing here is live  ▖  q to quit 
+                                                                                                                                                                
+ shep lookout   /home/ada/.shep  ·  the dashboard stays up so you can read what it had  ·  it will not exit on its own                                          
+host  load  ██░░░░░░░░ 2.31 4.10 3.88 / 10 cores     host mem  ████░░░░░░ 12.4G / 32.0G     1 errored · 0 parked   flock cpu 6.7%        █   flock mem 371.0M  …
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+                                                                                                                                                                
+  ID    NAME                  STATUS           PID      RESTARTS  EXIT       CFG   CPU 20s     CPU     MEM/CEIL    MEM       FROZEN    FOLD        SMIT         
+   ██ FLOCK                                                                                                                                                     
+  2     api                   errored          -        14        1          -              ▁  -       ░░░░░░░░░░  -         1h 18m    edge        -            
+  3     billing-reconciliat…  waiting-restart  -        3         1          -              ▁  -       ░░░░░░░░░░  -         1h 19m    -           -            
+  4     cron                  stopped          -        0         SIGTERM    -              ▁  -       ░░░░░░░░░░  -         1h 21m    -           -            
+  5     metrics               online           48240    0         -          -              ▂  0.4%    ░░░░░░░░░░  11.0M     1h 22m    -           -            
+  0     web                   online           48211    0         -          -              █  3.4%    ░░░░░░░░░░  182.0M    1h 15m    edge        -            
+  1     web                   online           48212    0         -          -              ▇  2.9%    ░░░░░░░░░░  178.0M    1h 16m    edge        -            
+                                                                                                                                                                
+                                                                                                                                                                
+                                                                                                                                                                
+                                                                                                                                                                
+                                                                                                                                                                
+                                                                                                                                                                
+                                                                                                                                                                
+                                                                                                                                                                
+                                                                                                                                                                
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+ ██ THE LINK  5 redials over 7.75s, all refused   ·   lookout has stopped polling and stopped re-dialling                                                       
+  ladder    █ 250ms  █ 500ms  █ 1s  █ 2s  █ 4s                                                                                                                  
+  refused   the shepherd did not answer: could not connect to `/tmp/shep-lookout-tests/run/shep.sock`: Connection refused (os error 61)                         
+  since     2026-08-14 14:32:07, 9m 53s ago      the sheep themselves may well still be running; lookout cannot see them to say                                 
+  try       r dials again now      or start the shepherd from another shell: shep muster                                                                        
+q quit   r retry the link   j/k still moves   every other key is refused while the link is down                                                         █ frozen

--- a/crates/shep-cli/src/lookout/snapshots/shep__lookout__frames__tests__frozen.snap
+++ b/crates/shep-cli/src/lookout/snapshots/shep__lookout__frames__tests__frozen.snap
@@ -28,7 +28,7 @@ host  load  ██░░░░░░░░ 2.31 4.10 3.88 / 10 cores     host me
 ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
  ██ THE LINK  5 redials over 7.75s, all refused   ·   lookout has stopped polling and stopped re-dialling                                                       
   ladder    █ 250ms  █ 500ms  █ 1s  █ 2s  █ 4s                                                                                                                  
-  refused   the shepherd did not answer: could not connect to `/tmp/shep-lookout-tests/run/shep.sock`: Connection refused (os error 61)                         
+  refused   the shepherd did not answer: could not connect to `/home/ada/.shep/run/shep.sock`: Connection refused (os error 61)                                 
   since     2026-08-14 14:32:07, 9m 53s ago      the sheep themselves may well still be running; lookout cannot see them to say                                 
   try       r dials again now      or start the shepherd from another shell: shep muster                                                                        
 q quit   r retry the link   j/k still moves   every other key is refused while the link is down                                                         █ frozen

--- a/crates/shep-cli/src/lookout/theme.rs
+++ b/crates/shep-cli/src/lookout/theme.rs
@@ -141,7 +141,31 @@ impl Palette {
         Self::fg(self.ink3)
     }
 
-    /// Damage that has happened: the frozen banner, a failed poll.
+    /// Every semantic colour collapsed onto [`Self::muted`]'s one ink.
+    ///
+    /// What a frozen dashboard renders its data through, so no cell can be
+    /// mistaken for live: an `online` in meadow two seconds after the
+    /// shepherd died is the one lie this screen can tell.
+    ///
+    /// [`Self::line`] and [`Self::ground`] keep their colours. Both are
+    /// chrome rather than a reading: a rule separates regions and the
+    /// ground carries the cursor, and `j`/`k` still move while the link is
+    /// down.
+    #[must_use]
+    pub fn frozen(self) -> Self {
+        Self {
+            meadow: self.ink3,
+            bark: self.ink3,
+            butter: self.ink3,
+            ink3: self.ink3,
+            sky: self.ink3,
+            gauge_rest: self.ink3,
+            line: self.line,
+            paper2: self.paper2,
+        }
+    }
+
+    /// Damage that has happened: a spent reconnect ladder, a failed poll.
     #[must_use]
     pub fn alarm(self) -> Style {
         Self::fg(self.bark)

--- a/crates/shep-cli/src/lookout/view/bleats.rs
+++ b/crates/shep-cli/src/lookout/view/bleats.rs
@@ -199,6 +199,7 @@ mod tests {
         });
         app.update(Msg::Frozen {
             at_local: "12:00:00".to_string(),
+            why: super::super::fixtures::FROZEN_WHY.to_string(),
         });
         app.update(Msg::Key(KeyPress::SelectUp));
         assert_eq!(

--- a/crates/shep-cli/src/lookout/view/detail.rs
+++ b/crates/shep-cli/src/lookout/view/detail.rs
@@ -504,6 +504,7 @@ mod tests {
 
         app.update(Msg::Frozen {
             at_local: "2026-08-16 09:00:00".to_string(),
+            why: super::super::fixtures::FROZEN_WHY.to_string(),
         });
         app.update(Msg::Tick {
             now: t0 + Duration::from_secs(3_600),

--- a/crates/shep-cli/src/lookout/view/fixtures.rs
+++ b/crates/shep-cli/src/lookout/view/fixtures.rs
@@ -26,7 +26,7 @@ use crate::style::StyleSource;
 /// The link panel renders it verbatim, so every test that freezes a
 /// dashboard feeds it verbatim rather than inventing a shorter sentence the
 /// panel would never see.
-pub const FROZEN_WHY: &str = "the shepherd did not answer: could not connect to `/tmp/shep-lookout-tests/run/shep.sock`: Connection refused (os error 61)";
+pub const FROZEN_WHY: &str = "the shepherd did not answer: could not connect to `/home/ada/.shep/run/shep.sock`: Connection refused (os error 61)";
 
 /// No colour at all: the palette every fixture uses unless the test is about
 /// colour.

--- a/crates/shep-cli/src/lookout/view/fixtures.rs
+++ b/crates/shep-cli/src/lookout/view/fixtures.rs
@@ -20,6 +20,14 @@ use super::super::theme::Palette;
 use crate::commands::settings::{DogView, ScalarView, SettingField, SettingsSnapshot};
 use crate::style::StyleSource;
 
+/// What the last dial said when the ladder ran out, in
+/// `super::super::source::LinkError::Unreachable`'s own shape.
+///
+/// The link panel renders it verbatim, so every test that freezes a
+/// dashboard feeds it verbatim rather than inventing a shorter sentence the
+/// panel would never see.
+pub const FROZEN_WHY: &str = "the shepherd did not answer: could not connect to `/tmp/shep-lookout-tests/run/shep.sock`: Connection refused (os error 61)";
+
 /// No colour at all: the palette every fixture uses unless the test is about
 /// colour.
 pub fn plain() -> Palette {

--- a/crates/shep-cli/src/lookout/view/flock.rs
+++ b/crates/shep-cli/src/lookout/view/flock.rs
@@ -154,6 +154,26 @@ impl Column {
         }
     }
 
+    /// The header text on a frozen dashboard.
+    ///
+    /// [`Self::header`] for every column but [`Self::Uptime`], whose cells
+    /// hold a duration that stopped advancing the moment the link did.
+    /// `UPTIME` over a stalled number is the one cell on the frozen frame
+    /// that reads as live, and the whole point of that screen is that none
+    /// of them may.
+    ///
+    /// `FROZEN`, not the design's own `FROZEN AT`: [`Self::width`] gives
+    /// this column 8 cells, `FROZEN AT` is 9, and widening it moves every
+    /// threshold in [`TIERS`]. The band two rows above already carries the
+    /// timestamp the `AT` would point at.
+    #[must_use]
+    pub const fn frozen_header(self) -> &'static str {
+        match self {
+            Self::Uptime => "FROZEN",
+            _ => self.header(),
+        }
+    }
+
     /// The fixed width of this column's cells. `Name` reports `0`: it is
     /// the column that takes the remainder, and [`name_width`] computes it.
     #[must_use]
@@ -583,8 +603,12 @@ pub fn fit(text: &str, width: u16) -> String {
 }
 
 /// The header line: every column name, muted.
+///
+/// `frozen` swaps [`Column::header`] for [`Column::frozen_header`], which
+/// differs for exactly one column. See that method for why the rename is
+/// the header's job rather than the cell's.
 #[must_use]
-pub fn header_line(columns: &[Column], width: u16, style: Style) -> Line<'static> {
+pub fn header_line(columns: &[Column], width: u16, style: Style, frozen: bool) -> Line<'static> {
     let name = name_width(width, columns);
     let mut text = String::new();
     for (index, column) in columns.iter().enumerate() {
@@ -596,7 +620,12 @@ pub fn header_line(columns: &[Column], width: u16, style: Style) -> Line<'static
         } else {
             column.width()
         };
-        text.push_str(&fit(column.header(), cell_width));
+        let header = if frozen {
+            column.frozen_header()
+        } else {
+            column.header()
+        };
+        text.push_str(&fit(header, cell_width));
     }
     Line::from(Span::styled(text, style))
 }
@@ -659,7 +688,7 @@ pub fn key_line(
             },
         ),
         RowKey::Group(name) => group_line(app, name, columns, width, selected),
-        RowKey::Section(label) => section_line(label, width, app.palette().muted()),
+        RowKey::Section(label) => section_line(label, width, app.data_palette().muted()),
         // Flat view never emits a `RowKey::Fold`: `push_fold_rows` builds
         // them and only runs under `Grouping::ByFold`, whose rows go through
         // `fold_key_line` instead. `key_line` is the flat renderer, reached
@@ -691,7 +720,7 @@ fn group_line(
     width: u16,
     selected: bool,
 ) -> Line<'static> {
-    let palette = app.palette();
+    let palette = app.data_palette();
     let totals = app.group_totals(name);
     let name_width = self::name_width(width, columns);
     let ground = if selected {
@@ -802,7 +831,7 @@ pub fn fold_key_line(
             || Line::from(Span::raw(" ".repeat(usize::from(width)))),
             |row| fold_member_line(app, row, columns, width, selected),
         ),
-        RowKey::Section(label) => section_line(label, width, app.palette().muted()),
+        RowKey::Section(label) => section_line(label, width, app.data_palette().muted()),
     }
 }
 
@@ -820,7 +849,7 @@ fn fold_header_line(
     width: u16,
     selected: bool,
 ) -> Line<'static> {
-    let palette = app.palette();
+    let palette = app.data_palette();
     let totals = app.fold_totals(name);
     let total_memory = total_flock_memory(app);
     let share_percent = fold_share_percent(totals.memory, total_memory);
@@ -962,7 +991,7 @@ fn fold_group_line(
     width: u16,
     selected: bool,
 ) -> Line<'static> {
-    let palette = app.palette();
+    let palette = app.data_palette();
     let totals = app.group_totals(name);
     let status = app.group_uniform_status(name);
     let status_style = status.map_or(Style::default(), |status| palette.status(status));
@@ -1025,7 +1054,7 @@ fn fold_member_line(
     width: u16,
     selected: bool,
 ) -> Line<'static> {
-    let palette = app.palette();
+    let palette = app.data_palette();
     let status_style = palette.reported(row.reported());
     let name_width = fold_name_width(width, columns);
     let ground = if selected {
@@ -1101,7 +1130,7 @@ pub fn row_line(
     grouped: bool,
     selected: bool,
 ) -> Line<'static> {
-    let palette = app.palette();
+    let palette = app.data_palette();
     let name = name_width(width, columns);
     let status_style = palette.reported(row.reported());
     let status = Some(row.info.status);
@@ -1345,6 +1374,36 @@ mod tests {
     use super::super::fixtures;
     use super::*;
     use std::ffi::OsStr;
+
+    /// `FROZEN` has to fit the column it renames, and the column is not
+    /// growing to hold it: [`Column::width`] gives `Uptime` 8 cells, and
+    /// every threshold in [`TIERS`] is derived from the sum of those
+    /// widths. The design's own `FROZEN AT` is 9.
+    #[test]
+    fn the_frozen_header_fits_the_column_it_renames() {
+        use crate::output::width::visible_width;
+
+        assert_eq!(Column::Uptime.frozen_header(), "FROZEN");
+        assert!(
+            visible_width(Column::Uptime.frozen_header()) <= usize::from(Column::Uptime.width()),
+            "FROZEN does not fit UPTIME's own 8 cells"
+        );
+        assert!(
+            visible_width("FROZEN AT") > usize::from(Column::Uptime.width()),
+            "the design's own header now fits, so this rename has no reason to exist"
+        );
+    }
+
+    /// Exactly one column reads differently once the link is gone.
+    #[test]
+    fn only_the_uptime_column_is_renamed_by_a_freeze() {
+        let renamed: Vec<&str> = ALL
+            .iter()
+            .filter(|column| column.frozen_header() != column.header())
+            .map(|column| column.header())
+            .collect();
+        assert_eq!(renamed, vec!["UPTIME"]);
+    }
 
     #[test]
     fn the_painted_gutter_is_one_column_and_holds_no_glyph() {

--- a/crates/shep-cli/src/lookout/view/host.rs
+++ b/crates/shep-cli/src/lookout/view/host.rs
@@ -24,7 +24,7 @@ use crate::output::{human_bytes, human_duration};
 /// The strip, fitted to `width`.
 #[must_use]
 pub fn strip_line(app: &App, width: u16) -> Line<'static> {
-    Line::from(Ink::fit(&runs(app), width, app.palette()))
+    Line::from(Ink::fit(&runs(app), width, app.data_palette()))
 }
 
 // One run of the strip and the role it renders in.

--- a/crates/shep-cli/src/lookout/view/link_panel.rs
+++ b/crates/shep-cli/src/lookout/view/link_panel.rs
@@ -1,0 +1,313 @@
+//! The link panel: what the dashboard tried, when it stopped, and what is
+//! left to do about it.
+//!
+//! Drawn only once the link is [`Link::Lost`], where it takes the rows the
+//! detail band and the bleats feed had. Those two are readings the shepherd
+//! gave, and a dead shepherd's readings are history; this is the one region
+//! of a frozen dashboard still describing the present.
+
+use core::time::Duration;
+
+use ratatui::text::{Line, Span};
+
+use super::super::app::{App, Link};
+use super::super::link::{RECONNECT_ATTEMPTS, RECONNECT_FIRST_WAIT, RECONNECT_MAX_WAIT};
+use super::detail::chip_text;
+use super::flock::fit;
+use crate::output::human_duration;
+use crate::output::width::char_columns;
+use crate::vocabulary::Role;
+
+/// The panel's rows: one rule and five lines.
+///
+/// Six against the feed's seven, so the frozen bottom stack is never taller
+/// than the live one it replaces and no height tier has to move.
+pub const LINK_ROWS: u16 = 6;
+
+/// The narrowest terminal the dashboard draws into at all
+/// ([`super::MIN_TERM_WIDTH`]), repeated here so the panel's own width
+/// sweep starts where the pane's does.
+#[cfg(test)]
+const MIN_PANEL_WIDTH: u16 = super::MIN_TERM_WIDTH;
+
+/// The label gutter, in cells: the width of [`chip_text`]'s own
+/// `" \u{2588}\u{2588} THE LINK"`.
+///
+/// One space, two blocks, one space, eight letters. The three label rows pad
+/// to it so their values start in the same column the chip's sentence does.
+const LABEL_WIDTH: usize = 12;
+
+/// The four lines under the panel's rule.
+///
+/// Empty when the link is not [`Link::Lost`]. `view::draw` claims these rows
+/// only on a frozen frame, so that case does not arise; it draws blank rows
+/// rather than panicking if it ever does.
+#[must_use]
+pub fn panel_lines(app: &App, width: u16) -> Vec<Line<'static>> {
+    let Link::Lost { at_local, why } = app.link() else {
+        return Vec::new();
+    };
+    let palette = app.palette();
+    let rungs = ladder();
+    let total: Duration = rungs.iter().sum();
+
+    let chip = chip_text("THE LINK");
+    let head = format!(
+        "  {} redials over {}, all refused   ·   lookout has stopped polling and stopped re-dialling",
+        rungs.len(),
+        seconds(total),
+    );
+
+    let mut ladder_spans = vec![Span::styled(label("ladder"), palette.muted())];
+    for rung in &rungs {
+        ladder_spans.push(Span::styled("\u{2588}", palette.alarm()));
+        ladder_spans.push(Span::styled(
+            format!(" {}  ", rung_label(*rung)),
+            palette.muted(),
+        ));
+    }
+
+    let since = format!(
+        "{at_local}, {} ago",
+        human_duration(millis(app.frozen_for())),
+    );
+
+    vec![
+        Line::from(vec![
+            Span::styled(chip, palette.band(Role::Bark)),
+            Span::styled(head, palette.muted()),
+        ]),
+        Line::from(ladder_spans),
+        // Its own row, not the ladder's tail. The design drew a
+        // forty-character paraphrase there; the real sentence is a hundred
+        // and twenty, since `LinkError::Unreachable` names the socket it
+        // dialled as well as what the OS said, and both halves earn their
+        // cells. Sharing the ladder's row would truncate the reason and
+        // keep the path, which is the wrong half to lose.
+        Line::from(vec![
+            Span::styled(label("refused"), palette.muted()),
+            Span::styled(why.clone(), palette.muted()),
+        ]),
+        Line::from(vec![
+            Span::styled(label("since"), palette.muted()),
+            Span::styled(
+                format!(
+                    "{since}      the sheep themselves may well still be running; lookout cannot see them to say"
+                ),
+                palette.muted(),
+            ),
+        ]),
+        Line::from(vec![
+            Span::styled(label("try"), palette.muted()),
+            Span::styled("r", palette.attention()),
+            Span::styled(
+                " dials again now      or start the shepherd from another shell: shep muster"
+                    .to_string(),
+                palette.muted(),
+            ),
+        ]),
+    ]
+    .into_iter()
+    .map(|line| clamp(line, width))
+    .collect()
+}
+
+/// `"  <name>"` padded to [`LABEL_WIDTH`].
+fn label(name: &str) -> String {
+    let text = format!("  {name}");
+    let used: usize = text.chars().map(char_columns).sum();
+    format!("{text}{}", " ".repeat(LABEL_WIDTH.saturating_sub(used)))
+}
+
+/// Every rung the ladder climbs, in the order `super::super::link::run_link`
+/// climbs them.
+///
+/// Derived rather than written out, so moving a constant moves the panel
+/// with it: the doubling and its ceiling are that function's own.
+fn ladder() -> Vec<Duration> {
+    let mut wait = RECONNECT_FIRST_WAIT;
+    let mut out = Vec::new();
+    for _ in 0..RECONNECT_ATTEMPTS {
+        out.push(wait);
+        wait = (wait * 2).min(RECONNECT_MAX_WAIT);
+    }
+    out
+}
+
+/// One rung: `250ms` under a second, `4s` at or over one.
+///
+/// Every value the ladder produces is a whole number of milliseconds or of
+/// seconds, since it starts at a whole number of milliseconds and doubles.
+fn rung_label(wait: Duration) -> String {
+    let ms = millis(wait);
+    if ms < 1_000 {
+        format!("{ms}ms")
+    } else {
+        format!("{}s", ms / 1_000)
+    }
+}
+
+/// The ladder's total, to two decimals with trailing zeros trimmed: `7.75s`.
+fn seconds(total: Duration) -> String {
+    let text = format!("{:.2}", total.as_secs_f64());
+    let trimmed = text.trim_end_matches('0').trim_end_matches('.');
+    format!("{trimmed}s")
+}
+
+/// `Duration` as whole milliseconds, saturating rather than wrapping on a
+/// span no dashboard will ever reach.
+fn millis(duration: Duration) -> u64 {
+    u64::try_from(duration.as_millis()).unwrap_or(u64::MAX)
+}
+
+/// `line` truncated to `width` columns.
+///
+/// Applied to every row: the panel's sentences are long by design, and a
+/// terminal narrower than the design target must drop their tails rather
+/// than have `Buffer::set_line` cut them mid-span in silence.
+fn clamp(line: Line<'static>, width: u16) -> Line<'static> {
+    let mut budget = usize::from(width);
+    let mut spans = Vec::with_capacity(line.spans.len());
+    for span in line.spans {
+        if budget == 0 {
+            break;
+        }
+        let used: usize = span.content.chars().map(char_columns).sum();
+        if used <= budget {
+            budget -= used;
+            spans.push(span);
+        } else {
+            let cut = fit(&span.content, u16::try_from(budget).unwrap_or(u16::MAX));
+            budget = 0;
+            spans.push(Span::styled(cut, span.style));
+        }
+    }
+    Line::from(spans)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::super::app::Msg;
+    use super::super::fixtures;
+    use super::*;
+    use crate::output::width::visible_width;
+
+    fn frozen() -> App {
+        let mut app = fixtures::full_app();
+        app.update(Msg::Frozen {
+            at_local: "2026-08-14 14:32:07".to_string(),
+            why: fixtures::FROZEN_WHY.to_string(),
+        });
+        app
+    }
+
+    fn text(app: &App, width: u16) -> Vec<String> {
+        panel_lines(app, width)
+            .iter()
+            .map(ToString::to_string)
+            .collect()
+    }
+
+    /// The panel claims to say what the ladder did. Written out rather than
+    /// derived a second way, so moving a constant without meaning to fails
+    /// here instead of shipping a panel that describes a ladder shep no
+    /// longer climbs.
+    #[test]
+    fn the_ladder_reads_off_the_reconnect_constants() {
+        assert_eq!(RECONNECT_ATTEMPTS, 5);
+        assert_eq!(RECONNECT_FIRST_WAIT, Duration::from_millis(250));
+        assert_eq!(RECONNECT_MAX_WAIT, Duration::from_secs(4));
+
+        let rungs = ladder();
+        assert_eq!(
+            rungs,
+            vec![
+                Duration::from_millis(250),
+                Duration::from_millis(500),
+                Duration::from_secs(1),
+                Duration::from_secs(2),
+                Duration::from_secs(4),
+            ]
+        );
+        assert_eq!(seconds(rungs.iter().sum()), "7.75s");
+
+        let lines = text(&frozen(), 160);
+        assert!(
+            lines[0].contains("5 redials over 7.75s, all refused"),
+            "{lines:?}"
+        );
+        assert!(
+            lines[1]
+                .contains("\u{2588} 250ms  \u{2588} 500ms  \u{2588} 1s  \u{2588} 2s  \u{2588} 4s"),
+            "{lines:?}"
+        );
+    }
+
+    /// The three labels and the chip share a column, so their values line
+    /// up down the panel. Measured rather than counted by eye: the chip's
+    /// width is `cell::band`'s to decide, not this module's.
+    #[test]
+    fn every_label_starts_its_value_in_the_chip_s_own_column() {
+        assert_eq!(visible_width(&chip_text("THE LINK")), LABEL_WIDTH);
+        for name in ["ladder", "since", "try", "refused"] {
+            assert_eq!(visible_width(&label(name)), LABEL_WIDTH, "{name}");
+        }
+    }
+
+    /// Five lines, whatever the terminal, and none of them wider than it.
+    #[test]
+    fn no_line_outruns_the_terminal_it_is_drawn_into() {
+        let app = frozen();
+        for width in [MIN_PANEL_WIDTH, 40, 80, 120, 160, 200] {
+            let lines = panel_lines(&app, width);
+            assert_eq!(lines.len(), usize::from(LINK_ROWS - 1), "at {width}");
+            for line in &lines {
+                let used: usize = line
+                    .spans
+                    .iter()
+                    .flat_map(|span| span.content.chars())
+                    .map(char_columns)
+                    .sum();
+                assert!(used <= usize::from(width), "{used} cells at {width}");
+            }
+        }
+    }
+
+    /// `view::draw` claims the panel's rows only on a frozen frame. If that
+    /// ever stops being true, blank rows are the failure mode rather than a
+    /// panic.
+    #[test]
+    fn a_live_link_draws_nothing() {
+        assert!(panel_lines(&fixtures::full_app(), 160).is_empty());
+    }
+
+    /// The `since` line is the one thing here that moves, and it counts
+    /// from the freeze rather than from the dashboard opening.
+    ///
+    /// Its own clock, not `fixtures::full_app`'s: the freeze instant is
+    /// whatever `App::now` held when `Msg::Frozen` landed, so a test that
+    /// ticked against a fresh `Instant::now()` would be measuring how long
+    /// the fixture took to build as well.
+    #[test]
+    fn the_age_counts_from_the_freeze_and_says_when_it_was() {
+        let t0 = std::time::Instant::now();
+        let mut app = App::new(
+            super::super::super::theme::Palette::detect(None, None, None),
+            super::super::super::app::Control::ReadOnly,
+            "/home/ada/.shep".to_string(),
+            t0,
+        );
+        app.update(Msg::Frozen {
+            at_local: "2026-08-14 14:32:07".to_string(),
+            why: fixtures::FROZEN_WHY.to_string(),
+        });
+        let before = text(&app, 160)[3].clone();
+        assert!(before.contains("2026-08-14 14:32:07, 0s ago"), "{before}");
+
+        app.update(Msg::Tick {
+            now: t0 + Duration::from_secs(252),
+        });
+        let after = text(&app, 160)[3].clone();
+        assert!(after.contains("2026-08-14 14:32:07, 4m 12s ago"), "{after}");
+    }
+}

--- a/crates/shep-cli/src/lookout/view/link_panel.rs
+++ b/crates/shep-cli/src/lookout/view/link_panel.rs
@@ -97,11 +97,16 @@ pub fn panel_lines(app: &App, width: u16) -> Vec<Line<'static>> {
                 palette.muted(),
             ),
         ]),
+        // Not the design's `r dials again now`. `r` is refused once the
+        // link is lost (`App::on_key`'s `KeyPress::Refresh` arm), and
+        // nothing is left to answer a redial anyway: `run_link` returns
+        // after sending `Msg::Frozen`, taking the poll channel's receiver
+        // with it. A row promising a key that does nothing is worse than
+        // no row.
         Line::from(vec![
-            Span::styled(label("try"), palette.muted()),
-            Span::styled("r", palette.attention()),
+            Span::styled(label("try"), palette.attention()),
             Span::styled(
-                " dials again now      or start the shepherd from another shell: shep muster"
+                "shep muster, from another shell      then reopen lookout: it does not reconnect on its own"
                     .to_string(),
                 palette.muted(),
             ),

--- a/crates/shep-cli/src/lookout/view/mod.rs
+++ b/crates/shep-cli/src/lookout/view/mod.rs
@@ -886,7 +886,11 @@ mod tests {
             .next_back()
             .expect("a status bar")
             .to_string();
-        assert!(bar.contains("r retry the link"), "{bar:?}");
+        assert!(bar.contains("j/k still moves"), "{bar:?}");
+        assert!(
+            !bar.contains("   r "),
+            "the bar must not offer a key a freeze has already refused: {bar:?}"
+        );
         assert!(bar.contains("\u{2588} frozen"), "{bar:?}");
     }
 

--- a/crates/shep-cli/src/lookout/view/mod.rs
+++ b/crates/shep-cli/src/lookout/view/mod.rs
@@ -838,9 +838,6 @@ mod tests {
         assert_eq!(unpainted, 0, "an unselected row carries no ground at all");
     }
 
-    /// Last values stay on screen, with a sentence admitting they are
-    /// stale.
-    #[test]
     /// Also found by capturing a real screen: at 90 columns the row under
     /// the band ran off the edge mid-word while the five lines below it all
     /// marked their own cuts, which reads as a rendering fault rather than
@@ -893,6 +890,8 @@ mod tests {
         assert!(bar.contains("\u{2588} frozen"), "{bar:?}");
     }
 
+    /// Last values stay on screen, under a band that says in words how
+    /// stale they are.
     #[test]
     fn a_frozen_link_says_so_in_the_band_and_keeps_the_home_path_below_it() {
         let mut app = App::new(
@@ -1169,8 +1168,11 @@ mod tests {
                     );
                     // The row above the status bar belongs to the bottom-most
                     // pane that is up, so it is never blank: a blank one means
-                    // the upward layout left a hole.
-                    if (panes.feed || panes.detail) && !(frozen && !panes.feed) {
+                    // the upward layout left a hole. One condition for both
+                    // link states: `PANE_TIERS` never gives a terminal the
+                    // detail band without the feed, and the link panel draws
+                    // at the feed's own tier.
+                    if panes.feed || panes.detail {
                         let above = lines[lines.len() - 2];
                         assert!(
                             !above.trim().is_empty(),

--- a/crates/shep-cli/src/lookout/view/mod.rs
+++ b/crates/shep-cli/src/lookout/view/mod.rs
@@ -11,6 +11,7 @@ pub mod cell;
 pub mod detail;
 pub mod flock;
 pub mod host;
+pub mod link_panel;
 pub mod pane;
 pub mod scroll;
 pub mod settings;
@@ -218,6 +219,9 @@ pub fn draw(app: &App, frame: &mut Frame<'_>) {
     if roomy {
         y += 1;
     }
+    // Read four times below: the column header's own wording, and the three
+    // panes the bottom stack chooses between.
+    let frozen = matches!(app.link(), Link::Lost { .. });
 
     // The settings screen and the config pane each own the whole body
     // between the title and the status bar: a swap, not an overlay, so
@@ -292,7 +296,7 @@ pub fn draw(app: &App, frame: &mut Frame<'_>) {
         y += 1;
     }
     let header = match app.grouping() {
-        Grouping::Flat => flock::header_line(flat_columns, table_width, palette.muted()),
+        Grouping::Flat => flock::header_line(flat_columns, table_width, palette.muted(), frozen),
         Grouping::ByFold => {
             flock::fold_columns_header_line(fold_columns, table_width, palette.muted())
         }
@@ -304,11 +308,20 @@ pub fn draw(app: &App, frame: &mut Frame<'_>) {
     // the detail pane and the feed are up claim their rows off `bottom`
     // first, and the table gets whatever is left between `y` and `floor`.
     let mut floor = bottom;
-    let feed_at = panes.feed.then(|| {
+    // One pane or two, never both shapes. A frozen dashboard's detail band
+    // and feed are two more frozen readings, and neither answers the
+    // question their operator is holding; the link panel is the only thing
+    // on the screen that can. It claims the rows at the tier the feed
+    // appears at, since that is the shorter of the two the pair need.
+    let link_at = (frozen && panes.feed).then(|| {
+        floor -= link_panel::LINK_ROWS;
+        floor
+    });
+    let feed_at = (!frozen && panes.feed).then(|| {
         floor -= FEED_ROWS;
         floor
     });
-    let detail_at = panes.detail.then(|| {
+    let detail_at = (!frozen && panes.detail).then(|| {
         floor -= DETAIL_ROWS;
         floor
     });
@@ -358,7 +371,18 @@ pub fn draw(app: &App, frame: &mut Frame<'_>) {
                 } else {
                     Role::Meadow
                 };
-                section_band(&label.to_ascii_uppercase(), role, &palette, table_width)
+                // The data palette, not the chrome one: this band sits
+                // inside the table, and a meadow row in a dead-grey table
+                // reads as the one thing on it that is still alive. Frozen,
+                // meadow and sky both resolve to the muted ink and the two
+                // bands are told apart by their own words, which is what
+                // `NO_COLOR` already asks of them.
+                section_band(
+                    &label.to_ascii_uppercase(),
+                    role,
+                    &app.data_palette(),
+                    table_width,
+                )
             } else {
                 match app.grouping() {
                     Grouping::Flat => {
@@ -398,6 +422,18 @@ pub fn draw(app: &App, frame: &mut Frame<'_>) {
             buffer.set_line(area.x, top + 1 + offset, line, width);
         }
     }
+    if let Some(top) = link_at {
+        buffer.set_line(
+            area.x,
+            top,
+            &status::rule_line(palette.line(), width),
+            width,
+        );
+        for (offset, line) in link_panel::panel_lines(app, width).iter().enumerate() {
+            let offset = u16::try_from(offset).unwrap_or(0);
+            buffer.set_line(area.x, top + 1 + offset, line, width);
+        }
+    }
 
     buffer.set_line(area.x, bottom, &status::status_line(app, width), width);
 }
@@ -411,22 +447,35 @@ pub fn draw(app: &App, frame: &mut Frame<'_>) {
 /// ratatui paints a span's background, and applies `Modifier::REVERSED`,
 /// only under the cells its text occupies, so a band that stopped where its
 /// text stopped would leave the rest of the row unpainted.
+///
+/// The bark arm says something else entirely. A dead shepherd's row spends
+/// its whole width on what happened and when, since every other number on
+/// the screen is now history and the flock count is one of them;
+/// `status::banner_line` picks up the `$SHEP_HOME` this loses.
 fn title_band(app: &App, width: u16) -> Line<'static> {
-    let left = format!("shep lookout   {}", app.home());
-    let visible = app.rows().len();
-    let total = app.flock_len();
-    let right = if app.filter().is_empty() {
-        format!(" {total} in the flock")
-    } else {
-        format!(" {visible} of {total} in the flock")
+    let (left, right, role) = match app.link() {
+        Link::Lost { at_local, .. } => (
+            format!(" THE SHEPHERD HAS DIED  \u{2596}  these values are frozen as of {at_local}"),
+            " nothing here is live  \u{2596}  q to quit ".to_string(),
+            Role::Bark,
+        ),
+        Link::Live | Link::Retrying { .. } => {
+            let visible = app.rows().len();
+            let total = app.flock_len();
+            let right = if app.filter().is_empty() {
+                format!(" {total} in the flock")
+            } else {
+                format!(" {visible} of {total} in the flock")
+            };
+            (
+                format!("shep lookout   {}", app.home()),
+                right,
+                Role::Meadow,
+            )
+        }
     };
     let budget = width.saturating_sub(u16::try_from(right.chars().count()).unwrap_or(0));
     let text = format!("{}{right}", flock::fit(&left, budget));
-    let role = if matches!(app.link(), Link::Lost { .. }) {
-        Role::Bark
-    } else {
-        Role::Meadow
-    };
     band_line(text, width, app.palette().band(role))
 }
 
@@ -498,6 +547,7 @@ mod tests {
         let mut app = fixtures::app_with(Vec::new(), fixtures::coloured());
         app.update(Msg::Frozen {
             at_local: "2026-08-14 14:32:07".to_string(),
+            why: fixtures::FROZEN_WHY.to_string(),
         });
         let line = title_band(&app, 80);
         assert_eq!(line.spans[0].style.fg, Some(Color::Indexed(166)));
@@ -791,7 +841,7 @@ mod tests {
     /// Last values stay on screen, with a sentence admitting they are
     /// stale.
     #[test]
-    fn a_frozen_link_puts_the_banner_under_the_title() {
+    fn a_frozen_link_says_so_in_the_band_and_keeps_the_home_path_below_it() {
         let mut app = App::new(
             Palette::detect(None, None, None),
             Control::ReadOnly,
@@ -800,11 +850,28 @@ mod tests {
         );
         app.update(Msg::Frozen {
             at_local: "2026-08-14 14:32:07".to_string(),
+            why: fixtures::FROZEN_WHY.to_string(),
         });
-        let frame = draw_to(&app, 100, 12);
-        let banner = frame.lines().nth(1).expect("a second line").to_string();
-        assert!(banner.contains("the shepherd has died"));
-        assert!(banner.contains("2026-08-14 14:32:07"));
+        // 160, the design target: the row below the band carries three
+        // clauses and a `$SHEP_HOME`, and a narrower terminal truncates the
+        // tail rather than rewrapping it.
+        let frame = draw_to(&app, 160, 12);
+        let mut lines = frame.lines();
+
+        let band = lines.next().expect("a title band");
+        assert!(band.contains("THE SHEPHERD HAS DIED"), "{band:?}");
+        assert!(band.contains("2026-08-14 14:32:07"), "{band:?}");
+        assert!(
+            !band.contains("in the flock"),
+            "the flock count is one more frozen number: {band:?}"
+        );
+
+        // The row the band displaced. `$SHEP_HOME` is the one thing on the
+        // title row an operator still needs, since it says which dashboard
+        // they are looking at.
+        let under = lines.next().expect("a second line");
+        assert!(under.contains("/home/ada/.shep"), "{under:?}");
+        assert!(under.contains("it will not exit on its own"), "{under:?}");
     }
 
     /// An operator who does not know the control state is one keystroke
@@ -978,120 +1045,155 @@ mod tests {
 
     /// `Buffer::set_line` outside the area is a panic in debug and a silent
     /// no-op otherwise, and the arithmetic here has four moving parts.
+    ///
+    /// Swept in both link states, because they lay the bottom stack out
+    /// differently: live gets the detail band and the feed, frozen gets the
+    /// link panel in place of both.
     #[test]
     fn every_pane_lands_inside_its_own_rows_across_the_size_sweep() {
-        let mut app = fixtures::full_app();
-        app.update(Msg::Frozen {
+        let live = fixtures::full_app();
+        let mut lost = fixtures::full_app();
+        lost.update(Msg::Frozen {
             at_local: "2026-08-14 14:32:07".to_string(),
+            why: fixtures::FROZEN_WHY.to_string(),
         });
-        for height in flock::MIN_HEIGHT..=60 {
-            for width in [MIN_TERM_WIDTH, 40, 51, 80, 120, 200] {
-                let frame = draw_to(&app, width, height);
-                let lines: Vec<&str> = frame.lines().collect();
-                let panes = panes_for(height);
+        for (frozen, app) in [(false, &live), (true, &lost)] {
+            for height in flock::MIN_HEIGHT..=60 {
+                for width in [MIN_TERM_WIDTH, 40, 51, 80, 120, 200] {
+                    let frame = draw_to(app, width, height);
+                    let lines: Vec<&str> = frame.lines().collect();
+                    let panes = panes_for(height);
 
-                // The table's own row band, recomputed independently of
-                // `draw`: title (1) + banner (1, this fixture is frozen) +
-                // host strip if up + header/rule (2) is where it starts;
-                // `floor`, walked the same way `draw` does, is where it ends.
-                let table_body_start = 2 + if panes.host { HOST_ROWS } else { 0 } + 2;
-                let mut floor = height - 1;
-                if panes.feed {
-                    floor -= FEED_ROWS;
-                }
-                if panes.detail {
-                    floor -= DETAIL_ROWS;
-                }
-                let table_body_end = floor;
-                for (i, line) in lines.iter().enumerate() {
-                    let i = u16::try_from(i).unwrap_or(u16::MAX);
-                    if i < table_body_start || i >= table_body_end {
-                        continue;
+                    // The table's own row band, recomputed independently of
+                    // `draw`: title (1) + banner (1, both fixtures carry one) +
+                    // host strip if up + header/rule (2) is where it starts;
+                    // `floor`, walked the same way `draw` does, is where it ends.
+                    let table_body_start = 2 + if panes.host { HOST_ROWS } else { 0 } + 2;
+                    let mut floor = height - 1;
+                    if frozen {
+                        if panes.feed {
+                            floor -= link_panel::LINK_ROWS;
+                        }
+                    } else {
+                        if panes.feed {
+                            floor -= FEED_ROWS;
+                        }
+                        if panes.detail {
+                            floor -= DETAIL_ROWS;
+                        }
                     }
-                    assert!(
-                        !line.starts_with("bleats  "),
-                        "the feed header sits inside the table's own rows at \
+                    let table_body_end = floor;
+                    for (i, line) in lines.iter().enumerate() {
+                        let i = u16::try_from(i).unwrap_or(u16::MAX);
+                        if i < table_body_start || i >= table_body_end {
+                            continue;
+                        }
+                        assert!(
+                            !line.starts_with("bleats  "),
+                            "the feed header sits inside the table's own rows at \
                          {width}x{height}, row {i}"
-                    );
-                    assert!(
-                        !line.starts_with("out  /home/ada/.shep/logs/"),
-                        "the detail pane's out path sits inside the table's \
+                        );
+                        assert!(
+                            !line.starts_with("out  /home/ada/.shep/logs/"),
+                            "the detail pane's out path sits inside the table's \
                          own rows at {width}x{height}, row {i}"
-                    );
-                }
+                        );
+                    }
 
-                // Not `lines.len() == height`: `frames::render_text` maps
-                // `(0..area.height)` by construction, so that holds even for
-                // a `draw` that drew nothing. It is a property of the
-                // renderer, not of this layout.
-                let last = lines.last().unwrap();
-                assert!(
-                    last.contains("read-only"),
-                    "the status bar survived at {width}x{height}: {last:?}"
-                );
-                // The row above the status bar belongs to the bottom-most
-                // pane that is up, so it is never blank: a blank one means
-                // the upward layout left a hole.
-                if panes.feed || panes.detail {
-                    let above = lines[lines.len() - 2];
+                    // Not `lines.len() == height`: `frames::render_text` maps
+                    // `(0..area.height)` by construction, so that holds even for
+                    // a `draw` that drew nothing. It is a property of the
+                    // renderer, not of this layout.
+                    let last = lines.last().unwrap();
+                    let mark = if frozen {
+                        "\u{2588} frozen"
+                    } else {
+                        "read-only"
+                    };
                     assert!(
-                        !above.trim().is_empty(),
-                        "a blank row above the status bar at {width}x{height}"
+                        last.contains(mark),
+                        "the status bar survived at {width}x{height}: {last:?}"
                     );
-                }
-                // Every pane that is up appears exactly once and sits in
-                // its own band.
-                if panes.host {
-                    let positions: Vec<usize> = lines
-                        .iter()
-                        .enumerate()
-                        .filter(|(_, l)| l.starts_with("host  "))
-                        .map(|(i, _)| i)
-                        .collect();
-                    assert_eq!(positions.len(), 1, "the strip at {width}x{height}");
-                    assert!(
-                        u16::try_from(positions[0]).unwrap_or(u16::MAX) < table_body_start,
-                        "the strip at {width}x{height} sits at row {}, at or below the table",
-                        positions[0]
-                    );
-                }
-                if panes.feed {
-                    // `contains`, not `starts_with`: the `BLEATS` chip
-                    // leads the line, and nothing else on screen carries it.
-                    let positions: Vec<usize> = lines
-                        .iter()
-                        .enumerate()
-                        .filter(|(_, l)| l.contains("BLEATS"))
-                        .map(|(i, _)| i)
-                        .collect();
-                    assert_eq!(positions.len(), 1, "the feed header at {width}x{height}");
-                    assert!(
-                        u16::try_from(positions[0]).unwrap_or(0) >= table_body_end,
-                        "the feed header at {width}x{height} sits at row {}, inside or above the table",
-                        positions[0]
-                    );
-                }
-                if panes.detail {
-                    // The `\u{2502}` divider, not a bare `out  `: the feed's
-                    // own body lines are tagged `out  ` too, and the merged
-                    // log row's own path can truncate away at a narrow
-                    // width, but its divider never does.
-                    let positions: Vec<usize> = lines
-                        .iter()
-                        .enumerate()
-                        .filter(|(_, l)| l.starts_with("out  ") && l.contains('\u{2502}'))
-                        .map(|(i, _)| i)
-                        .collect();
-                    assert_eq!(
-                        positions.len(),
-                        1,
-                        "the detail pane's out path at {width}x{height}"
-                    );
-                    assert!(
-                        u16::try_from(positions[0]).unwrap_or(0) >= table_body_end,
-                        "the detail pane's out path at {width}x{height} sits at row {}, inside or above the table",
-                        positions[0]
-                    );
+                    // The row above the status bar belongs to the bottom-most
+                    // pane that is up, so it is never blank: a blank one means
+                    // the upward layout left a hole.
+                    if (panes.feed || panes.detail) && !(frozen && !panes.feed) {
+                        let above = lines[lines.len() - 2];
+                        assert!(
+                            !above.trim().is_empty(),
+                            "a blank row above the status bar at {width}x{height}"
+                        );
+                    }
+                    // Every pane that is up appears exactly once and sits in
+                    // its own band.
+                    if panes.host {
+                        let positions: Vec<usize> = lines
+                            .iter()
+                            .enumerate()
+                            .filter(|(_, l)| l.starts_with("host  "))
+                            .map(|(i, _)| i)
+                            .collect();
+                        assert_eq!(positions.len(), 1, "the strip at {width}x{height}");
+                        assert!(
+                            u16::try_from(positions[0]).unwrap_or(u16::MAX) < table_body_start,
+                            "the strip at {width}x{height} sits at row {}, at or below the table",
+                            positions[0]
+                        );
+                    }
+                    if panes.feed {
+                        // `contains`, not `starts_with`: the chip leads the
+                        // line, and nothing else on screen carries either word.
+                        // A frozen frame's `BLEATS` is gone and `THE LINK` is
+                        // in its slot.
+                        let chip = if frozen { "THE LINK" } else { "BLEATS" };
+                        let positions: Vec<usize> = lines
+                            .iter()
+                            .enumerate()
+                            .filter(|(_, l)| l.contains(chip))
+                            .map(|(i, _)| i)
+                            .collect();
+                        assert_eq!(positions.len(), 1, "the {chip} header at {width}x{height}");
+                        assert!(
+                            u16::try_from(positions[0]).unwrap_or(0) >= table_body_end,
+                            "the {chip} header at {width}x{height} sits at row {}, inside or above the table",
+                            positions[0]
+                        );
+                    }
+                    if panes.detail && !frozen {
+                        // The `\u{2502}` divider, not a bare `out  `: the feed's
+                        // own body lines are tagged `out  ` too, and the merged
+                        // log row's own path can truncate away at a narrow
+                        // width, but its divider never does.
+                        let positions: Vec<usize> = lines
+                            .iter()
+                            .enumerate()
+                            .filter(|(_, l)| l.starts_with("out  ") && l.contains('\u{2502}'))
+                            .map(|(i, _)| i)
+                            .collect();
+                        assert_eq!(
+                            positions.len(),
+                            1,
+                            "the detail pane's out path at {width}x{height}"
+                        );
+                        assert!(
+                            u16::try_from(positions[0]).unwrap_or(0) >= table_body_end,
+                            "the detail pane's out path at {width}x{height} sits at row {}, inside or above the table",
+                            positions[0]
+                        );
+                    }
+                    // The two panes the link panel replaces are gone outright,
+                    // not merely moved: both are readings a dead shepherd
+                    // cannot refresh.
+                    if frozen {
+                        assert!(
+                            !lines.iter().any(|l| l.contains("BLEATS")),
+                            "the feed survived a freeze at {width}x{height}"
+                        );
+                        assert!(
+                            !lines.iter().any(|l| l.starts_with("lambs  ")),
+                            "the detail band survived a freeze at {width}x{height}"
+                        );
+                    }
                 }
             }
         }

--- a/crates/shep-cli/src/lookout/view/mod.rs
+++ b/crates/shep-cli/src/lookout/view/mod.rs
@@ -265,7 +265,7 @@ pub fn draw(app: &App, frame: &mut Frame<'_>) {
         Body::FlockTable => {}
     }
 
-    if let Some(banner) = status::banner_line(app) {
+    if let Some(banner) = status::banner_line(app, width) {
         buffer.set_line(area.x, y, &banner, width);
         y += 1;
     }
@@ -841,6 +841,32 @@ mod tests {
     /// Last values stay on screen, with a sentence admitting they are
     /// stale.
     #[test]
+    /// Also found by capturing a real screen: at 90 columns the row under
+    /// the band ran off the edge mid-word while the five lines below it all
+    /// marked their own cuts, which reads as a rendering fault rather than
+    /// as a narrow terminal.
+    #[test]
+    fn the_row_under_the_band_marks_its_own_truncation() {
+        let mut app = fixtures::full_app();
+        app.update(Msg::Frozen {
+            at_local: "2026-08-14 14:32:07".to_string(),
+            why: fixtures::FROZEN_WHY.to_string(),
+        });
+        let under = |width| {
+            draw_to(&app, width, 24)
+                .lines()
+                .nth(1)
+                .expect("a second line")
+                .to_string()
+        };
+        assert!(under(90).trim_end().ends_with('…'), "{:?}", under(90));
+        assert!(
+            under(160).contains("it will not exit on its own"),
+            "and the whole sentence survives where it fits: {:?}",
+            under(160)
+        );
+    }
+
     /// Found by capturing a real dashboard rather than by any test here:
     /// killing the shepherd leaves `the shepherd is shutting down` as a
     /// notice, notices outrank the key hint, and the bar then spends the

--- a/crates/shep-cli/src/lookout/view/mod.rs
+++ b/crates/shep-cli/src/lookout/view/mod.rs
@@ -841,6 +841,33 @@ mod tests {
     /// Last values stay on screen, with a sentence admitting they are
     /// stale.
     #[test]
+    /// Found by capturing a real dashboard rather than by any test here:
+    /// killing the shepherd leaves `the shepherd is shutting down` as a
+    /// notice, notices outrank the key hint, and the bar then spends the
+    /// rest of the session on a sentence about a process that is gone
+    /// instead of on the three keys that still work.
+    #[test]
+    fn a_freeze_clears_the_notice_that_would_sit_on_the_key_hint() {
+        let mut app = fixtures::full_app();
+        app.update(Msg::BusLagged { count: 4 });
+        assert!(app.notice().is_some(), "a notice to be cleared");
+
+        app.update(Msg::Frozen {
+            at_local: "2026-08-14 14:32:07".to_string(),
+            why: fixtures::FROZEN_WHY.to_string(),
+        });
+        assert!(app.notice().is_none());
+
+        let bar = draw_to(&app, 160, 30)
+            .lines()
+            .next_back()
+            .expect("a status bar")
+            .to_string();
+        assert!(bar.contains("r retry the link"), "{bar:?}");
+        assert!(bar.contains("\u{2588} frozen"), "{bar:?}");
+    }
+
+    #[test]
     fn a_frozen_link_says_so_in_the_band_and_keeps_the_home_path_below_it() {
         let mut app = App::new(
             Palette::detect(None, None, None),

--- a/crates/shep-cli/src/lookout/view/status.rs
+++ b/crates/shep-cli/src/lookout/view/status.rs
@@ -18,6 +18,7 @@ use super::settings::field_label;
 
 /// The banner, when there is one. `None` while the link is live.
 ///
+///
 /// What happened and when the values stopped being current, so an operator
 /// reading `online` knows how much to trust it. The frozen row says neither:
 /// once the link is lost, `view::title_band` carries the death sentence in
@@ -25,7 +26,7 @@ use super::settings::field_label;
 /// the title band no longer has space for, plus the two things an operator
 /// staring at a dead dashboard actually needs told.
 #[must_use]
-pub fn banner_line(app: &App) -> Option<Line<'static>> {
+pub fn banner_line(app: &App, width: u16) -> Option<Line<'static>> {
     let palette = app.palette();
     match app.link() {
         Link::Live => None,
@@ -33,10 +34,19 @@ pub fn banner_line(app: &App) -> Option<Line<'static>> {
             retrying_sentence(*attempt),
             palette.attention(),
         ))),
+        // Through `fit`, unlike the retrying sentence above, which is
+        // short enough that no terminal cuts it. Three clauses and a
+        // `$SHEP_HOME` do not fit 90 columns, and `Buffer::set_line` cuts
+        // what does not fit in silence: a sentence ending mid-word beside
+        // five other lines that all mark their own truncation reads as a
+        // rendering fault rather than as a narrow terminal.
         Link::Lost { .. } => Some(Line::from(Span::styled(
-            format!(
-                " shep lookout   {}  ·  the dashboard stays up so you can read what it had  ·  it will not exit on its own",
-                app.home()
+            fit(
+                &format!(
+                    " shep lookout   {}  ·  the dashboard stays up so you can read what it had  ·  it will not exit on its own",
+                    app.home()
+                ),
+                width,
             ),
             palette.muted(),
         ))),

--- a/crates/shep-cli/src/lookout/view/status.rs
+++ b/crates/shep-cli/src/lookout/view/status.rs
@@ -55,11 +55,15 @@ pub fn banner_line(app: &App, width: u16) -> Option<Line<'static>> {
 
 /// The key hint once the link is [`Link::Lost`].
 ///
-/// Three keys, because three keys still do something: `q` leaves, `r` dials
-/// again, and `j`/`k` move a cursor over values that are already history.
-/// The last clause is the whole rest of the keymap, said once rather than
+/// Two keys, because two keys still do something: `q` leaves, and `j`/`k`
+/// move a cursor over values that are already history. `r` is not among
+/// them, whatever the design's own copy says: it is refused like the rest
+/// (`App::on_key`), and `super::super::link::run_link` has already returned
+/// by the time a freeze lands, so no task survives to answer a redial. The
+/// last clause is the whole rest of the keymap, said once rather than
 /// discovered a keypress at a time.
-const FROZEN_HINT: &str = "q quit   r retry the link   j/k still moves   every other key is refused while the link is down";
+const FROZEN_HINT: &str =
+    "q quit   j/k still moves   every other key is refused while the link is down";
 
 /// The bottom line: eight slots, highest priority first: the settings
 /// screen's armed or in-flight edit, a dashboard confirm, the settings

--- a/crates/shep-cli/src/lookout/view/status.rs
+++ b/crates/shep-cli/src/lookout/view/status.rs
@@ -18,9 +18,12 @@ use super::settings::field_label;
 
 /// The banner, when there is one. `None` while the link is live.
 ///
-/// The frozen sentence names what happened and when the values stopped
-/// being current, so an operator reading `online` knows how much to trust
-/// it.
+/// What happened and when the values stopped being current, so an operator
+/// reading `online` knows how much to trust it. The frozen row says neither:
+/// once the link is lost, `view::title_band` carries the death sentence in
+/// bark across the whole row above, and this row picks up the `$SHEP_HOME`
+/// the title band no longer has space for, plus the two things an operator
+/// staring at a dead dashboard actually needs told.
 #[must_use]
 pub fn banner_line(app: &App) -> Option<Line<'static>> {
     let palette = app.palette();
@@ -30,12 +33,23 @@ pub fn banner_line(app: &App) -> Option<Line<'static>> {
             retrying_sentence(*attempt),
             palette.attention(),
         ))),
-        Link::Lost { at_local } => Some(Line::from(Span::styled(
-            format!("the shepherd has died: these values are frozen as of {at_local}"),
-            palette.alarm(),
+        Link::Lost { .. } => Some(Line::from(Span::styled(
+            format!(
+                " shep lookout   {}  ·  the dashboard stays up so you can read what it had  ·  it will not exit on its own",
+                app.home()
+            ),
+            palette.muted(),
         ))),
     }
 }
+
+/// The key hint once the link is [`Link::Lost`].
+///
+/// Three keys, because three keys still do something: `q` leaves, `r` dials
+/// again, and `j`/`k` move a cursor over values that are already history.
+/// The last clause is the whole rest of the keymap, said once rather than
+/// discovered a keypress at a time.
+const FROZEN_HINT: &str = "q quit   r retry the link   j/k still moves   every other key is refused while the link is down";
 
 /// The bottom line: eight slots, highest priority first: the settings
 /// screen's armed or in-flight edit, a dashboard confirm, the settings
@@ -169,6 +183,13 @@ pub fn status_line(app: &App, width: u16) -> Line<'static> {
             format!("filter \"{}\"   / edit   esc clear", app.filter()),
             palette.muted(),
         )
+    } else if matches!(app.link(), Link::Lost { .. }) {
+        // Only this branch, not the pane hints above: a pane opened before
+        // the freeze keeps naming its own keys, and this line is the flock
+        // table's. Every action key `hint_for` would name is refused once
+        // the link is gone, so naming them would teach the operator three
+        // keys that do nothing.
+        (FROZEN_HINT.to_string(), palette.attention())
     } else {
         // Butter: the keys, same rule as the pane's own hint above.
         (
@@ -182,7 +203,12 @@ pub fn status_line(app: &App, width: u16) -> Line<'static> {
     // tail: control state means nothing on a screen with no action keys of
     // its own, and whether the view is pinned to the newest line is the
     // fact this screen's own operator needs a keystroke away from.
-    let right = if app.bleats_pane().is_some_and(BleatsPane::following) {
+    let right = if matches!(app.link(), Link::Lost { .. }) {
+        // Ahead of both: whether this dashboard is reading a live shepherd
+        // outranks whether a pane is pinned to the newest line, and it
+        // outranks a control state that no longer decides anything.
+        "\u{2588} frozen"
+    } else if app.bleats_pane().is_some_and(BleatsPane::following) {
         "\u{2588} following"
     } else {
         match app.control() {

--- a/docs/lookout/README.md
+++ b/docs/lookout/README.md
@@ -42,11 +42,17 @@ cargo test -p shep --lib --all-features -- --ignored write_the_gallery
 - **Daemon death: bounded retry, then freeze, never exit.** The link task
   re-dials the shepherd 5 times, at 250/500/1000/2000/4000 ms — about 7.75 s
   of waiting — before it gives up. Once the ladder is exhausted, lookout
-  shows the frozen banner (`the shepherd has died: these values are frozen
-  as of <time>`), stops polling and re-dialling, and leaves the last known
-  values on screen. The uptime column stops advancing with it: a frozen
-  dashboard whose clock kept counting would be lying about a specific sheep
-  by name. lookout never exits on its own — the operator quits with `q`.
+  stops polling and re-dialling and leaves the last known values on screen.
+  The title band turns bark and carries `THE SHEPHERD HAS DIED ▖ these
+  values are frozen as of <time>`, and the table, the host strip and the
+  section bands all go to one muted ink, so no cell can be read as current.
+  The `UPTIME` header becomes `FROZEN` over a duration that stopped
+  advancing when the link did: a frozen dashboard whose clock kept counting
+  would be lying about a specific sheep by name. The detail band and the
+  bleats feed give their rows to the link panel, which names the ladder it
+  climbed, quotes the last dial's own error, counts how long ago that was,
+  and says what is left to try. lookout never exits on its own — the
+  operator quits with `q`, or presses `r` to dial again.
   A shepherd that was **never** running is a different case: that connect
   attempt happens before raw mode is entered, and a failure there is the
   ordinary `daemon_unreachable` refusal every other verb gives, not eight
@@ -69,8 +75,8 @@ cargo test -p shep --lib --all-features -- --ignored write_the_gallery
   no way to refuse a keypress it cannot tell apart from `shep stop`.
 - **Colour is always redundant with text.** Every coloured cell says the
   same thing in words that the colour is repeating — the STATUS column
-  prints `errored` under `--bark`, the banner prints `the shepherd has
-  died` under `--bark`. Nothing here is colour-only, so `NO_COLOR` and a
+  prints `errored` under `--bark`, the frozen band prints `THE SHEPHERD HAS
+  DIED` under `--bark`. Nothing here is colour-only, so `NO_COLOR` and a
   16-colour terminal both lose decoration, never information.
 - **Narrow terminals drop columns in a fixed order**, least diagnostic
   first, one at a time, at the width in brackets: `MEM/CEIL` (134), `CPU 20s`
@@ -156,7 +162,9 @@ debt.
 - **The title, the two section bands, and the selected row all paint now.**
   The title and the `FLOCK`/`DOGS` bands are reverse video: meadow for the
   flock band, sky for dogs, and the title turns bark when the link to the
-  shepherd has frozen. The selected row and the status bar are the only two
+  shepherd has frozen. Frozen, the two section bands go muted with the rest
+  of the table and are told apart by their own words, which is what
+  `NO_COLOR` already asks of them. The selected row and the status bar are the only two
   rows that ever paint a background; everywhere else the operator's own
   terminal background shows through. Under `NO_COLOR` the roles disappear
   but the reverse video stays, so a band still names its section in plain

--- a/docs/lookout/README.md
+++ b/docs/lookout/README.md
@@ -52,7 +52,9 @@ cargo test -p shep --lib --all-features -- --ignored write_the_gallery
   bleats feed give their rows to the link panel, which names the ladder it
   climbed, quotes the last dial's own error, counts how long ago that was,
   and says what is left to try. lookout never exits on its own — the
-  operator quits with `q`, or presses `r` to dial again.
+  operator quits with `q`. `r` is refused with the rest of the keymap:
+  `run_link` has already returned by then, so nothing survives to answer a
+  redial, and the panel says `shep muster` instead.
   A shepherd that was **never** running is a different case: that connect
   attempt happens before raw mode is entered, and a failure there is the
   ordinary `daemon_unreachable` refusal every other verb gives, not eight

--- a/docs/lookout/frames.ansi
+++ b/docs/lookout/frames.ansi
@@ -417,8 +417,8 @@ The ladder ran out. The band says so in bark, the whole table and the host strip
 [0m[38;5;245m  ladder    [0m[38;5;166m█[0m[38;5;245m 250ms  [0m[38;5;166m█[0m[38;5;245m 500ms  [0m[38;5;166m█[0m[38;5;245m 1s  [0m[38;5;166m█[0m[38;5;245m 2s  [0m[38;5;166m█[0m[38;5;245m 4s  [0m                                                                                                                [0m
 [0m[38;5;245m  refused   the shepherd did not answer: could not connect to `/home/ada/.shep/run/shep.sock`: Connection refused (os error 61)[0m                                 [0m
 [0m[38;5;245m  since     2026-08-14 14:32:07, 9m 53s ago      the sheep themselves may well still be running; lookout cannot see them to say[0m                                 [0m
-[0m[38;5;245m  try       [0m[38;5;221mr[0m[38;5;245m dials again now      or start the shepherd from another shell: shep muster[0m                                                                        [0m
-[0m[38;5;221m[48;5;235mq quit   r retry the link   j/k still moves   every other key is refused while the link is down                                                        [0m[38;5;245m[48;5;235m █ frozen[0m
+[0m[38;5;221m  try       [0m[38;5;245mshep muster, from another shell      then reopen lookout: it does not reconnect on its own[0m                                                          [0m
+[0m[38;5;221m[48;5;235mq quit   j/k still moves   every other key is refused while the link is down                                                                           [0m[38;5;245m[48;5;235m █ frozen[0m
 
 
 === refused  (120x30) ===

--- a/docs/lookout/frames.ansi
+++ b/docs/lookout/frames.ansi
@@ -386,39 +386,39 @@ The shepherd stopped answering. Five attempts over about eight seconds before th
 [0m[38;5;221m[48;5;235mq quit   j/k select   / filter   F folds   x stop   R restart   L reload   s settings   e edit   * your…[0m[38;5;245m[48;5;235m control enabled[0m
 
 
-=== frozen  (120x30) ===
-The ladder ran out. Last known values stay, the uptime clock has stopped, and so has the host strip: one line ticking over on a frozen screen is a contradiction on the same frame.
+=== frozen  (160x30) ===
+The ladder ran out. The band says so in bark, the whole table and the host strip go to one muted ink so no cell reads as live, and UPTIME becomes FROZEN over a duration that has stopped advancing. The detail band and the feed give their rows to the link panel: they describe a shepherd that is gone, and it describes what happened.
 
-[0m[7m[38;5;166mshep lookout   /home/ada/.shep                                                                            6 in the flock[0m
-                                                                                                                        [0m
-[0m[38;5;166mthe shepherd has died: these values are frozen as of 2026-08-14 14:32:07[0m                                                [0m
-[0m[38;5;245mhost  load  [0m[38;5;221m██░░░░░░░░[0m[38;5;245m 2.31 4.10 3.88 / 10 cores     host mem  [0m[38;5;74m████░░░░░░[0m[38;5;245m 12.4G / 32.0G     1 errored · 0 parked   floc…[0m
-[0m[38;5;238m────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────[0m
-                                                                                                                        [0m
-  [0m[38;5;245mID    NAME        STATUS           PID      RESTARTS  EXIT       CPU     MEM       UPTIME    FOLD        SMIT         [0m
-  [0m[7m[38;5;29m ██ FLOCK                                                                                                             [0m
-[0m[48;5;235m [0m [0m[48;5;235m2     api         [0m[38;5;166m[48;5;235merrored        [0m[48;5;235m  -        14        1          -       -         1h 18m    edge        -            [0m
-  3     billing-r…  [0m[38;5;221mwaiting-restart[0m  -        3         1          -       -         1h 19m    -           -            [0m
-  4     cron        [0m[38;5;245mstopped        [0m  -        0         SIGTERM    -       -         1h 21m    -           -            [0m
-  5     metrics     [0m[38;5;29monline         [0m  48240    0         -          0.4%    11.0M     1h 22m    -           -            [0m
-  0     web         [0m[38;5;29monline         [0m  48211    0         -          3.4%    182.0M    1h 15m    edge        -            [0m
-  1     web         [0m[38;5;29monline         [0m  48212    0         -          2.9%    178.0M    1h 16m    edge        -            [0m
-                                                                                                                        [0m
-                                                                                                                        [0m
-                                                                                                                        [0m
-[0m[38;5;238m────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────[0m
-[0m[7m[38;5;29m ██ SHEEP 2[0m  api   [0m[38;5;166merrored[0m   pid -   restarts 14   uptime 1h 18m   cpu -   mem -   fold edge                            [0m
-[0m[38;5;245mlambs  3 parent-pid descendants, read 0s ago   48220 node   48221 node   48222 node                                     [0m
-[0m[38;5;245mout  /home/ada/.shep/logs/api-2-out.log[0m[38;5;238m   │   [0m[38;5;245merr  /home/ada/.shep/logs/api-2-err.log                                   [0m
-                                                                                                                        [0m
-[0m[38;5;238m────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────[0m
-[0m[7m[38;5;221m ██ BLEATS[0m [0m[38;5;221mapi  … 1 earlier line not shown                                                                              [0m
-[0m[38;5;245mout  [0mGET /healthz 200 3ms                                                                                               [0m
-[0m[38;5;245mout  [0mGET /v1/orders 200 44ms                                                                                            [0m
-[0m[38;5;245mout  [0mPOST /v1/orders 201 88ms                                                                                           [0m
-[0m[38;5;245mout  [0mGET /v1/orders/8821 200 9ms                                                                                        [0m
-[0m[38;5;245mout  [0mconnection pool: 14/50 in use                                                                                      [0m
-[0m[38;5;221m[48;5;235mq quit   j/k select   / filter   F folds   x stop   R restart   L reload   s settings   e edit   * your…[0m[38;5;245m[48;5;235m control enabled[0m
+[0m[7m[38;5;166m THE SHEPHERD HAS DIED  ▖  these values are frozen as of 2026-08-14 14:32:07                                                 nothing here is live  ▖  q to quit [0m
+                                                                                                                                                                [0m
+[0m[38;5;245m shep lookout   /home/ada/.shep  ·  the dashboard stays up so you can read what it had  ·  it will not exit on its own                                          [0m
+[0m[38;5;245mhost  load  ██░░░░░░░░ 2.31 4.10 3.88 / 10 cores     host mem  ████░░░░░░ 12.4G / 32.0G     1 errored · 0 parked   flock cpu 6.7%        █   flock mem 371.0M  …[0m
+[0m[38;5;238m────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────[0m
+                                                                                                                                                                [0m
+  [0m[38;5;245mID    NAME                  STATUS           PID      RESTARTS  EXIT       CFG   CPU 20s     CPU     MEM/CEIL    MEM       FROZEN    FOLD        SMIT         [0m
+  [0m[7m[38;5;245m ██ FLOCK                                                                                                                                                     [0m
+[0m[48;5;235m [0m [0m[48;5;235m2     api                   [0m[38;5;245m[48;5;235merrored        [0m[48;5;235m  -        14        1          -     [0m[38;5;245m[48;5;235m         ▁[0m[48;5;235m  -       [0m[38;5;245m[48;5;235m░░░░░░░░░░[0m[48;5;235m  -         1h 18m    edge        -            [0m
+  3     billing-reconciliat…  [0m[38;5;245mwaiting-restart[0m  -        3         1          -     [0m[38;5;245m         ▁[0m  -       [0m[38;5;245m░░░░░░░░░░[0m  -         1h 19m    -           -            [0m
+  4     cron                  [0m[38;5;245mstopped        [0m  -        0         SIGTERM    -     [0m[38;5;245m         ▁[0m  -       [0m[38;5;245m░░░░░░░░░░[0m  -         1h 21m    -           -            [0m
+  5     metrics               [0m[38;5;245monline         [0m  48240    0         -          -     [0m[38;5;245m         ▂[0m  0.4%    [0m[38;5;245m░░░░░░░░░░[0m  11.0M     1h 22m    -           -            [0m
+  0     web                   [0m[38;5;245monline         [0m  48211    0         -          -     [0m[38;5;245m         █[0m  3.4%    [0m[38;5;245m░░░░░░░░░░[0m  182.0M    1h 15m    edge        -            [0m
+  1     web                   [0m[38;5;245monline         [0m  48212    0         -          -     [0m[38;5;245m         ▇[0m  2.9%    [0m[38;5;245m░░░░░░░░░░[0m  178.0M    1h 16m    edge        -            [0m
+                                                                                                                                                                [0m
+                                                                                                                                                                [0m
+                                                                                                                                                                [0m
+                                                                                                                                                                [0m
+                                                                                                                                                                [0m
+                                                                                                                                                                [0m
+                                                                                                                                                                [0m
+                                                                                                                                                                [0m
+                                                                                                                                                                [0m
+[0m[38;5;238m────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────[0m
+[0m[7m[38;5;166m ██ THE LINK[0m[38;5;245m  5 redials over 7.75s, all refused   ·   lookout has stopped polling and stopped re-dialling[0m                                                       [0m
+[0m[38;5;245m  ladder    [0m[38;5;166m█[0m[38;5;245m 250ms  [0m[38;5;166m█[0m[38;5;245m 500ms  [0m[38;5;166m█[0m[38;5;245m 1s  [0m[38;5;166m█[0m[38;5;245m 2s  [0m[38;5;166m█[0m[38;5;245m 4s  [0m                                                                                                                [0m
+[0m[38;5;245m  refused   the shepherd did not answer: could not connect to `/home/ada/.shep/run/shep.sock`: Connection refused (os error 61)[0m                                 [0m
+[0m[38;5;245m  since     2026-08-14 14:32:07, 9m 53s ago      the sheep themselves may well still be running; lookout cannot see them to say[0m                                 [0m
+[0m[38;5;245m  try       [0m[38;5;221mr[0m[38;5;245m dials again now      or start the shepherd from another shell: shep muster[0m                                                                        [0m
+[0m[38;5;221m[48;5;235mq quit   r retry the link   j/k still moves   every other key is refused while the link is down                                                        [0m[38;5;245m[48;5;235m █ frozen[0m
 
 
 === refused  (120x30) ===

--- a/docs/lookout/frames.txt
+++ b/docs/lookout/frames.txt
@@ -375,39 +375,39 @@ out  GET /v1/orders/8821 200 9ms
 out  connection pool: 14/50 in use                                                                                      
 q quit   j/k select   / filter   F folds   x stop   R restart   L reload   s settings   e edit   * your… control enabled
 
-=== frozen  (120x30) ===
-The ladder ran out. Last known values stay, the uptime clock has stopped, and so has the host strip: one line ticking over on a frozen screen is a contradiction on the same frame.
+=== frozen  (160x30) ===
+The ladder ran out. The band says so in bark, the whole table and the host strip go to one muted ink so no cell reads as live, and UPTIME becomes FROZEN over a duration that has stopped advancing. The detail band and the feed give their rows to the link panel: they describe a shepherd that is gone, and it describes what happened.
 
-shep lookout   /home/ada/.shep                                                                            6 in the flock
-                                                                                                                        
-the shepherd has died: these values are frozen as of 2026-08-14 14:32:07                                                
-host  load  ██░░░░░░░░ 2.31 4.10 3.88 / 10 cores     host mem  ████░░░░░░ 12.4G / 32.0G     1 errored · 0 parked   floc…
-────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-                                                                                                                        
-  ID    NAME        STATUS           PID      RESTARTS  EXIT       CPU     MEM       UPTIME    FOLD        SMIT         
-   ██ FLOCK                                                                                                             
-> 2     api         errored          -        14        1          -       -         1h 18m    edge        -            
-  3     billing-r…  waiting-restart  -        3         1          -       -         1h 19m    -           -            
-  4     cron        stopped          -        0         SIGTERM    -       -         1h 21m    -           -            
-  5     metrics     online           48240    0         -          0.4%    11.0M     1h 22m    -           -            
-  0     web         online           48211    0         -          3.4%    182.0M    1h 15m    edge        -            
-  1     web         online           48212    0         -          2.9%    178.0M    1h 16m    edge        -            
-                                                                                                                        
-                                                                                                                        
-                                                                                                                        
-────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
- ██ SHEEP 2  api   errored   pid -   restarts 14   uptime 1h 18m   cpu -   mem -   fold edge                            
-lambs  3 parent-pid descendants, read 0s ago   48220 node   48221 node   48222 node                                     
-out  /home/ada/.shep/logs/api-2-out.log   │   err  /home/ada/.shep/logs/api-2-err.log                                   
-                                                                                                                        
-────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
- ██ BLEATS api  … 1 earlier line not shown                                                                              
-out  GET /healthz 200 3ms                                                                                               
-out  GET /v1/orders 200 44ms                                                                                            
-out  POST /v1/orders 201 88ms                                                                                           
-out  GET /v1/orders/8821 200 9ms                                                                                        
-out  connection pool: 14/50 in use                                                                                      
-q quit   j/k select   / filter   F folds   x stop   R restart   L reload   s settings   e edit   * your… control enabled
+ THE SHEPHERD HAS DIED  ▖  these values are frozen as of 2026-08-14 14:32:07                                                 nothing here is live  ▖  q to quit 
+                                                                                                                                                                
+ shep lookout   /home/ada/.shep  ·  the dashboard stays up so you can read what it had  ·  it will not exit on its own                                          
+host  load  ██░░░░░░░░ 2.31 4.10 3.88 / 10 cores     host mem  ████░░░░░░ 12.4G / 32.0G     1 errored · 0 parked   flock cpu 6.7%        █   flock mem 371.0M  …
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+                                                                                                                                                                
+  ID    NAME                  STATUS           PID      RESTARTS  EXIT       CFG   CPU 20s     CPU     MEM/CEIL    MEM       FROZEN    FOLD        SMIT         
+   ██ FLOCK                                                                                                                                                     
+> 2     api                   errored          -        14        1          -              ▁  -       ░░░░░░░░░░  -         1h 18m    edge        -            
+  3     billing-reconciliat…  waiting-restart  -        3         1          -              ▁  -       ░░░░░░░░░░  -         1h 19m    -           -            
+  4     cron                  stopped          -        0         SIGTERM    -              ▁  -       ░░░░░░░░░░  -         1h 21m    -           -            
+  5     metrics               online           48240    0         -          -              ▂  0.4%    ░░░░░░░░░░  11.0M     1h 22m    -           -            
+  0     web                   online           48211    0         -          -              █  3.4%    ░░░░░░░░░░  182.0M    1h 15m    edge        -            
+  1     web                   online           48212    0         -          -              ▇  2.9%    ░░░░░░░░░░  178.0M    1h 16m    edge        -            
+                                                                                                                                                                
+                                                                                                                                                                
+                                                                                                                                                                
+                                                                                                                                                                
+                                                                                                                                                                
+                                                                                                                                                                
+                                                                                                                                                                
+                                                                                                                                                                
+                                                                                                                                                                
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+ ██ THE LINK  5 redials over 7.75s, all refused   ·   lookout has stopped polling and stopped re-dialling                                                       
+  ladder    █ 250ms  █ 500ms  █ 1s  █ 2s  █ 4s                                                                                                                  
+  refused   the shepherd did not answer: could not connect to `/home/ada/.shep/run/shep.sock`: Connection refused (os error 61)                                 
+  since     2026-08-14 14:32:07, 9m 53s ago      the sheep themselves may well still be running; lookout cannot see them to say                                 
+  try       r dials again now      or start the shepherd from another shell: shep muster                                                                        
+q quit   r retry the link   j/k still moves   every other key is refused while the link is down                                                         █ frozen
 
 === refused  (120x30) ===
 `x` with actions gated off. The refusal is literal, nothing about damage gets charming, and the panes below carry on.

--- a/docs/lookout/frames.txt
+++ b/docs/lookout/frames.txt
@@ -406,8 +406,8 @@ host  load  ██░░░░░░░░ 2.31 4.10 3.88 / 10 cores     host me
   ladder    █ 250ms  █ 500ms  █ 1s  █ 2s  █ 4s                                                                                                                  
   refused   the shepherd did not answer: could not connect to `/home/ada/.shep/run/shep.sock`: Connection refused (os error 61)                                 
   since     2026-08-14 14:32:07, 9m 53s ago      the sheep themselves may well still be running; lookout cannot see them to say                                 
-  try       r dials again now      or start the shepherd from another shell: shep muster                                                                        
-q quit   r retry the link   j/k still moves   every other key is refused while the link is down                                                         █ frozen
+  try       shep muster, from another shell      then reopen lookout: it does not reconnect on its own                                                          
+q quit   j/k still moves   every other key is refused while the link is down                                                                            █ frozen
 
 === refused  (120x30) ===
 `x` with actions gated off. The refusal is literal, nothing about damage gets charming, and the panes below carry on.

--- a/web/src/pages/docs/lookout.astro
+++ b/web/src/pages/docs/lookout.astro
@@ -115,8 +115,8 @@ host  load  ██░░░░░░░░ 2.31 4.10 3.88 / 10 cores     host me
   ladder    █ 250ms  █ 500ms  █ 1s  █ 2s  █ 4s
   refused   the shepherd did not answer: could not connect to \`/home/ada/.shep/run/shep.sock\`: Connection refused (os error 61)
   since     2026-08-14 14:32:07, 9m 53s ago      the sheep themselves may well still be running; lookout cannot see them to say
-  try       r dials again now      or start the shepherd from another shell: shep muster
-q quit   r retry the link   j/k still moves   every other key is refused while the link is down                                                         █ frozen`;
+  try       shep muster, from another shell      then reopen lookout: it does not reconnect on its own
+q quit   j/k still moves   every other key is refused while the link is down                                                                            █ frozen`;
 
 const refused = `shep lookout   /home/ada/.shep                                                                            6 in the flock
 host  load  ██░░░░░░░░ 2.31 4.10 3.88 / 10 cores     host mem  ████░░░░░░ 12.4G / 32.0G     0 errored · 0 parked   floc…
@@ -515,8 +515,9 @@ esc/s close   j/k select   g… control enabled`;
       gauge of a sheep's memory against its ceiling and <code>CPU 20s</code>{" "}
       is a sparkline of its CPU history; both restate a number CPU and MEM
       already carry, so they go first. A terminal needs 148 columns for the
-      gauge and 136 for the sparkline, wider than every frame on this page,
-      so neither shows up below. Every row's sparkline scales to the same
+      gauge and 136 for the sparkline, so the only frame on this page wide
+      enough to draw either is the frozen one further down. Every row's
+      sparkline scales to the same
       ceiling, the busiest sample any sheep has posted in the retained
       window, so rows read against each other rather than each one filling
       its own column.

--- a/web/src/pages/docs/lookout.astro
+++ b/web/src/pages/docs/lookout.astro
@@ -87,31 +87,36 @@ lambs  a fold has no single process to walk; select one sheep
 
 q quit   j/k select   / filter   F flat   z collapse   x stop   R restart   L reload   s settings   e edit   * yours   ! parked                  control enabled`;
 
-const frozen = `shep lookout   /home/ada/.shep                                                                            6 in the flock
-the shepherd has died: these values are frozen as of 2026-08-14 14:32:07
-host  load  ██░░░░░░░░ 2.31 4.10 3.88 / 10 cores     host mem  ████░░░░░░ 12.4G / 32.0G     1 errored · 0 parked   floc…
-────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-  ID    NAME        STATUS           PID      RESTARTS  EXIT       CPU     MEM       UPTIME    FOLD        SMIT
-   ██ FLOCK
-> 2     api         errored          -        14        1          -       -         1h 18m    edge        -
-  3     billing-r…  waiting-restart  -        3         1          -       -         1h 19m    -           -
-  4     cron        stopped          -        0         SIGTERM    -       -         1h 21m    -           -
-  5     metrics     online           48240    0         -          0.4%    11.0M     1h 22m    -           -
-  0     web         online           48211    0         -          3.4%    182.0M    1h 15m    edge        -
-  1     web         online           48212    0         -          2.9%    178.0M    1h 16m    edge        -
-────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
- ██ SHEEP 2  api   errored   pid -   restarts 14   uptime 1h 18m   cpu -   mem -   fold edge
-lambs  3 parent-pid descendants, read 0s ago   48220 node   48221 node   48222 node
-out  /home/ada/.shep/logs/api-2-out.log   │   err  /home/ada/.shep/logs/api-2-err.log
+const frozen = ` THE SHEPHERD HAS DIED  ▖  these values are frozen as of 2026-08-14 14:32:07                                                 nothing here is live  ▖  q to quit
 
-────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
- ██ BLEATS bleats  api  … 1 earlier line not shown
-out  GET /healthz 200 3ms
-out  GET /v1/orders 200 44ms
-out  POST /v1/orders 201 88ms
-out  GET /v1/orders/8821 200 9ms
-out  connection pool: 14/50 in use
-q quit   j/k select   / filter   x stop   R restart   L reload   s settings   e edit   * yours   ! park… control enabled`;
+ shep lookout   /home/ada/.shep  ·  the dashboard stays up so you can read what it had  ·  it will not exit on its own
+host  load  ██░░░░░░░░ 2.31 4.10 3.88 / 10 cores     host mem  ████░░░░░░ 12.4G / 32.0G     1 errored · 0 parked   flock cpu 6.7%        █   flock mem 371.0M  …
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+
+  ID    NAME                  STATUS           PID      RESTARTS  EXIT       CFG   CPU 20s     CPU     MEM/CEIL    MEM       FROZEN    FOLD        SMIT
+   ██ FLOCK
+> 2     api                   errored          -        14        1          -              ▁  -       ░░░░░░░░░░  -         1h 18m    edge        -
+  3     billing-reconciliat…  waiting-restart  -        3         1          -              ▁  -       ░░░░░░░░░░  -         1h 19m    -           -
+  4     cron                  stopped          -        0         SIGTERM    -              ▁  -       ░░░░░░░░░░  -         1h 21m    -           -
+  5     metrics               online           48240    0         -          -              ▂  0.4%    ░░░░░░░░░░  11.0M     1h 22m    -           -
+  0     web                   online           48211    0         -          -              █  3.4%    ░░░░░░░░░░  182.0M    1h 15m    edge        -
+  1     web                   online           48212    0         -          -              ▇  2.9%    ░░░░░░░░░░  178.0M    1h 16m    edge        -
+
+
+
+
+
+
+
+
+
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+ ██ THE LINK  5 redials over 7.75s, all refused   ·   lookout has stopped polling and stopped re-dialling
+  ladder    █ 250ms  █ 500ms  █ 1s  █ 2s  █ 4s
+  refused   the shepherd did not answer: could not connect to \`/home/ada/.shep/run/shep.sock\`: Connection refused (os error 61)
+  since     2026-08-14 14:32:07, 9m 53s ago      the sheep themselves may well still be running; lookout cannot see them to say
+  try       r dials again now      or start the shepherd from another shell: shep muster
+q quit   r retry the link   j/k still moves   every other key is refused while the link is down                                                         █ frozen`;
 
 const refused = `shep lookout   /home/ada/.shep                                                                            6 in the flock
 host  load  ██░░░░░░░░ 2.31 4.10 3.88 / 10 cores     host mem  ████░░░░░░ 12.4G / 32.0G     0 errored · 0 parked   floc…
@@ -552,14 +557,21 @@ esc/s close   j/k select   g… control enabled`;
     <h2>If the shepherd goes away</h2>
     <p>
       Lookout re-dials five times (at 250/500/1000/2000/4000&nbsp;ms, about
-      7.75 seconds total) before it gives up. Once the ladder is exhausted
-      it shows a frozen banner, stops polling, and leaves the last known
-      values on screen. The uptime column stops advancing with everything
-      else: a dashboard whose clock kept ticking while the rest froze would
-      be lying about a specific sheep by name. Lookout never exits on its
-      own. You quit with <code>q</code>.
+      7.75 seconds total) before it gives up. Then it stops polling and
+      leaves the last known values on screen, with the band saying so and
+      the whole table in one muted grey: nothing there is current, so
+      nothing there is allowed to look current. <code>UPTIME</code> becomes
+      <code>FROZEN</code>, because a clock still ticking after everything
+      around it stopped would be lying about a specific sheep by name.
     </p>
-    <CodeBlock label="120×30, shepherd dead">{frozen}</CodeBlock>
+    <p>
+      The sheep detail band and the bleats feed hand their rows to a link
+      panel. Both describe a shepherd that is gone; the panel describes
+      what happened to it, quoting the last dial's own error. Lookout never
+      exits on its own. <code>q</code> quits, <code>r</code> dials again,
+      and every other key refuses while the link is down.
+    </p>
+    <CodeBlock label="160×30, shepherd dead">{frozen}</CodeBlock>
 
     <h2>Actions</h2>
     <p>


### PR DESCRIPTION
Frame 1l from `docs/lookout/design-files`: what the dashboard shows once the retry ladder is spent.

- Title band turns bark and carries `THE SHEPHERD HAS DIED ▖ these values are frozen as of <time>`
- `Palette::frozen` collapses every semantic colour onto the muted ink, so no cell of data can read as live
- `UPTIME` becomes `FROZEN` over a duration that stopped advancing when the link did
- The detail band and the bleats feed give their rows to a new link panel: the ladder it climbed, the last dial's own error, how long ago that was, what is left to try
- `Msg::Frozen` carries `why`, which `run_link` used to discard
- `Scene::Frozen` moves from 120x30 to 160x30, where the whole column set actually draws

Four things in the frame are not built as drawn:

- `LAST BLEAT BEFORE THE LINK DROPPED`: lookout tails only the selected sheep's logs, and a frozen dashboard may not re-read a file at all
- The unlabelled 5-cell `░░░` column: identical on every row, carrying nothing
- The failure gets its own row rather than the ladder's tail, because the real error is 120 characters against the frame's 40
- `r dials again now` and `r retry the link` are gone. `r` is refused once the link is lost, and `run_link` has already returned by then, so nothing survives to answer a redial. Making it genuinely revive the link is a change to the freeze contract, not to a sentence, so it is not in here

Two bugs found by capturing a real frozen dashboard, not by any test in here:

- `shep kill` leaves `the shepherd is shutting down` as a notice, notices outrank the key hint, so the bar never said `r` still dials
- The row under the band cut mid-word at 90 columns with no ellipsis, next to five lines that all mark their own cuts

`rulings.md` lists 1l as going ahead as drawn with no gap. It had three.

Regenerated or rewritten: `docs/lookout/frames.txt`, `docs/lookout/frames.ansi`, `docs/lookout/README.md`, `web/src/pages/docs/lookout.astro`.

Every new test was mutated and watched fail. One mutant survived, which turned out to be a condition that distinguished nothing at any reachable terminal height, so it is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Lookout now presents a dedicated frozen-dashboard view when the link is lost.
  - Displays the loss reason, retry attempts, elapsed frozen time, reconnect guidance, and the time of disconnection.
  - Replaces the `UPTIME` heading with `FROZEN` and applies muted styling to inactive data.
  - Preserves a live link panel while other dashboard content remains static.

- **Documentation**
  - Updated Lookout documentation and examples to describe frozen-state behavior, retrying, and available controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

