### PR TITLE
fix(client): forward shep-client's schema feature to shep-core

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -318,6 +318,12 @@ jobs:
       # doctest broke under this feature set too, and only a test run reads it.
       - run: cargo test -p shep-client --locked --no-default-features
         if: ${{ needs.changes.outputs.rust == 'true' || needs.changes.result != 'success' || github.event_name == 'workflow_dispatch' }}
+      # The other half of that pair, and the only leg where `schema` reaches
+      # `shep-core/schema` on its own: every `--workspace` step turns that
+      # feature on through shep-cli, so a forward that stopped working would
+      # fail in a dog's build and nowhere in this file.
+      - run: cargo check -p shep-client --locked
+        if: ${{ needs.changes.outputs.rust == 'true' || needs.changes.result != 'success' || github.event_name == 'workflow_dispatch' }}
       # shep-core takes shep-channel with `default-features = false` to get
       # the wire types without the client (descriptor discovery, the reader
       # and writer threads, the handler layer). Nothing else in the

--- a/crates/shep-client/Cargo.toml
+++ b/crates/shep-client/Cargo.toml
@@ -21,7 +21,11 @@ default = ["schema"]
 # by default, so following the dog docs works with no feature line. Off is
 # additive, not broken: `probe` still answers the version flag and exits
 # silently on the schema flag.
-schema = ["dep:schemars", "dep:serde_json"]
+#
+# `shep-core/schema` carries the `JsonSchema` impls for `MemSize` and
+# `UpDuration`, which a dog's config type reaches through this crate's
+# `pub use shep_core` and cannot derive against without them.
+schema = ["dep:schemars", "dep:serde_json", "shep-core/schema"]
 
 # Option: expose `testing` (the hand-rolled daemon fakes) to other crates'
 # tests. Off by default, since it is test scaffolding, not public API.

--- a/crates/shep-client/src/lib.rs
+++ b/crates/shep-client/src/lib.rs
@@ -79,6 +79,17 @@ pub mod testing;
 
 pub use shep_core;
 
+// Pins the `schema` feature's forward to `shep-core/schema`: a dog reaches
+// these two through the re-export above, so a missing forward costs it a
+// second dependency it should never name. Workspace feature unification
+// hides that everywhere except `cargo check -p shep-client`.
+#[cfg(feature = "schema")]
+const _: () = {
+    const fn assert_json_schema<T: schemars::JsonSchema>() {}
+    assert_json_schema::<shep_core::values::MemSize>();
+    assert_json_schema::<shep_core::values::UpDuration>();
+};
+
 /// The wire protocol this client speaks, re-exported from
 /// [`shep_core::protocol::PROTOCOL_VERSION`].
 ///

--- a/docs/dogs.md
+++ b/docs/dogs.md
@@ -690,6 +690,7 @@ every field holding a credential:
 
 ```rust
 use shep_client::dogs::DogConfig;
+use shep_client::shep_core::values::{MemSize, UpDuration};
 
 #[derive(Default, serde::Deserialize, schemars::JsonSchema, DogConfig)]
 #[serde(deny_unknown_fields, default)]
@@ -699,6 +700,10 @@ struct MyDogConfig {
     webhook: String,
     /// What to watch.
     path: String,
+    /// How much to buffer before posting: `4M`, `512K`, or a byte count.
+    batch: Option<MemSize>,
+    /// How long to wait between posts: `30s`, `500ms`, `2h`.
+    every: Option<UpDuration>,
 }
 ```
 
@@ -714,6 +719,13 @@ a refusal rather than a silent pass.
 down, in a nested struct or in a map's values, is not covered by a mark down
 there: mark the field that holds them. Bark's own `sinks` map is marked
 whole for this reason, and every sink in it carries a webhook URL.
+
+**`MemSize` and `UpDuration` need no dependency of their own.** A dog
+configuring a size or a timer reads them out of
+`shep_client::shep_core::values`, and shep-client's `schema` feature turns on
+the shep-core feature those two `JsonSchema` impls sit behind. Neither type
+has a `Default`, so a field holding one is an `Option` or carries
+`#[serde(default = "...")]`.
 
 **Answering is optional, exactly as `--version` is.** A dog that says
 nothing is adopted, recorded as having no schema, and refused nothing, which

--- a/web/src/pages/docs/dogs.astro
+++ b/web/src/pages/docs/dogs.astro
@@ -24,6 +24,7 @@ const probeSnippet = `fn main() {
 }`;
 
 const configSnippet = `use shep_client::dogs::DogConfig;
+use shep_client::shep_core::values::{MemSize, UpDuration};
 
 #[derive(Default, serde::Deserialize, schemars::JsonSchema, DogConfig)]
 #[serde(deny_unknown_fields, default)]
@@ -33,6 +34,10 @@ struct MyDogConfig {
     webhook: String,
     /// What to watch.
     path: String,
+    /// How much to buffer before posting: \`4M\`, \`512K\`, or a byte count.
+    batch: Option<MemSize>,
+    /// How long to wait between posts: \`30s\`, \`500ms\`, \`2h\`.
+    every: Option<UpDuration>,
 }`;
 
 const schemaNotice = `notice[dog_schema_unreadable]: pydog answered \`--schema\` with something that
@@ -889,6 +894,15 @@ speaks protocol 8, accepts 8 and newer`}</CodeBlock>
       <code>sinks</code> map is marked whole for this reason, and every sink
       in it carries a webhook URL.
     </Callout>
+    <p>
+      <code>MemSize</code> and <code>UpDuration</code> need no dependency of
+      their own. A dog configuring a size or a timer reads them out of{" "}
+      <code>shep_client::shep_core::values</code>, and shep-client's{" "}
+      <code>schema</code> feature turns on the shep-core feature those two{" "}
+      <code>JsonSchema</code> impls sit behind. Neither type has a{" "}
+      <code>Default</code>, so a field holding one is an{" "}
+      <code>Option</code> or carries <code>#[serde(default = "...")]</code>.
+    </p>
     <Callout variant="note">
       Answering is optional, exactly as <code>--version</code> is. A dog
       that says nothing is adopted, recorded as having no schema, and


### PR DESCRIPTION
- shep-client's `schema` didn't turn on `shep-core/schema`, so a dog whose config type named `MemSize` or `UpDuration` failed to compile: `the trait bound MemSize: JsonSchema is not satisfied`
- Feature unification hid it. shep-cli asks shep-core for `schema` directly, so every `--workspace` build had it on
- `schema` now includes `shep-core/schema`. No new crate, and nothing took shep-client with `default-features = false`
- A `const _` in `lib.rs` plus a `cargo check -p shep-client` leg in the features job, since a workspace test can't see the gap
- Dog docs and the web copy now show a config type using `Option<MemSize>` and `Option<UpDuration>`, and say why no second dependency is needed

Reproduced against an out-of-workspace crate depending on shep-client by path: E0277 before, a schema carrying `$defs/MemSize` and `$defs/UpDuration` after. Gate green, plus `cargo deny check`, `astro build` and `astro check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded dog configuration examples with optional `batch` and `every` fields.
  * Added examples for memory-size and duration values, including supported formats.
  * Clarified schema requirements and default-value handling for these fields.

* **Bug Fixes**
  * Schema generation now supports the memory-size and uptime-duration types when using the schema feature.

* **Tests**
  * Added checks covering both default and disabled feature configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->