### PR TITLE
chore: release v0.7.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2068,7 +2068,7 @@ dependencies = [
 
 [[package]]
 name = "shep"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "anstyle",
  "assert_cmd",
@@ -2108,7 +2108,7 @@ dependencies = [
 
 [[package]]
 name = "shep-channel"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "command-fds",
  "serde",
@@ -2119,11 +2119,11 @@ dependencies = [
 
 [[package]]
 name = "shep-cli"
-version = "0.7.2"
+version = "0.7.3"
 
 [[package]]
 name = "shep-client"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "futures-util",
  "nix 0.29.0",
@@ -2139,7 +2139,7 @@ dependencies = [
 
 [[package]]
 name = "shep-core"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "annotate-snippets",
  "anstyle",
@@ -2172,7 +2172,7 @@ dependencies = [
 
 [[package]]
 name = "shep-daemon"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "bytes",
  "chrono",
@@ -2202,14 +2202,14 @@ dependencies = [
 
 [[package]]
 name = "shep-examples"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "nix 0.29.0",
 ]
 
 [[package]]
 name = "shep-macros"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "proc-macro2",
  "quote 1.0.47",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.7.2"
+version = "0.7.3"
 edition = "2024"
 # 1.88: serde-saphyr's let-chains need it; also the floor ratatui, sysinfo
 # and rmcp require.
@@ -33,11 +33,11 @@ license = "MIT OR Apache-2.0"
 # turn an inherited dependency's default features back on but never off, so the
 # floor is set off here. shep-core wants the wire types without the client
 # feature; a future consumer that wants the client opts back in.
-shep-channel = { path = "crates/shep-channel", version = "0.7.2", default-features = false }
-shep-core = { path = "crates/shep-core", version = "0.7.2" }
-shep-daemon = { path = "crates/shep-daemon", version = "0.7.2" }
-shep-client = { path = "crates/shep-client", version = "0.7.2" }
-shep-macros = { path = "crates/shep-macros", version = "0.7.2" }
+shep-channel = { path = "crates/shep-channel", version = "0.7.3", default-features = false }
+shep-core = { path = "crates/shep-core", version = "0.7.3" }
+shep-daemon = { path = "crates/shep-daemon", version = "0.7.3" }
+shep-client = { path = "crates/shep-client", version = "0.7.3" }
+shep-macros = { path = "crates/shep-macros", version = "0.7.3" }
 serde = { version = "1", default-features = false, features = ["derive"] }
 serde_json = { version = "1", default-features = false, features = ["std"] }
 toml = { version = "0.8", default-features = false, features = ["parse", "display"] }

--- a/crates/shep-channel/CHANGELOG.md
+++ b/crates/shep-channel/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this crate are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.3] - 2026-09-08
+
+
 ## [0.7.2] - 2026-09-08
 
 

--- a/crates/shep-cli/CHANGELOG.md
+++ b/crates/shep-cli/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.3] - 2026-09-08
+
+
 ## [0.7.2] - 2026-09-08
 
 ### Added

--- a/crates/shep-client/CHANGELOG.md
+++ b/crates/shep-client/CHANGELOG.md
@@ -10,6 +10,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.3] - 2026-09-08
+
+### Fixed
+
+- Forward the schema feature to shep-core
+
+
 ## [0.7.2] - 2026-09-08
 
 

--- a/crates/shep-core/CHANGELOG.md
+++ b/crates/shep-core/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.3] - 2026-09-08
+
+
 ## [0.7.2] - 2026-09-08
 
 ### Added

--- a/crates/shep-daemon/CHANGELOG.md
+++ b/crates/shep-daemon/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.3] - 2026-09-08
+
+
 ## [0.7.2] - 2026-09-08
 
 ### Added

--- a/crates/shep-macros/CHANGELOG.md
+++ b/crates/shep-macros/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.3] - 2026-09-08
+
+
 ## [0.7.2] - 2026-09-08
 
 


### PR DESCRIPTION



## 🤖 New release

* `shep-channel`: 0.7.2 -> 0.7.3
* `shep-core`: 0.7.2 -> 0.7.3
* `shep-daemon`: 0.7.2 -> 0.7.3
* `shep-macros`: 0.7.2 -> 0.7.3
* `shep-client`: 0.7.2 -> 0.7.3 (✓ API compatible changes)
* `shep`: 0.7.2 -> 0.7.3

<details><summary><i><b>Changelog</b></i></summary><p>





## `shep-client`

<blockquote>

## [0.7.3] - 2026-09-08

### Fixed

- Forward the schema feature to shep-core
</blockquote>



</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).