### PR TITLE
test: DRY pass over the test harnesses (qwen audit group G)

### DIFF
--- a/crates/shep-channel/tests/common/mod.rs
+++ b/crates/shep-channel/tests/common/mod.rs
@@ -1,0 +1,38 @@
+//! Shared by `fixtures.rs` and `wire_export.rs`, the two targets that hold a
+//! committed file against what the code produces.
+
+use std::fs;
+use std::path::Path;
+
+/// The environment variable that rewrites a committed file instead of
+/// asserting against it. One name, so blessing one corpus cannot silently
+/// take a different door from blessing the other.
+const BLESS: &str = "SHEP_CHANNEL_BLESS";
+
+/// Writes `produced` to `path` under [`BLESS`], and otherwise asserts the
+/// committed bytes match it.
+///
+/// `stale_hint` says who else reads these bytes, since the assertion fires
+/// on a change that is correct in Rust and breaking downstream.
+///
+/// # Panics
+///
+/// If the file cannot be written under [`BLESS`], if it cannot be read
+/// without it, or if the committed bytes differ.
+pub fn bless_or_compare(path: &Path, produced: &str, stale_hint: &str) {
+    if std::env::var_os(BLESS).is_some() {
+        let parent = path.parent().expect("a committed file has a parent");
+        fs::create_dir_all(parent).expect("create the corpus directory");
+        fs::write(path, produced).expect("write the committed file");
+        return;
+    }
+    let committed = fs::read_to_string(path).unwrap_or_else(|error| {
+        panic!("{}: {error}. Run with {BLESS}=1 to create it.", path.display())
+    });
+    assert_eq!(
+        committed,
+        produced,
+        "{} is stale. {stale_hint}",
+        path.display()
+    );
+}

--- a/crates/shep-channel/tests/common/mod.rs
+++ b/crates/shep-channel/tests/common/mod.rs
@@ -27,7 +27,10 @@ pub fn bless_or_compare(path: &Path, produced: &str, stale_hint: &str) {
         return;
     }
     let committed = fs::read_to_string(path).unwrap_or_else(|error| {
-        panic!("{}: {error}. Run with {BLESS}=1 to create it.", path.display())
+        panic!(
+            "{}: {error}. Run with {BLESS}=1 to create it.",
+            path.display()
+        )
     });
     assert_eq!(
         committed,

--- a/crates/shep-channel/tests/fixtures.rs
+++ b/crates/shep-channel/tests/fixtures.rs
@@ -9,34 +9,33 @@
 //!
 //! Regenerate with `SHEP_CHANNEL_BLESS=1 cargo test -p shep-channel --test fixtures`.
 
-use std::fs;
+use std::fmt::Debug;
 use std::path::PathBuf;
 
+use serde::Serialize;
+use serde::de::DeserializeOwned;
 use shep_channel::{ChildMessage, ShepherdMessage};
+
+mod common;
 
 fn fixtures_dir() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("fixtures")
 }
 
-fn check(name: &str, encoded: String) {
-    let path = fixtures_dir().join(format!("{name}.json"));
-    if std::env::var_os("SHEP_CHANNEL_BLESS").is_some() {
-        fs::create_dir_all(fixtures_dir()).expect("create fixtures dir");
-        fs::write(&path, &encoded).expect("write fixture");
-        return;
-    }
-    let committed = fs::read_to_string(&path).unwrap_or_else(|error| {
-        panic!(
-            "{}: {error}. Run with SHEP_CHANNEL_BLESS=1 to create it.",
-            path.display()
-        )
-    });
-    assert_eq!(
-        committed,
-        encoded,
-        "{} is stale. Three other libraries are written against these bytes.",
-        path.display()
+/// Holds one case against its committed file and against itself.
+///
+/// Generic over the message type so both corpora run the same check: a
+/// round trip that passes for one enum and not the other would otherwise
+/// depend on which of the two loops someone remembered to update.
+fn check<T: Serialize + DeserializeOwned + PartialEq + Debug>(name: &str, value: &T) {
+    let encoded = serde_json::to_string(value).expect("encode");
+    common::bless_or_compare(
+        &fixtures_dir().join(format!("{name}.json")),
+        &encoded,
+        "Three other libraries are written against these bytes.",
     );
+    let decoded: T = serde_json::from_str(&encoded).expect("decode");
+    assert_eq!(&decoded, value, "{name} does not survive a round trip");
 }
 
 #[test]
@@ -75,10 +74,7 @@ fn child_messages_match_their_fixtures() {
         ),
     ];
     for (name, value) in cases {
-        let encoded = serde_json::to_string(&value).expect("encode");
-        check(name, encoded.clone());
-        let decoded: ChildMessage = serde_json::from_str(&encoded).expect("decode");
-        assert_eq!(decoded, value, "{name} does not survive a round trip");
+        check(name, &value);
     }
 }
 
@@ -104,10 +100,7 @@ fn shepherd_messages_match_their_fixtures() {
         ),
     ];
     for (name, value) in cases {
-        let encoded = serde_json::to_string(&value).expect("encode");
-        check(name, encoded.clone());
-        let decoded: ShepherdMessage = serde_json::from_str(&encoded).expect("decode");
-        assert_eq!(decoded, value, "{name} does not survive a round trip");
+        check(name, &value);
     }
 }
 

--- a/crates/shep-channel/tests/wire_export.rs
+++ b/crates/shep-channel/tests/wire_export.rs
@@ -9,10 +9,11 @@
 
 use std::collections::BTreeSet;
 use std::fmt::Write as _;
-use std::fs;
 use std::path::PathBuf;
 
 use shep_channel::{CHANNEL_VERSION, ChildMessage, ShepherdMessage};
+
+mod common;
 
 /// One Go constant for one `kind` string.
 struct Kind {
@@ -293,24 +294,10 @@ fn check_keys<'a>(samples: impl Iterator<Item = (String, &'a str)>, fields: &[Fi
 
 #[test]
 fn the_committed_go_file_is_what_the_emitter_writes() {
-    let emitted = emit();
-    let path = wire_path();
-    if std::env::var_os("SHEP_CHANNEL_BLESS").is_some() {
-        fs::create_dir_all(path.parent().expect("wire/ has a parent")).expect("create wire dir");
-        fs::write(&path, &emitted).expect("write the wire file");
-        return;
-    }
-    let committed = fs::read_to_string(&path).unwrap_or_else(|error| {
-        panic!(
-            "{}: {error}. Run with SHEP_CHANNEL_BLESS=1 to create it.",
-            path.display()
-        )
-    });
-    assert_eq!(
-        committed,
-        emitted,
-        "{} is stale. github.com/shep-pm/shep-go/channel vendors these bytes as channel/wire.go.",
-        path.display()
+    common::bless_or_compare(
+        &wire_path(),
+        &emit(),
+        "github.com/shep-pm/shep-go/channel vendors these bytes as channel/wire.go.",
     );
 }
 

--- a/crates/shep-cli/tests/common/mod.rs
+++ b/crates/shep-cli/tests/common/mod.rs
@@ -22,7 +22,9 @@ use std::time::{Duration, Instant};
 pub fn wait_bounded(child: &mut Child, timeout: Duration, what: &str) -> ExitStatus {
     let deadline = Instant::now() + timeout;
     loop {
-        if let Some(status) = child.try_wait().unwrap_or_else(|error| panic!("poll {what}: {error}"))
+        if let Some(status) = child
+            .try_wait()
+            .unwrap_or_else(|error| panic!("poll {what}: {error}"))
         {
             return status;
         }

--- a/crates/shep-cli/tests/common/mod.rs
+++ b/crates/shep-cli/tests/common/mod.rs
@@ -1,0 +1,36 @@
+//! Shared by `init.rs` and `term_panic_order.rs`, the two targets that run
+//! the real `shep` binary as a child process and wait for it to exit.
+
+#![cfg(unix)]
+
+use std::process::{Child, ExitStatus};
+use std::time::{Duration, Instant};
+
+/// Polls `child.try_wait()` until it exits, or `timeout` elapses.
+///
+/// Polls rather than blocking in `Child::wait`, so a hung child fails with
+/// a named panic. The harness's own process timeout would instead fail the
+/// whole binary and name nothing.
+///
+/// `what` names the child, since both callers run a different one.
+///
+/// # Panics
+///
+/// If the child cannot be polled, or does not exit within `timeout`. A
+/// child that outlasts the timeout is killed and reaped first, so a failing
+/// assertion never leaves a process behind.
+pub fn wait_bounded(child: &mut Child, timeout: Duration, what: &str) -> ExitStatus {
+    let deadline = Instant::now() + timeout;
+    loop {
+        if let Some(status) = child.try_wait().unwrap_or_else(|error| panic!("poll {what}: {error}"))
+        {
+            return status;
+        }
+        if Instant::now() >= deadline {
+            let _ = child.kill();
+            let _ = child.wait();
+            panic!("{what} did not exit within {timeout:?}");
+        }
+        std::thread::sleep(Duration::from_millis(20));
+    }
+}

--- a/crates/shep-cli/tests/init.rs
+++ b/crates/shep-cli/tests/init.rs
@@ -23,6 +23,9 @@ use nix::sys::signal::{self, Signal};
 use nix::unistd::Pid;
 use tempfile::TempDir;
 
+mod common;
+use common::wait_bounded;
+
 /// Bound on every wait in this file: reading the init's pid line, the
 /// flock coming online, and the process's exit after a signal. Generous
 /// headroom for a loaded CI boot, not a protocol timeout.
@@ -159,24 +162,6 @@ fn poll_online_sheep(home: &Path, deadline: Duration) -> serde_json::Value {
     }
 }
 
-/// Polls `child.try_wait()` until it exits, or `timeout` elapses. A
-/// named panic here, rather than the harness's own process timeout,
-/// which would fail the whole binary and name nothing.
-fn wait_bounded(child: &mut Child, timeout: Duration) -> std::process::ExitStatus {
-    let deadline = Instant::now() + timeout;
-    loop {
-        if let Some(status) = child.try_wait().expect("poll shep runtime") {
-            return status;
-        }
-        if Instant::now() >= deadline {
-            let _ = child.kill();
-            let _ = child.wait();
-            panic!("shep runtime did not exit within {timeout:?}");
-        }
-        std::thread::sleep(Duration::from_millis(20));
-    }
-}
-
 /// Best-effort cleanup so a panicking assertion never leaves a real
 /// daemon or sleeping sheep behind: SIGKILLs the supervisor, if known,
 /// then the init.
@@ -221,7 +206,7 @@ fn a_sigterm_to_the_init_reaches_the_flock_and_the_status_is_the_childs() {
 
     signal::kill(Pid::from_raw(init_pid), Signal::SIGTERM).expect("send SIGTERM to the init");
 
-    let status = wait_bounded(&mut guard.child, INIT_DEADLINE);
+    let status = wait_bounded(&mut guard.child, INIT_DEADLINE, "the shep runtime");
     assert_eq!(
         status.code(),
         Some(0),
@@ -254,7 +239,7 @@ fn a_supervisor_killed_by_sigkill_makes_the_init_exit_137() {
     signal::kill(Pid::from_raw(supervisor_pid), Signal::SIGKILL)
         .expect("SIGKILL the supervisor directly");
 
-    let status = wait_bounded(&mut guard.child, INIT_DEADLINE);
+    let status = wait_bounded(&mut guard.child, INIT_DEADLINE, "the shep runtime");
     assert_eq!(
         status.code(),
         Some(137),

--- a/crates/shep-cli/tests/term_panic_order.rs
+++ b/crates/shep-cli/tests/term_panic_order.rs
@@ -14,9 +14,12 @@
 
 use std::fs::File;
 use std::process::{Command, Stdio};
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 use assert_cmd::cargo::CommandCargoExt as _;
+
+mod common;
+use common::wait_bounded;
 
 /// Five seconds: generous headroom for a hook install and panic, not a
 /// tight bound. Enforced by hand (`wait_bounded`) rather than
@@ -43,7 +46,8 @@ fn the_restore_escape_lands_before_the_panic_backtrace() {
         .stdout(Stdio::from(sink))
         .stderr(Stdio::from(sink_for_stderr));
 
-    let status = wait_bounded(cmd, PROBE_TIMEOUT);
+    let mut child = cmd.spawn().expect("spawn the probe subprocess");
+    let status = wait_bounded(&mut child, PROBE_TIMEOUT, "the probe subprocess");
     assert!(
         !status.success(),
         "the probe is supposed to panic, not exit cleanly"
@@ -59,26 +63,6 @@ fn the_restore_escape_lands_before_the_panic_backtrace() {
          {panic_at}; merged output:\n{}",
         String::from_utf8_lossy(&merged)
     );
-}
-
-/// Spawns `cmd` and polls for its exit rather than blocking on
-/// `Command::status()`. A hung probe then fails with a named panic.
-/// The harness's own process timeout would instead fail the whole
-/// binary and name nothing.
-fn wait_bounded(mut cmd: Command, timeout: Duration) -> std::process::ExitStatus {
-    let mut child = cmd.spawn().expect("spawn the probe subprocess");
-    let deadline = Instant::now() + timeout;
-    loop {
-        if let Some(status) = child.try_wait().expect("poll the probe subprocess") {
-            return status;
-        }
-        if Instant::now() >= deadline {
-            let _ = child.kill();
-            let _ = child.wait();
-            panic!("probe subprocess did not exit within {timeout:?}");
-        }
-        std::thread::sleep(Duration::from_millis(20));
-    }
 }
 
 fn find(haystack: &[u8], needle: &[u8]) -> Option<usize> {

--- a/crates/shep-client/src/testing.rs
+++ b/crates/shep-client/src/testing.rs
@@ -30,6 +30,7 @@ use shep_core::protocol::{
 };
 use shep_core::status::ProcStatus;
 
+use crate::spawn::SpawnOptions;
 use crate::{Client, ReconnectingClient};
 
 /// A control address valid on the platform running the test, unique to
@@ -61,13 +62,25 @@ pub fn control_address(dir: &Path) -> PathBuf {
     }
 }
 
+/// Binds `path`, naming it if the bind fails.
+///
+/// Thirteen fakes in this module bind a listener, and a bare `unwrap` on
+/// any of them reports an `AddrInUse` or a `NotFound` without saying which
+/// address it was.
+///
+/// # Panics
+///
+/// If `path` cannot be bound.
+fn bind(path: &Path) -> Listener {
+    Listener::bind(path).unwrap_or_else(|error| panic!("bind {}: {error}", path.display()))
+}
+
 /// The framed transport a fake daemon holds for one accepted client.
 ///
 /// Not [`crate::connection::Frames`], the client's side: the two coincide
 /// on unix but differ on Windows, where a named pipe's server end is its
 /// own type.
 type Frames = Framed<ServerStream, tokio_util::codec::LengthDelimitedCodec>;
-use crate::spawn::SpawnOptions;
 
 /// Serves exactly one connection, replying to the `Hello` with `reply` and
 /// closing. Returns the `Hello` the client actually sent.
@@ -78,7 +91,7 @@ use crate::spawn::SpawnOptions;
 /// Panics if `path` cannot be bound or the connection fails partway
 /// through the handshake.
 pub async fn fake_daemon(path: &Path, reply: HelloReply) -> JoinHandle<Hello> {
-    let mut listener = Listener::bind(path).unwrap();
+    let mut listener = bind(path);
     tokio::spawn(async move {
         let stream = listener.accept().await.unwrap();
         let mut frames = Framed::new(stream, codec());
@@ -102,7 +115,7 @@ pub async fn serve_one_request(
     ack: HelloAck,
     response: Response,
 ) -> JoinHandle<Envelope> {
-    let mut listener = Listener::bind(path).unwrap();
+    let mut listener = bind(path);
     tokio::spawn(async move {
         let stream = listener.accept().await.unwrap();
         let mut frames = Framed::new(stream, codec());
@@ -129,7 +142,7 @@ pub fn fake_daemon_wedged_after_handshake(
     path: &Path,
     ack: HelloAck,
 ) -> (JoinHandle<()>, Arc<AtomicBool>) {
-    let mut listener = Listener::bind(path).unwrap();
+    let mut listener = bind(path);
     let handshook = Arc::new(AtomicBool::new(false));
     let flag = Arc::clone(&handshook);
     let handle = tokio::spawn(async move {
@@ -170,7 +183,7 @@ pub fn fake_daemon_accepting_repeatedly_with_ack(
     ack: HelloAck,
     reply: Response,
 ) -> (JoinHandle<()>, Arc<AtomicU32>) {
-    let mut listener = Listener::bind(path).unwrap();
+    let mut listener = bind(path);
     let served = Arc::new(AtomicU32::new(0));
     let counter = Arc::clone(&served);
     let handle = tokio::spawn(async move {
@@ -297,7 +310,7 @@ pub fn fake_daemon_across_handovers(path: &Path, handshakes: Vec<Handshake>) -> 
         !handshakes.is_empty(),
         "a handover fixture needs at least one generation"
     );
-    let mut listener = Listener::bind(path).unwrap();
+    let mut listener = bind(path);
     let (cut_tx, mut cut_rx) = mpsc::channel(SCRIPT_CHANNEL_CAPACITY);
     let cut_on_next_request = Arc::new(AtomicBool::new(false));
     let accepted = Arc::new(AtomicU32::new(0));
@@ -853,7 +866,7 @@ pub async fn fake_reconnecting_client_on(path: &Path) -> (ReconnectingClient, Fa
 /// Panics if `path` cannot be bound.
 #[must_use]
 pub fn fake_daemon_scripted_on(path: &Path, ack: HelloAck) -> FakeDaemon {
-    let listener = Listener::bind(path).unwrap();
+    let listener = bind(path);
     let (script_tx, script_rx) = mpsc::channel(SCRIPT_CHANNEL_CAPACITY);
     let armed_list = Arc::new(Mutex::new(None));
     let armed_list_sequence = Arc::new(Mutex::new(VecDeque::new()));
@@ -912,7 +925,7 @@ pub async fn fake_daemon_answering_with_ack(
     ack: HelloAck,
     answer: impl Fn(&Request) -> Response + Send + Sync + Clone + 'static,
 ) -> mpsc::UnboundedReceiver<Envelope> {
-    let mut listener = Listener::bind(path).unwrap();
+    let mut listener = bind(path);
     let (tx, rx) = mpsc::unbounded_channel();
     tokio::spawn(async move {
         while let Ok(stream) = listener.accept().await {
@@ -955,7 +968,7 @@ pub async fn fake_client_answering(
     path: &Path,
     answer: impl Fn(&Request) -> Response + Send + 'static,
 ) -> (Client, mpsc::UnboundedReceiver<Envelope>) {
-    let mut listener = Listener::bind(path).unwrap();
+    let mut listener = bind(path);
     let (tx, rx) = mpsc::unbounded_channel();
     tokio::spawn(async move {
         let stream = listener.accept().await.unwrap();
@@ -982,7 +995,7 @@ pub async fn fake_client_answering(
 /// the returned channel, for asserting on what a `Client` puts on the wire
 /// rather than on how the daemon answers.
 pub async fn fake_client_capturing_envelopes(path: &Path) -> (Client, mpsc::Receiver<Envelope>) {
-    let mut listener = Listener::bind(path).unwrap();
+    let mut listener = bind(path);
     let (tx, rx) = mpsc::channel(SCRIPT_CHANNEL_CAPACITY);
     tokio::spawn(async move {
         let stream = listener.accept().await.unwrap();
@@ -1058,7 +1071,7 @@ pub async fn fake_client_event_then_reply(path: &Path) -> (Client, FakeDaemon) {
 /// connection, for testing that a `Client` fails every pending request with
 /// `RequestError::Closed` rather than hanging.
 pub async fn fake_client_that_closes_after_handshake(path: &Path) -> (Client, JoinHandle<()>) {
-    let mut listener = Listener::bind(path).unwrap();
+    let mut listener = bind(path);
     let task = tokio::spawn(async move {
         let stream = listener.accept().await.unwrap();
         let mut frames = Framed::new(stream, codec());
@@ -1076,7 +1089,7 @@ pub async fn fake_client_that_closes_after_handshake(path: &Path) -> (Client, Jo
 /// Unlike [`fake_client_that_closes_after_handshake`], which never accepts
 /// the request at all.
 pub async fn fake_client_that_dies_mid_request(path: &Path) -> (Client, JoinHandle<()>) {
-    let mut listener = Listener::bind(path).unwrap();
+    let mut listener = bind(path);
     let task = tokio::spawn(async move {
         let stream = listener.accept().await.unwrap();
         let mut frames = Framed::new(stream, codec());
@@ -1098,7 +1111,7 @@ pub async fn fake_client_that_dies_mid_request(path: &Path) -> (Client, JoinHand
 /// `FakeDaemon`'s `serve_scripted` loop always answers some request
 /// promptly, and no `ScriptCommand` means never answering.
 pub async fn fake_client_that_never_replies(path: &Path) -> (Client, JoinHandle<()>) {
-    let mut listener = Listener::bind(path).unwrap();
+    let mut listener = bind(path);
     let task = tokio::spawn(async move {
         let stream = listener.accept().await.unwrap();
         let mut frames = Framed::new(stream, codec());
@@ -1136,7 +1149,7 @@ pub fn fast_opts() -> SpawnOptions {
 ///
 /// Panics if `path` cannot be bound.
 pub fn start_fake_daemon_answering_on(path: &Path) {
-    let mut listener = Listener::bind(path).unwrap();
+    let mut listener = bind(path);
     tokio::spawn(async move {
         let stream = listener.accept().await.unwrap();
         let mut frames = Framed::new(stream, codec());

--- a/crates/shep-client/tests/event_stream.rs
+++ b/crates/shep-client/tests/event_stream.rs
@@ -7,14 +7,27 @@
 
 use std::time::Duration;
 
-use shep_client::Lagged;
 use shep_client::testing::{fake_client_with_push, sample_info};
+use shep_client::{EventStream, Lagged};
 use shep_core::protocol::{BusEvent, ProcessEventKind, Response};
 
 /// Every `stream.next()` in this file is wrapped in this bound so a broken
 /// implementation fails with a named assertion instead of hanging the test
 /// run.
 const EVENT_TIMEOUT: Duration = Duration::from_secs(1);
+
+/// The next event, or a named panic for each of the three ways there is
+/// not one: the stream hangs, it ends, or it reports a lag.
+///
+/// `want` says what the caller was waiting for, and all three panics carry
+/// it. The two bare `unwrap`s this replaces did not.
+async fn next_event(stream: &mut EventStream, want: &str) -> BusEvent {
+    tokio::time::timeout(EVENT_TIMEOUT, stream.next())
+        .await
+        .unwrap_or_else(|_| panic!("{want}: nothing arrived within {EVENT_TIMEOUT:?}"))
+        .unwrap_or_else(|| panic!("{want}: the stream ended first"))
+        .unwrap_or_else(|Lagged { count }| panic!("{want}: lagged by {count} instead"))
+}
 
 #[tokio::test]
 async fn subscribe_yields_events_the_daemon_pushes() {
@@ -33,11 +46,7 @@ async fn subscribe_yields_events_the_daemon_pushes() {
     }
 
     for i in 0..3u32 {
-        let event = tokio::time::timeout(EVENT_TIMEOUT, stream.next())
-            .await
-            .expect("a pushed event must arrive, not hang")
-            .unwrap()
-            .unwrap();
+        let event = next_event(&mut stream, "a pushed event must arrive").await;
         assert_eq!(
             event,
             BusEvent::LogOut {
@@ -80,11 +89,11 @@ async fn subscribing_installs_the_receiver_before_the_request_is_sent() {
     .unwrap();
 
     assert!(matches!(
-        tokio::time::timeout(EVENT_TIMEOUT, stream.next())
-            .await
-            .expect("the pre-installed receiver must observe the queued event")
-            .unwrap()
-            .unwrap(),
+        next_event(
+            &mut stream,
+            "the pre-installed receiver must observe the queued event"
+        )
+        .await,
         BusEvent::Process {
             event: ProcessEventKind::Online,
             ..
@@ -108,11 +117,7 @@ async fn a_daemon_shutdown_event_ends_the_stream_cleanly() {
     daemon.close().await;
 
     assert_eq!(
-        tokio::time::timeout(EVENT_TIMEOUT, stream.next())
-            .await
-            .expect("the DaemonShutdown event must arrive, not hang")
-            .unwrap()
-            .unwrap(),
+        next_event(&mut stream, "the DaemonShutdown event must arrive").await,
         BusEvent::DaemonShutdown
     );
     assert!(

--- a/crates/shep-daemon/src/testing.rs
+++ b/crates/shep-daemon/src/testing.rs
@@ -360,26 +360,36 @@ fn harness_sampling(scripts: Vec<ProcScript>, readings: Vec<Vec<ProcessRss>>) ->
 /// [`harness_sampling`], over a runner the caller built.
 fn harness_sampling_with(runner: ScriptedRunner, readings: Vec<Vec<ProcessRss>>) -> Harness {
     harness_with_runner(runner, |reports| {
-        let sampler: Arc<dyn MemorySampler> = Arc::new(ScriptedSampler::new(readings));
-        let stats = Arc::new(StatsState::new(Arc::clone(&sampler)));
-        Extras {
-            clock: Arc::new(TestClock::starting_at(
-                "2026-01-01T00:00:00Z"
-                    .parse()
-                    .expect("a valid RFC3339 timestamp"),
-            )),
-            enforcer: Arc::new(crate::limits::PollingEnforcer::start(
-                sampler,
-                reports.breaches.clone(),
-                Arc::clone(&stats),
-            )),
-            // A fixture nobody configured behaves like a daemon nobody
-            // configured.
-            max_cron_sleep: DEFAULT_MAX_CRON_SLEEP,
-            reports,
-            stats,
-        }
+        standard_extras(Arc::new(ScriptedSampler::new(readings)), reports)
     })
+}
+
+/// The [`Extras`] every scripted harness runs with, over a caller-chosen
+/// sampler.
+///
+/// The sampler is the only part a fixture varies. Everything else is the
+/// fixed test environment: a clock that does not move on its own, an
+/// enforcer polling that sampler, and the defaults a daemon nobody
+/// configured would run with.
+fn standard_extras(sampler: Arc<dyn MemorySampler>, reports: ExtrasReports) -> Extras {
+    let stats = Arc::new(StatsState::new(Arc::clone(&sampler)));
+    Extras {
+        clock: Arc::new(TestClock::starting_at(
+            "2026-01-01T00:00:00Z"
+                .parse()
+                .expect("a valid RFC3339 timestamp"),
+        )),
+        enforcer: Arc::new(crate::limits::PollingEnforcer::start(
+            sampler,
+            reports.breaches.clone(),
+            Arc::clone(&stats),
+        )),
+        // A fixture nobody configured behaves like a daemon nobody
+        // configured.
+        max_cron_sleep: DEFAULT_MAX_CRON_SLEEP,
+        reports,
+        stats,
+    }
 }
 
 /// [`harness`], over a process table that reports process identities.
@@ -392,24 +402,10 @@ pub(crate) fn harness_identifying(
     identities: Vec<ProcessIdentity>,
 ) -> Harness {
     harness_with_extras(scripts, |reports| {
-        let sampler: Arc<dyn MemorySampler> =
-            Arc::new(ScriptedSampler::identifying(vec![identities]));
-        let stats = Arc::new(StatsState::new(Arc::clone(&sampler)));
-        Extras {
-            clock: Arc::new(TestClock::starting_at(
-                "2026-01-01T00:00:00Z"
-                    .parse()
-                    .expect("a valid RFC3339 timestamp"),
-            )),
-            enforcer: Arc::new(crate::limits::PollingEnforcer::start(
-                sampler,
-                reports.breaches.clone(),
-                Arc::clone(&stats),
-            )),
-            max_cron_sleep: DEFAULT_MAX_CRON_SLEEP,
+        standard_extras(
+            Arc::new(ScriptedSampler::identifying(vec![identities])),
             reports,
-            stats,
-        }
+        )
     })
 }
 

--- a/crates/shep-daemon/tests/real_runner.rs
+++ b/crates/shep-daemon/tests/real_runner.rs
@@ -1,8 +1,8 @@
 //! Behavioral tests for [`shep_daemon::tokio_runner::TokioRunner`] against
 //! real `/bin/sh` child processes.
 //!
-// Runs on the real, unpaused clock, in a separate binary from the
-// paused-clock unit tests.
+//! Runs on the real, unpaused clock, in a separate binary from the
+//! paused-clock unit tests.
 
 #![cfg(unix)]
 
@@ -16,7 +16,7 @@ use shep_core::signals::OperatorSignal;
 use shep_daemon::channel::{ChildMessage, ShepherdMessage};
 use shep_daemon::privilege::Credentials;
 use shep_daemon::runner::{
-    AdoptSpec, AdoptedReaper, ProcIo, ProcessRunner, RunningProcess, SpawnSpec, StdinWrite,
+    AdoptSpec, AdoptedReaper, LogLine, ProcIo, ProcessRunner, RunningProcess, SpawnSpec, StdinWrite,
     StopSignal,
 };
 use shep_daemon::tokio_runner::TokioRunner;
@@ -57,6 +57,34 @@ fn spec_for(dir: &tempfile::TempDir, program: &str, args: &[&str]) -> SpawnSpec 
 /// How long a log line gets to travel from the pump's `write_all` to the
 /// file: slack for a loaded runner, not an expected duration.
 const LOG_WRITE_DEADLINE: Duration = Duration::from_secs(5);
+
+/// Twice the other budgets in this file, for the cases written with more
+/// slack.
+///
+/// Nothing distinguishes those cases. The literal arrived three separate
+/// times in three unrelated features, and one `proc.wait()` asserting
+/// "the adopted pid must be reaped within the budget" runs on
+/// [`REAP_DEADLINE`] while three others asserting the same thing run on
+/// this. Named so a slow-CI fix has one place to go, not because the
+/// difference means anything.
+const LONG_DEADLINE: Duration = Duration::from_secs(10);
+
+/// The child's next log line, or a named panic for either way there is not
+/// one: nothing arrives inside `deadline`, or the pump's channel closes.
+///
+/// `want` says what the caller was waiting for, and both panics carry it.
+/// The second `expect` this replaces had its own string at every site,
+/// seven distinct ones saying the log channel had closed.
+///
+/// # Panics
+///
+/// If no line arrives within `deadline`, or the log channel closes first.
+async fn recv_log(io: &mut ProcIo, deadline: Duration, want: &str) -> LogLine {
+    tokio::time::timeout(deadline, io.logs.recv())
+        .await
+        .unwrap_or_else(|_| panic!("{want}: nothing arrived within {deadline:?}"))
+        .unwrap_or_else(|| panic!("{want}: the log channel closed first"))
+}
 
 /// A log file's contents with the daemon's per-line timestamp stripped,
 /// so an assertion is about what the sheep wrote.
@@ -172,10 +200,7 @@ async fn a_reopen_moves_a_real_childs_output_onto_the_recreated_path() {
     // it is written leaves a real process behind for the rest of the run.
     let _reaper = Reaper(vec![i32::try_from(proc.pid()).unwrap()]);
 
-    let line = tokio::time::timeout(LOG_WRITE_DEADLINE, io.logs.recv())
-        .await
-        .expect("the child's first line must arrive")
-        .expect("logs closed before the first line");
+    let line = recv_log(&mut io, LOG_WRITE_DEADLINE, "the child's first line must arrive").await;
     assert_eq!(line.line, "before");
     await_file_contents(&out_file, "before\n").await;
 
@@ -206,10 +231,7 @@ async fn a_reopen_moves_a_real_childs_output_onto_the_recreated_path() {
     assert_eq!(unstamped_file(&archive), "before\n");
 
     fs::write(&marker, "").unwrap();
-    let line = tokio::time::timeout(LOG_WRITE_DEADLINE, io.logs.recv())
-        .await
-        .expect("the child's second line must arrive")
-        .expect("logs closed before the second line");
+    let line = recv_log(&mut io, LOG_WRITE_DEADLINE, "the child's second line must arrive").await;
     assert_eq!(line.line, "after");
 
     await_file_contents(&out_file, "after\n").await;
@@ -253,7 +275,7 @@ async fn signal_ignored_then_kill_tree_reaps() {
     );
 
     proc.kill_tree().unwrap();
-    let outcome = tokio::time::timeout(Duration::from_secs(5), proc.wait())
+    let outcome = tokio::time::timeout(REAP_DEADLINE, proc.wait())
         .await
         .expect("kill_tree should reap promptly");
     assert_eq!(outcome.signal, Some(9));
@@ -285,18 +307,12 @@ async fn a_process_signal_reaches_the_sheep_and_not_its_lamb() {
     let (mut proc, mut io) = runner.spawn(&spec).unwrap();
     let _reaper = Reaper(vec![i32::try_from(proc.pid()).unwrap()]);
 
-    let ready = tokio::time::timeout(Duration::from_secs(10), io.logs.recv())
-        .await
-        .expect("the lamb did not announce itself within 10s")
-        .expect("log channel closed");
+    let ready = recv_log(&mut io, LONG_DEADLINE, "the lamb did not announce itself within 10s").await;
     assert_eq!(ready.line, "lamb-ready");
 
     proc.signal_process(OperatorSignal::Usr1).unwrap();
 
-    let answer = tokio::time::timeout(Duration::from_secs(10), io.logs.recv())
-        .await
-        .expect("nothing answered the signal within 10s")
-        .expect("log channel closed");
+    let answer = recv_log(&mut io, LONG_DEADLINE, "nothing answered the signal within 10s").await;
     assert_eq!(answer.line, "sheep-got-it");
 
     // And nothing else follows it. A group delivery would put `lamb-got-it` on
@@ -395,16 +411,13 @@ async fn a_graceful_stop_reaches_a_forked_grandchild() {
 
     // The wrapper prints `$!` only after forking, so receiving this line
     // proves the grandchild already exists.
-    let line = tokio::time::timeout(Duration::from_secs(5), io.logs.recv())
-        .await
-        .expect("the wrapper must report its forked child's pid")
-        .expect("logs channel closed before the pid arrived");
+    let line = recv_log(&mut io, LOG_WRITE_DEADLINE, "the wrapper must report its forked child's pid").await;
     let grandchild: i32 = line.line.trim().parse().expect("`echo $!` prints a pid");
     reaper.0.push(grandchild);
     assert_ne!(grandchild, leader, "sanity: `&` really forked");
 
     proc.signal(StopSignal::Term).unwrap();
-    let outcome = tokio::time::timeout(Duration::from_secs(5), proc.wait())
+    let outcome = tokio::time::timeout(REAP_DEADLINE, proc.wait())
         .await
         .expect("the wrapper must exit on SIGTERM");
     assert_eq!(
@@ -429,7 +442,7 @@ async fn shepherd_channel_delivers_ready() {
 
     let (mut proc, mut io) = runner.spawn(&spec).unwrap();
 
-    let msg = tokio::time::timeout(Duration::from_secs(5), io.from_child.recv())
+    let msg = tokio::time::timeout(CHANNEL_DEADLINE, io.from_child.recv())
         .await
         .expect("shepherd-channel Ready should arrive promptly")
         .expect("from_child closed before Ready arrived");
@@ -439,7 +452,7 @@ async fn shepherd_channel_delivers_ready() {
     // SIGKILL, or the fork can miss the group signal entirely.
     tokio::time::sleep(Duration::from_millis(100)).await;
     proc.kill_tree().unwrap();
-    let outcome = tokio::time::timeout(Duration::from_secs(5), proc.wait())
+    let outcome = tokio::time::timeout(REAP_DEADLINE, proc.wait())
         .await
         .expect("kill_tree should reap promptly");
     assert_eq!(outcome.signal, Some(9));
@@ -678,17 +691,11 @@ async fn a_dropped_child_runs_as_the_requested_user() {
 
     let runner = TokioRunner::new();
     let (mut proc, mut io) = runner.spawn(&spec).unwrap();
-    let uid_line = tokio::time::timeout(Duration::from_secs(5), io.logs.recv())
-        .await
-        .expect("the child must print its uid")
-        .expect("the log pump must deliver the line");
+    let uid_line = recv_log(&mut io, LOG_WRITE_DEADLINE, "the child must print its uid").await;
     assert_eq!(uid_line.line.trim(), target.uid.as_raw().to_string());
     assert!(!uid_line.err);
 
-    let groups_line = tokio::time::timeout(Duration::from_secs(5), io.logs.recv())
-        .await
-        .expect("the child must print its group list")
-        .expect("the log pump must deliver the line");
+    let groups_line = recv_log(&mut io, LOG_WRITE_DEADLINE, "the child must print its group list").await;
     let groups: Vec<&str> = groups_line.line.split_whitespace().collect();
     assert_eq!(
         groups,
@@ -799,10 +806,7 @@ async fn a_bare_interpreter_resolves_via_the_seeded_path() {
 
     let runner = TokioRunner::new();
     let (mut proc, mut io) = runner.spawn(&spec).unwrap();
-    let line = tokio::time::timeout(Duration::from_secs(5), io.logs.recv())
-        .await
-        .expect("the shim must resolve via the seeded PATH and produce output")
-        .expect("logs channel closed before the line arrived");
+    let line = recv_log(&mut io, LOG_WRITE_DEADLINE, "the shim must resolve via the seeded PATH and produce output").await;
     assert_eq!(line.line, "shim-exec-ok");
     assert!(!line.err);
     let outcome = proc.wait().await;
@@ -832,10 +836,7 @@ async fn a_real_child_reads_a_line_written_to_its_stdin() {
         .unwrap();
     ack.await.unwrap().unwrap();
 
-    let line = tokio::time::timeout(Duration::from_secs(10), io.logs.recv())
-        .await
-        .expect("no stdout line within 10s")
-        .expect("log channel closed");
+    let line = recv_log(&mut io, LONG_DEADLINE, "no stdout line within 10s").await;
     assert!(!line.err);
     assert_eq!(line.line, "hello sheep");
 }
@@ -852,7 +853,7 @@ async fn a_child_that_did_not_ask_for_stdin_gets_eof_at_once() {
     let (mut proc, io) = runner.spawn(&spec).unwrap();
 
     assert!(io.to_stdin.is_closed());
-    let outcome = tokio::time::timeout(Duration::from_secs(10), proc.wait())
+    let outcome = tokio::time::timeout(LONG_DEADLINE, proc.wait())
         .await
         .expect("cat did not exit on EOF within 10s");
     assert_eq!(outcome.code, Some(0));
@@ -917,7 +918,7 @@ async fn an_adopted_proc_reports_its_real_exit() {
         "an adopted proc keeps the pid it was given"
     );
 
-    let outcome = tokio::time::timeout(Duration::from_secs(10), proc.wait())
+    let outcome = tokio::time::timeout(LONG_DEADLINE, proc.wait())
         .await
         .expect("the adopted pid must be reaped within the budget");
     assert_eq!((outcome.code, outcome.signal), (Some(3), None));
@@ -936,7 +937,7 @@ async fn a_spawned_proc_still_reports_its_real_exit() {
         .spawn(&spec_for(&dir, "/bin/sh", &["-c", "exit 4"]))
         .unwrap();
 
-    let outcome = tokio::time::timeout(Duration::from_secs(10), proc.wait())
+    let outcome = tokio::time::timeout(LONG_DEADLINE, proc.wait())
         .await
         .expect("a spawned child must be waited within the budget");
     assert_eq!((outcome.code, outcome.signal), (Some(4), None));
@@ -967,7 +968,7 @@ async fn an_adopted_proc_reports_a_signal_as_a_signal() {
     proc.signal_process(OperatorSignal::Kill)
         .expect("SIGKILL the adopted sheep");
 
-    let outcome = tokio::time::timeout(Duration::from_secs(10), proc.wait())
+    let outcome = tokio::time::timeout(LONG_DEADLINE, proc.wait())
         .await
         .expect("the adopted pid must be reaped within the budget");
     assert_eq!((outcome.code, outcome.signal), (None, Some(9)));
@@ -1013,14 +1014,11 @@ async fn an_adopted_pump_appends_the_carried_pipes_lines_through_the_carried_han
         .adopt(spec)
         .expect("the real runner must be able to adopt");
 
-    let line = tokio::time::timeout(Duration::from_secs(10), io.logs.recv())
-        .await
-        .expect("the carried pipe must still be pumped")
-        .expect("the pump must forward the line");
+    let line = recv_log(&mut io, LONG_DEADLINE, "the carried pipe must still be pumped").await;
     assert_eq!(line.line, "after-the-handover");
     await_file_contents(&out_file, "before-the-handover\nafter-the-handover\n").await;
 
-    let outcome = tokio::time::timeout(Duration::from_secs(10), proc.wait())
+    let outcome = tokio::time::timeout(LONG_DEADLINE, proc.wait())
         .await
         .expect("the adopted pid must be reaped within the budget");
     assert_eq!(outcome.code, Some(0));

--- a/crates/shep-daemon/tests/real_runner.rs
+++ b/crates/shep-daemon/tests/real_runner.rs
@@ -16,8 +16,8 @@ use shep_core::signals::OperatorSignal;
 use shep_daemon::channel::{ChildMessage, ShepherdMessage};
 use shep_daemon::privilege::Credentials;
 use shep_daemon::runner::{
-    AdoptSpec, AdoptedReaper, LogLine, ProcIo, ProcessRunner, RunningProcess, SpawnSpec, StdinWrite,
-    StopSignal,
+    AdoptSpec, AdoptedReaper, LogLine, ProcIo, ProcessRunner, RunningProcess, SpawnSpec,
+    StdinWrite, StopSignal,
 };
 use shep_daemon::tokio_runner::TokioRunner;
 
@@ -200,7 +200,12 @@ async fn a_reopen_moves_a_real_childs_output_onto_the_recreated_path() {
     // it is written leaves a real process behind for the rest of the run.
     let _reaper = Reaper(vec![i32::try_from(proc.pid()).unwrap()]);
 
-    let line = recv_log(&mut io, LOG_WRITE_DEADLINE, "the child's first line must arrive").await;
+    let line = recv_log(
+        &mut io,
+        LOG_WRITE_DEADLINE,
+        "the child's first line must arrive",
+    )
+    .await;
     assert_eq!(line.line, "before");
     await_file_contents(&out_file, "before\n").await;
 
@@ -231,7 +236,12 @@ async fn a_reopen_moves_a_real_childs_output_onto_the_recreated_path() {
     assert_eq!(unstamped_file(&archive), "before\n");
 
     fs::write(&marker, "").unwrap();
-    let line = recv_log(&mut io, LOG_WRITE_DEADLINE, "the child's second line must arrive").await;
+    let line = recv_log(
+        &mut io,
+        LOG_WRITE_DEADLINE,
+        "the child's second line must arrive",
+    )
+    .await;
     assert_eq!(line.line, "after");
 
     await_file_contents(&out_file, "after\n").await;
@@ -307,12 +317,22 @@ async fn a_process_signal_reaches_the_sheep_and_not_its_lamb() {
     let (mut proc, mut io) = runner.spawn(&spec).unwrap();
     let _reaper = Reaper(vec![i32::try_from(proc.pid()).unwrap()]);
 
-    let ready = recv_log(&mut io, LONG_DEADLINE, "the lamb did not announce itself within 10s").await;
+    let ready = recv_log(
+        &mut io,
+        LONG_DEADLINE,
+        "the lamb did not announce itself within 10s",
+    )
+    .await;
     assert_eq!(ready.line, "lamb-ready");
 
     proc.signal_process(OperatorSignal::Usr1).unwrap();
 
-    let answer = recv_log(&mut io, LONG_DEADLINE, "nothing answered the signal within 10s").await;
+    let answer = recv_log(
+        &mut io,
+        LONG_DEADLINE,
+        "nothing answered the signal within 10s",
+    )
+    .await;
     assert_eq!(answer.line, "sheep-got-it");
 
     // And nothing else follows it. A group delivery would put `lamb-got-it` on
@@ -411,7 +431,12 @@ async fn a_graceful_stop_reaches_a_forked_grandchild() {
 
     // The wrapper prints `$!` only after forking, so receiving this line
     // proves the grandchild already exists.
-    let line = recv_log(&mut io, LOG_WRITE_DEADLINE, "the wrapper must report its forked child's pid").await;
+    let line = recv_log(
+        &mut io,
+        LOG_WRITE_DEADLINE,
+        "the wrapper must report its forked child's pid",
+    )
+    .await;
     let grandchild: i32 = line.line.trim().parse().expect("`echo $!` prints a pid");
     reaper.0.push(grandchild);
     assert_ne!(grandchild, leader, "sanity: `&` really forked");
@@ -695,7 +720,12 @@ async fn a_dropped_child_runs_as_the_requested_user() {
     assert_eq!(uid_line.line.trim(), target.uid.as_raw().to_string());
     assert!(!uid_line.err);
 
-    let groups_line = recv_log(&mut io, LOG_WRITE_DEADLINE, "the child must print its group list").await;
+    let groups_line = recv_log(
+        &mut io,
+        LOG_WRITE_DEADLINE,
+        "the child must print its group list",
+    )
+    .await;
     let groups: Vec<&str> = groups_line.line.split_whitespace().collect();
     assert_eq!(
         groups,
@@ -806,7 +836,12 @@ async fn a_bare_interpreter_resolves_via_the_seeded_path() {
 
     let runner = TokioRunner::new();
     let (mut proc, mut io) = runner.spawn(&spec).unwrap();
-    let line = recv_log(&mut io, LOG_WRITE_DEADLINE, "the shim must resolve via the seeded PATH and produce output").await;
+    let line = recv_log(
+        &mut io,
+        LOG_WRITE_DEADLINE,
+        "the shim must resolve via the seeded PATH and produce output",
+    )
+    .await;
     assert_eq!(line.line, "shim-exec-ok");
     assert!(!line.err);
     let outcome = proc.wait().await;
@@ -1014,7 +1049,12 @@ async fn an_adopted_pump_appends_the_carried_pipes_lines_through_the_carried_han
         .adopt(spec)
         .expect("the real runner must be able to adopt");
 
-    let line = recv_log(&mut io, LONG_DEADLINE, "the carried pipe must still be pumped").await;
+    let line = recv_log(
+        &mut io,
+        LONG_DEADLINE,
+        "the carried pipe must still be pumped",
+    )
+    .await;
     assert_eq!(line.line, "after-the-handover");
     await_file_contents(&out_file, "before-the-handover\nafter-the-handover\n").await;
 

--- a/crates/shep-daemon/tests/real_runner_windows.rs
+++ b/crates/shep-daemon/tests/real_runner_windows.rs
@@ -9,7 +9,7 @@
 #![cfg(windows)]
 
 use std::collections::BTreeMap;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use shep_daemon::runner::{ProcessRunner, RunningProcess, SpawnSpec, StopSignal};
@@ -68,50 +68,59 @@ fn cmd_spec(dir: &tempfile::TempDir, args: &[&str]) -> SpawnSpec {
     }
 }
 
-/// Reads `path` until it contains `needle`, or fails after [`SETTLE`].
+/// Reads `out_file` until it contains `needle`, or fails after [`SETTLE`].
 ///
 /// Polls rather than reading once: the log pump writes on its own task, so
 /// a single read right after the child exits can race it.
-async fn wait_for_log(path: &PathBuf, needle: &str) -> String {
+///
+/// `err_file` is only read on the way to the panic. An empty log says
+/// nothing arrived, not why, and a sheep that failed to launch reports it
+/// on stderr.
+///
+/// # Panics
+///
+/// If `needle` has not reached `out_file` within [`SETTLE`].
+async fn wait_for_log(out_file: &Path, err_file: &Path, needle: &str) -> String {
     let started = tokio::time::Instant::now();
-    let deadline = tokio::time::Instant::now() + SETTLE;
+    let deadline = started + SETTLE;
     let mut last = String::new();
     while tokio::time::Instant::now() < deadline {
-        last = std::fs::read_to_string(path).unwrap_or_default();
+        last = std::fs::read_to_string(out_file).unwrap_or_default();
         if last.contains(needle) {
             return last;
         }
         tokio::time::sleep(Duration::from_millis(50)).await;
     }
-    // An empty log says nothing arrived, not why. A sheep that failed to
-    // launch reports it on stderr, in a sibling file this does not check.
-    let sibling = path.with_file_name(path.file_name().and_then(|name| name.to_str()).map_or_else(
-        || "web-err.log".to_string(),
-        |name| name.replace("out", "err"),
-    ));
     panic!(
         "{needle:?} never reached {} after {:?}; last saw {last:?}\n\
          out file exists: {}, len {:?}\n\
          stderr file {}: {:?}",
-        path.display(),
+        out_file.display(),
         started.elapsed(),
-        path.exists(),
-        std::fs::metadata(path).map(|m| m.len()).ok(),
-        sibling.display(),
-        std::fs::read_to_string(&sibling).ok(),
+        out_file.exists(),
+        std::fs::metadata(out_file).map(|m| m.len()).ok(),
+        err_file.display(),
+        std::fs::read_to_string(err_file).ok(),
     );
 }
 
-/// Whether `pid` names a live process right now.
-fn pid_is_alive(pid: u32) -> bool {
-    use sysinfo::{Pid, ProcessRefreshKind, ProcessesToUpdate};
+/// A process table read fresh, since both readers below want the state
+/// right now rather than whatever a cached `System` last saw.
+fn fresh_process_table() -> sysinfo::System {
+    use sysinfo::{ProcessRefreshKind, ProcessesToUpdate};
     let mut system = sysinfo::System::new();
     system.refresh_processes_specifics(
         ProcessesToUpdate::All,
         true,
         ProcessRefreshKind::everything(),
     );
-    system.process(Pid::from_u32(pid)).is_some()
+    system
+}
+
+/// Whether `pid` names a live process right now.
+fn pid_is_alive(pid: u32) -> bool {
+    use sysinfo::Pid;
+    fresh_process_table().process(Pid::from_u32(pid)).is_some()
 }
 
 /// Every live `ping` the sheep has spawned.
@@ -122,14 +131,8 @@ fn pid_is_alive(pid: u32) -> bool {
 /// order handed that one back a third of the time. Callers fail on an empty
 /// answer rather than skip the assertion.
 fn pings_under(parent: u32) -> Vec<u32> {
-    use sysinfo::{Pid, ProcessRefreshKind, ProcessesToUpdate};
-    let mut system = sysinfo::System::new();
-    system.refresh_processes_specifics(
-        ProcessesToUpdate::All,
-        true,
-        ProcessRefreshKind::everything(),
-    );
-    system
+    use sysinfo::Pid;
+    fresh_process_table()
         .processes()
         .values()
         .filter(|process| process.parent() == Some(Pid::from_u32(parent)))
@@ -159,7 +162,7 @@ async fn a_real_child_writes_its_stdout_to_the_log_file() {
         outcome.signal, None,
         "a Windows exit carries no signal number, ever"
     );
-    let logged = wait_for_log(&spec.out_file, "hello-from-windows").await;
+    let logged = wait_for_log(&spec.out_file, &spec.err_file, "hello-from-windows").await;
     assert!(logged.contains("hello-from-windows"), "{logged}");
 }
 
@@ -225,7 +228,7 @@ async fn kill_tree_reaches_a_grandchild_and_not_just_the_sheep() {
     let (mut proc, _io) = runner.spawn(&spec).unwrap();
     // The batch says when it has started its grandchild; the pid itself
     // comes from the process table, since `cmd` cannot report one.
-    wait_for_log(&spec.out_file, "LAMB-STARTED").await;
+    wait_for_log(&spec.out_file, &spec.err_file, "LAMB-STARTED").await;
     let sheep = proc.pid();
     // Both pings, not whichever is up first: `LAMB-STARTED` is echoed
     // between the background ping and the foreground one, so a snapshot on
@@ -335,7 +338,7 @@ async fn a_child_reaches_the_shepherd_channel_by_pipe_name() {
 
     let message = got.unwrap_or_else(|_| {
         panic!(
-            "no channel message within {SETTLE:?}; child saw SHEP_CHANNEL_PIPE={saw:?};              child stderr={child_err:?}"
+            "no channel message within {SETTLE:?}; child saw SHEP_CHANNEL_PIPE={saw:?}; child stderr={child_err:?}"
         )
     });
     assert!(


### PR DESCRIPTION
Group G of the qwen audit: 22 claims against 10 test-harness files. 15 confirmed and fixed, 7 left as they are. No production code, no public API change.

Fixed:

- `bless_or_compare` shared by `fixtures.rs` and `wire_export.rs`, so the `SHEP_CHANNEL_BLESS` name has one home
- `check<T>` generic over the message type, replacing one round-trip loop per enum
- `bind` helper for the 13 `Listener::bind(path).unwrap()` calls in `shep-client`, which now name the path they failed on
- `next_event` for the three five-line timeout chains in `event_stream.rs`
- `wait_bounded` shared by `init.rs` and `term_panic_order.rs`, which each had their own copy under the same name
- `standard_extras` for the `Extras` block built identically by two daemon harnesses
- `recv_log` for 10 sites in `real_runner.rs`, and each inline `Duration` literal replaced by the constant naming its meaning
- `fresh_process_table` for the duplicated `sysinfo` refresh in the Windows tests
- four small ones: a `//` line inside a `//!` block, a doubled `Instant::now()`, a stderr path rebuilt with `name.replace("out", "err")`, and 14 stray spaces in a panic string

Left alone, with the reason in each commit:

- `fake_client_with_push`: an alias, but all seven call sites really do use push
- `EVENT_TIMEOUT` in two files: sharing it means a `common` module inside the one test whose subject is what is in scope
- `base_spec()` for `sh_spec` and `spec_for`: `..base_spec()` turns "adding a `SpawnSpec` field breaks both fixtures" into a silent inherit
- `tempdir()` plus `control_address()` in 21 tests: `testing.rs` says the caller owns the `TempDir` and the crate takes no dev-dependencies
- renaming `fake_client_on`, renaming the `Handovers` field, and a `wait_proc` helper: reasons in the commits

Six of the 22 claims were wrong in their details. `bind_and_frames` cannot exist, since the bind has to happen before the function returns and the accept inside the spawned task. The `recv_log` count was 11 including a site with no timeout, and the second `expect` message varied too, seven distinct strings. The event-stream count was 5 including one that asserts the stream ended. The `.replace("out", "err")` example given, `troubleshoot.log`, contains no `out`.

Verified:

- `cargo +1.93 fmt --all -- --check`: exit 0
- `cargo +1.93 clippy --workspace --all-targets --all-features -- -D warnings`: exit 0, the lint job's own pair
- `cargo test --workspace --tests`: exit 0, 33 suites, 3377 passed
- `cargo check --workspace --all-targets --all-features --target x86_64-pc-windows-gnu`: exit 0, needed because `real_runner_windows.rs` is `#![cfg(windows)]`

The lint job caught a formatting failure on the first push. The `recv_log` conversion was a regex substitution that put three calls over the width limit, and I had not run `cargo fmt` before opening this. Fixed in `style(daemon): rustfmt the recv_log call sites`, and the commands above are now the lint job's exact pair rather than the narrower local clippy I ran first.

Two things worth knowing:

`cargo test --workspace --tests` cannot run this workspace green on its own. `--tests` skips the normal example build and `daemon_e2e.rs` asserts on `target/debug/examples/reuse_port_sheep`, so four tests fail. `--examples` does not help either: under `cargo test` it builds a hashed test binary instead of the plain path. One `cargo build --workspace --examples` fixes it in 0.22s.

`real_runner.rs` runs the same assertion on two budgets: one `proc.wait()` asserting "the adopted pid must be reaped within the budget" uses `REAP_DEADLINE` at 5s while three others asserting the same string use 10s. `git log -S` shows the 10s literal arriving three separate times in three unrelated features, so it is drift rather than design. I named it `LONG_DEADLINE` and said so in its doc instead of collapsing the two, since picking one is a call about CI flake headroom.

Commits are typed `test(...)` rather than `refactor(...)` on purpose: release-plz walks individual commits, and a `refactor` here would put test-harness churn in four changelogs and bump four crates for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

