### PR TITLE
refactor(dogs): qwen audit group E, dog and bark duplication

### DIFF
--- a/crates/shep-cli/src/dog/bark/mod.rs
+++ b/crates/shep-cli/src/dog/bark/mod.rs
@@ -150,6 +150,46 @@ pub fn rules_for(config: &BarkConfig) -> Result<Rules, rules::RulesError> {
     Rules::new(rule_list, &config.sinks)
 }
 
+/// Everything a delivery needs, so the five values that travel together
+/// through [`reconcile`], [`spawn_firings`] and [`deliver_and_record`]
+/// travel as one.
+///
+/// `Clone` is what [`spawn_firings`] hands each spawned task: three
+/// [`Arc`] bumps and two copies, the same clones it used to make one by
+/// one. A config reload rebinds `sinks`, `sink_timeout` and `max_bytes`
+/// in place; `append_lock` and `barks_path` outlive every reload.
+///
+/// `Debug` is safe despite `sinks` holding webhook URLs, which are bearer
+/// credentials: [`Sink`]'s own `Debug` redacts them.
+#[derive(Debug, Clone)]
+struct Delivery {
+    /// Every configured sink by name, for resolving a firing's own list.
+    sinks: Arc<BTreeMap<String, Sink>>,
+    /// Serializes this process's appends to `barks_path`.
+    append_lock: Arc<Mutex<()>>,
+    /// Where the bark trail is written.
+    barks_path: Arc<PathBuf>,
+    /// How long one sink delivery may take.
+    sink_timeout: Duration,
+    /// The trail's size ceiling.
+    max_bytes: u64,
+}
+
+/// The poll timer for `period`.
+///
+/// `interval_at`, not `interval`: a plain `interval` fires its first tick
+/// immediately, so the first poll would be attributable to the timer's
+/// startup rather than to a drop or an elapsed interval.
+///
+/// One function, not two call sites: a reload that rebuilt the timer and
+/// forgot `MissedTickBehavior::Delay` would leave a poll that ran long
+/// firing a burst of catch-up ticks.
+fn poll_timer(period: Duration) -> tokio::time::Interval {
+    let mut interval = tokio::time::interval_at(tokio::time::Instant::now() + period, period);
+    interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
+    interval
+}
+
 /// Bark's loop: subscribe for speed, poll for correctness. Ends on
 /// `SIGINT`/`SIGTERM` or when `events` does.
 ///
@@ -169,19 +209,22 @@ pub fn run_loop<E: EventSource, F: FlockSource, C: ConfigSource>(
     barks_path: &Path,
     config_source: C,
 ) -> impl Future<Output = ExitCode> + Send + use<E, F, C> {
-    let mut sinks = Arc::new(config.sinks.clone());
-    let mut sink_timeout = config.sink_timeout.as_duration();
-    let mut max_bytes = config.history_bytes;
-    // `interval_at`, not `interval`: a plain `interval` fires its first
-    // tick immediately, so the first poll would be attributable to the
-    // timer's startup rather than to a drop or an elapsed interval.
+    let sinks = Arc::new(config.sinks.clone());
+    let sink_timeout = config.sink_timeout.as_duration();
+    let max_bytes = config.history_bytes;
     let mut poll_period = config.poll.as_duration();
     let barks_path = Arc::new(barks_path.to_path_buf());
 
     async move {
         let mut events = events;
         let mut rules = rules;
-        let append_lock = Arc::new(Mutex::new(()));
+        let mut delivery = Delivery {
+            sinks,
+            append_lock: Arc::new(Mutex::new(())),
+            barks_path,
+            sink_timeout,
+            max_bytes,
+        };
 
         let mut sigterm = match crate::shutdown::Terminate::install() {
             Ok(sigterm) => sigterm,
@@ -191,9 +234,7 @@ pub fn run_loop<E: EventSource, F: FlockSource, C: ConfigSource>(
             }
         };
 
-        let mut poll_interval =
-            tokio::time::interval_at(tokio::time::Instant::now() + poll_period, poll_period);
-        poll_interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
+        let mut poll_interval = poll_timer(poll_period);
 
         loop {
             tokio::select! {
@@ -214,9 +255,9 @@ pub fn run_loop<E: EventSource, F: FlockSource, C: ConfigSource>(
                                 // In place, never a restart: sinks and
                                 // rules are pure data with no OS resource
                                 // to rebind.
-                                sinks = Arc::new(next.sinks.clone());
-                                sink_timeout = next.sink_timeout.as_duration();
-                                max_bytes = next.history_bytes;
+                                delivery.sinks = Arc::new(next.sinks.clone());
+                                delivery.sink_timeout = next.sink_timeout.as_duration();
+                                delivery.max_bytes = next.history_bytes;
                                 // Rebuilt, which resets each rule's
                                 // per-subject debounce: carrying it over
                                 // a renumbered rule set would key state on
@@ -224,28 +265,24 @@ pub fn run_loop<E: EventSource, F: FlockSource, C: ConfigSource>(
                                 rules = next_rules;
                                 if next.poll.as_duration() != poll_period {
                                     poll_period = next.poll.as_duration();
-                                    poll_interval = tokio::time::interval_at(
-                                        tokio::time::Instant::now() + poll_period,
-                                        poll_period,
-                                    );
-                                    poll_interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
+                                    poll_interval = poll_timer(poll_period);
                                 }
                                 eprintln!("shep dog bark: reloaded [bark] from dogs.toml");
                             }
                         }
                         Some(Ok(event)) => {
                             let firings = rules.on_event(&event, now_ms());
-                            spawn_firings(firings, &sinks, &append_lock, &barks_path, sink_timeout, max_bytes);
+                            spawn_firings(firings, &delivery);
                         }
                         Some(Err(_dropped)) => {
                             // The drop says nothing about what was lost;
                             // only the shepherd can.
-                            reconcile(&flock, &mut rules, &sinks, &append_lock, &barks_path, sink_timeout, max_bytes).await;
+                            reconcile(&flock, &mut rules, &delivery).await;
                         }
                     }
                 }
                 _ = poll_interval.tick() => {
-                    reconcile(&flock, &mut rules, &sinks, &append_lock, &barks_path, sink_timeout, max_bytes).await;
+                    reconcile(&flock, &mut rules, &delivery).await;
                 }
             }
         }
@@ -298,26 +335,11 @@ async fn reloaded_config<C: ConfigSource>(source: &C) -> Option<(BarkConfig, Rul
 ///
 /// A failed poll is logged and dropped: the next bus event or interval
 /// tick tries again.
-async fn reconcile<F: FlockSource>(
-    flock: &F,
-    rules: &mut Rules,
-    sinks: &Arc<BTreeMap<String, Sink>>,
-    append_lock: &Arc<Mutex<()>>,
-    barks_path: &Arc<PathBuf>,
-    sink_timeout: Duration,
-    max_bytes: u64,
-) {
+async fn reconcile<F: FlockSource>(flock: &F, rules: &mut Rules, delivery: &Delivery) {
     match flock.flock().await {
         Ok(snapshot) => {
             let firings = rules.on_poll(&snapshot, now_ms());
-            spawn_firings(
-                firings,
-                sinks,
-                append_lock,
-                barks_path,
-                sink_timeout,
-                max_bytes,
-            );
+            spawn_firings(firings, delivery);
         }
         Err(err) => eprintln!("shep dog bark: reconciliation poll failed: {err}"),
     }
@@ -326,28 +348,11 @@ async fn reconcile<F: FlockSource>(
 /// Spawns one delivery task per firing, so [`run_loop`]'s own `select!`
 /// returns to reading the next event immediately rather than waiting on any
 /// of them.
-fn spawn_firings(
-    firings: Vec<Firing>,
-    sinks: &Arc<BTreeMap<String, Sink>>,
-    append_lock: &Arc<Mutex<()>>,
-    barks_path: &Arc<PathBuf>,
-    sink_timeout: Duration,
-    max_bytes: u64,
-) {
+fn spawn_firings(firings: Vec<Firing>, delivery: &Delivery) {
     for firing in firings {
-        let sinks = Arc::clone(sinks);
-        let append_lock = Arc::clone(append_lock);
-        let barks_path = Arc::clone(barks_path);
+        let delivery = delivery.clone();
         tokio::spawn(async move {
-            deliver_and_record(
-                firing,
-                &sinks,
-                &append_lock,
-                &barks_path,
-                sink_timeout,
-                max_bytes,
-            )
-            .await;
+            deliver_and_record(firing, &delivery).await;
         });
     }
 }
@@ -360,22 +365,15 @@ fn spawn_firings(
 /// refused it: the local trail is what an operator reads when the page
 /// never arrived.
 ///
-/// `append_lock` covers only the [`barks::append`] call, a
+/// [`Delivery::append_lock`] covers only the [`barks::append`] call, a
 /// read-modify-rename against one file that several of these run at once.
 /// It does not replace `append`'s own cross-process `flock(2)`.
-async fn deliver_and_record(
-    firing: Firing,
-    sinks: &BTreeMap<String, Sink>,
-    append_lock: &Mutex<()>,
-    barks_path: &Path,
-    sink_timeout: Duration,
-    max_bytes: u64,
-) {
+async fn deliver_and_record(firing: Firing, delivery: &Delivery) {
     let mut bark = firing.bark;
     let mut outcomes = Vec::with_capacity(firing.sinks.len());
     for name in &firing.sinks {
-        let outcome = match sinks.get(name) {
-            Some(sink) => match sinks::deliver(sink, &bark, sink_timeout).await {
+        let outcome = match delivery.sinks.get(name) {
+            Some(sink) => match sinks::deliver(sink, &bark, delivery.sink_timeout).await {
                 Ok(()) => SinkOutcome {
                     sink: name.clone(),
                     error: None,
@@ -397,8 +395,8 @@ async fn deliver_and_record(
     }
     bark.sinks = outcomes;
 
-    let _guard = append_lock.lock().await;
-    if let Err(err) = barks::append(barks_path, &bark, max_bytes) {
+    let _guard = delivery.append_lock.lock().await;
+    if let Err(err) = barks::append(&delivery.barks_path, &bark, delivery.max_bytes) {
         eprintln!("shep dog bark: could not record a fired bark: {err}");
     }
 }
@@ -598,6 +596,12 @@ mod tests {
         process_event(name, ProcessEventKind::Errored)
     }
 
+    /// A JSON sink POSTing to `url` with the default body. Every sink
+    /// these tests configure is this one.
+    fn json_sink(url: String) -> Sink {
+        Sink::Json { url, body: None }
+    }
+
     /// A cheap bus event no rule below fires on: filler for overflowing
     /// the broadcast channel's small capacity.
     fn log_event(i: u32) -> BusEvent {
@@ -617,10 +621,7 @@ mod tests {
         let mut sinks = BTreeMap::new();
         sinks.insert(
             "ops".to_owned(),
-            Sink::Json {
-                url: "http://127.0.0.1:1/hook".to_owned(),
-                body: None,
-            },
+            json_sink("http://127.0.0.1:1/hook".to_owned()),
         );
         Rules::new(
             vec![rules::Rule {
@@ -638,13 +639,7 @@ mod tests {
     /// poll that fires is attributable to the lag path.
     fn config_with_sink(addr: SocketAddr, _barks_path: &Path) -> BarkConfig {
         let mut sinks = BTreeMap::new();
-        sinks.insert(
-            "ops".to_owned(),
-            Sink::Json {
-                url: format!("http://{addr}/hook"),
-                body: None,
-            },
-        );
+        sinks.insert("ops".to_owned(), json_sink(format!("http://{addr}/hook")));
         BarkConfig {
             sinks,
             rules: Vec::new(),
@@ -741,14 +736,7 @@ mod tests {
         let barks_path = dir.path().join("barks.jsonl");
 
         let mut sinks = BTreeMap::new();
-        sinks.insert(
-            "ops".to_owned(),
-            Sink::Json {
-                url: format!("http://{addr}/hook"),
-                body: None,
-            },
-        );
-        let append_lock = Mutex::new(());
+        sinks.insert("ops".to_owned(), json_sink(format!("http://{addr}/hook")));
         let firing = Firing {
             bark: Bark {
                 at_ms: 1_000,
@@ -762,11 +750,13 @@ mod tests {
 
         deliver_and_record(
             firing,
-            &sinks,
-            &append_lock,
-            &barks_path,
-            Duration::from_secs(5),
-            barks::DEFAULT_MAX_BYTES,
+            &Delivery {
+                sinks: Arc::new(sinks),
+                append_lock: Arc::new(Mutex::new(())),
+                barks_path: Arc::new(barks_path.clone()),
+                sink_timeout: Duration::from_secs(5),
+                max_bytes: barks::DEFAULT_MAX_BYTES,
+            },
         )
         .await;
 
@@ -802,17 +792,11 @@ mod tests {
         let mut sinks = BTreeMap::new();
         sinks.insert(
             "slow".to_owned(),
-            Sink::Json {
-                url: format!("http://{slow_addr}/hook"),
-                body: None,
-            },
+            json_sink(format!("http://{slow_addr}/hook")),
         );
         sinks.insert(
             "fast".to_owned(),
-            Sink::Json {
-                url: format!("http://{fast_addr}/hook"),
-                body: None,
-            },
+            json_sink(format!("http://{fast_addr}/hook")),
         );
         let rules = Rules::new(
             vec![

--- a/crates/shep-cli/src/dog/bark/rules.rs
+++ b/crates/shep-cli/src/dog/bark/rules.rs
@@ -96,6 +96,16 @@ pub enum Trigger {
     },
 }
 
+/// What a [`Trigger::GaveUp`] firing says about `name`.
+///
+/// One function rather than the literal at both trigger sites: the bus
+/// route reads an `Errored` event and the poll route reads an `Errored`
+/// status, and an operator seeing two spellings of the same alert would
+/// read it as two different alerts.
+fn gave_up_message(name: &str) -> String {
+    format!("{name} gave up: restart budget exhausted")
+}
+
 /// The rule-kind name [`Bark::rule`] records for a firing: the same
 /// snake_case spelling a `[dog.bark.rules]` entry's own `on = "..."` key
 /// uses, so an operator reading `barks.jsonl` sees no vocabulary mismatch
@@ -277,19 +287,34 @@ impl Rules {
         }]
     }
 
-    /// Whether rule `idx` may fire for `subject` now, recording the firing
-    /// when it can. Shared by the bus route and the poll route, so an
-    /// event both see fires once.
-    fn try_fire(&mut self, idx: usize, subject: &str, now_ms: u64, debounce: UpDuration) -> bool {
+    /// The firing rule `idx` produces for `subject` now, or `None` when
+    /// its debounce has not elapsed. Shared by the bus route and the poll
+    /// route, so an event both see fires once.
+    ///
+    /// The caller decides whether the rule triggered at all and supplies
+    /// the `message`; everything from the debounce onward is the same on
+    /// both routes.
+    fn fire(&mut self, idx: usize, subject: &str, now_ms: u64, message: String) -> Option<Firing> {
+        let debounce = self.rules[idx].debounce;
         let state = self.subjects.entry(subject.to_owned()).or_default();
         let ready = state
             .last_fired
             .get(&idx)
             .is_none_or(|&last| now_ms.saturating_sub(last) >= debounce.as_millis());
-        if ready {
-            state.last_fired.insert(idx, now_ms);
+        if !ready {
+            return None;
         }
-        ready
+        state.last_fired.insert(idx, now_ms);
+        Some(Firing {
+            bark: Bark {
+                at_ms: now_ms,
+                rule: trigger_name(&self.rules[idx].when).to_owned(),
+                subject: subject.to_owned(),
+                message,
+                sinks: Vec::new(),
+            },
+            sinks: self.rules[idx].sinks.clone(),
+        })
     }
 
     /// Whether a `RestartRate` rule has accumulated `threshold` or more
@@ -330,32 +355,18 @@ impl Rules {
         let kind_wire = wire_spelling(kind);
         let mut firings = Vec::new();
         for idx in 0..self.rules.len() {
-            let debounce = self.rules[idx].debounce;
             let trigger = self.rules[idx].when.clone();
             let message = match &trigger {
                 Trigger::Event { kinds } if kinds.iter().any(|k| k == &kind_wire) => {
                     Some(format!("{} {kind_wire}", info.name))
                 }
                 Trigger::GaveUp {} if kind == ProcessEventKind::Errored => {
-                    Some(format!("{} gave up: restart budget exhausted", info.name))
+                    Some(gave_up_message(&info.name))
                 }
                 _ => None,
             };
             let Some(message) = message else { continue };
-            if !self.try_fire(idx, &info.name, now_ms, debounce) {
-                continue;
-            }
-            let sinks = self.rules[idx].sinks.clone();
-            firings.push(Firing {
-                bark: Bark {
-                    at_ms: now_ms,
-                    rule: trigger_name(&trigger).to_owned(),
-                    subject: info.name.clone(),
-                    message,
-                    sinks: Vec::new(),
-                },
-                sinks,
-            });
+            firings.extend(self.fire(idx, &info.name, now_ms, message));
         }
         firings
     }
@@ -372,13 +383,11 @@ impl Rules {
         let mut firings = Vec::new();
         for info in flock {
             for idx in 0..self.rules.len() {
-                let debounce = self.rules[idx].debounce;
                 let trigger = self.rules[idx].when.clone();
                 let message = match &trigger {
                     Trigger::Event { .. } => None,
-                    Trigger::GaveUp {} => (info.status == ProcStatus::Errored).then(|| {
-                        format!("{} gave up: restart budget exhausted", info.name)
-                    }),
+                    Trigger::GaveUp {} => (info.status == ProcStatus::Errored)
+                        .then(|| gave_up_message(&info.name)),
                     Trigger::RestartRate { restarts, within } => self
                         .restart_window_crossed(
                             idx,
@@ -405,20 +414,7 @@ impl Rules {
                     }),
                 };
                 let Some(message) = message else { continue };
-                if !self.try_fire(idx, &info.name, now_ms, debounce) {
-                    continue;
-                }
-                let sinks = self.rules[idx].sinks.clone();
-                firings.push(Firing {
-                    bark: Bark {
-                        at_ms: now_ms,
-                        rule: trigger_name(&trigger).to_owned(),
-                        subject: info.name.clone(),
-                        message,
-                        sinks: Vec::new(),
-                    },
-                    sinks,
-                });
+                firings.extend(self.fire(idx, &info.name, now_ms, message));
             }
         }
         firings

--- a/crates/shep-cli/src/dog/bark/sinks.rs
+++ b/crates/shep-cli/src/dog/bark/sinks.rs
@@ -307,20 +307,15 @@ fn substitute(template: &str, bark: &Bark) -> String {
 /// `s`, escaped for use inside a JSON string's quotes, not a JSON string
 /// literal itself: [`substitute`]'s own template already supplies the
 /// surrounding quotes.
+///
+/// serde_json's own writer rather than an escape table of our own:
+/// [`substitute`] hands its output to [`render_body`], which parses the
+/// result with serde_json, so the escaping and the parsing have to agree
+/// on every character. Going through the writer makes them agree by
+/// construction instead of by maintenance.
 fn json_escape(s: &str) -> String {
-    let mut out = String::with_capacity(s.len());
-    for ch in s.chars() {
-        match ch {
-            '"' => out.push_str("\\\""),
-            '\\' => out.push_str("\\\\"),
-            '\n' => out.push_str("\\n"),
-            '\r' => out.push_str("\\r"),
-            '\t' => out.push_str("\\t"),
-            c if (c as u32) < 0x20 => out.push_str(&format!("\\u{:04x}", c as u32)),
-            c => out.push(c),
-        }
-    }
-    out
+    let quoted = serde_json::to_string(s).expect("a str always serializes as a JSON string");
+    quoted[1..quoted.len() - 1].to_owned()
 }
 
 /// POSTs `bark` to `sink`, bounded by `timeout`.
@@ -555,6 +550,25 @@ mod tests {
             body: Some(r#"{"text": "{message}"}"#.to_string()),
         };
         let bark = bark_for("web", r#"app "we"b" crashed"#);
+        let rendered = render_body(&sink, &bark).unwrap();
+        let value: serde_json::Value = serde_json::from_str(&rendered).unwrap();
+        assert_eq!(value["text"], bark.message);
+    }
+
+    /// The control characters JSON refuses raw inside a string, including
+    /// the two a `\u00XX` escape and a short escape spell differently.
+    /// What matters is that the rendered body parses back to the message
+    /// it was built from, not which of the two spellings is used.
+    #[test]
+    fn control_characters_survive_the_round_trip() {
+        let sink = Sink::Json {
+            url: "http://127.0.0.1:1/".to_string(),
+            body: Some(r#"{"text": "{message}"}"#.to_string()),
+        };
+        let bark = bark_for(
+            "web",
+            "tab\there\nnewline\u{8}backspace\u{c}formfeed\u{1}one",
+        );
         let rendered = render_body(&sink, &bark).unwrap();
         let value: serde_json::Value = serde_json::from_str(&rendered).unwrap();
         assert_eq!(value["text"], bark.message);

--- a/crates/shep-cli/src/dog/metrics/exposition.rs
+++ b/crates/shep-cli/src/dog/metrics/exposition.rs
@@ -42,13 +42,9 @@ impl MetricGroup {
     /// Appends one series line. `label_str` comes from [`labels`], braces
     /// included, or empty for a label-less metric.
     fn push(&mut self, label_str: &str, value: impl fmt::Display) {
-        let name = self.name;
-        let _ = writeln!(self.series_line(), "{name}{label_str} {value}");
-    }
-
-    fn series_line(&mut self) -> &mut String {
-        self.series.push(String::new());
-        self.series.last_mut().expect("just pushed")
+        let mut line = String::new();
+        let _ = writeln!(line, "{}{label_str} {value}", self.name);
+        self.series.push(line);
     }
 
     /// Renders this group's `# HELP`/`# TYPE` pair and series, or nothing

--- a/crates/shep-cli/src/dog/metrics/mod.rs
+++ b/crates/shep-cli/src/dog/metrics/mod.rs
@@ -194,9 +194,8 @@ async fn handle_connection(mut stream: TcpStream, client: Arc<ReconnectingClient
     };
     let path = request
         .target
-        .split('?')
-        .next()
-        .unwrap_or(request.target.as_str());
+        .split_once('?')
+        .map_or(request.target.as_str(), |(path, _query)| path);
     if path != "/metrics" {
         let _: Result<(), HttpError> = http::write_response(
             &mut stream,

--- a/crates/shep-cli/src/dog/mod.rs
+++ b/crates/shep-cli/src/dog/mod.rs
@@ -333,6 +333,20 @@ impl bark::EventSource for EventStream {
     }
 }
 
+/// The error for a reply that is not the variant the request names.
+///
+/// Never returned by a daemon on the same protocol version; kept
+/// reportable rather than `unreachable!()`. One function rather than the
+/// literal at each impl, so the two reports keep saying the same thing
+/// in the same shape.
+fn unexpected_reply(request: &str, expected: &str) -> RequestError {
+    RequestError::Rpc(RpcError {
+        code: RpcErrorCode::Internal,
+        message: format!("the shepherd answered {request} with something other than {expected}"),
+        daemon_version: None,
+    })
+}
+
 /// Wraps [`ReconnectingClient`] as both [`bark::FlockSource`] and
 /// [`bark::ConfigSource`]. [`ReconnectingClient`] is not `Clone`, so the
 /// two roles reach it through one [`Arc`] rather than through two clients
@@ -347,15 +361,7 @@ impl bark::FlockSource for ClientShepherd {
     async fn flock(&self) -> Result<Vec<ProcessInfo>, RequestError> {
         match self.client.request(Request::ListFlock).await? {
             Response::Flock(flock) => Ok(flock),
-            // Never returned by a daemon on the same protocol version;
-            // kept reportable rather than `unreachable!()`.
-            _ => Err(RequestError::Rpc(RpcError {
-                code: RpcErrorCode::Internal,
-                message: "the shepherd answered ListFlock with something other than \
-                          Response::Flock"
-                    .to_owned(),
-                daemon_version: None,
-            })),
+            _ => Err(unexpected_reply("ListFlock", "Response::Flock")),
         }
     }
 }
@@ -370,15 +376,7 @@ impl bark::ConfigSource for ClientShepherd {
             .await?;
         match response {
             Response::DogSection { toml } => Ok(toml.as_str().to_string()),
-            // Never returned by a daemon on the same protocol version;
-            // kept reportable rather than `unreachable!()`.
-            _ => Err(RequestError::Rpc(RpcError {
-                code: RpcErrorCode::Internal,
-                message: "the shepherd answered DogConfig with something other than \
-                          Response::DogSection"
-                    .to_owned(),
-                daemon_version: None,
-            })),
+            _ => Err(unexpected_reply("DogConfig", "Response::DogSection")),
         }
     }
 }


### PR DESCRIPTION
Group E of the qwen audit, the `crates/shep-cli/src/dog/` findings. 9 of 10 confirmed and fixed, 1 dismissed.

- `rules.rs`: `on_event` and `on_poll` ended with the same 15 lines, byte-identical modulo indent. `try_fire` grows into `fire`, returning `Option<Firing>` instead of `bool`, so both routes get one call
- `rules.rs`: the "gave up: restart budget exhausted" text moves to `gave_up_message`
- `bark/mod.rs`: the 5 parallel delivery parameters become a `Delivery` struct, and `spawn_firings`'s three `Arc::clone` calls collapse into one
- `bark/mod.rs`: `interval_at` plus `set_missed_tick_behavior` was written at startup and again on reload. Now `poll_timer`
- `dog/mod.rs`: the two hand-built "unexpected reply" `RpcError`s become `unexpected_reply(request, expected)`
- `sinks.rs`: `json_escape` uses serde_json's writer instead of its own escape table
- `exposition.rs`: `series_line` folds into `push`
- `metrics/mod.rs`: `split('?').next().unwrap_or(...)` becomes `split_once`
- tests: `Sink::Json { url, body: None }` was spelled out 5 times, now `json_sink(url)`

Dismissed: sharing `Request::DogConfig` between `DogRuntime::start` and `ClientShepherd::section`. They report through different error models, and `exit_code_for` maps `UnexpectedReply` to `ExitCode::Internal` while `Request` defers to `ExitCode::from(RequestError)`. A shared helper changes the dog's exit code.

One wire-visible change: U+0008 and U+000C in a templated sink body go out as `\b` and `\f` instead of `\u0008` and `\u000c`. Both parse back the same. `control_characters_survive_the_round_trip` covers it and passes against the old escaper too, so it is a regression test rather than a description of the new behaviour.

Heads up for anyone running the other audit groups: the plan's `cargo test -p shep-cli` selects `crates/shep-cli-redirect`, the empty crates.io placeholder. 0 tests, exit 0. The package is `shep`. Groups A, B, E and F all list the wrong one.

```
cargo test -p shep --lib --bins                     1666 passed, 0 failed, 3 ignored
cargo clippy -p shep --lib --bins -- -D warnings    clean
cargo fmt --all --check                             clean
cargo test -p shep --doc                            clean
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
