### PR TITLE
refactor(cli): consolidate command response plumbing

### DIFF
--- a/crates/shep-cli/src/commands/admin.rs
+++ b/crates/shep-cli/src/commands/admin.rs
@@ -104,21 +104,14 @@ async fn kill_socket_free_with_wait(
     }
     #[cfg(unix)]
     {
-        if wait_for_socket_to_disappear(&paths.socket, wait).await {
-            write_outcome(emit(
-                &mut *streams.out,
-                streams.fmt,
-                "kill",
-                KillRow {
-                    pid,
-                    socket_removed: true,
-                },
-                streams.style,
-            ))
-        } else {
-            let message = "the shepherd was signalled, but teardown is still in progress";
-            streams.fail(ExitCode::DeadlineExceeded, message)
-        }
+        report_teardown(
+            streams,
+            &paths.socket,
+            pid,
+            wait,
+            "the shepherd was signalled, but teardown is still in progress",
+        )
+        .await
     }
     // Unreachable: `signal_graceful_stop` already returned on this platform.
     #[cfg(windows)]
@@ -182,24 +175,45 @@ pub async fn kill_with_wait(client: Client, streams: &mut Streams<'_>, wait: Dur
 
     match response {
         Ok(Response::ShuttingDown) => {
-            if wait_for_socket_to_disappear(&socket, wait).await {
-                write_outcome(emit(
-                    &mut *streams.out,
-                    streams.fmt,
-                    "kill",
-                    KillRow {
-                        pid,
-                        socket_removed: true,
-                    },
-                    streams.style,
-                ))
-            } else {
-                let message = "the daemon acknowledged shutdown, but teardown is still in progress";
-                streams.fail(ExitCode::DeadlineExceeded, message)
-            }
+            report_teardown(
+                streams,
+                &socket,
+                pid,
+                wait,
+                "the daemon acknowledged shutdown, but teardown is still in progress",
+            )
+            .await
         }
         Ok(_unrecognised) => unexpected_response(streams),
         Err(err) => client_error(streams, &err),
+    }
+}
+
+/// Waits out the shepherd's teardown and reports what it found.
+///
+/// `still_going` is the sentence for the wait elapsing, and is the only
+/// thing the two callers differ on: one signalled the process, the other was
+/// told the shutdown had started.
+async fn report_teardown(
+    streams: &mut Streams<'_>,
+    socket: &Path,
+    pid: u32,
+    wait: Duration,
+    still_going: &str,
+) -> ExitCode {
+    if wait_for_socket_to_disappear(socket, wait).await {
+        write_outcome(emit(
+            &mut *streams.out,
+            streams.fmt,
+            "kill",
+            KillRow {
+                pid,
+                socket_removed: true,
+            },
+            streams.style,
+        ))
+    } else {
+        streams.fail(ExitCode::DeadlineExceeded, still_going)
     }
 }
 

--- a/crates/shep-cli/src/commands/admin.rs
+++ b/crates/shep-cli/src/commands/admin.rs
@@ -14,6 +14,7 @@ use shep_core::paths::ShepPaths;
 use shep_core::protocol::{Request, Response};
 use shep_daemon::boot::{self, Shepherd};
 
+use crate::commands::rpc::{client_error, unexpected_response};
 use crate::exit::ExitCode;
 use crate::output::{KillRow, Streams, emit, write_outcome};
 
@@ -197,14 +198,8 @@ pub async fn kill_with_wait(client: Client, streams: &mut Streams<'_>, wait: Dur
                 streams.fail(ExitCode::DeadlineExceeded, message)
             }
         }
-        Ok(_) => {
-            let message = "the daemon answered with a response this client does not understand";
-            streams.fail(ExitCode::Internal, message)
-        }
-        Err(err) => {
-            let code = ExitCode::from(&err);
-            streams.fail(code, &err.to_string())
-        }
+        Ok(_unrecognised) => unexpected_response(streams),
+        Err(err) => client_error(streams, &err),
     }
 }
 

--- a/crates/shep-cli/src/commands/admin.rs
+++ b/crates/shep-cli/src/commands/admin.rs
@@ -281,6 +281,39 @@ mod tests {
         paths
     }
 
+    /// Runs [`kill`] against a bare table-format `Streams` and hands back
+    /// its exit code beside everything it wrote.
+    async fn run_kill(paths: &ShepPaths) -> (ExitCode, Vec<u8>, Vec<u8>) {
+        let mut out = Vec::new();
+        let mut err = Vec::new();
+        let code = {
+            let mut streams = Streams {
+                out: &mut out,
+                err: &mut err,
+                style: crate::style::Presentation::BARE,
+                fmt: Format::Table,
+            };
+            kill(paths, &mut streams).await
+        };
+        (code, out, err)
+    }
+
+    /// [`run_kill`] for the handshake path, which takes its client by value.
+    async fn run_kill_with_wait(client: Client, wait: Duration) -> (ExitCode, Vec<u8>, Vec<u8>) {
+        let mut out = Vec::new();
+        let mut err = Vec::new();
+        let code = {
+            let mut streams = Streams {
+                out: &mut out,
+                err: &mut err,
+                style: crate::style::Presentation::BARE,
+                fmt: Format::Table,
+            };
+            kill_with_wait(client, &mut streams, wait).await
+        };
+        (code, out, err)
+    }
+
     /// Holds `paths`'s pidfile lock the way a live shepherd does, recording
     /// `pid` or leaving the file empty for one that has not reached its own
     /// `record` yet.
@@ -339,17 +372,7 @@ mod tests {
             status
         });
 
-        let mut out = Vec::new();
-        let mut err = Vec::new();
-        let code = {
-            let mut streams = Streams {
-                out: &mut out,
-                err: &mut err,
-                style: crate::style::Presentation::BARE,
-                fmt: Format::Table,
-            };
-            kill(&paths, &mut streams).await
-        };
+        let (code, _out, err) = run_kill(&paths).await;
         assert_eq!(code, ExitCode::Success, "{}", String::from_utf8_lossy(&err));
         let status = reaper.join().unwrap();
         assert_eq!(
@@ -367,17 +390,7 @@ mod tests {
 
         // Stale file, nothing holds the lock. Signalling 999999 could hit an
         // unrelated process that has since been given that pid.
-        let mut out = Vec::new();
-        let mut err = Vec::new();
-        let code = {
-            let mut streams = Streams {
-                out: &mut out,
-                err: &mut err,
-                style: crate::style::Presentation::BARE,
-                fmt: Format::Table,
-            };
-            kill(&paths, &mut streams).await
-        };
+        let (code, _out, err) = run_kill(&paths).await;
         assert_ne!(code, ExitCode::Success);
         let err = String::from_utf8(err).unwrap();
         assert!(err.contains("no shepherd"), "{err}");
@@ -392,17 +405,7 @@ mod tests {
         let paths = test_paths(&dir);
         let _lock = hold_pidfile_lock(&paths, None);
 
-        let mut out = Vec::new();
-        let mut err = Vec::new();
-        let code = {
-            let mut streams = Streams {
-                out: &mut out,
-                err: &mut err,
-                style: crate::style::Presentation::BARE,
-                fmt: Format::Table,
-            };
-            kill(&paths, &mut streams).await
-        };
+        let (code, _out, err) = run_kill(&paths).await;
         assert_ne!(code, ExitCode::Success);
         let err = String::from_utf8(err).unwrap();
         assert!(err.contains("starting up"), "{err}");
@@ -420,17 +423,7 @@ mod tests {
         daemon.reply_shutting_down_then_unlink_after(Duration::from_millis(120));
 
         assert!(path.exists());
-        let mut out = Vec::new();
-        let mut err = Vec::new();
-        let code = {
-            let mut streams = Streams {
-                out: &mut out,
-                err: &mut err,
-                style: crate::style::Presentation::BARE,
-                fmt: Format::Table,
-            };
-            kill_with_wait(client, &mut streams, KILL_TEARDOWN_WAIT).await
-        };
+        let (code, _out, _err) = run_kill_with_wait(client, KILL_TEARDOWN_WAIT).await;
         assert_eq!(code, ExitCode::Success);
         assert!(
             !path.exists(),
@@ -448,17 +441,7 @@ mod tests {
         let (client, daemon) = fake_client_on(&path).await;
         daemon.reply_shutting_down_and_never_unlink();
 
-        let mut out = Vec::new();
-        let mut err = Vec::new();
-        let code = {
-            let mut streams = Streams {
-                out: &mut out,
-                err: &mut err,
-                style: crate::style::Presentation::BARE,
-                fmt: Format::Table,
-            };
-            kill_with_wait(client, &mut streams, Duration::from_millis(80)).await
-        };
+        let (code, _out, _err) = run_kill_with_wait(client, Duration::from_millis(80)).await;
         assert_eq!(code, ExitCode::DeadlineExceeded);
         assert!(
             path.exists(),

--- a/crates/shep-cli/src/commands/bleats.rs
+++ b/crates/shep-cli/src/commands/bleats.rs
@@ -22,6 +22,7 @@ use shep_core::protocol::{BusEvent, ProcessInfo, Request, Response};
 use shep_core::selector::ProcessSelector;
 
 use crate::cli::{BleatsArgs, Format};
+use crate::commands::rpc::{client_error, unexpected_response};
 use crate::commands::selector::parse_selector;
 use crate::exit::ExitCode;
 use crate::output::{self, Streams, write_outcome};
@@ -61,14 +62,8 @@ async fn resolve_names(
 ) -> Result<HashMap<u32, ProcessInfo>, ExitCode> {
     match client.request(Request::ListFlock).await {
         Ok(Response::Flock(procs)) => Ok(procs.into_iter().map(|p| (p.id, p)).collect()),
-        Ok(_unrecognised) => {
-            let message = "the daemon answered with a response this client does not understand";
-            Err(streams.fail(ExitCode::Internal, message))
-        }
-        Err(err) => {
-            let code = ExitCode::from(&err);
-            Err(streams.fail(code, &err.to_string()))
-        }
+        Ok(_unrecognised) => Err(unexpected_response(streams)),
+        Err(err) => Err(client_error(streams, &err)),
     }
 }
 

--- a/crates/shep-cli/src/commands/dev.rs
+++ b/crates/shep-cli/src/commands/dev.rs
@@ -34,13 +34,20 @@ const UNRESOLVED_DEV_HOME: &str =
 /// land the forced `watch = true` on production apps.
 ///
 /// The home is injected as [`ShepPaths::resolve`]'s own answer for
-/// `SHEP_HOME`, so every derived path matches the other verbs.
-fn dev_home(env: &impl Fn(&str) -> Option<String>, home_dir: &Path) -> ShepPaths {
-    let home = env("SHEP_DEV_HOME")
-        .map(PathBuf::from)
-        .unwrap_or_else(|| home_dir.join(".shep-dev"));
+/// `SHEP_HOME`, so every derived path matches the other verbs. `resolve`
+/// therefore never reaches its own `home_dir` fallback, and is handed the
+/// dev home rather than a second path that would go unread.
+///
+/// `home_dir` is read for the `~/.shep-dev` fallback alone, so `None` (no
+/// passwd home, no `$HOME`) is answerable as long as `$SHEP_DEV_HOME` names
+/// somewhere. `None` back means neither did.
+fn dev_home(env: &impl Fn(&str) -> Option<String>, home_dir: Option<&Path>) -> Option<ShepPaths> {
+    let home = match env("SHEP_DEV_HOME") {
+        Some(dir) => PathBuf::from(dir),
+        None => home_dir?.join(".shep-dev"),
+    };
     let inject = |key: &str| (key == "SHEP_HOME").then(|| home.to_string_lossy().into_owned());
-    ShepPaths::resolve(&inject, home_dir)
+    Some(ShepPaths::resolve(&inject, &home))
 }
 
 /// Sets `watch = true` on every app, in place: rebuilding each [`AppConfig`]
@@ -131,15 +138,10 @@ pub async fn dev(
             None
         }
     };
-    let home_dir = match (
-        user_home(&|key| std::env::var_os(key)),
-        env("SHEP_DEV_HOME"),
-    ) {
-        (Some(dir), _) => dir,
-        (None, Some(_)) => PathBuf::new(),
-        (None, None) => return streams.fail(ExitCode::Usage, UNRESOLVED_DEV_HOME),
+    let home_dir = user_home(&|key| std::env::var_os(key));
+    let Some(paths) = dev_home(&env, home_dir.as_deref()) else {
+        return streams.fail(ExitCode::Usage, UNRESOLVED_DEV_HOME);
     };
-    let paths = dev_home(&env, &home_dir);
 
     let options = ForegroundOptions {
         paths,
@@ -161,7 +163,7 @@ mod tests {
             "SHEP_HOME" => Some("/srv/production".to_string()),
             _ => None,
         };
-        let paths = dev_home(&env, Path::new("/home/ada"));
+        let paths = dev_home(&env, Some(Path::new("/home/ada"))).unwrap();
         assert_eq!(paths.home, Path::new("/home/ada/.shep-dev"));
 
         let env = |key: &str| match key {
@@ -170,9 +172,19 @@ mod tests {
             _ => None,
         };
         assert_eq!(
-            dev_home(&env, Path::new("/home/ada")).home,
+            dev_home(&env, Some(Path::new("/home/ada"))).unwrap().home,
             Path::new("/tmp/t1")
         );
+
+        // No passwd home and no `$HOME`: `$SHEP_DEV_HOME` alone still
+        // answers, and without it there is nowhere to put a dev flock.
+        assert_eq!(
+            dev_home(&env, None).unwrap().home,
+            Path::new("/tmp/t1"),
+            "`$SHEP_DEV_HOME` names the home outright, so no fallback is needed"
+        );
+        let no_dev_home = |key: &str| (key == "SHEP_HOME").then(|| "/srv/production".to_string());
+        assert!(dev_home(&no_dev_home, None).is_none());
     }
 
     #[test]

--- a/crates/shep-cli/src/commands/dog_migration.rs
+++ b/crates/shep-cli/src/commands/dog_migration.rs
@@ -61,7 +61,7 @@ pub(crate) fn migrate_dog_sections(paths: &ShepPaths) -> Result<Vec<String>, Dog
         let incoming: BTreeMap<String, Item> = doc
             .take_dog_sections()
             .into_iter()
-            .filter(|(_, section)| !section.as_table_like().is_some_and(TableLike::is_empty))
+            .filter(|(_, section)| item_has_content(section))
             .collect();
         // `take_dog_sections` removes the whole `[dog]` table before deciding
         // what to hand back, so a count cannot see what it dropped: compare
@@ -89,11 +89,7 @@ pub(crate) fn migrate_dog_sections(paths: &ShepPaths) -> Result<Vec<String>, Dog
         // Over values on both sides: a bare `[metrics]` in `dogs.toml` is not
         // a second value, so the section carrying values wins. A destination
         // `[[metrics]]` is not table-like, so it refuses.
-        let collides = |name: &String| {
-            merged
-                .get(name)
-                .is_some_and(|item| !item.as_table_like().is_some_and(TableLike::is_empty))
-        };
+        let collides = |name: &String| merged.get(name).is_some_and(item_has_content);
         if let Some(name) = incoming.keys().find(|name| collides(name)) {
             return Err(DogMigrationError::WouldOverwrite { name: name.clone() });
         }
@@ -209,6 +205,15 @@ fn declared_dog_names(table: &toml::Table) -> BTreeSet<String> {
 ///
 /// A `[[dog.metrics]]` that carries values is not this, and still refuses:
 /// there is no one section for it to become.
+/// Whether `item` holds something, rather than being a bare table header.
+///
+/// An `Item` that is not a table at all counts as content: `dog = 3` is a
+/// section to carry over and refuse a collision on, not an empty one.
+fn item_has_content(item: &Item) -> bool {
+    !item.as_table_like().is_some_and(TableLike::is_empty)
+}
+
+/// Whether `value` declares nothing at all.
 fn declares_nothing(value: &toml::Value) -> bool {
     match value {
         toml::Value::Table(table) => table.is_empty(),

--- a/crates/shep-cli/src/commands/dog_migration.rs
+++ b/crates/shep-cli/src/commands/dog_migration.rs
@@ -196,6 +196,14 @@ fn declared_dog_names(table: &toml::Table) -> BTreeSet<String> {
     }
 }
 
+/// Whether `item` holds something, rather than being a bare table header.
+///
+/// An `Item` that is not a table at all counts as content: `dog = 3` is a
+/// section to carry over and refuse a collision on, not an empty one.
+fn item_has_content(item: &Item) -> bool {
+    !item.as_table_like().is_some_and(TableLike::is_empty)
+}
+
 /// Whether `value` holds nothing an operator could lose by not moving it.
 ///
 /// An empty table, an empty array, and an array of tables that are all empty.
@@ -205,15 +213,6 @@ fn declared_dog_names(table: &toml::Table) -> BTreeSet<String> {
 ///
 /// A `[[dog.metrics]]` that carries values is not this, and still refuses:
 /// there is no one section for it to become.
-/// Whether `item` holds something, rather than being a bare table header.
-///
-/// An `Item` that is not a table at all counts as content: `dog = 3` is a
-/// section to carry over and refuse a collision on, not an empty one.
-fn item_has_content(item: &Item) -> bool {
-    !item.as_table_like().is_some_and(TableLike::is_empty)
-}
-
-/// Whether `value` declares nothing at all.
 fn declares_nothing(value: &toml::Value) -> bool {
     match value {
         toml::Value::Table(table) => table.is_empty(),

--- a/crates/shep-cli/src/commands/dogs.rs
+++ b/crates/shep-cli/src/commands/dogs.rs
@@ -25,6 +25,7 @@ use shep_core::protocol::{DogSource, MIN_SUPPORTED, Request, Response, SelectorS
 
 use crate::cli::{AdoptArgs, BarksArgs};
 use crate::commands::dog_migration::{self, DogMigrationError};
+use crate::commands::rpc::{client_error, unexpected_response};
 use crate::commands::shep_toml::{ShepToml, ShepTomlError};
 use crate::exit::ExitCode;
 use crate::output::{
@@ -265,14 +266,8 @@ async fn enable_after_config(
                 streams.style,
             ))
         }
-        Ok(_) => {
-            let message = "the daemon answered with a response this client does not understand";
-            streams.fail(ExitCode::Internal, message)
-        }
-        Err(err) => {
-            let code = ExitCode::from(&err);
-            streams.fail(code, &err.to_string())
-        }
+        Ok(_unrecognised) => unexpected_response(streams),
+        Err(err) => client_error(streams, &err),
     }
 }
 
@@ -354,14 +349,8 @@ async fn disable_after_config(
                 streams.style,
             ))
         }
-        Ok(_) => {
-            let message = "the daemon answered with a response this client does not understand";
-            streams.fail(ExitCode::Internal, message)
-        }
-        Err(err) => {
-            let code = ExitCode::from(&err);
-            streams.fail(code, &err.to_string())
-        }
+        Ok(_unrecognised) => unexpected_response(streams),
+        Err(err) => client_error(streams, &err),
     }
 }
 
@@ -1288,14 +1277,8 @@ async fn adopt_after_config(
                 streams.style,
             ))
         }
-        Ok(_) => {
-            let message = "the daemon answered with a response this client does not understand";
-            streams.fail(ExitCode::Internal, message)
-        }
-        Err(err) => {
-            let code = ExitCode::from(&err);
-            streams.fail(code, &err.to_string())
-        }
+        Ok(_unrecognised) => unexpected_response(streams),
+        Err(err) => client_error(streams, &err),
     }
 }
 
@@ -1380,14 +1363,8 @@ async fn rehome_after_config(
                 streams.style,
             ))
         }
-        Ok(_) => {
-            let message = "the daemon answered with a response this client does not understand";
-            streams.fail(ExitCode::Internal, message)
-        }
-        Err(err) => {
-            let code = ExitCode::from(&err);
-            streams.fail(code, &err.to_string())
-        }
+        Ok(_unrecognised) => unexpected_response(streams),
+        Err(err) => client_error(streams, &err),
     }
 }
 

--- a/crates/shep-cli/src/commands/import/dotenv/mod.rs
+++ b/crates/shep-cli/src/commands/import/dotenv/mod.rs
@@ -40,6 +40,7 @@ use shep_core::secrets;
 use plan::{Class, ImportPlan, Planned};
 
 use crate::cli::ImportEnvArgs;
+use crate::commands::rpc::{UNRECOGNISED, unexpected_response};
 use crate::commands::secret::{daemon_config, exit_code_for};
 use crate::exit::ExitCode;
 use crate::output::{ImportEnvRow, ImportEnvRows, Streams, emit, write_outcome};
@@ -156,7 +157,7 @@ pub async fn import_env(
         // so: the operator is otherwise told a batch failed and left with no
         // account of the other store.
         Ok(_) => {
-            let message = format!("{UNDERSTOOD_NOTHING}{}", already_written(written));
+            let message = format!("{UNRECOGNISED}{}", already_written(written));
             return streams.fail(ExitCode::Internal, &message);
         }
         Err(err) => {
@@ -172,10 +173,6 @@ pub async fn import_env(
     streams.aside("parked", &message);
     emit_rows(streams, &plan, &environment)
 }
-
-/// What a reply this build does not understand is reported as.
-const UNDERSTOOD_NOTHING: &str =
-    "the daemon answered with a response this client does not understand";
 
 /// The environment whose slot the secrets go in: `--env`, else the sheep's
 /// own `environment`, else `[daemon] environment`.
@@ -205,7 +202,7 @@ async fn resolve_environment(
             .environment
             .clone()
             .unwrap_or_else(|| daemon_config(paths).daemon.environment)),
-        Ok(_) => Err(streams.fail(ExitCode::Internal, UNDERSTOOD_NOTHING)),
+        Ok(_) => Err(unexpected_response(streams)),
         Err(err) => Err(streams.fail(ExitCode::from(&err), &err.to_string())),
     }
 }
@@ -259,7 +256,7 @@ async fn probe_env(
     };
     match client.request(request).await {
         Ok(Response::SheepEnvBatch { collisions, .. }) => Ok(collisions),
-        Ok(_) => Err(streams.fail(ExitCode::Internal, UNDERSTOOD_NOTHING)),
+        Ok(_) => Err(unexpected_response(streams)),
         Err(err) => Err(streams.fail(ExitCode::from(&err), &err.to_string())),
     }
 }

--- a/crates/shep-cli/src/commands/import/pm2/env.rs
+++ b/crates/shep-cli/src/commands/import/pm2/env.rs
@@ -116,20 +116,23 @@ pub(crate) fn split(row: &DumpRow) -> AppEnv {
     }
 }
 
+/// Whether `key` is in a closed list: named outright, or under one of its
+/// prefixes.
+///
+/// The matching rule for both lists, so a third kind of match added later
+/// reaches them together.
+fn in_closed_set(key: &str, exact: &[&str], prefixes: &[&str]) -> bool {
+    exact.contains(&key) || prefixes.iter().any(|prefix| key.starts_with(prefix))
+}
+
 /// Whether `key` is a login shell's own variable rather than an app's.
 fn is_session_shell(key: &str) -> bool {
-    SESSION_SHELL.contains(&key)
-        || SESSION_SHELL_PREFIXES
-            .iter()
-            .any(|prefix| key.starts_with(prefix))
+    in_closed_set(key, SESSION_SHELL, SESSION_SHELL_PREFIXES)
 }
 
 /// Whether `key` is one pm2 injects into a process it supervises.
 fn is_pm2_injected(key: &str) -> bool {
-    PM2_INJECTED.contains(&key)
-        || PM2_INJECTED_PREFIXES
-            .iter()
-            .any(|prefix| key.starts_with(prefix))
+    in_closed_set(key, PM2_INJECTED, PM2_INJECTED_PREFIXES)
 }
 
 #[cfg(test)]

--- a/crates/shep-cli/src/commands/import/pm2/mod.rs
+++ b/crates/shep-cli/src/commands/import/pm2/mod.rs
@@ -223,14 +223,9 @@ mod tests {
         }
     }
 
-    #[test]
-    fn an_existing_flockfile_is_not_overwritten_without_force() {
-        let dir = tempfile::tempdir().unwrap();
-        let out = dir.path().join("Flockfile.toml");
-        std::fs::write(&out, "[[app]]\nname = \"mine\"\nscript = \"./mine\"\n").unwrap();
-        let dump = dir.path().join("dump.pm2");
-        std::fs::write(&dump, include_str!("testdata/dump.pm2.json")).unwrap();
-
+    /// Runs `import` against a bare table-format `Streams` and hands back
+    /// its exit code beside everything it wrote.
+    fn run_import(args: &ImportPm2Args) -> (ExitCode, Vec<u8>, Vec<u8>) {
         let mut out_buf = Vec::new();
         let mut err_buf = Vec::new();
         let code = {
@@ -240,8 +235,20 @@ mod tests {
                 style: crate::style::Presentation::BARE,
                 fmt: Format::Table,
             };
-            import(&mut streams, &args(&dump, &out, false, false))
+            import(&mut streams, args)
         };
+        (code, out_buf, err_buf)
+    }
+
+    #[test]
+    fn an_existing_flockfile_is_not_overwritten_without_force() {
+        let dir = tempfile::tempdir().unwrap();
+        let out = dir.path().join("Flockfile.toml");
+        std::fs::write(&out, "[[app]]\nname = \"mine\"\nscript = \"./mine\"\n").unwrap();
+        let dump = dir.path().join("dump.pm2");
+        std::fs::write(&dump, include_str!("testdata/dump.pm2.json")).unwrap();
+
+        let (code, _out_buf, _err_buf) = run_import(&args(&dump, &out, false, false));
         assert_eq!(code, ExitCode::Usage);
         assert!(std::fs::read_to_string(&out).unwrap().contains("mine"));
     }
@@ -253,17 +260,7 @@ mod tests {
         std::fs::write(&dump, include_str!("testdata/dump.pm2.json")).unwrap();
         let out = dir.path().join("Flockfile.toml");
 
-        let mut out_buf = Vec::new();
-        let mut err_buf = Vec::new();
-        let code = {
-            let mut streams = Streams {
-                out: &mut out_buf,
-                err: &mut err_buf,
-                style: crate::style::Presentation::BARE,
-                fmt: Format::Table,
-            };
-            import(&mut streams, &args(&dump, &out, true, false))
-        };
+        let (code, out_buf, _err_buf) = run_import(&args(&dump, &out, true, false));
         assert_eq!(code, ExitCode::Success);
         assert!(!out.exists(), "--dry-run writes nothing");
         let printed = String::from_utf8(out_buf).unwrap();
@@ -285,17 +282,7 @@ mod tests {
         std::fs::write(&dump, include_str!("testdata/dump.pm2.json")).unwrap();
         let out = dir.path().join("Flockfile.toml");
 
-        let mut out_buf = Vec::new();
-        let mut err_buf = Vec::new();
-        {
-            let mut streams = Streams {
-                out: &mut out_buf,
-                err: &mut err_buf,
-                style: crate::style::Presentation::BARE,
-                fmt: Format::Table,
-            };
-            let _ = import(&mut streams, &args(&dump, &out, true, false));
-        }
+        let (_code, _out_buf, err_buf) = run_import(&args(&dump, &out, true, false));
         let report = String::from_utf8(err_buf).unwrap();
         assert!(report.contains("api"), "{report}");
         assert!(report.contains("SO_REUSEPORT"), "{report}");
@@ -310,17 +297,7 @@ mod tests {
         let dump = dir.path().join("nope.pm2");
         let out = dir.path().join("Flockfile.toml");
 
-        let mut out_buf = Vec::new();
-        let mut err_buf = Vec::new();
-        let code = {
-            let mut streams = Streams {
-                out: &mut out_buf,
-                err: &mut err_buf,
-                style: crate::style::Presentation::BARE,
-                fmt: Format::Table,
-            };
-            import(&mut streams, &args(&dump, &out, false, false))
-        };
+        let (code, _out_buf, err_buf) = run_import(&args(&dump, &out, false, false));
         assert_eq!(code, ExitCode::Usage);
         let report = String::from_utf8(err_buf).unwrap();
         assert!(report.contains(&dump.display().to_string()), "{report}");
@@ -334,17 +311,7 @@ mod tests {
         std::fs::write(&dump, "not json").unwrap();
         let out = dir.path().join("Flockfile.toml");
 
-        let mut out_buf = Vec::new();
-        let mut err_buf = Vec::new();
-        let code = {
-            let mut streams = Streams {
-                out: &mut out_buf,
-                err: &mut err_buf,
-                style: crate::style::Presentation::BARE,
-                fmt: Format::Table,
-            };
-            import(&mut streams, &args(&dump, &out, false, false))
-        };
+        let (code, _out_buf, _err_buf) = run_import(&args(&dump, &out, false, false));
         assert_eq!(code, ExitCode::InvalidConfig);
     }
 }

--- a/crates/shep-cli/src/commands/lifecycle.rs
+++ b/crates/shep-cli/src/commands/lifecycle.rs
@@ -25,6 +25,7 @@ use crate::cli::Format;
 use crate::cli::{ResetMode, SelectorArgs, StartArgs, StockArgs};
 use crate::commands::bounded::{Bounded, run_bounded};
 use crate::commands::dogs;
+use crate::commands::rpc::{client_error, request_payload, unexpected_response};
 use crate::commands::selector::parse_selector;
 use crate::exit::ExitCode;
 use crate::output::{
@@ -424,38 +425,6 @@ fn resolve_target_declared(
     }
 }
 
-/// Sends `body`, renders the answer through [`render_outcome`], and maps
-/// every failure to its exit code
-///
-/// `None` for `deadline` defers to the client's default. An answer `extract`
-/// does not recognise maps to [`ExitCode::Internal`].
-async fn request_and_render<T, F>(
-    client: &Client,
-    streams: &mut Streams<'_>,
-    command: &str,
-    body: Request,
-    deadline: Option<Duration>,
-    extract: F,
-) -> ExitCode
-where
-    T: Render,
-    F: FnOnce(Response) -> Option<T>,
-{
-    match client.request_with_deadline(body, deadline).await {
-        Ok(response) => match extract(response) {
-            Some(payload) => render_outcome(client, streams, command, payload).await,
-            None => {
-                let message = "the daemon answered with a response this client does not understand";
-                streams.fail(ExitCode::Internal, message)
-            }
-        },
-        Err(err) => {
-            let code = ExitCode::from(&err);
-            streams.fail(code, &err.to_string())
-        }
-    }
-}
-
 /// Parses every selector the invocation named, refusing on the first bad one
 ///
 /// All-or-nothing: a typo in the third target must not be discovered after
@@ -501,16 +470,9 @@ where
         {
             Ok(response) => match extract(response) {
                 Some(mut rows) => collected.append(&mut rows),
-                None => {
-                    let message =
-                        "the daemon answered with a response this client does not understand";
-                    failure = failure.or(Some(streams.fail(ExitCode::Internal, message)));
-                }
+                None => failure = failure.or(Some(unexpected_response(streams))),
             },
-            Err(err) => {
-                let code = ExitCode::from(&err);
-                failure = failure.or(Some(streams.fail(code, &err.to_string())));
-            }
+            Err(err) => failure = failure.or(Some(client_error(streams, &err))),
         }
     }
     (collected, failure)
@@ -1823,21 +1785,26 @@ pub async fn delete(client: &Client, streams: &mut Streams<'_>, args: &SelectorA
 /// name. `START_DEADLINE` rather than the client's default, since a stock-up
 /// spawns processes.
 pub async fn stock(client: &Client, streams: &mut Streams<'_>, args: &StockArgs) -> ExitCode {
-    request_and_render(
-        client,
-        streams,
-        "stock",
-        Request::Scale {
-            name: args.name.clone(),
-            count: args.count,
-        },
-        Some(START_DEADLINE),
-        |response| match response {
-            Response::Scaled(procs) => Some(FlockRows(procs)),
-            _ => None,
-        },
-    )
-    .await
+    let body = Request::Scale {
+        name: args.name.clone(),
+        count: args.count,
+    };
+    let rows =
+        request_payload(
+            client,
+            streams,
+            body,
+            Some(START_DEADLINE),
+            |response| match response {
+                Response::Scaled(procs) => Some(FlockRows(procs)),
+                _ => None,
+            },
+        )
+        .await;
+    match rows {
+        Ok(rows) => render_outcome(client, streams, "stock", rows).await,
+        Err(code) => code,
+    }
 }
 
 #[cfg(test)]

--- a/crates/shep-cli/src/commands/lifecycle.rs
+++ b/crates/shep-cli/src/commands/lifecycle.rs
@@ -26,7 +26,7 @@ use crate::cli::{ResetMode, SelectorArgs, StartArgs, StockArgs};
 use crate::commands::bounded::{Bounded, run_bounded};
 use crate::commands::dogs;
 use crate::commands::rpc::{client_error, request_payload, unexpected_response};
-use crate::commands::selector::parse_selector;
+use crate::commands::selector::{parse_selector, parse_selector_spec};
 use crate::exit::ExitCode;
 use crate::output::{
     DeletedIds, FlockRows, Render, Streams, emit, emit_flock, emit_partial, write_outcome,
@@ -435,7 +435,7 @@ fn parse_selectors(
 ) -> Result<Vec<SelectorSpec>, ExitCode> {
     let mut parsed = Vec::with_capacity(raw.len());
     for one in raw {
-        parsed.push(SelectorSpec::from(&parse_selector(streams, one)?));
+        parsed.push(parse_selector_spec(streams, one)?);
     }
     Ok(parsed)
 }

--- a/crates/shep-cli/src/commands/logs.rs
+++ b/crates/shep-cli/src/commands/logs.rs
@@ -10,11 +10,11 @@
 
 use shep_client::{Client, LOG_PLANE_DEADLINE};
 use shep_core::paths::ShepPaths;
-use shep_core::protocol::{Request, Response, SelectorSpec};
+use shep_core::protocol::{Request, Response};
 
 use crate::cli::{FlushArgs, ReopenArgs};
 use crate::commands::rpc::request_and_render;
-use crate::commands::selector::parse_selector;
+use crate::commands::selector::parse_selector_spec;
 use crate::exit::ExitCode;
 use crate::launch;
 use crate::output::{
@@ -34,8 +34,8 @@ use crate::output::{
 /// Sent with [`LOG_PLANE_DEADLINE`]: the daemon visits matched sheep serially
 /// with no per-sheep bound, so the client's 5s default would time out.
 pub async fn reopen(client: &Client, streams: &mut Streams<'_>, args: &ReopenArgs) -> ExitCode {
-    let selector = match parse_selector(streams, &args.selector) {
-        Ok(selector) => SelectorSpec::from(&selector),
+    let selector = match parse_selector_spec(streams, &args.selector) {
+        Ok(selector) => selector,
         Err(code) => return code,
     };
     request_and_render(
@@ -72,8 +72,8 @@ pub async fn flush(client: &Client, streams: &mut Streams<'_>, args: &FlushArgs)
             "flush needs a selector, or --daemon for the shepherd's own logs",
         );
     };
-    let selector = match parse_selector(streams, raw) {
-        Ok(selector) => SelectorSpec::from(&selector),
+    let selector = match parse_selector_spec(streams, raw) {
+        Ok(selector) => selector,
         Err(code) => return code,
     };
     request_and_render(
@@ -147,6 +147,7 @@ mod tests {
     use crate::cli::Format;
     use shep_client::testing::{fake_client_capturing_envelopes, fake_client_replying_err};
     use shep_core::protocol::RpcErrorCode;
+    use shep_core::protocol::SelectorSpec;
 
     fn args(selector: &str) -> ReopenArgs {
         ReopenArgs {

--- a/crates/shep-cli/src/commands/logs.rs
+++ b/crates/shep-cli/src/commands/logs.rs
@@ -8,59 +8,18 @@
 //! and the daemon does the file I/O, so nothing here asks anything of the
 //! child.
 
-use std::time::Duration;
-
 use shep_client::{Client, LOG_PLANE_DEADLINE};
 use shep_core::paths::ShepPaths;
 use shep_core::protocol::{Request, Response, SelectorSpec};
 
 use crate::cli::{FlushArgs, ReopenArgs};
+use crate::commands::rpc::request_and_render;
 use crate::commands::selector::parse_selector;
 use crate::exit::ExitCode;
 use crate::launch;
 use crate::output::{
-    EmptiedFile, EmptiedFiles, FlockRows, FlushedRows, Render, Streams, emit, write_outcome,
+    EmptiedFile, EmptiedFiles, FlockRows, FlushedRows, Streams, emit, write_outcome,
 };
-
-/// Sends `body` with `deadline` (`None` defers to the client's own default),
-/// renders whatever the daemon answers through [`emit`], and maps every way
-/// that can go wrong to its exit code.
-///
-/// `extract` pulls the verb's own payload out of `Response`, which is
-/// `#[non_exhaustive]`: an answer it does not recognise maps to
-/// [`ExitCode::Internal`] rather than being guessed at.
-async fn request_and_render<T, F>(
-    client: &Client,
-    streams: &mut Streams<'_>,
-    command: &str,
-    body: Request,
-    deadline: Option<Duration>,
-    extract: F,
-) -> ExitCode
-where
-    T: Render,
-    F: FnOnce(Response) -> Option<T>,
-{
-    match client.request_with_deadline(body, deadline).await {
-        Ok(response) => match extract(response) {
-            Some(payload) => write_outcome(emit(
-                &mut *streams.out,
-                streams.fmt,
-                command,
-                payload,
-                streams.style,
-            )),
-            None => {
-                let message = "the daemon answered with a response this client does not understand";
-                streams.fail(ExitCode::Internal, message)
-            }
-        },
-        Err(err) => {
-            let code = ExitCode::from(&err);
-            streams.fail(code, &err.to_string())
-        }
-    }
-}
 
 /// Reopens the log files of the sheep matching `args.selector`, for an
 /// external rotator that has renamed them.

--- a/crates/shep-cli/src/commands/mod.rs
+++ b/crates/shep-cli/src/commands/mod.rs
@@ -23,6 +23,7 @@ pub mod query;
 // reparent-to-init rule, so there is nothing for a reaper to do.
 #[cfg(unix)]
 pub(crate) mod reap;
+pub(crate) mod rpc;
 pub mod runtime;
 pub mod schema;
 pub mod secret;

--- a/crates/shep-cli/src/commands/muster.rs
+++ b/crates/shep-cli/src/commands/muster.rs
@@ -2,15 +2,17 @@
 //! it on demand.
 //!
 //! Neither `Request::SaveRoll` nor `Request::Muster` carries fields: the roll
-//! always covers the whole flock, so there is no selector to parse. Two call
-//! sites, each inlining its own match rather than sharing
-//! `commands::query`'s `request_and_render`.
+//! always covers the whole flock, so there is no selector to parse. `save`
+//! renders one row and goes through [`request_and_render`]; `muster` keeps
+//! its own match, since its success arm writes a notice and a flourish
+//! around the table.
 
 use shep_client::{Client, RELOAD_DEADLINE};
 use shep_core::protocol::{Request, Response};
 use shep_core::status::ProcStatus;
 
 use crate::cli::Format;
+use crate::commands::rpc::{client_error, request_and_render, unexpected_response};
 use crate::exit::ExitCode;
 use crate::flourish;
 use crate::output::{FlockRows, SavedRollRow, Streams, emit, write_outcome};
@@ -18,23 +20,18 @@ use crate::output::{FlockRows, SavedRollRow, Streams, emit, write_outcome};
 /// Asks the daemon to write the muster roll now, and reports where it landed
 /// and how many apps it recorded. A failed save is loud, never a no-op.
 pub async fn save(client: &Client, streams: &mut Streams<'_>) -> ExitCode {
-    match client.request(Request::SaveRoll).await {
-        Ok(Response::RollSaved { path, apps }) => write_outcome(emit(
-            &mut *streams.out,
-            streams.fmt,
-            "save",
-            SavedRollRow { file: path, apps },
-            streams.style,
-        )),
-        Ok(_unrecognised) => {
-            let message = "the daemon answered with a response this client does not understand";
-            streams.fail(ExitCode::Internal, message)
-        }
-        Err(err) => {
-            let code = ExitCode::from(&err);
-            streams.fail(code, &err.to_string())
-        }
-    }
+    request_and_render(
+        client,
+        streams,
+        "save",
+        Request::SaveRoll,
+        None,
+        |response| match response {
+            Response::RollSaved { path, apps } => Some(SavedRollRow { file: path, apps }),
+            _ => None,
+        },
+    )
+    .await
 }
 
 /// Asks the daemon to assemble the flock from the muster roll `save` wrote,
@@ -84,14 +81,8 @@ pub async fn muster(client: &Client, streams: &mut Streams<'_>) -> ExitCode {
             }
             outcome
         }
-        Ok(_unrecognised) => {
-            let message = "the daemon answered with a response this client does not understand";
-            streams.fail(ExitCode::Internal, message)
-        }
-        Err(err) => {
-            let code = ExitCode::from(&err);
-            streams.fail(code, &err.to_string())
-        }
+        Ok(_unrecognised) => unexpected_response(streams),
+        Err(err) => client_error(streams, &err),
     }
 }
 

--- a/crates/shep-cli/src/commands/query.rs
+++ b/crates/shep-cli/src/commands/query.rs
@@ -21,6 +21,7 @@ use shep_core::status::ProcStatus;
 use shep_daemon::snapshot::FlockSnapshot;
 
 use crate::cli::{DogsArgs, FoldArgs, Format, SelectorArgs};
+use crate::commands::rpc::{client_error, request_and_render, unexpected_response};
 use crate::commands::secret::daemon_config;
 use crate::commands::selector::parse_selector;
 use crate::dog_index::{self, AvailableDog, DogSourceKind};
@@ -28,48 +29,9 @@ use crate::exit::ExitCode;
 use crate::fetch;
 use crate::flourish;
 use crate::output::{
-    AvailableDogRows, DescribedSecret, DogRows, Render, RolledSheep, RolledSheepRows, SecretStatus,
+    AvailableDogRows, DescribedSecret, DogRows, RolledSheep, RolledSheepRows, SecretStatus,
     Streams, emit, emit_described, emit_flock, write_outcome,
 };
-
-/// Sends `body`, renders whatever the daemon answers through [`emit`], and
-/// maps every way that can go wrong to its exit code.
-///
-/// `extract` pulls the verb's own payload out of `Response`, which is
-/// `#[non_exhaustive]`: an answer it does not recognise maps to
-/// [`ExitCode::Internal`] rather than being guessed at. Every query verb uses
-/// the client's default deadline, so there is no deadline parameter.
-async fn request_and_render<T, F>(
-    client: &Client,
-    streams: &mut Streams<'_>,
-    command: &str,
-    body: Request,
-    extract: F,
-) -> ExitCode
-where
-    T: Render,
-    F: FnOnce(Response) -> Option<T>,
-{
-    match client.request(body).await {
-        Ok(response) => match extract(response) {
-            Some(payload) => write_outcome(emit(
-                &mut *streams.out,
-                streams.fmt,
-                command,
-                payload,
-                streams.style,
-            )),
-            None => {
-                let message = "the daemon answered with a response this client does not understand";
-                streams.fail(ExitCode::Internal, message)
-            }
-        },
-        Err(err) => {
-            let code = ExitCode::from(&err);
-            streams.fail(code, &err.to_string())
-        }
-    }
-}
 
 /// `describe` and `fold`'s shared body: one `Request::Describe` against
 /// `selector`, rendered through [`emit_described`] as the sheep table and
@@ -82,8 +44,8 @@ where
 /// diagnostic this feature was built for.
 ///
 /// Not routed through [`request_and_render`]: `emit_described` renders one
-/// `Vec<ProcessInfo>` into two tables, which no single [`Render`] impl can
-/// express.
+/// `Vec<ProcessInfo>` into two tables, which no single
+/// [`crate::output::Render`] impl can express.
 async fn describe_selector(
     client: &Client,
     streams: &mut Streams<'_>,
@@ -119,14 +81,8 @@ async fn describe_selector(
             );
             write_outcome(result)
         }
-        Ok(_) => {
-            let message = "the daemon answered with a response this client does not understand";
-            streams.fail(ExitCode::Internal, message)
-        }
-        Err(err) => {
-            let code = ExitCode::from(&err);
-            streams.fail(code, &err.to_string())
-        }
+        Ok(_unrecognised) => unexpected_response(streams),
+        Err(err) => client_error(streams, &err),
     }
 }
 
@@ -311,7 +267,7 @@ pub fn flock_from_roll(streams: &mut Streams<'_>, paths: &ShepPaths) -> ExitCode
 ///
 /// The flourish is gated on `Format::Table` and `streams.style.level.sheep()`
 /// and nothing else. Not routed through [`request_and_render`], which renders
-/// one [`Render`] type per verb rather than two tables from one
+/// one [`crate::output::Render`] type per verb rather than two tables from one
 /// `Vec<ProcessInfo>`.
 pub async fn flock(client: &Client, streams: &mut Streams<'_>) -> ExitCode {
     match client.request(Request::ListFlock).await {
@@ -331,14 +287,8 @@ pub async fn flock(client: &Client, streams: &mut Streams<'_>) -> ExitCode {
                 streams.style,
             ))
         }
-        Ok(_) => {
-            let message = "the daemon answered with a response this client does not understand";
-            streams.fail(ExitCode::Internal, message)
-        }
-        Err(err) => {
-            let code = ExitCode::from(&err);
-            streams.fail(code, &err.to_string())
-        }
+        Ok(_unrecognised) => unexpected_response(streams),
+        Err(err) => client_error(streams, &err),
     }
 }
 
@@ -373,6 +323,7 @@ pub async fn dogs(client: &Client, streams: &mut Streams<'_>, args: &DogsArgs) -
         streams,
         "dogs",
         Request::ListFlock,
+        None,
         |response| match response {
             Response::Flock(procs) => Some(DogRows(
                 procs

--- a/crates/shep-cli/src/commands/query.rs
+++ b/crates/shep-cli/src/commands/query.rs
@@ -23,7 +23,7 @@ use shep_daemon::snapshot::FlockSnapshot;
 use crate::cli::{DogsArgs, FoldArgs, Format, SelectorArgs};
 use crate::commands::rpc::{client_error, request_and_render, unexpected_response};
 use crate::commands::secret::daemon_config;
-use crate::commands::selector::parse_selector;
+use crate::commands::selector::parse_selector_spec;
 use crate::dog_index::{self, AvailableDog, DogSourceKind};
 use crate::exit::ExitCode;
 use crate::fetch;
@@ -510,8 +510,8 @@ pub async fn describe(
     // a tree per sheep, so merging them would lose that shape.
     let mut failure: Option<ExitCode> = None;
     for raw in &args.selectors {
-        let selector = match parse_selector(streams, raw) {
-            Ok(selector) => SelectorSpec::from(&selector),
+        let selector = match parse_selector_spec(streams, raw) {
+            Ok(selector) => selector,
             Err(code) => return code,
         };
         let code = describe_selector(client, streams, paths, "describe", true, selector).await;

--- a/crates/shep-cli/src/commands/rpc.rs
+++ b/crates/shep-cli/src/commands/rpc.rs
@@ -1,0 +1,90 @@
+//! One request to the daemon, the answer rendered, and every way that can go
+//! wrong mapped to an exit code.
+//!
+//! A verb that sends one request and renders one payload calls
+//! [`request_and_render`]. A verb whose success arm renders something no
+//! single [`Render`] impl expresses — two tables out of one
+//! `Vec<ProcessInfo>`, a flourish above the table, a notice beside an empty
+//! one — keeps its own `match` on the answer and shares only
+//! [`unexpected_response`] and [`client_error`], the two arms every verb
+//! handles alike.
+
+use std::time::Duration;
+
+use shep_client::{Client, RequestError};
+use shep_core::protocol::{Request, Response};
+
+use crate::exit::ExitCode;
+use crate::output::{Render, Streams, emit, write_outcome};
+
+/// What a reply this build does not recognise is reported as.
+///
+/// `pub(crate)` for the one caller that appends to it rather than reporting
+/// it alone: `import::dotenv` says which store it already wrote.
+pub(crate) const UNRECOGNISED: &str =
+    "the daemon answered with a response this client does not understand";
+
+/// Reports an answer this client cannot render, and hands back its code.
+///
+/// `Response` is `#[non_exhaustive]`, so a variant a newer daemon added
+/// reaches here rather than being guessed at.
+pub(crate) fn unexpected_response(streams: &mut Streams<'_>) -> ExitCode {
+    streams.fail(ExitCode::Internal, UNRECOGNISED)
+}
+
+/// Reports a request that never produced an answer, and hands back its code.
+pub(crate) fn client_error(streams: &mut Streams<'_>, err: &RequestError) -> ExitCode {
+    streams.fail(ExitCode::from(err), &err.to_string())
+}
+
+/// Sends `body` with `deadline` (`None` defers to the client's own default)
+/// and pulls the verb's own payload out of the answer.
+///
+/// For a verb that renders its payload itself; [`request_and_render`] is the
+/// shorter road for one that does not.
+///
+/// # Errors
+///
+/// The [`ExitCode`] already reported to `streams.err`: the request failed, or
+/// `extract` did not recognise the answer.
+pub(crate) async fn request_payload<T, F>(
+    client: &Client,
+    streams: &mut Streams<'_>,
+    body: Request,
+    deadline: Option<Duration>,
+    extract: F,
+) -> Result<T, ExitCode>
+where
+    F: FnOnce(Response) -> Option<T>,
+{
+    match client.request_with_deadline(body, deadline).await {
+        Ok(response) => extract(response).ok_or_else(|| unexpected_response(streams)),
+        Err(err) => Err(client_error(streams, &err)),
+    }
+}
+
+/// Sends `body`, renders whatever the daemon answers through [`emit`] under
+/// `command`, and maps every way that can go wrong to its exit code.
+pub(crate) async fn request_and_render<T, F>(
+    client: &Client,
+    streams: &mut Streams<'_>,
+    command: &str,
+    body: Request,
+    deadline: Option<Duration>,
+    extract: F,
+) -> ExitCode
+where
+    T: Render,
+    F: FnOnce(Response) -> Option<T>,
+{
+    match request_payload(client, streams, body, deadline, extract).await {
+        Ok(payload) => write_outcome(emit(
+            &mut *streams.out,
+            streams.fmt,
+            command,
+            payload,
+            streams.style,
+        )),
+        Err(code) => code,
+    }
+}

--- a/crates/shep-cli/src/commands/runtime.rs
+++ b/crates/shep-cli/src/commands/runtime.rs
@@ -60,19 +60,16 @@ pub async fn runtime(
     // `SHEP_FORCE_INIT` is read here and nowhere else: it exists to make the
     // split reachable from a test harness. Unix only, because Windows has no
     // zombie state and no reparent-to-init rule, so there is nothing to reap.
-    #[cfg(windows)]
-    return foreground::run(streams, quiet, options).await;
-
     #[cfg(unix)]
-    let forced = std::env::var_os("SHEP_FORCE_INIT").is_some();
-    #[cfg(unix)]
-    if !reap::should_split(std::process::id(), args.supervise, forced) {
-        return foreground::run(streams, quiet, options).await;
+    {
+        let forced = std::env::var_os("SHEP_FORCE_INIT").is_some();
+        if reap::should_split(std::process::id(), args.supervise, forced) {
+            // `run_init` never returns; the empty match is how an
+            // `Infallible` is spent as a statement.
+            match reap::run_init().await {}
+        }
     }
-    // `Infallible` does not coerce to `ExitCode` as a bare tail expression,
-    // so the empty match performs it. `run_init` never returns.
-    #[cfg(unix)]
-    match reap::run_init().await {}
+    foreground::run(streams, quiet, options).await
 }
 
 /// Discovers a Flockfile in the current directory, or reports

--- a/crates/shep-cli/src/commands/secret.rs
+++ b/crates/shep-cli/src/commands/secret.rs
@@ -22,7 +22,8 @@ use shep_core::secrets::{
 use crate::cli::{Format, SecretArgs, SecretCommand};
 use crate::exit::ExitCode;
 use crate::output::{
-    SecretKeyRow, SecretKeyRows, SecretSlotRow, SecretValueRow, Streams, emit, write_outcome,
+    Render, SecretKeyRow, SecretKeyRows, SecretSlotRow, SecretValueRow, Streams, emit,
+    write_outcome,
 };
 
 /// The one sentence that tells an operator how to open the read gate.
@@ -247,13 +248,7 @@ fn get(
                     key: key.to_string(),
                     value,
                 };
-                write_outcome(emit(
-                    &mut *streams.out,
-                    streams.fmt,
-                    "secret",
-                    row,
-                    streams.style,
-                ))
+                emit_secret(streams, row)
             }
         },
         Ok(None) => {
@@ -346,13 +341,7 @@ fn list(streams: &mut Streams<'_>, paths: &ShepPaths) -> ExitCode {
                     })
                     .collect(),
             );
-            write_outcome(emit(
-                &mut *streams.out,
-                streams.fmt,
-                "secret",
-                rows,
-                streams.style,
-            ))
+            emit_secret(streams, rows)
         }
         Err(err) => fail(streams, &err),
     }
@@ -361,10 +350,17 @@ fn list(streams: &mut Streams<'_>, paths: &ShepPaths) -> ExitCode {
 /// The one report `set` and `unset` share: which slot changed, never what
 /// is in it.
 fn emit_slot(streams: &mut Streams<'_>, key: &str, environment: &str) -> ExitCode {
-    let row = SecretSlotRow {
-        key: key.to_string(),
-        environment: environment.to_string(),
-    };
+    emit_secret(
+        streams,
+        SecretSlotRow {
+            key: key.to_string(),
+            environment: environment.to_string(),
+        },
+    )
+}
+
+/// Renders `row` under the one envelope command every `secret` verb reports.
+fn emit_secret<T: Render>(streams: &mut Streams<'_>, row: T) -> ExitCode {
     write_outcome(emit(
         &mut *streams.out,
         streams.fmt,

--- a/crates/shep-cli/src/commands/selector.rs
+++ b/crates/shep-cli/src/commands/selector.rs
@@ -1,6 +1,7 @@
 //! One `parse_selector`, shared by `lifecycle`, `logs`, `query`, `bleats`
 //! and `trigger`.
 
+use shep_core::protocol::SelectorSpec;
 use shep_core::selector::ProcessSelector;
 
 use crate::exit::ExitCode;
@@ -9,8 +10,10 @@ use crate::output::Streams;
 /// Parses `raw` client-side, so a malformed selector is a local usage error
 /// rather than a round trip. The daemon re-parses it anyway.
 ///
-/// Returns a [`ProcessSelector`], not a `SelectorSpec`: callers that put one
-/// on the wire convert with `SelectorSpec::from(&selector)` themselves.
+/// Returns a [`ProcessSelector`], for the two callers that match it locally
+/// rather than sending it: `bleats` filters its subscription and `start`
+/// tries a token as a name before treating it as a target. Everything that
+/// puts one on the wire wants [`parse_selector_spec`].
 pub(crate) fn parse_selector(
     streams: &mut Streams<'_>,
     raw: &str,
@@ -19,6 +22,21 @@ pub(crate) fn parse_selector(
         Ok(selector) => Ok(selector),
         Err(err) => Err(streams.fail(ExitCode::Usage, &err.to_string())),
     }
+}
+
+/// [`parse_selector`] for a caller that puts the result on the wire.
+///
+/// The conversion is here rather than at each verb so `SelectorSpec::from`
+/// is applied one way, by everything that sends a selector.
+///
+/// # Errors
+///
+/// The [`ExitCode`] [`parse_selector`] already reported.
+pub(crate) fn parse_selector_spec(
+    streams: &mut Streams<'_>,
+    raw: &str,
+) -> Result<SelectorSpec, ExitCode> {
+    parse_selector(streams, raw).map(|selector| SelectorSpec::from(&selector))
 }
 
 #[cfg(test)]

--- a/crates/shep-cli/src/commands/serve.rs
+++ b/crates/shep-cli/src/commands/serve.rs
@@ -12,16 +12,16 @@
 
 use std::net::{IpAddr, SocketAddr};
 use std::path::{Path, PathBuf};
-use std::time::Duration;
 
-use shep_client::{Client, START_DEADLINE};
+use shep_client::START_DEADLINE;
 use shep_core::config::AppConfig;
 use shep_core::paths::ShepPaths;
 use shep_core::protocol::{Request, Response};
 
 use crate::cli::ServeArgs;
+use crate::commands::rpc::request_and_render;
 use crate::exit::ExitCode;
-use crate::output::{FlockRows, Render, Streams, emit, write_outcome};
+use crate::output::{FlockRows, Streams};
 use crate::serve::auth::{self, AuthError, Credentials};
 use crate::serve::worker::{self, ServeConfig};
 
@@ -316,44 +316,6 @@ async fn register(
         },
     )
     .await
-}
-
-/// Sends `body`, renders whatever the daemon answers through [`emit`], and
-/// maps every way that can go wrong to its exit code.
-///
-/// A copy of `commands::lifecycle`'s helper of the same name and shape,
-/// also duplicated in `commands::logs` and `commands::query`.
-async fn request_and_render<T, F>(
-    client: &Client,
-    streams: &mut Streams<'_>,
-    command: &str,
-    body: Request,
-    deadline: Option<Duration>,
-    extract: F,
-) -> ExitCode
-where
-    T: Render,
-    F: FnOnce(Response) -> Option<T>,
-{
-    match client.request_with_deadline(body, deadline).await {
-        Ok(response) => match extract(response) {
-            Some(payload) => write_outcome(emit(
-                &mut *streams.out,
-                streams.fmt,
-                command,
-                payload,
-                streams.style,
-            )),
-            None => {
-                let message = "the daemon answered with a response this client does not understand";
-                streams.fail(ExitCode::Internal, message)
-            }
-        },
-        Err(err) => {
-            let code = ExitCode::from(&err);
-            streams.fail(code, &err.to_string())
-        }
-    }
 }
 
 #[cfg(test)]

--- a/crates/shep-cli/src/commands/signal.rs
+++ b/crates/shep-cli/src/commands/signal.rs
@@ -12,9 +12,10 @@ use shep_core::protocol::{Request, Response, SelectorSpec};
 use shep_core::signals::OperatorSignal;
 
 use crate::cli::SignalArgs;
+use crate::commands::rpc::request_and_render;
 use crate::commands::selector::parse_selector;
 use crate::exit::ExitCode;
-use crate::output::{SignalledRows, Streams, emit, write_outcome};
+use crate::output::{SignalledRows, Streams};
 
 /// Sends `args.signal` to the sheep matching `args.selector`, and renders one
 /// row per match.
@@ -40,23 +41,18 @@ pub async fn signal(client: &Client, streams: &mut Streams<'_>, args: &SignalArg
         signal: sig.as_str().to_string(),
     };
 
-    match client.request(body).await {
-        Ok(Response::Signalled(replies)) => write_outcome(emit(
-            &mut *streams.out,
-            streams.fmt,
-            "signal",
-            SignalledRows(replies),
-            streams.style,
-        )),
-        Ok(_unrecognised) => {
-            let message = "the daemon answered with a response this client does not understand";
-            streams.fail(ExitCode::Internal, message)
-        }
-        Err(err) => {
-            let code = ExitCode::from(&err);
-            streams.fail(code, &err.to_string())
-        }
-    }
+    request_and_render(
+        client,
+        streams,
+        "signal",
+        body,
+        None,
+        |response| match response {
+            Response::Signalled(replies) => Some(SignalledRows(replies)),
+            _ => None,
+        },
+    )
+    .await
 }
 
 #[cfg(test)]

--- a/crates/shep-cli/src/commands/signal.rs
+++ b/crates/shep-cli/src/commands/signal.rs
@@ -8,20 +8,20 @@
 //! non-`Success` only when the RPC itself failed.
 
 use shep_client::Client;
-use shep_core::protocol::{Request, Response, SelectorSpec};
+use shep_core::protocol::{Request, Response};
 use shep_core::signals::OperatorSignal;
 
 use crate::cli::SignalArgs;
 use crate::commands::rpc::request_and_render;
-use crate::commands::selector::parse_selector;
+use crate::commands::selector::parse_selector_spec;
 use crate::exit::ExitCode;
 use crate::output::{SignalledRows, Streams};
 
 /// Sends `args.signal` to the sheep matching `args.selector`, and renders one
 /// row per match.
 pub async fn signal(client: &Client, streams: &mut Streams<'_>, args: &SignalArgs) -> ExitCode {
-    let selector = match parse_selector(streams, &args.selector) {
-        Ok(selector) => SelectorSpec::from(&selector),
+    let selector = match parse_selector_spec(streams, &args.selector) {
+        Ok(selector) => selector,
         Err(code) => return code,
     };
 
@@ -59,6 +59,7 @@ pub async fn signal(client: &Client, streams: &mut Streams<'_>, args: &SignalArg
 mod tests {
     use shep_client::testing::{fake_client_capturing_envelopes, fake_client_replying_err};
     use shep_core::protocol::RpcErrorCode;
+    use shep_core::protocol::SelectorSpec;
 
     use super::*;
     use crate::cli::Format;

--- a/crates/shep-cli/src/commands/startup/unit.rs
+++ b/crates/shep-cli/src/commands/startup/unit.rs
@@ -587,12 +587,13 @@ mod tests {
         assert!(rendered.contains("binds its control socket before the restore"));
     }
 
-    /// fails if a metacharacter in a path escapes the double quotes.
-    #[test]
-    fn the_openrc_script_quotes_shell_metacharacters() {
-        let mut s = spec();
-        s.home = PathBuf::from(r#"/tmp/we"ird/$HOME/`x`/back\slash"#);
-        let rendered = openrc_script(&s);
+    /// A `home` carrying every character [`sh_double_quoted`] escapes.
+    const SHELL_METACHARACTER_HOME: &str = r#"/tmp/we"ird/$HOME/`x`/back\slash"#;
+
+    /// Asserts a script built from [`SHELL_METACHARACTER_HOME`] escaped all
+    /// four, so a fifth character added to the escape set is pinned here
+    /// rather than in each rc flavour's test.
+    fn assert_double_quoted_escapes(rendered: &str) {
         assert!(
             rendered.contains(r#"we\"ird"#),
             "a quote must be escaped: {rendered}"
@@ -609,6 +610,15 @@ mod tests {
             rendered.contains(r"back\\slash"),
             "a backslash must be escaped: {rendered}"
         );
+    }
+
+    /// fails if a metacharacter in a path escapes the double quotes.
+    #[test]
+    fn the_openrc_script_quotes_shell_metacharacters() {
+        let mut s = spec();
+        s.home = PathBuf::from(SHELL_METACHARACTER_HOME);
+        let rendered = openrc_script(&s);
+        assert_double_quoted_escapes(&rendered);
     }
 
     /// openrc derives defaults from `name`/`RC_SVCNAME`; a constant `name`
@@ -679,24 +689,9 @@ mod tests {
     #[test]
     fn the_freebsd_script_quotes_shell_metacharacters() {
         let mut s = spec();
-        s.home = PathBuf::from(r#"/tmp/we"ird/$HOME/`x`/back\slash"#);
+        s.home = PathBuf::from(SHELL_METACHARACTER_HOME);
         let rendered = freebsd_rc_script(&s);
-        assert!(
-            rendered.contains(r#"we\"ird"#),
-            "a quote must be escaped: {rendered}"
-        );
-        assert!(
-            rendered.contains(r"\$HOME"),
-            "a dollar must be escaped: {rendered}"
-        );
-        assert!(
-            rendered.contains(r"\`x\`"),
-            "a backtick must be escaped: {rendered}"
-        );
-        assert!(
-            rendered.contains(r"back\\slash"),
-            "a backslash must be escaped: {rendered}"
-        );
+        assert_double_quoted_escapes(&rendered);
     }
 
     /// fails if a metacharacter in `home` escapes the quoting in the
@@ -705,24 +700,9 @@ mod tests {
     #[test]
     fn the_openbsd_script_quotes_shell_metacharacters() {
         let mut s = spec();
-        s.home = PathBuf::from(r#"/tmp/we"ird/$HOME/`x`/back\slash"#);
+        s.home = PathBuf::from(SHELL_METACHARACTER_HOME);
         let rendered = openbsd_rc_script(&s);
-        assert!(
-            rendered.contains(r#"we\"ird"#),
-            "a quote must be escaped: {rendered}"
-        );
-        assert!(
-            rendered.contains(r"\$HOME"),
-            "a dollar must be escaped: {rendered}"
-        );
-        assert!(
-            rendered.contains(r"\`x\`"),
-            "a backtick must be escaped: {rendered}"
-        );
-        assert!(
-            rendered.contains(r"back\\slash"),
-            "a backslash must be escaped: {rendered}"
-        );
+        assert_double_quoted_escapes(&rendered);
     }
 
     /// fails if a `PATH` containing a space becomes two environment entries.

--- a/crates/shep-cli/src/commands/trigger.rs
+++ b/crates/shep-cli/src/commands/trigger.rs
@@ -65,12 +65,21 @@ mod tests {
         }
     }
 
-    /// `"/[/"` is one of the only three inputs the selector grammar rejects.
-    #[tokio::test]
-    async fn a_malformed_selector_exits_usage_without_a_round_trip() {
+    /// Runs the verb against a fake daemon that captures envelopes.
+    ///
+    /// The same shape as `commands::whisper`'s helper, so the two verbs'
+    /// tests read alike.
+    async fn run(
+        args: &TriggerArgs,
+    ) -> (
+        ExitCode,
+        Vec<u8>,
+        Vec<u8>,
+        tokio::sync::mpsc::Receiver<shep_core::protocol::Envelope>,
+    ) {
         let dir = tempfile::tempdir().unwrap();
         let path = shep_client::testing::control_address(dir.path());
-        let (client, mut envelopes) = fake_client_capturing_envelopes(&path).await;
+        let (client, envelopes) = fake_client_capturing_envelopes(&path).await;
         let mut out = Vec::new();
         let mut err = Vec::new();
         let code = {
@@ -80,8 +89,15 @@ mod tests {
                 style: crate::style::Presentation::BARE,
                 fmt: Format::Table,
             };
-            trigger(&client, &mut streams, &args("/[/", "ping", None)).await
+            trigger(&client, &mut streams, args).await
         };
+        (code, out, err, envelopes)
+    }
+
+    /// `"/[/"` is one of the only three inputs the selector grammar rejects.
+    #[tokio::test]
+    async fn a_malformed_selector_exits_usage_without_a_round_trip() {
+        let (code, _out, _err, mut envelopes) = run(&args("/[/", "ping", None)).await;
         assert_eq!(code, ExitCode::Usage);
         assert!(
             envelopes.try_recv().is_err(),
@@ -114,18 +130,7 @@ mod tests {
     /// catches a dropped field.
     #[tokio::test]
     async fn the_request_carries_the_selector_action_params_and_trigger_deadline() {
-        let dir = tempfile::tempdir().unwrap();
-        let path = shep_client::testing::control_address(dir.path());
-        let (client, mut envelopes) = fake_client_capturing_envelopes(&path).await;
-        let mut out = Vec::new();
-        let mut err = Vec::new();
-        let mut streams = Streams {
-            out: &mut out,
-            err: &mut err,
-            style: crate::style::Presentation::BARE,
-            fmt: Format::Table,
-        };
-        let _ = trigger(&client, &mut streams, &args("web", "gc", Some("--force"))).await;
+        let (_code, _out, _err, mut envelopes) = run(&args("web", "gc", Some("--force"))).await;
 
         let envelope = envelopes.recv().await.unwrap();
         assert_eq!(
@@ -148,20 +153,7 @@ mod tests {
     /// `match` has no arm for.
     #[tokio::test]
     async fn an_unrecognised_response_exits_internal() {
-        let dir = tempfile::tempdir().unwrap();
-        let path = shep_client::testing::control_address(dir.path());
-        let (client, _envelopes) = fake_client_capturing_envelopes(&path).await;
-        let mut out = Vec::new();
-        let mut err = Vec::new();
-        let code = {
-            let mut streams = Streams {
-                out: &mut out,
-                err: &mut err,
-                style: crate::style::Presentation::BARE,
-                fmt: Format::Table,
-            };
-            trigger(&client, &mut streams, &args("web", "ping", None)).await
-        };
+        let (code, out, err, _envelopes) = run(&args("web", "ping", None)).await;
         assert_eq!(code, ExitCode::Internal);
         assert!(out.is_empty());
         assert!(!err.is_empty());

--- a/crates/shep-cli/src/commands/trigger.rs
+++ b/crates/shep-cli/src/commands/trigger.rs
@@ -12,9 +12,10 @@ use shep_client::{Client, TRIGGER_DEADLINE};
 use shep_core::protocol::{Request, Response, SelectorSpec};
 
 use crate::cli::TriggerArgs;
+use crate::commands::rpc::request_and_render;
 use crate::commands::selector::parse_selector;
 use crate::exit::ExitCode;
-use crate::output::{Streams, TriggeredRows, emit, write_outcome};
+use crate::output::{Streams, TriggeredRows};
 
 /// Sends `args.action` (and `args.params`, if any) to the sheep matching
 /// `args.selector`, and renders one row per match.
@@ -33,26 +34,19 @@ pub async fn trigger(client: &Client, streams: &mut Streams<'_>, args: &TriggerA
         params: args.params.clone(),
     };
 
-    match client
-        .request_with_deadline(body, Some(TRIGGER_DEADLINE))
-        .await
-    {
-        Ok(Response::Triggered(replies)) => write_outcome(emit(
-            &mut *streams.out,
-            streams.fmt,
-            "trigger",
-            TriggeredRows(replies),
-            streams.style,
-        )),
-        Ok(_unrecognised) => {
-            let message = "the daemon answered with a response this client does not understand";
-            streams.fail(ExitCode::Internal, message)
-        }
-        Err(err) => {
-            let code = ExitCode::from(&err);
-            streams.fail(code, &err.to_string())
-        }
-    }
+    let deadline = Some(TRIGGER_DEADLINE);
+    request_and_render(
+        client,
+        streams,
+        "trigger",
+        body,
+        deadline,
+        |response| match response {
+            Response::Triggered(replies) => Some(TriggeredRows(replies)),
+            _ => None,
+        },
+    )
+    .await
 }
 
 #[cfg(test)]

--- a/crates/shep-cli/src/commands/trigger.rs
+++ b/crates/shep-cli/src/commands/trigger.rs
@@ -9,11 +9,11 @@
 //! non-`Success` only when the RPC itself failed.
 
 use shep_client::{Client, TRIGGER_DEADLINE};
-use shep_core::protocol::{Request, Response, SelectorSpec};
+use shep_core::protocol::{Request, Response};
 
 use crate::cli::TriggerArgs;
 use crate::commands::rpc::request_and_render;
-use crate::commands::selector::parse_selector;
+use crate::commands::selector::parse_selector_spec;
 use crate::exit::ExitCode;
 use crate::output::{Streams, TriggeredRows};
 
@@ -23,8 +23,8 @@ use crate::output::{Streams, TriggeredRows};
 /// `action` and `params` are carried exactly as typed: neither this side nor
 /// the daemon parses them.
 pub async fn trigger(client: &Client, streams: &mut Streams<'_>, args: &TriggerArgs) -> ExitCode {
-    let selector = match parse_selector(streams, &args.selector) {
-        Ok(selector) => SelectorSpec::from(&selector),
+    let selector = match parse_selector_spec(streams, &args.selector) {
+        Ok(selector) => selector,
         Err(code) => return code,
     };
 
@@ -53,6 +53,7 @@ pub async fn trigger(client: &Client, streams: &mut Streams<'_>, args: &TriggerA
 mod tests {
     use shep_client::testing::{fake_client_capturing_envelopes, fake_client_replying_err};
     use shep_core::protocol::RpcErrorCode;
+    use shep_core::protocol::SelectorSpec;
 
     use super::*;
     use crate::cli::Format;

--- a/crates/shep-cli/src/commands/whisper.rs
+++ b/crates/shep-cli/src/commands/whisper.rs
@@ -11,19 +11,19 @@
 //! app read them.
 
 use shep_client::Client;
-use shep_core::protocol::{Request, Response, SelectorSpec};
+use shep_core::protocol::{Request, Response};
 
 use crate::cli::WhisperArgs;
 use crate::commands::rpc::request_and_render;
-use crate::commands::selector::parse_selector;
+use crate::commands::selector::parse_selector_spec;
 use crate::exit::ExitCode;
 use crate::output::{SentLineRows, Streams};
 
 /// Writes `args.line` to the stdin of the sheep matching `args.selector`,
 /// and renders one row per match.
 pub async fn whisper(client: &Client, streams: &mut Streams<'_>, args: &WhisperArgs) -> ExitCode {
-    let selector = match parse_selector(streams, &args.selector) {
-        Ok(selector) => SelectorSpec::from(&selector),
+    let selector = match parse_selector_spec(streams, &args.selector) {
+        Ok(selector) => selector,
         Err(code) => return code,
     };
 
@@ -57,6 +57,7 @@ pub async fn whisper(client: &Client, streams: &mut Streams<'_>, args: &WhisperA
 mod tests {
     use shep_client::testing::{fake_client_capturing_envelopes, fake_client_replying_err};
     use shep_core::protocol::RpcErrorCode;
+    use shep_core::protocol::SelectorSpec;
 
     use super::*;
     use crate::cli::Format;

--- a/crates/shep-cli/src/commands/whisper.rs
+++ b/crates/shep-cli/src/commands/whisper.rs
@@ -14,9 +14,10 @@ use shep_client::Client;
 use shep_core::protocol::{Request, Response, SelectorSpec};
 
 use crate::cli::WhisperArgs;
+use crate::commands::rpc::request_and_render;
 use crate::commands::selector::parse_selector;
 use crate::exit::ExitCode;
-use crate::output::{SentLineRows, Streams, emit, write_outcome};
+use crate::output::{SentLineRows, Streams};
 
 /// Writes `args.line` to the stdin of the sheep matching `args.selector`,
 /// and renders one row per match.
@@ -38,23 +39,18 @@ pub async fn whisper(client: &Client, streams: &mut Streams<'_>, args: &WhisperA
         line: args.line.clone(),
     };
 
-    match client.request(body).await {
-        Ok(Response::SentLine(rows)) => write_outcome(emit(
-            &mut *streams.out,
-            streams.fmt,
-            "whisper",
-            SentLineRows(rows),
-            streams.style,
-        )),
-        Ok(_unrecognised) => {
-            let message = "the daemon answered with a response this client does not understand";
-            streams.fail(ExitCode::Internal, message)
-        }
-        Err(err) => {
-            let code = ExitCode::from(&err);
-            streams.fail(code, &err.to_string())
-        }
-    }
+    request_and_render(
+        client,
+        streams,
+        "whisper",
+        body,
+        None,
+        |response| match response {
+            Response::SentLine(rows) => Some(SentLineRows(rows)),
+            _ => None,
+        },
+    )
+    .await
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Group A of the qwen audit: CLI command response plumbing. 17 claims checked against the code, 13 acted on.

- `request_and_render` had 4 definitions and 9 more verbs inlining it by hand. One now, in `commands/rpc.rs`, plus `request_payload` for the verbs that render their own output
- `admin.rs` polled for teardown and emitted the same `KillRow` twice
- One predicate, match rule, emit and `#[cfg(unix)]` block in `dog_migration.rs`, `import/pm2/env.rs`, `secret.rs`, `runtime.rs`
- `dev_home` takes `Option<&Path>` instead of being handed `PathBuf::new()` as a sentinel
- `parse_selector_spec` in `commands/selector.rs`: `SelectorSpec::from(&parse_selector(..)?)` was written out 7 times
- Test setup hoisted in `admin.rs`, `trigger.rs`, `import/pm2/mod.rs`, `startup/unit.rs`

Left duplicated on purpose, reasons in the commits: `import::dotenv`'s two failure arms append which store was already written, and `query::flock`, `query::describe_selector` and `muster::muster` have success arms no single `Render` value expresses.

Two audit claims were wrong:

- The proposed predicate for `dog_migration` flips a De Morgan. `is_some_and(|t| !t.is_empty())` answers false for a non-table `Item` where the original answers true
- `fn test_streams() -> (Vec<u8>, Vec<u8>, Streams<'static>)` cannot compile, since `Streams<'a>` borrows the buffers it would be returned beside

`cargo test -p shep-cli` runs zero tests and exits 0. `shep-cli` is the crates.io placeholder at `crates/shep-cli-redirect/`. This directory is package `shep`. The audit plan lists that shape for groups B, E and F too.

Not done: `runtime.rs`'s `DISCOVERY_NAMES` duplicates `shep_core`'s private `DISCOVERY_ORDER`. They agree today, but the fix edits a file group D owns.

Verified: 1665 tests pass, `clippy --all-targets --all-features -D warnings` clean, doctests and `fmt --check` clean, and `cargo check --target x86_64-pc-windows-gnu` clean since three fixes sit on a platform split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Standardized handling and reporting of unexpected daemon responses and request failures across CLI commands.
  - Improved consistency when resolving development-home paths, including cases where no home directory is available.

- **Refactor**
  - Consolidated command request, response rendering, selector parsing, and error-reporting behavior for more consistent CLI output.
  - Simplified runtime and secret-output handling without changing expected command behavior.

- **Tests**
  - Expanded coverage for development-home resolution, shell escaping, shutdown flows, and command execution scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->