### PR TITLE
test(daemon): qwen audit group C, daemon internals

### DIFF
--- a/crates/shep-daemon/src/assemble.rs
+++ b/crates/shep-daemon/src/assemble.rs
@@ -407,24 +407,6 @@ mod tests {
     }
 
     #[test]
-    fn env_adds_shep_instance() {
-        let app_config = AppConfig {
-            name: "web".to_string(),
-            script: "/usr/bin/python3".to_string(),
-            args: vec!["app.py".to_string()],
-            interpreter: Some("none".to_string()),
-            ..Default::default()
-        };
-        let app = normalize(app_config).unwrap();
-        let paths = test_paths();
-
-        let spec = assemble(&app, 1, &paths, None, &no_secrets()).unwrap();
-
-        assert!(spec.env.contains_key("SHEP_INSTANCE"));
-        assert_eq!(spec.env.get("SHEP_INSTANCE").map(|s| s.as_str()), Some("1"));
-    }
-
-    #[test]
     fn every_child_learns_its_slot_and_its_name() {
         let app = normalize(AppConfig {
             name: "worker".to_string(),

--- a/crates/shep-daemon/src/backoff.rs
+++ b/crates/shep-daemon/src/backoff.rs
@@ -113,12 +113,6 @@ mod tests {
     }
 
     #[test]
-    fn stable_exit_is_never_delayed_even_with_a_configured_backoff() {
-        let app = shep_core::config::AppConfig::minimal("p", "./p");
-        assert_eq!(restart_delay(&app, 0), None);
-    }
-
-    #[test]
     fn an_explicit_none_still_means_no_backoff() {
         let mut app = shep_core::config::AppConfig::minimal("p", "./p");
         app.exp_backoff_restart_delay = None;

--- a/crates/shep-daemon/src/fake.rs
+++ b/crates/shep-daemon/src/fake.rs
@@ -61,17 +61,7 @@ impl ProcScript {
     /// Exits immediately with `code`
     #[must_use]
     pub fn const_exit(code: i32) -> Self {
-        Self {
-            delay_ms: 0,
-            outcome: ExitOutcome {
-                code: Some(code),
-                signal: None,
-            },
-            obeys_signal: true,
-            obeys_kill: true,
-            lamb_holds_the_pipe: false,
-            reads_stdin: true,
-        }
+        Self::stable_then_exit(0, code)
     }
 
     /// Exits after `ms` milliseconds with `code`

--- a/crates/shep-daemon/src/handover/adopt.rs
+++ b/crates/shep-daemon/src/handover/adopt.rs
@@ -342,6 +342,10 @@ mod tests {
     use crate::privilege::SpawnIdentity;
     use shep_core::status::ProcStatus;
 
+    /// A number this process will never own, the same floor `sys`'s own
+    /// refusal tests use.
+    const NEVER_OPEN: RawFd = 4096;
+
     /// One carried sheep named `web`, whose descriptors are `fds`.
     fn carried(fds: CarriedFds) -> CarriedSheep {
         carried_slot(0, fds)
@@ -541,18 +545,20 @@ mod tests {
         let mut adopted = adopt(&blob).expect("a merged-log clustered app must be adoptable");
 
         assert_eq!(adopted.sheep.len(), 2, "one adopted sheep per instance");
-        let mut zero = adopted.sheep[0].out_log.take().expect("slot 0's log");
-        let mut one = adopted.sheep[1].out_log.take().expect("slot 1's log");
+        let zero = adopted.sheep[0].out_log.take().expect("slot 0's log");
+        let one = adopted.sheep[1].out_log.take().expect("slot 1's log");
         // Alternated, so a second handle that had become an alias of the
         // first shows up as lost text rather than two clean halves. Flushed
         // per line because a `tokio::fs::File` hands the real `write(2)` to
         // the blocking pool, which finishes in its own order.
-        for line in ["zero-1\n", "one-1\n", "zero-2\n", "one-2\n"] {
-            let handle = if line.starts_with("zero") {
-                &mut zero
-            } else {
-                &mut one
-            };
+        let mut handles = [zero, one];
+        for (line, slot) in [
+            ("zero-1\n", 0),
+            ("one-1\n", 1),
+            ("zero-2\n", 0),
+            ("one-2\n", 1),
+        ] {
+            let handle = &mut handles[slot];
             handle.write_all(line.as_bytes()).await.unwrap();
             handle.flush().await.unwrap();
         }
@@ -565,10 +571,6 @@ mod tests {
 
     #[tokio::test]
     async fn a_blob_naming_a_descriptor_that_is_not_open_fails_loudly() {
-        // fd 4096 is a number this process will never own, the same floor
-        // `sys`'s own refusal tests use.
-        const NEVER_OPEN: RawFd = 4096;
-
         let dir = tempfile::tempdir().unwrap();
         let socket = dir.path().join("shep.sock");
         let blob = blob_with(
@@ -600,8 +602,6 @@ mod tests {
     async fn a_refused_rehydrate_leaves_the_pidfile_lock_held() {
         // The pidfile is adopted last, so a failure before it leaves that
         // descriptor open and unowned, and its `flock` held.
-        const NEVER_OPEN: RawFd = 4096;
-
         let dir = tempfile::tempdir().unwrap();
         let socket = dir.path().join("shep.sock");
         let blob = blob_with(

--- a/crates/shep-daemon/src/limits/mod.rs
+++ b/crates/shep-daemon/src/limits/mod.rs
@@ -184,19 +184,7 @@ mod tests {
     use tokio::sync::mpsc;
 
     use super::*;
-    use crate::limits::sample::ProcessRss;
-    use crate::testing::ScriptedSampler;
-
-    /// Every case here is about the memory ceiling, so none carries CPU
-    /// time.
-    fn rss(pid: u32, parent: Option<u32>, bytes: u64) -> ProcessRss {
-        ProcessRss {
-            pid,
-            parent,
-            bytes,
-            cpu_ms: 0,
-        }
-    }
+    use crate::testing::{ScriptedSampler, rss, rss_cpu};
 
     /// Generous bound on how long a test may wait for a breach on the paused
     /// tokio clock. Costs no wall-clock time: the runtime auto-advances to
@@ -246,17 +234,6 @@ mod tests {
             Err(_) => {} // the window elapsed with nothing arriving
             Ok(Some(breach)) => panic!("unexpected breach observed: {breach:?}"),
             Ok(None) => panic!("breach channel disconnected while checking for no breach"),
-        }
-    }
-
-    /// A reading carrying CPU time, for the one case here that is about the
-    /// sampling half rather than the ceiling.
-    fn rss_cpu(pid: u32, parent: Option<u32>, bytes: u64, cpu_ms: u64) -> ProcessRss {
-        ProcessRss {
-            pid,
-            parent,
-            bytes,
-            cpu_ms,
         }
     }
 

--- a/crates/shep-daemon/src/limits/sample.rs
+++ b/crates/shep-daemon/src/limits/sample.rs
@@ -265,21 +265,7 @@ pub fn tree_rss(table: &[ProcessRss], root: u32) -> u64 {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    /// A reading with no CPU time on it, for the memory cases.
-    fn rss(pid: u32, parent: Option<u32>, bytes: u64) -> ProcessRss {
-        rss_cpu(pid, parent, bytes, 0)
-    }
-
-    /// A reading carrying both quantities, for the CPU cases.
-    fn rss_cpu(pid: u32, parent: Option<u32>, bytes: u64, cpu_ms: u64) -> ProcessRss {
-        ProcessRss {
-            pid,
-            parent,
-            bytes,
-            cpu_ms,
-        }
-    }
+    use crate::testing::{rss, rss_cpu};
 
     #[test]
     fn lone_root_sums_its_own_bytes() {

--- a/crates/shep-daemon/src/limits/stats.rs
+++ b/crates/shep-daemon/src/limits/stats.rs
@@ -145,7 +145,7 @@ impl StatsState {
     /// For a caller with no index already in hand. The polling tick always
     /// has one and uses [`Self::record_baseline`] directly, so this has no
     /// production caller; it lets a test set a baseline in one line.
-    #[allow(dead_code, reason = "called only by this crate's tests")]
+    #[cfg(test)]
     pub(crate) fn record_baseline_now(&self, now: Instant) {
         let table = self.sampler.sample();
         self.record_baseline(&TreeIndex::build(&table), now);

--- a/crates/shep-daemon/src/limits/stats.rs
+++ b/crates/shep-daemon/src/limits/stats.rs
@@ -302,18 +302,8 @@ mod tests {
     use core::time::Duration;
 
     use super::super::MEMORY_POLL_INTERVAL;
-    use super::super::sample::ProcessRss;
     use super::*;
-    use crate::testing::{ScriptedSampler, identity};
-
-    fn rss_cpu(pid: u32, parent: Option<u32>, bytes: u64, cpu_ms: u64) -> ProcessRss {
-        ProcessRss {
-            pid,
-            parent,
-            bytes,
-            cpu_ms,
-        }
-    }
+    use crate::testing::{ScriptedSampler, identity, rss_cpu};
 
     #[tokio::test(start_paused = true)]
     async fn a_sheep_with_no_baseline_reports_no_cpu_but_still_reports_memory() {

--- a/crates/shep-daemon/src/testing.rs
+++ b/crates/shep-daemon/src/testing.rs
@@ -671,6 +671,21 @@ impl Clock for TestClock {
     }
 }
 
+/// A reading with no CPU time on it, for the memory cases.
+pub(crate) fn rss(pid: u32, parent: Option<u32>, bytes: u64) -> ProcessRss {
+    rss_cpu(pid, parent, bytes, 0)
+}
+
+/// A reading carrying both quantities, for the CPU cases.
+pub(crate) fn rss_cpu(pid: u32, parent: Option<u32>, bytes: u64, cpu_ms: u64) -> ProcessRss {
+    ProcessRss {
+        pid,
+        parent,
+        bytes,
+        cpu_ms,
+    }
+}
+
 // A scripted sequence rather than one fixed table: the polling memory-limit
 // enforcer's tests need the reading to change between polls, such as a tree
 // that crosses its limit only on the third tick.

--- a/crates/shep-daemon/src/watch/mod.rs
+++ b/crates/shep-daemon/src/watch/mod.rs
@@ -628,6 +628,29 @@ mod tests {
         }
     }
 
+    /// A watch group over `root` treating every path under it as a trigger,
+    /// with the sender its batches go in through.
+    ///
+    /// The two cases that need a narrower filter build their own
+    /// [`RootedFilter`] and spawn inline.
+    fn spawn_group_matching_everything(
+        root: &Path,
+        name: &str,
+        handle: &SupervisorHandle,
+    ) -> (
+        mpsc::UnboundedSender<WatchBatch>,
+        tokio::task::JoinHandle<()>,
+    ) {
+        let (tx, group_rx) = mpsc::unbounded_channel();
+        let group = tokio::spawn(run_group(
+            name.to_string(),
+            matches_everything(root.to_path_buf()),
+            group_rx,
+            handle.clone(),
+        ));
+        (tx, group)
+    }
+
     /// Builds a batch with `rescan: false`.
     fn changed(paths: Vec<PathBuf>) -> WatchBatch {
         WatchBatch {
@@ -656,13 +679,7 @@ mod tests {
         let name = "web";
         start_app(&handle, name, 1).await;
         let root = PathBuf::from("/watched");
-        let (tx, group_rx) = mpsc::unbounded_channel();
-        let group = tokio::spawn(run_group(
-            name.to_string(),
-            matches_everything(root.clone()),
-            group_rx,
-            handle.clone(),
-        ));
+        let (tx, group) = spawn_group_matching_everything(&root, name, &handle);
 
         tx.send(changed(vec![root.join(".git/index")])).unwrap();
         assert_no_restart_within(&mut rx, name, Duration::from_secs(5)).await;
@@ -680,13 +697,7 @@ mod tests {
         let name = "web";
         start_app(&handle, name, 1).await;
         let root = PathBuf::from("/watched");
-        let (tx, group_rx) = mpsc::unbounded_channel();
-        let group = tokio::spawn(run_group(
-            name.to_string(),
-            matches_everything(root.clone()),
-            group_rx,
-            handle.clone(),
-        ));
+        let (tx, group) = spawn_group_matching_everything(&root, name, &handle);
 
         tx.send(changed(vec![root.join("src/main.rs")])).unwrap();
         let info = expect_restart(&mut rx, name, EVENT_WAIT).await;
@@ -734,13 +745,7 @@ mod tests {
         let name = "web";
         start_app(&handle, name, 1).await;
         let root = PathBuf::from("/watched");
-        let (tx, group_rx) = mpsc::unbounded_channel();
-        let group = tokio::spawn(run_group(
-            name.to_string(),
-            matches_everything(root.clone()),
-            group_rx,
-            handle.clone(),
-        ));
+        let (tx, group) = spawn_group_matching_everything(&root, name, &handle);
 
         // The root, with no rescan flag on it: a `chmod` of that inode, or
         // FSEvents' arm-time `Create(Folder)`.
@@ -765,13 +770,7 @@ mod tests {
         let name = "web";
         start_app(&handle, name, 1).await;
         let root = PathBuf::from("/watched");
-        let (tx, group_rx) = mpsc::unbounded_channel();
-        let group = tokio::spawn(run_group(
-            name.to_string(),
-            matches_everything(root.clone()),
-            group_rx,
-            handle.clone(),
-        ));
+        let (tx, group) = spawn_group_matching_everything(&root, name, &handle);
 
         tx.send(changed(vec![root.join(".git/index")])).unwrap();
         tx.send(rescan_marker()).unwrap();
@@ -795,13 +794,7 @@ mod tests {
         let name = "web";
         start_app(&handle, name, 1).await;
         let root = PathBuf::from("/watched");
-        let (tx, group_rx) = mpsc::unbounded_channel();
-        let group = tokio::spawn(run_group(
-            name.to_string(),
-            matches_everything(root.clone()),
-            group_rx,
-            handle.clone(),
-        ));
+        let (tx, group) = spawn_group_matching_everything(&root, name, &handle);
 
         // Batch 1 kicks off a restart. The scripted process ignores its
         // graceful signal, so the kill ladder is stuck on the full
@@ -828,13 +821,7 @@ mod tests {
     async fn dropping_the_sender_ends_the_group_task() {
         let (handle, _rx, _dir) = spawn_test_fixture(vec![]);
         let root = PathBuf::from("/watched");
-        let (tx, group_rx) = mpsc::unbounded_channel();
-        let group = tokio::spawn(run_group(
-            "ghost".to_string(),
-            matches_everything(root),
-            group_rx,
-            handle,
-        ));
+        let (tx, group) = spawn_group_matching_everything(&root, "ghost", &handle);
 
         drop(tx);
 
@@ -856,13 +843,7 @@ mod tests {
         handle.stop(ProcessSelector::Id(stopped_id)).await.unwrap();
 
         let root = PathBuf::from("/watched");
-        let (tx, group_rx) = mpsc::unbounded_channel();
-        let group = tokio::spawn(run_group(
-            name.to_string(),
-            matches_everything(root.clone()),
-            group_rx,
-            handle.clone(),
-        ));
+        let (tx, group) = spawn_group_matching_everything(&root, name, &handle);
 
         tx.send(changed(vec![root.join("src/main.rs")])).unwrap();
 
@@ -900,13 +881,7 @@ mod tests {
         let infos = start_app(&handle, name, 2).await;
         let (held, released) = (infos[0].id, infos[1].id);
         let root = PathBuf::from("/watched");
-        let (tx, group_rx) = mpsc::unbounded_channel();
-        let group = tokio::spawn(run_group(
-            name.to_string(),
-            matches_everything(root.clone()),
-            group_rx,
-            handle.clone(),
-        ));
+        let (tx, group) = spawn_group_matching_everything(&root, name, &handle);
 
         // The batch claims BOTH instances' next exit and starts both kill
         // ladders. Only the second sheep's ladder can finish without the clock
@@ -951,13 +926,7 @@ mod tests {
         let (handle, mut rx, _dir) = spawn_test_fixture(vec![ProcScript::never_exits(); 2]);
         let name = "ghost";
         let root = PathBuf::from("/watched");
-        let (tx, group_rx) = mpsc::unbounded_channel();
-        let group = tokio::spawn(run_group(
-            name.to_string(),
-            matches_everything(root.clone()),
-            group_rx,
-            handle.clone(),
-        ));
+        let (tx, group) = spawn_group_matching_everything(&root, name, &handle);
 
         // `name` matches nothing yet: the restart resolves `NotFound`, and
         // the loop must stay alive rather than returning.
@@ -995,13 +964,7 @@ mod tests {
         );
 
         let root = PathBuf::from("/watched");
-        let (tx, group_rx) = mpsc::unbounded_channel();
-        let group = tokio::spawn(run_group(
-            name.to_string(),
-            matches_everything(root.clone()),
-            group_rx,
-            handle,
-        ));
+        let (tx, group) = spawn_group_matching_everything(&root, name, &handle);
 
         tx.send(changed(vec![root.join("src/main.rs")])).unwrap();
         tokio::time::timeout(EVENT_WAIT, group)
@@ -1163,13 +1126,7 @@ mod tests {
                 handle.start(vec![normalize(app).unwrap()]).await.unwrap();
 
                 let root = PathBuf::from("/watched");
-                let (tx, group_rx) = mpsc::unbounded_channel();
-                let group = tokio::spawn(run_group(
-                    name.to_string(),
-                    matches_everything(root.clone()),
-                    group_rx,
-                    handle.clone(),
-                ));
+                let (tx, group) = spawn_group_matching_everything(&root, name, &handle);
 
                 let start = tokio::time::Instant::now();
                 // Drained by its own task, started before the first send:


### PR DESCRIPTION
Group C of the qwen audit: 18 findings over 13 files under `crates/shep-daemon/src/`, no HIGH. Checked each against the code first. 8 held up, 10 did not.

Fixed:

- `watch::tests` repeated the same 7-line group setup in 11 tests. One `spawn_group_matching_everything` helper, 60 lines gone. The 2 tests wanting a narrower filter still spawn inline
- `rss` and `rss_cpu` were hand-rolled in all three `limits` test modules, `rss_cpu` byte-identical in each. Moved to `crate::testing`, whose own header says to share these rather than hand-roll them
- `record_baseline_now` was `pub(crate)` plus `#[allow(dead_code)]`. Now `#[cfg(test)]`, matching `watched_for_test` two functions below it. All 6 callers sit in test modules
- `ProcScript::const_exit` spelled out all 6 fields when it is exactly `stable_then_exit(0, code)`
- Dropped 2 tests a sibling already covers. `stable_exit_is_never_delayed_even_with_a_configured_backoff` did not configure a backoff, and `env_adds_shep_instance` asserts strictly less than the test under it
- `two_instances_sharing_one_log_file_are_both_adopted` picked its write target with `line.starts_with("zero")`. Both handles append to one file, so a rename that left the predicate behind would push all 4 writes through one handle and still pass green. Slot indices now

Dismissed, three of them flatly wrong:

- let_chains "is unstable": stabilized in 1.88, which is our MSRV exactly
- `Result::unwrap_infallible()` "is stable Rust": checked with rustc, still nightly only
- `ReloadState::None` "shadows `Option::None`": nothing glob-imports the variants, so every site is already qualified. It is also a serde wire string read across a handover
- adopt.rs slot mapping "silently diverges": `adopt_sheep` destructures without `..` and `dry_run` matches without `_`, so a 7th slot breaks the build at both. The proposed enum would wrap 5 unrelated types and unwrap them back through 5 unreachable arms
- fake.rs three setters, and server.rs `handshake_refuses_protocol_skew_before_closing`: the first saves zero lines, the second would route a handshake test through a helper documented for dog restart bookkeeping

Left duplicated on purpose:

- bus.rs `wants_logs` against `BusEvent::topic`: the test at bus.rs:733 is documented as the join that keeps it honest, and the fix needs shep-core, which belongs to group D
- `STAGE_SLACK` against `RELOAD_DEADLINE_SLACK`: the doc already cross-references them. Different deadlines, and sharing one means a reload tune silently retunes boot
- fds.rs `keep_raw_across_exec` and `close_raw_after_exec`: a closure helper nets 2 lines at the exec boundary
- limits `retain` collecting breaches inside its predicate: the comment says it is summed and self-disarmed in one locked section, and splitting adds a second traversal under that lock

Verified:

- `cargo test -p shep-daemon --lib --bins`: 959 passed, down from 961 by exactly the 2 deletions
- `cargo test -p shep-daemon --doc`: 3 passed
- `cargo clippy -p shep-daemon --all-targets`: clean. Ran `--all-targets` rather than `--lib --bins` because nearly every edit is test code, and it caught 2 unused imports the narrower shape would have missed
- `cargo fmt --all --check`: clean

No workspace gate and no cross-target checks, so CI is the first look at Linux and Windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
