### PR TITLE
refactor(core): DRY and code-smell fixes from the qwen audit, group D

### DIFF
--- a/crates/shep-core/src/atomic_file.rs
+++ b/crates/shep-core/src/atomic_file.rs
@@ -66,6 +66,16 @@ pub fn create_staging_file(
     builder.tempfile_in(parent)
 }
 
+/// The directory `path` lives in, or the current directory when `path` is a
+/// bare filename.
+///
+/// Every store under `$SHEP_HOME` stages, locks and publishes beside the
+/// file it is replacing, so all of them need this same fallback; written out
+/// separately at each site it is a decision four callers can disagree about.
+pub(crate) fn parent_of(path: &Path) -> &Path {
+    path.parent().unwrap_or_else(|| Path::new("."))
+}
+
 // `sync_all` on the staged file flushes its contents; the rename's
 // directory entry is a separate change to the parent directory, which
 // this flushes. Only an unclean shutdown can lose an entry a completed
@@ -112,7 +122,7 @@ pub fn publish(tmp: tempfile::NamedTempFile, path: &Path) -> std::io::Result<()>
     // inside the error and its `Drop` removes the staging file, so a failed
     // replace does not leave one behind.
     tmp.persist(path).map_err(|err| err.error)?;
-    sync_dir(path.parent().unwrap_or_else(|| Path::new(".")))
+    sync_dir(parent_of(path))
 }
 
 /// Replaces `path` with `value` as pretty-printed JSON and one trailing
@@ -132,8 +142,7 @@ where
 {
     use std::io::Write as _;
 
-    let parent = path.parent().unwrap_or_else(|| Path::new("."));
-    let mut tmp = create_staging_file(parent, prefix, ".tmp")?;
+    let mut tmp = create_staging_file(parent_of(path), prefix, ".tmp")?;
 
     let json = serde_json::to_string_pretty(value).map_err(std::io::Error::other)?;
     tmp.write_all(json.as_bytes())?;

--- a/crates/shep-core/src/barks.rs
+++ b/crates/shep-core/src/barks.rs
@@ -154,14 +154,10 @@ pub fn append(path: &Path, bark: &Bark, max_bytes: u64) -> Result<(), BarkError>
 /// - [`BarkError::Io`]: the file exists and could not be read. A missing
 ///   file is `Ok(Vec::new())`: no barks yet is not a fault.
 pub fn read(path: &Path) -> Result<Vec<Bark>, BarkError> {
-    match std::fs::read_to_string(path) {
-        Ok(text) => Ok(text
-            .lines()
-            .filter_map(|line| serde_json::from_str(line).ok())
-            .collect()),
-        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(Vec::new()),
-        Err(err) => Err(BarkError::Io(err)),
-    }
+    Ok(read_text(path)?
+        .lines()
+        .filter_map(|line| serde_json::from_str(line).ok())
+        .collect())
 }
 
 /// `path`'s existing lines, raw and unparsed, or an empty ring if the
@@ -172,9 +168,18 @@ pub fn read(path: &Path) -> Result<Vec<Bark>, BarkError> {
 /// left, still counts toward the byte cap and survives an eviction it
 /// does not trigger. [`read`] is where an unparseable line is dropped.
 fn read_lines(path: &Path) -> Result<Vec<String>, BarkError> {
+    Ok(read_text(path)?.lines().map(str::to_owned).collect())
+}
+
+/// `path`'s bytes, or an empty string if the file is not there yet.
+///
+/// A ring nobody has written to is an empty ring, not a fault, and both
+/// readers above want exactly that reading before they go their separate
+/// ways on what to do with the lines.
+fn read_text(path: &Path) -> Result<String, BarkError> {
     match std::fs::read_to_string(path) {
-        Ok(text) => Ok(text.lines().map(str::to_owned).collect()),
-        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(Vec::new()),
+        Ok(text) => Ok(text),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(String::new()),
         Err(err) => Err(BarkError::Io(err)),
     }
 }

--- a/crates/shep-core/src/barks.rs
+++ b/crates/shep-core/src/barks.rs
@@ -194,7 +194,7 @@ fn ring_bytes(lines: &[String]) -> u64 {
 /// staging file. [`FileLock`] already keeps two appenders apart; this is
 /// the second lock for a caller that reaches `write_ring` another way.
 fn write_ring(path: &Path, lines: &[String]) -> Result<(), BarkError> {
-    let parent = path.parent().unwrap_or_else(|| Path::new("."));
+    let parent = crate::atomic_file::parent_of(path);
     let mut tmp = crate::atomic_file::create_staging_file(parent, "barks", ".tmp")?;
 
     for line in lines {

--- a/crates/shep-core/src/config/apply.rs
+++ b/crates/shep-core/src/config/apply.rs
@@ -183,12 +183,19 @@ mod tests {
     /// fails if any AppConfig field is missing from the table. A field added
     /// to the struct without a group would route as its default and either
     /// apply live when it cannot, or need a restart when it does not.
-    #[test]
-    fn every_appconfig_field_has_a_group() {
+    /// The field names `AppConfig` serializes, which is what both tests
+    /// below mean by "every field".
+    fn appconfig_fields() -> serde_json::Map<String, serde_json::Value> {
         let serde_json::Value::Object(fields) = serde_json::to_value(AppConfig::default()).unwrap()
         else {
             panic!("AppConfig must serialize as an object");
         };
+        fields
+    }
+
+    #[test]
+    fn every_appconfig_field_has_a_group() {
+        let fields = appconfig_fields();
         let missing: Vec<&String> = fields.keys().filter(|k| !is_classified(k)).collect();
         assert!(
             missing.is_empty(),
@@ -223,10 +230,7 @@ mod tests {
     /// fails if the split drifts from what the spec recorded.
     #[test]
     fn the_split_is_nineteen_five_fifteen_three() {
-        let serde_json::Value::Object(fields) = serde_json::to_value(AppConfig::default()).unwrap()
-        else {
-            panic!("AppConfig must serialize as an object");
-        };
+        let fields = appconfig_fields();
         let count = |want: ApplyGroup| fields.keys().filter(|k| apply_group(k) == want).count();
         assert_eq!(count(ApplyGroup::Live), 19, "Live");
         assert_eq!(count(ApplyGroup::NextSpawn), 5, "NextSpawn");

--- a/crates/shep-core/src/config/flockfile.rs
+++ b/crates/shep-core/src/config/flockfile.rs
@@ -217,19 +217,9 @@ impl Flockfile {
     /// - [`FlockfileError::NoApps`]: parsed fine but declared no apps.
     /// - [`FlockfileError::UnknownKeys`]: named a key no field claims.
     pub fn parse(source: &str, format: FlockFormat) -> Result<Self, FlockfileError> {
-        let raw = parse_raw_denying_unknown(source, format)?;
-        let RawFlockfile {
-            schema: _schema,
-            // Discarded by name. Whatever a dog wrote under `[dog]` is that
-            // dog's to read out of the file itself; shep only had to stop
-            // refusing the document for containing it.
-            dog: _dog,
-            apps,
-        } = raw;
-        if apps.is_empty() {
-            return Err(FlockfileError::NoApps);
-        }
-        Ok(Self { apps })
+        Ok(Self {
+            apps: parse_nonempty_apps(source, format)?,
+        })
     }
 
     /// Parses `text` and reports, per app, which keys the document wrote.
@@ -249,15 +239,7 @@ impl Flockfile {
         // Same reasoning as `Flockfile::parse`: this reads a Flockfile off
         // disk (the reload/muster path in shep-cli), not a value off the
         // wire, so a typo here must still be loud.
-        let raw = parse_raw_denying_unknown(text, format)?;
-        let RawFlockfile {
-            schema: _schema,
-            dog: _dog,
-            apps,
-        } = raw;
-        if apps.is_empty() {
-            return Err(FlockfileError::NoApps);
-        }
+        let apps = parse_nonempty_apps(text, format)?;
 
         // A document that reached this point already parsed successfully
         // into `RawFlockfile` above, so the same source deserializing into a
@@ -291,6 +273,31 @@ impl Flockfile {
             })
             .collect())
     }
+}
+
+/// The apps a Flockfile declares, refusing a document that declares none.
+///
+/// Both public entry points start here. The top-level fields that are not
+/// apps are discarded by name, so the next one to arrive — `$schema` and
+/// `dog` both came in this way, and `deny_unknown_fields` means the next one
+/// must too — is a change to `RawFlockfile` and to this destructure, rather
+/// than to two callers that have to stay in step.
+fn parse_nonempty_apps(
+    source: &str,
+    format: FlockFormat,
+) -> Result<Vec<AppConfig>, FlockfileError> {
+    let RawFlockfile {
+        schema: _schema,
+        // Discarded by name. Whatever a dog wrote under `[dog]` is that
+        // dog's to read out of the file itself; shep only had to stop
+        // refusing the document for containing it.
+        dog: _dog,
+        apps,
+    } = parse_raw_denying_unknown(source, format)?;
+    if apps.is_empty() {
+        return Err(FlockfileError::NoApps);
+    }
+    Ok(apps)
 }
 
 // Shared by `Flockfile::parse` and `parse_declared`: both read a Flockfile

--- a/crates/shep-core/src/config/graph.rs
+++ b/crates/shep-core/src/config/graph.rs
@@ -637,6 +637,23 @@ mod tests {
         assert_eq!(out.stages, vec![vec!["a", "b"], vec!["x"], vec!["y"]]);
     }
 
+    /// Every stage is non-empty and internally sorted, the shape both
+    /// proptests below check before going on to their own invariant.
+    ///
+    /// Returns rather than asserts: `prop_assert!` expands to an early
+    /// return of a `TestCaseError`, which is what lets a failure shrink.
+    fn stages_are_well_formed(
+        stages: &[Vec<String>],
+    ) -> Result<(), proptest::test_runner::TestCaseError> {
+        for stage in stages {
+            proptest::prop_assert!(!stage.is_empty(), "an empty stage: {:?}", stages);
+            let mut sorted = stage.clone();
+            sorted.sort();
+            proptest::prop_assert_eq!(stage, &sorted, "an unsorted stage: {:?}", stages);
+        }
+        Ok(())
+    }
+
     proptest::proptest! {
         #[test]
         fn every_edge_is_respected_in_the_planned_order(
@@ -660,12 +677,7 @@ mod tests {
                 .collect();
             let out = plan(&nodes);
             proptest::prop_assert!(out.cycles.is_empty());
-            for stage in &out.stages {
-                proptest::prop_assert!(!stage.is_empty(), "an empty stage: {:?}", out.stages);
-                let mut sorted = stage.clone();
-                sorted.sort();
-                proptest::prop_assert_eq!(stage, &sorted, "an unsorted stage: {:?}", out.stages);
-            }
+            stages_are_well_formed(&out.stages)?;
             let mut stage_of = std::collections::BTreeMap::new();
             for (index, stage) in out.stages.iter().enumerate() {
                 for name in stage {
@@ -720,12 +732,7 @@ mod tests {
                 .collect();
             let out = plan(&nodes);
 
-            for stage in &out.stages {
-                proptest::prop_assert!(!stage.is_empty(), "an empty stage: {:?}", out.stages);
-                let mut sorted = stage.clone();
-                sorted.sort();
-                proptest::prop_assert_eq!(stage, &sorted, "an unsorted stage: {:?}", out.stages);
-            }
+            stages_are_well_formed(&out.stages)?;
 
             // Determinism against input order: planning the same nodes in a
             // different order must produce the identical plan. The reorder

--- a/crates/shep-core/src/config/scaffold.rs
+++ b/crates/shep-core/src/config/scaffold.rs
@@ -136,6 +136,13 @@ struct Syntax {
     trailing_sep: bool,
     /// Whether field names are quoted.
     quoted_keys: bool,
+    /// Whether a field's value is rendered by `toml::Value`'s `Display`
+    /// rather than by `serde_json`.
+    ///
+    /// TOML is the only format that needs it, and it is asked here rather
+    /// than inferred from another field: reading it off `separator` made a
+    /// cosmetic choice decide which serializer runs.
+    toml_literals: bool,
 }
 
 impl Syntax {
@@ -153,6 +160,7 @@ impl Syntax {
                 member_sep: "",
                 trailing_sep: false,
                 quoted_keys: false,
+                toml_literals: true,
             },
             // The lone `-` works because a sequence item whose value is a
             // block mapping on the following lines is valid YAML, so the
@@ -167,6 +175,7 @@ impl Syntax {
                 member_sep: "",
                 trailing_sep: false,
                 quoted_keys: false,
+                toml_literals: false,
             },
             FlockFormat::Json5 => Self {
                 marker: Some("//"),
@@ -178,6 +187,7 @@ impl Syntax {
                 member_sep: ",",
                 trailing_sep: true,
                 quoted_keys: false,
+                toml_literals: false,
             },
             FlockFormat::Json => Self {
                 marker: None,
@@ -189,6 +199,7 @@ impl Syntax {
                 member_sep: ",",
                 trailing_sep: false,
                 quoted_keys: true,
+                toml_literals: false,
             },
         }
     }
@@ -232,10 +243,15 @@ impl Scaffold {
     /// The field names this scaffold shows, in the order it shows them.
     fn field_names(self) -> Vec<String> {
         match self.depth {
-            Depth::Curated => CURATED.iter().map(|name| (*name).to_owned()).collect(),
+            Depth::Curated => curated_names(),
             Depth::All => grouped_order(),
         }
     }
+}
+
+/// [`CURATED`] as owned strings, the form both callers below want.
+fn curated_names() -> Vec<String> {
+    CURATED.iter().map(|name| (*name).to_owned()).collect()
 }
 
 /// Every field name: the curated four first, then the rest by
@@ -269,7 +285,7 @@ fn grouped_order() -> Vec<String> {
         .collect();
     rest.sort_by_key(|name| rank(name));
 
-    let mut names: Vec<String> = CURATED.iter().map(|name| (*name).to_owned()).collect();
+    let mut names: Vec<String> = curated_names();
     names.extend(rest);
     names
 }
@@ -419,7 +435,7 @@ fn literal(syntax: &Syntax, field: &serde_json::Value) -> String {
     // rendering serves three of the four formats. TOML is the odd one:
     // `toml::Value`'s Display is what knows to write an array inline and a
     // string with TOML's own escaping.
-    if syntax.separator == " = " {
+    if syntax.toml_literals {
         toml::Value::try_from(&value)
             .expect("a schema example must be representable as TOML")
             .to_string()

--- a/crates/shep-core/src/config/template.rs
+++ b/crates/shep-core/src/config/template.rs
@@ -298,6 +298,21 @@ pub(crate) fn validate(value: &str) -> Result<(), TemplateError> {
     }
 }
 
+/// The text a token that both renderers resolve identically expands to, or
+/// `None` for a token neither knows positionally.
+///
+/// The two positional tokens live here rather than in each renderer's match:
+/// a third one added to only one of them would make a value render one way
+/// under `render_positional` and another under `render`, which is not a
+/// difference either caller could see coming.
+fn positional<'a>(token: &str, name: &'a str, slot: &'a str) -> Option<&'a str> {
+    match token {
+        "instance" => Some(slot),
+        "name" => Some(name),
+        _ => None,
+    }
+}
+
 /// Substitutes `{{instance}}` and `{{name}}` only, leaving every other
 /// token, `{{secret:...}}` included, exactly as written.
 ///
@@ -314,9 +329,10 @@ pub fn render_positional(value: &str, name: &str, instance: u32) -> String {
     let _: Result<Completion, Infallible> = walk(value, |segment| {
         match segment {
             Segment::Literal(literal) => out.push_str(literal),
-            Segment::Token("instance") => out.push_str(&slot),
-            Segment::Token("name") => out.push_str(name),
-            Segment::Token(token) => push_token(&mut out, token),
+            Segment::Token(token) => match positional(token, name, &slot) {
+                Some(text) => out.push_str(text),
+                None => push_token(&mut out, token),
+            },
         }
         Ok(())
     });
@@ -348,11 +364,12 @@ pub fn render(
     walk(value, |segment| {
         match segment {
             Segment::Literal(literal) => out.push_str(literal),
-            Segment::Token("instance") => out.push_str(&slot),
-            Segment::Token("name") => out.push_str(name),
-            Segment::Token(token) => match secret_reference(token) {
-                Some(reference) => out.push_str(resolve_secret(&reference, secrets)?),
-                None => push_token(&mut out, token),
+            Segment::Token(token) => match positional(token, name, &slot) {
+                Some(text) => out.push_str(text),
+                None => match secret_reference(token) {
+                    Some(reference) => out.push_str(resolve_secret(&reference, secrets)?),
+                    None => push_token(&mut out, token),
+                },
             },
         }
         Ok(())

--- a/crates/shep-core/src/file_lock.rs
+++ b/crates/shep-core/src/file_lock.rs
@@ -129,7 +129,7 @@ fn lock_path(path: &Path) -> PathBuf {
         .map(std::ffi::OsStr::to_os_string)
         .unwrap_or_default();
     name.push(".lock");
-    path.parent().unwrap_or_else(|| Path::new(".")).join(name)
+    crate::atomic_file::parent_of(path).join(name)
 }
 
 #[cfg(test)]

--- a/crates/shep-core/src/protocol/events.rs
+++ b/crates/shep-core/src/protocol/events.rs
@@ -394,30 +394,13 @@ mod tests {
         ] {
             let event = BusEvent::Process {
                 event: kind,
-                info: ProcessInfo {
-                    id: 3,
-                    name: "web".to_string(),
-                    status: ProcStatus::Stopping,
-                    pid: Some(4242),
-                    restarts: 0,
-                    uptime_ms: 0,
-                    fold: None,
-                    depends_on: Vec::new(),
-                    out_file: None,
-                    err_file: None,
-                    cpu_percent: None,
-                    memory_bytes: None,
-                    dog: None,
-                    lambs: None,
-                    last_exit: None,
-                    smit: None,
-                    instance: None,
-                    handshook: None,
-                    dog_stale: None,
-                    pending: None,
-                    overridden: None,
-                    max_memory: None,
-                },
+                // Scaffolding: `topic()` reads only `event`, and nothing
+                // here is asserted. The builder says so; the exhaustive
+                // literal in `bus_event_wire_snapshots` says the opposite
+                // about its own row, deliberately.
+                info: ProcessInfo::builder(3, "web", ProcStatus::Stopping)
+                    .pid(Some(4242))
+                    .build(),
                 manually: true,
                 at_ms: 0,
             };

--- a/crates/shep-core/src/selector.rs
+++ b/crates/shep-core/src/selector.rs
@@ -60,6 +60,20 @@ fn glob_to_regex(input: &str) -> Result<String, SelectorError> {
         .map_or(source.clone(), ToString::to_string))
 }
 
+/// `s` as a `u32`, if every byte of it is an ASCII digit.
+///
+/// The digit check is not redundant beside `parse`: `u32::from_str` accepts
+/// a leading `+`, so `"+5"` would otherwise be an id and `"web:+2"` an
+/// instance slot. Both of the places this grammar reads a number want the
+/// same answer, and `None` means "not a number here", which lets each caller
+/// fall through to the form it tries next.
+fn parse_u32_digits(s: &str) -> Option<u32> {
+    if s.is_empty() || !s.bytes().all(|b| b.is_ascii_digit()) {
+        return None;
+    }
+    s.parse().ok()
+}
+
 impl ProcessSelector {
     /// Parses CLI selector syntax
     ///
@@ -90,9 +104,7 @@ impl ProcessSelector {
                 .map(Self::Regex)
                 .map_err(|e| SelectorError::BadRegex(e.to_string()));
         }
-        if input.bytes().all(|b| b.is_ascii_digit())
-            && let Ok(id) = input.parse()
-        {
+        if let Some(id) = parse_u32_digits(input) {
             return Ok(Self::Id(id));
         }
         if is_glob(input) {
@@ -107,9 +119,7 @@ impl ProcessSelector {
         // cannot cut a name in half.
         if let Some((name, slot)) = input.rsplit_once(':')
             && !name.is_empty()
-            && !slot.is_empty()
-            && slot.bytes().all(|b| b.is_ascii_digit())
-            && let Ok(slot) = slot.parse()
+            && let Some(slot) = parse_u32_digits(slot)
         {
             return Ok(Self::Instance {
                 name: name.to_string(),
@@ -392,6 +402,21 @@ mod tests {
         assert!(matches!(
             ProcessSelector::parse("42").unwrap(),
             ProcessSelector::Id(42)
+        ));
+    }
+
+    #[test]
+    fn a_signed_number_is_a_name_at_both_sites_that_read_one() {
+        // `u32::from_str` accepts a leading `+`, so without the digit check
+        // in `parse_u32_digits` these would be an id and an instance slot.
+        // Both readers share that check, so both stay names.
+        assert!(matches!(
+            ProcessSelector::parse("+5").unwrap(),
+            ProcessSelector::Name(name) if name == "+5"
+        ));
+        assert!(matches!(
+            ProcessSelector::parse("web:+2").unwrap(),
+            ProcessSelector::Name(name) if name == "web:+2"
         ));
     }
 

--- a/crates/shep-core/src/transport.rs
+++ b/crates/shep-core/src/transport.rs
@@ -240,6 +240,22 @@ impl Listener {
         self.listener.as_raw_fd()
     }
 
+    /// A fresh idle instance on this listener's pipe name.
+    ///
+    /// `first_pipe_instance` stays unset, unlike at `bind`: setting it again
+    /// would refuse to recreate this listener's own instance. Both of
+    /// [`Self::accept`]'s creations want exactly this instance and differ
+    /// only in what they do with a failure, so the options are written once.
+    ///
+    /// # Errors
+    /// Whatever `CreateNamedPipe` says.
+    #[cfg(windows)]
+    fn create_instance(&self) -> io::Result<tokio::net::windows::named_pipe::NamedPipeServer> {
+        tokio::net::windows::named_pipe::ServerOptions::new()
+            .reject_remote_clients(true)
+            .create(&self.addr)
+    }
+
     /// Waits for the next peer and returns its connected stream.
     ///
     /// # Errors
@@ -259,17 +275,12 @@ impl Listener {
         }
         #[cfg(windows)]
         {
-            use tokio::net::windows::named_pipe::ServerOptions;
             // The slot is empty only if a previous accept could not create
             // a replacement. Make one now rather than at that failure, so a
             // transient `create` error costs one accept instead of the
             // daemon's whole ability to serve.
             if self.server.is_none() {
-                self.server = Some(
-                    ServerOptions::new()
-                        .reject_remote_clients(true)
-                        .create(&self.addr)?,
-                );
+                self.server = Some(self.create_instance()?);
             }
             // Resolves when a client attaches to the instance we hold.
             let Some(server) = self.server.as_ref() else {
@@ -283,14 +294,9 @@ impl Listener {
                 .server
                 .take()
                 .unwrap_or_else(|| unreachable!("the slot was just filled"));
-            // `first_pipe_instance` stays unset here: set once at `bind`,
-            // setting it again would refuse to recreate this listener's
-            // own instance. A failure here leaves the slot empty (peer
-            // already handed over); the next accept retries creation.
-            self.server = ServerOptions::new()
-                .reject_remote_clients(true)
-                .create(&self.addr)
-                .ok();
+            // A failure here leaves the slot empty (the peer is already
+            // handed over); the next accept retries the creation.
+            self.server = self.create_instance().ok();
             Ok(connected)
         }
     }

--- a/crates/shep-core/src/values.rs
+++ b/crates/shep-core/src/values.rs
@@ -11,6 +11,13 @@ const KIB: u64 = 1024;
 const MIB: u64 = 1024 * KIB;
 const GIB: u64 = 1024 * MIB;
 
+// Milliseconds per unit of the Flockfile grammar `^\d+(ms|h|m|s)?$`, the
+// same way the binary units above are written: a definition each, so the
+// parser and the formatter cannot drift apart on one of them.
+const MS_PER_S: u64 = 1_000;
+const MS_PER_MIN: u64 = 60 * MS_PER_S;
+const MS_PER_H: u64 = 60 * MS_PER_MIN;
+
 /// A memory quantity in bytes, used for memory-limit thresholds
 ///
 /// Parses the Flockfile grammar `^\d+(G|M|K)?$` (binary units; plain digits
@@ -250,9 +257,9 @@ impl FromStr for UpDuration {
             (rest, 1)
         } else {
             match s.as_bytes()[s.len() - 1] {
-                b'h' => (&s[..s.len() - 1], 3_600_000),
-                b'm' => (&s[..s.len() - 1], 60_000),
-                b's' => (&s[..s.len() - 1], 1_000),
+                b'h' => (&s[..s.len() - 1], MS_PER_H),
+                b'm' => (&s[..s.len() - 1], MS_PER_MIN),
+                b's' => (&s[..s.len() - 1], MS_PER_S),
                 _ => (s, 1),
             }
         };
@@ -276,9 +283,9 @@ impl fmt::Display for UpDuration {
         let ms = self.as_millis();
         match ms {
             0 => f.write_str("0"),
-            v if v % 3_600_000 == 0 => write!(f, "{}h", v / 3_600_000),
-            v if v % 60_000 == 0 => write!(f, "{}m", v / 60_000),
-            v if v % 1_000 == 0 => write!(f, "{}s", v / 1_000),
+            v if v % MS_PER_H == 0 => write!(f, "{}h", v / MS_PER_H),
+            v if v % MS_PER_MIN == 0 => write!(f, "{}m", v / MS_PER_MIN),
+            v if v % MS_PER_S == 0 => write!(f, "{}s", v / MS_PER_S),
             v => write!(f, "{v}"),
         }
     }


### PR DESCRIPTION
Work group D from the qwen audit plan, 20 findings across shep-core. Verified each against the code first, and twelve of them are fixed here.

- `atomic_file::parent_of` for four copies of `path.parent().unwrap_or_else(|| Path::new("."))`
- `barks::read_text` shared by `read` and `read_lines`
- `MS_PER_S`/`MS_PER_MIN`/`MS_PER_H` in `values.rs`, matching the existing `KIB`/`MIB`/`GIB`
- `parse_u32_digits` in `selector.rs`, plus a test pinning `+5` and `web:+2` as names
- `Listener::create_instance` for the Windows pipe options
- `parse_nonempty_apps` in `flockfile.rs`, so a new top-level key edits one destructure
- `positional` in `template.rs`, so both renderers agree on `{{instance}}` and `{{name}}`
- `Syntax.toml_literals` replacing `separator == " = "` as the "is this TOML" test
- shared fixtures in `apply.rs`, `graph.rs` and `events.rs`

The other eight have their reasons in the commit messages. Two worth naming: `FlockfileError`'s four per-format variants are real duplication but public, so collapsing them is a breaking change. The 21-field `ProcessInfo` literals in `bus_event_wire_snapshots` and `frame.rs` stay literals, because a new field has to break a wire fixture.

Found one real bug and left it. `parse_tcp` doesn't trim its target but `parse_http` does, so `"  db:5432"` is `InvalidHost` while `"  http://host/  "` parses. Fixing it widens the TCP grammar, so it needs a decision rather than a patch.

`cargo test -p shep-core --lib --bins` does not compile `config/scaffold.rs`. It's behind the default-off `schema` feature, and 15 tests go with it. Ran everything with `--all-features`.

Gates: 492 lib tests, 6 doctests, clippy `-D warnings`, `cargo fmt --check`, and `cargo check --target x86_64-pc-windows-gnu` for the Windows code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
