### PR TITLE
refactor(core): export the Flockfile discovery order

### DIFF
--- a/crates/shep-cli/src/commands/runtime.rs
+++ b/crates/shep-cli/src/commands/runtime.rs
@@ -5,7 +5,7 @@
 
 use std::path::PathBuf;
 
-use shep_core::config::discover;
+use shep_core::config::{DISCOVERY_ORDER, discover};
 use shep_core::paths::ShepPaths;
 
 use crate::cli::RuntimeArgs;
@@ -15,14 +15,6 @@ use crate::commands::lifecycle::{resolve_target, target_exit_code};
 use crate::commands::reap;
 use crate::exit::ExitCode;
 use crate::output::Streams;
-
-/// The ten filenames [`discover`] looks for, in the order it looks
-///
-/// Spelled out because `shep_core::config::flockfile::DISCOVERY_ORDER` is
-/// private.
-const DISCOVERY_NAMES: &str = "Flockfile.toml, Flockfile.yaml, Flockfile.yml, Flockfile.json, \
-     Flockfile.json5, flockfile.toml, flockfile.yaml, flockfile.yml, flockfile.json, \
-     flockfile.json5";
 
 /// Runs `shep runtime`
 ///
@@ -86,8 +78,9 @@ pub(crate) fn discovered_target(streams: &mut Streams<'_>) -> Result<String, Exi
         Some(path) => Ok(path.to_string_lossy().into_owned()),
         None => {
             let message = format!(
-                "no Flockfile found in {} (looked for {DISCOVERY_NAMES})",
-                cwd.display()
+                "no Flockfile found in {} (looked for {})",
+                cwd.display(),
+                DISCOVERY_ORDER.join(", ")
             );
             Err(streams.fail(ExitCode::Usage, &message))
         }

--- a/crates/shep-core/src/config/flockfile.rs
+++ b/crates/shep-core/src/config/flockfile.rs
@@ -444,7 +444,8 @@ fn json5_nesting_depth(source: &str) -> u32 {
     max_depth
 }
 
-const DISCOVERY_ORDER: [&str; 10] = [
+/// The filenames [`discover`] looks for, in the order it looks (spec §5)
+pub const DISCOVERY_ORDER: &[&str] = &[
     "Flockfile.toml",
     "Flockfile.yaml",
     "Flockfile.yml",

--- a/crates/shep-core/src/config/mod.rs
+++ b/crates/shep-core/src/config/mod.rs
@@ -20,7 +20,9 @@ pub use apply::{ApplyGroup, ResetDepth, apply_group};
 pub use cron::{CronParseError, CronSchedule, CronScheduleError};
 pub use daemon::{DaemonConfig, DaemonConfigError, DaemonOverrides, LogLevel, parse_daemon_bool};
 pub use dogs::{DogsConfig, DogsConfigError};
-pub use flockfile::{DeclaredApp, FlockFormat, Flockfile, FlockfileError, discover};
+pub use flockfile::{
+    DISCOVERY_ORDER, DeclaredApp, FlockFormat, Flockfile, FlockfileError, discover,
+};
 #[cfg(feature = "schema")]
 pub use flockfile::{flockfile_schema_json, flockfile_schema_string};
 pub use graph::{BootNode, BootPlan, NodeKind, Unresolved, plan, render_cycle};


### PR DESCRIPTION
`shep runtime`'s "no Flockfile found" error listed the ten discovery filenames from its own copy of the list, because `DISCOVERY_ORDER` was private in shep-core. The two agreed, so nothing was broken: add or rename a filename in shep-core and the CLI's error would go wrong with nothing failing.

- `DISCOVERY_ORDER` is now `pub const DISCOVERY_ORDER: &[&str]`, re-exported from `shep_core::config`
- A slice rather than `[&str; 10]`, so an eleventh name is not a type change for a caller
- `runtime.rs` joins it with `", "` and `DISCOVERY_NAMES` is gone. Message text is identical, so nothing in `web/` needs regenerating
- Still hand-written: the same ten names in `web/src/pages/docs/first-flockfile.astro:275`. Correct today, and no generator reaches into an Astro code block

481 shep-core tests, 1658 shep tests, clippy and fmt clean.
