### PR TITLE
docs(cli): point SecretDelete's doc comment at Remove

### DIFF
--- a/crates/shep-cli/src/lookout/app.rs
+++ b/crates/shep-cli/src/lookout/app.rs
@@ -191,7 +191,7 @@ pub enum KeyPress {
     /// tab's environment, in the secrets pane. `Enter` confirms.
     ///
     /// Capital, and `d` is left alone: `d` is already
-    /// [`Self::ListRemove`], and `map_key` dispatches on mode rather than
+    /// [`Self::Remove`], and `map_key` dispatches on mode rather than
     /// pane, so the two cannot share a key.
     SecretDelete,
     /// `Tab`: moves the config pane's focus to the next group.


### PR DESCRIPTION
- `KeyPress::SecretDelete`'s doc comment linked `Self::ListRemove`, which #206 renamed to `Self::Remove`
- The point it makes survives the rename: `d` maps to `Remove`, `D` to `SecretDelete`, and `map_key` takes an `InputMode` rather than a pane, so the two still cannot share a key. Only the link target changed
- Nothing else in the workspace names `ListRemove`. The remaining hits are in the plan and spec docs that record the rename
- No check caught this: `mod lookout;` is private, so rustdoc never documents `KeyPress` and the docs job had no broken link warning to promote

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Corrected a keyboard shortcut documentation reference to point to the appropriate removal action.
  - No user-facing behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->