### PR TITLE
fix(daemon): pass PYTHONUTF8/PYTHONIOENCODING through on Windows

### DIFF
--- a/crates/shep-daemon/src/assemble.rs
+++ b/crates/shep-daemon/src/assemble.rs
@@ -112,12 +112,14 @@ const INHERITED_UNIX: &[&str] = &["HOME", "USER", "LANG", "TZ"];
 /// non-console stdio handle (a pipe, which is what every spawned child gets)
 /// makes CPython on Windows fall back to the legacy ANSI code page for
 /// `sys.stdout`/`sys.stderr`, and any non-ASCII byte an app prints then
-/// raises `UnicodeEncodeError`. Neither variable has a unix equivalent to
-/// piggyback on: `LANG` on unix already carries a UTF-8 locale through, but
-/// Windows has nothing that plays the same role for a child's stdio
-/// encoding. Setting either in the daemon's own environment now reaches
-/// every spawned app; an app can still set them itself, per-app, in its
-/// Flockfile `env`.
+/// raises `UnicodeEncodeError`. Neither has a unix equivalent to piggyback
+/// on. `LANG` is what decides a child's stdio encoding there and
+/// [`INHERITED_UNIX`] forwards it, which is not the same as setting one: a
+/// daemon started with no `LANG`, or with one naming a non-UTF-8 locale,
+/// hands that to its children. Windows has no variable in that role to
+/// forward at all. Setting either in the daemon's own environment now
+/// reaches every spawned app; an app can still set them itself, per-app, in
+/// its Flockfile `env`.
 const INHERITED_WINDOWS: &[&str] = &[
     "SystemRoot",
     "windir",

--- a/crates/shep-daemon/src/assemble.rs
+++ b/crates/shep-daemon/src/assemble.rs
@@ -110,9 +110,11 @@ const INHERITED_UNIX: &[&str] = &["HOME", "USER", "LANG", "TZ"];
 ///
 /// `PYTHONUTF8`/`PYTHONIOENCODING` are here for one specific failure: a
 /// non-console stdio handle (a pipe, which is what every spawned child gets)
-/// makes CPython on Windows fall back to the legacy ANSI code page for
-/// `sys.stdout`/`sys.stderr`, and any non-ASCII byte an app prints then
-/// raises `UnicodeEncodeError`. Neither has a unix equivalent to piggyback
+/// makes CPython up to 3.14 fall back to the legacy ANSI code page for
+/// `sys.stdout`/`sys.stderr` on Windows, and any non-ASCII byte an app prints
+/// then raises `UnicodeEncodeError`. CPython 3.15 turns UTF-8 mode on by
+/// default (PEP 686), so these two matter for an older interpreter and for
+/// anything that sets `PYTHONUTF8=0`. Neither has a unix equivalent to piggyback
 /// on. `LANG` is what decides a child's stdio encoding there and
 /// [`INHERITED_UNIX`] forwards it, which is not the same as setting one: a
 /// daemon started with no `LANG`, or with one naming a non-UTF-8 locale,

--- a/crates/shep-daemon/src/assemble.rs
+++ b/crates/shep-daemon/src/assemble.rs
@@ -102,6 +102,17 @@ const INHERITED: &[&str] = &["HOME", "USER", "LANG", "TZ"];
 /// resolve and run `.cmd` files at all. `TEMP`/`TMP` and the
 /// `USERPROFILE`/`APPDATA`/`LOCALAPPDATA` trio are where most runtimes keep
 /// per-user state. Still a closed allowlist, not inherit-everything.
+///
+/// `PYTHONUTF8`/`PYTHONIOENCODING` are here for one specific failure: a
+/// non-console stdio handle (a pipe, which is what every spawned child gets)
+/// makes CPython on Windows fall back to the legacy ANSI code page for
+/// `sys.stdout`/`sys.stderr`, and any non-ASCII byte an app prints then
+/// raises `UnicodeEncodeError`. Neither variable has a unix equivalent to
+/// piggyback on: `LANG` on unix already carries a UTF-8 locale through, but
+/// Windows has nothing that plays the same role for a child's stdio
+/// encoding. Setting either in the daemon's own environment now reaches
+/// every spawned app; an app can still set them itself, per-app, in its
+/// Flockfile `env`.
 #[cfg(windows)]
 const INHERITED: &[&str] = &[
     "SystemRoot",
@@ -121,6 +132,8 @@ const INHERITED: &[&str] = &[
     "OS",
     "LANG",
     "TZ",
+    "PYTHONUTF8",
+    "PYTHONIOENCODING",
 ];
 
 /// Which of an app's fields carried a `{{secret:...}}` that would not
@@ -650,6 +663,18 @@ mod tests {
             !path.is_empty(),
             "an empty PATH is exactly the ENOENT failure mode"
         );
+    }
+
+    // Pins list membership rather than mutating process env: base_env()
+    // reads std::env::var directly (no injectable seam, unlike
+    // DaemonConfig::load's env closure), and mutating real process env
+    // from a test is both unsound to do concurrently and, since edition
+    // 2024, `unsafe` to call at all.
+    #[cfg(windows)]
+    #[test]
+    fn windows_inherits_the_stdio_encoding_vars() {
+        assert!(INHERITED.contains(&"PYTHONUTF8"));
+        assert!(INHERITED.contains(&"PYTHONIOENCODING"));
     }
 
     #[test]

--- a/crates/shep-daemon/src/assemble.rs
+++ b/crates/shep-daemon/src/assemble.rs
@@ -58,24 +58,30 @@ pub fn instance_slots(existing: &[u32], count: u32) -> Vec<u32> {
 }
 
 /// The env every spawned child starts from, before the app's own `env` map
-/// is folded on top (app config always wins on conflict).
+/// is folded on top (app config always wins on conflict), plus `PATH`:
+/// without one, a bare program or interpreter name can never be found by
+/// exec, so it's seeded unconditionally rather than left to `keys`.
 ///
-/// Without a `PATH` here, a bare program or interpreter name can never be
-/// found by exec. Reads the daemon's own environment once, so this stays a
-/// pure function of process state, not I/O.
-fn base_env() -> BTreeMap<String, String> {
+/// [`build`] calls this with the platform-selected [`INHERITED`] and a
+/// `std::env::var` reader; a test can pass [`INHERITED_WINDOWS`] and a fake
+/// reader instead, on any host, without touching real process env.
+/// Mutating that from a test is unsound under a parallel test binary, and
+/// `std::env::set_var` is itself `unsafe` since edition 2024.
+fn inherited_env(
+    keys: &[&str],
+    env_reader: &dyn Fn(&str) -> Option<String>,
+) -> BTreeMap<String, String> {
     let mut env = BTreeMap::new();
-    // An empty PATH ("PATH=") is treated as absent: `Ok("")` would
+    // An empty PATH ("PATH=") is treated as absent: `Some("")` would
     // otherwise slip through `unwrap_or_else`, and an empty PATH resolves a
     // bare program against the cwd instead of searching.
-    let path = std::env::var("PATH")
-        .ok()
+    let path = env_reader("PATH")
         .filter(|value| !value.is_empty())
         .unwrap_or_else(|| DEFAULT_PATH.to_string());
     env.insert("PATH".to_string(), path);
-    for key in INHERITED {
-        if let Ok(value) = std::env::var(key) {
-            env.insert(key.to_string(), value);
+    for key in keys {
+        if let Some(value) = env_reader(key) {
+            env.insert((*key).to_string(), value);
         }
     }
     env
@@ -92,8 +98,7 @@ const DEFAULT_PATH: &str = "/usr/local/bin:/usr/bin:/bin";
 const DEFAULT_PATH: &str = r"C:\Windows\system32;C:\Windows;C:\Windows\System32\Wbem";
 
 /// Variables inherited from the daemon's own environment, on top of `PATH`.
-#[cfg(unix)]
-const INHERITED: &[&str] = &["HOME", "USER", "LANG", "TZ"];
+const INHERITED_UNIX: &[&str] = &["HOME", "USER", "LANG", "TZ"];
 
 /// Variables inherited from the daemon's own environment, on top of `PATH`.
 ///
@@ -113,8 +118,7 @@ const INHERITED: &[&str] = &["HOME", "USER", "LANG", "TZ"];
 /// encoding. Setting either in the daemon's own environment now reaches
 /// every spawned app; an app can still set them itself, per-app, in its
 /// Flockfile `env`.
-#[cfg(windows)]
-const INHERITED: &[&str] = &[
+const INHERITED_WINDOWS: &[&str] = &[
     "SystemRoot",
     "windir",
     "SystemDrive",
@@ -135,6 +139,19 @@ const INHERITED: &[&str] = &[
     "PYTHONUTF8",
     "PYTHONIOENCODING",
 ];
+
+/// The list [`build`] actually reads on this build. Picked with `cfg!`
+/// rather than `#[cfg(...)]` gating [`INHERITED_UNIX`]/[`INHERITED_WINDOWS`]
+/// themselves: both stay referenced on every target this way, so a test can
+/// run either platform's list (and [`inherited_env`]'s filtering) on any
+/// host, the same way this crate's unit-file renderers are pinned by text
+/// on a Mac without a systemd host, and `-D warnings` never calls the other
+/// platform's list dead code.
+const INHERITED: &[&str] = if cfg!(windows) {
+    INHERITED_WINDOWS
+} else {
+    INHERITED_UNIX
+};
 
 /// Which of an app's fields carried a `{{secret:...}}` that would not
 /// resolve, and why.
@@ -231,6 +248,10 @@ pub fn assemble(
                 }
             })
         },
+        InheritedEnv {
+            keys: INHERITED,
+            reader: &|key: &str| std::env::var(key).ok(),
+        },
     )
 }
 
@@ -273,6 +294,10 @@ pub(crate) fn describe(
             Ok(template::render(value, &name, instance, secrets)
                 .unwrap_or_else(|_| template::render_positional(value, &name, instance)))
         },
+        InheritedEnv {
+            keys: INHERITED,
+            reader: &|key: &str| std::env::var(key).ok(),
+        },
     );
     match built {
         Ok(spec) => spec,
@@ -280,9 +305,18 @@ pub(crate) fn describe(
     }
 }
 
+/// [`inherited_env`]'s two arguments bundled into one: a key list plus a
+/// reader, so [`build`] takes one parameter for this instead of two, and a
+/// test can substitute both without touching real process env.
+struct InheritedEnv<'a> {
+    keys: &'a [&'a str],
+    reader: &'a dyn Fn(&str) -> Option<String>,
+}
+
 /// [`assemble`] and [`describe`] over one body: `render` is handed each
 /// templated value with the field name to blame, and decides what an
-/// unresolvable `{{secret:...}}` costs.
+/// unresolvable `{{secret:...}}` costs. Both callers in this module pass
+/// [`INHERITED`] and a `std::env::var` closure as `inherited`.
 ///
 /// # Errors
 ///
@@ -294,6 +328,7 @@ fn build<E>(
     credentials: Option<Credentials>,
     environment: &str,
     mut render: impl FnMut(&str, &str) -> Result<String, E>,
+    inherited: InheritedEnv<'_>,
 ) -> Result<SpawnSpec, E> {
     let config = app.config();
     let name = config.name.clone();
@@ -318,7 +353,7 @@ fn build<E>(
     // Anything not seeded here is invisible to the child: tokio_runner.rs
     // calls env_clear() then envs(&spec.env). Each value renders through the
     // grammar as it is inserted.
-    let mut env = base_env();
+    let mut env = inherited_env(inherited.keys, inherited.reader);
     for (key, value) in &config.env {
         let value = render(value, key)?;
         env.insert(key.clone(), value);
@@ -665,16 +700,47 @@ mod tests {
         );
     }
 
-    // Pins list membership rather than mutating process env: base_env()
-    // reads std::env::var directly (no injectable seam, unlike
-    // DaemonConfig::load's env closure), and mutating real process env
-    // from a test is both unsound to do concurrently and, since edition
-    // 2024, `unsafe` to call at all.
-    #[cfg(windows)]
+    // Goes through `build`, the function `assemble`/`describe` actually call,
+    // rather than asserting on `INHERITED_WINDOWS.contains(...)` directly: a
+    // list-membership assert would stay green even if `build` stopped
+    // reading its `inherited` argument at all. Passes `INHERITED_WINDOWS`
+    // explicitly so this runs on any host rather than only in CI's Windows
+    // job, the same way this crate's other unit-file renderers are pinned
+    // by text without needing the OS they render for.
     #[test]
-    fn windows_inherits_the_stdio_encoding_vars() {
-        assert!(INHERITED.contains(&"PYTHONUTF8"));
-        assert!(INHERITED.contains(&"PYTHONIOENCODING"));
+    fn windows_stdio_encoding_vars_reach_spec_env() {
+        let app_config = AppConfig {
+            name: "web".to_string(),
+            script: "app.js".to_string(),
+            interpreter: Some("none".to_string()),
+            ..Default::default()
+        };
+        let app = normalize(app_config).unwrap();
+        let fake_env = |key: &str| match key {
+            "PYTHONUTF8" => Some("1".to_string()),
+            "PYTHONIOENCODING" => Some("utf-8".to_string()),
+            _ => None,
+        };
+
+        let spec = build::<Infallible>(
+            &app,
+            0,
+            &test_paths(),
+            None,
+            "production",
+            |value, _field| Ok(value.to_string()),
+            InheritedEnv {
+                keys: INHERITED_WINDOWS,
+                reader: &fake_env,
+            },
+        )
+        .expect("no template in this app can fail to render");
+
+        assert_eq!(spec.env.get("PYTHONUTF8").map(String::as_str), Some("1"));
+        assert_eq!(
+            spec.env.get("PYTHONIOENCODING").map(String::as_str),
+            Some("utf-8")
+        );
     }
 
     #[test]

--- a/web/src/pages/docs/not-built.astro
+++ b/web/src/pages/docs/not-built.astro
@@ -106,12 +106,15 @@ import CodeBlock from "../../components/docs/CodeBlock.astro";
     </p>
     <CodeBlock>{`UnicodeEncodeError: 'charmap' codec can't encode characters in position 5-7: character maps to <undefined>`}</CodeBlock>
     <p>
-      CPython on Windows picks its stdout/stderr encoding by whether a real
-      console is attached. A shepherd-managed process never has one, since
-      its output is a pipe, so CPython falls back to the legacy code page
-      (<code>cp1252</code> on a US/Western install) instead of UTF-8. The
-      app runs fine at a terminal and crashes the moment shep supervises it,
-      the first time it prints anything outside that code page.
+      Up to CPython 3.14, Python on Windows picks its stdout/stderr encoding
+      by whether a real console is attached. A shepherd-managed process never
+      has one, since its output is a pipe, so CPython falls back to the legacy
+      code page (<code>cp1252</code> on a US/Western install) instead of
+      UTF-8. The app runs fine at a terminal and crashes the moment shep
+      supervises it, the first time it prints anything outside that code
+      page. CPython 3.15 turns UTF-8 mode on by default (<a
+      href="https://peps.python.org/pep-0686/">PEP 686</a>), so upgrading
+      fixes it too, unless something sets <code>PYTHONUTF8=0</code>.
     </p>
     <p>
       Two environment variables fix it: <code>PYTHONUTF8=1</code> and{" "}

--- a/web/src/pages/docs/not-built.astro
+++ b/web/src/pages/docs/not-built.astro
@@ -9,6 +9,7 @@
 import DocsLayout from "../../layouts/DocsLayout.astro";
 import ReferencePills from "../../components/docs/ReferencePills.astro";
 import Callout from "../../components/docs/Callout.astro";
+import CodeBlock from "../../components/docs/CodeBlock.astro";
 ---
 
 <DocsLayout
@@ -96,6 +97,33 @@ import Callout from "../../components/docs/Callout.astro";
       <code>%SystemRoot%</code>), and an append-mode handle cannot be
       truncated there, which broke <code>shep start</code>'s autostart
       outright. Neither is visible to a compiler.
+    </p>
+
+    <h3>A Python app can crash on its own output</h3>
+    <p>
+      Not a shep bug, but a real operator report, so it's named here where a
+      search for the error will find it:
+    </p>
+    <CodeBlock>{`UnicodeEncodeError: 'charmap' codec can't encode characters in position 5-7: character maps to <undefined>`}</CodeBlock>
+    <p>
+      CPython on Windows picks its stdout/stderr encoding by whether a real
+      console is attached. A shepherd-managed process never has one, since
+      its output is a pipe, so CPython falls back to the legacy code page
+      (<code>cp1252</code> on a US/Western install) instead of UTF-8. The
+      app runs fine at a terminal and crashes the moment shep supervises it,
+      the first time it prints anything outside that code page.
+    </p>
+    <p>
+      Two environment variables fix it: <code>PYTHONUTF8=1</code> and{" "}
+      <code>PYTHONIOENCODING=utf-8</code>. Set them in the app's own{" "}
+      <code>env</code> to fix that one app. Or set them once in the
+      shepherd's own environment before <code>shep startup</code> or{" "}
+      <code>shep start</code>: they're now on the short list of variables
+      shep passes down to every child on Windows, same as{" "}
+      <code>TEMP</code> or <code>USERPROFILE</code>, so an operator running
+      several Python apps doesn't repeat them per app. Unix needs neither,
+      since <code>LANG</code> already carries a UTF-8 locale through and
+      shep passes that one down too.
     </p>
 
     <h2>Five smaller cuts, argued for rather than just missing</h2>

--- a/web/src/pages/docs/not-built.astro
+++ b/web/src/pages/docs/not-built.astro
@@ -121,9 +121,10 @@ import CodeBlock from "../../components/docs/CodeBlock.astro";
       <code>shep start</code>: they're now on the short list of variables
       shep passes down to every child on Windows, same as{" "}
       <code>TEMP</code> or <code>USERPROFILE</code>, so an operator running
-      several Python apps doesn't repeat them per app. Unix needs neither,
-      since <code>LANG</code> already carries a UTF-8 locale through and
-      shep passes that one down too.
+      several Python apps doesn't repeat them per app. Unix has{" "}
+      <code>LANG</code> in that role and shep passes it down, so a shepherd
+      whose own <code>LANG</code> names a UTF-8 locale gives its children
+      one. Windows has no equivalent to pass.
     </p>
 
     <h2>Five smaller cuts, argued for rather than just missing</h2>


### PR DESCRIPTION
A Python app managed by shep on Windows can crash the moment it prints anything outside the legacy code page: `UnicodeEncodeError: 'charmap' codec can't encode characters in position 5-7: character maps to <undefined>`. CPython picks that legacy encoding for stdout/stderr whenever there's no real console attached, which is always true for a shepherd-managed child. Unix doesn't see this because `LANG` already carries a UTF-8 locale through; Windows has nothing playing that role.

- Adds `PYTHONUTF8` and `PYTHONIOENCODING` to the Windows env allowlist in `crates/shep-daemon/src/assemble.rs`, so setting either in the shepherd's own environment reaches every child, same as `TEMP` or `USERPROFILE`
- Adds a regression test through `build` with a fake env reader, asserting both vars land in the child's `SpawnSpec.env`. The allowlist is now `INHERITED_UNIX`/`INHERITED_WINDOWS` picked by `cfg!`, so the Windows list runs on any host rather than only in CI's Windows job
- Documents the crash and the fix on `/docs/not-built`, quoting the exact error string so a search finds it

Verified on the maintainer's own Windows box, not just cross-compiled: built shep there and ran a script with `interpreter = "none"` pointing straight at `python.exe`, the same shape as the real app that hit this (a raw `.exe`, no interpreter configured). It crashes with the exact reported error without the fix, and runs clean twice in a row with `PYTHONUTF8=1`/`PYTHONIOENCODING=utf-8` set in the daemon's own environment.

Rejected:
- Auto-seeding `PYTHONUTF8` whenever shep applies a `[interpreters]` entry. Doesn't fix the reported case, since that app names a bare `.exe` with no interpreter configured, so shep never knows it's Python. Also fights the existing rule that shep never guesses beyond what's written.
- A fix on the log-writer side. The crash happens inside the child before a byte reaches shep.
- A general UTF-8-stdio escape hatch: an env every child gets regardless of platform, or a per-app opt-in flag. Bigger surface and a real config decision, not a bug fix. Leaving this one to you rather than building it speculatively.

Looked like a second bug and isn't: shep reported `EXIT=120` and a short stderr in the log, but 120 is CPython's own signal that `Py_FinalizeEx()` could not flush stdout ([bpo-5319](https://bugs.python.org/issue5319)). The encode fails at shutdown so the buffer never reaches the pipe. Nothing filed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Windows-managed processes now inherit Python UTF-8 encoding settings, improving support for non-ASCII output.
  * Environment settings are consistently propagated to managed processes across supported platforms.

* **Documentation**
  * Documented Windows console encoding behavior and recommended environment settings for Python applications.
  * Added guidance for resolving Python Unicode encoding errors when running under supervision, including upgrade and configuration options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->