### PR TITLE
fix(daemon): refresh reported log paths on respawn

### DIFF
--- a/crates/shep-daemon/src/entry.rs
+++ b/crates/shep-daemon/src/entry.rs
@@ -83,7 +83,10 @@ pub struct ProcessEntry {
     /// [`assemble`](crate::assemble::assemble) built.
     ///
     /// Carried here so `ProcessInfo` can report it without re-deriving the
-    /// `merge_logs`-dependent default. Fixed at registration.
+    /// `merge_logs`-dependent default. Set at registration and refreshed by
+    /// every respawn, since `out_file` is `ApplyGroup::NeedsRespawn`: a
+    /// config load leaves this at the old value until the respawn that
+    /// promotes [`Self::pending`] moves the child onto the new one.
     pub out_file: PathBuf,
     /// Where this instance's stderr is appended, resolved exactly as
     /// [`Self::out_file`].

--- a/crates/shep-daemon/src/supervisor.rs
+++ b/crates/shep-daemon/src/supervisor.rs
@@ -4448,6 +4448,10 @@ impl<R: ProcessRunner> Actor<R> {
         });
         for id in survivors.iter().chain(orphaned_by_failed_spawn.iter()) {
             if let Some(slot) = self.sheep.get_mut(id) {
+                // `out_file`/`err_file` need no refresh here: `stored` only
+                // moves `instances`, no log-path template reads that
+                // (`render` substitutes `{{instance}}`/`{{name}}` alone),
+                // and a survivor's own `instance` is untouched by a scale.
                 slot.entry.spec = stored.clone();
                 match &mut slot.entry.pending {
                     // A slot already owed a config keeps it, with the count

--- a/crates/shep-daemon/src/supervisor.rs
+++ b/crates/shep-daemon/src/supervisor.rs
@@ -3934,6 +3934,12 @@ impl<R: ProcessRunner> Actor<R> {
                 slot.entry.pid = Some(pid);
                 slot.entry.started_at = Some(tokio::time::Instant::now());
                 slot.entry.restarts += 1;
+                // `out_file`/`err_file` are `ApplyGroup::NeedsRespawn`: this
+                // respawn is when they take effect. `to_info` reads these
+                // fields, not `spec`, so a moved path reaches an operator
+                // only once it moves here too.
+                slot.entry.out_file = spec.out_file;
+                slot.entry.err_file = spec.err_file;
                 // A different process under the same id, so an earlier reload's
                 // verdict about the last one does not apply to it.
                 slot.ready_failed = false;
@@ -19787,6 +19793,60 @@ mod tests {
             entry.pid,
             Some(APPLY_FIRST_PID),
             "a promotion is only reachable through a process that actually replaced the old one"
+        );
+    }
+
+    /// Without this refresh, `to_info` keeps naming a respawned child's old
+    /// log path forever: `out_file`/`err_file` are `ApplyGroup::NeedsRespawn`,
+    /// so a restart is the one moment they take effect, and every reader
+    /// built on `to_info` (`shep describe`, the muster roll) inherits it.
+    #[tokio::test(start_paused = true)]
+    async fn restart_refreshes_the_reported_log_paths_from_the_new_spec() {
+        let dir = tempfile::tempdir().unwrap();
+        let (mut actor, _enforcer) = actor_over(&dir, &[app_with("web", |_| {})]);
+
+        let mut file = AppConfig::minimal("web", "./srv");
+        file.out_file = Some("/var/log/moved-out.log".to_string());
+        file.err_file = Some("/var/log/moved-err.log".to_string());
+        apply_config(
+            &mut actor,
+            vec![declared_app(
+                file,
+                &["name", "script", "out_file", "err_file"],
+            )],
+            ResetDepth::None,
+        )
+        .await;
+        assert!(
+            actor.sheep[&0].entry.pending.is_some(),
+            "the fixture must really park the change, or this case proves nothing"
+        );
+
+        let (reply, _answer) = oneshot::channel();
+        actor.begin_manual(
+            ProcessSelector::Name("web".to_string()),
+            ManualKind::Restart,
+            CommandOrigin::Operator,
+            ReplyKind::Info(reply),
+        );
+        actor.handle_exited(
+            0,
+            ExitOutcome {
+                code: Some(0),
+                signal: None,
+            },
+        );
+
+        let after = to_info(&actor.sheep[&0].entry, &actor.smits);
+        assert_eq!(
+            after.out_file.as_deref(),
+            Some("/var/log/moved-out.log"),
+            "the restarted child writes to the moved path; the listing must say so"
+        );
+        assert_eq!(
+            after.err_file.as_deref(),
+            Some("/var/log/moved-err.log"),
+            "and the same for stderr"
         );
     }
 

--- a/crates/shep-daemon/src/supervisor.rs
+++ b/crates/shep-daemon/src/supervisor.rs
@@ -4449,9 +4449,13 @@ impl<R: ProcessRunner> Actor<R> {
         for id in survivors.iter().chain(orphaned_by_failed_spawn.iter()) {
             if let Some(slot) = self.sheep.get_mut(id) {
                 // `out_file`/`err_file` need no refresh here: `stored` only
-                // moves `instances`, no log-path template reads that
-                // (`render` substitutes `{{instance}}`/`{{name}}` alone),
-                // and a survivor's own `instance` is untouched by a scale.
+                // moves `instances`, and no token an accepted log path may
+                // carry reads that. `normalize` refuses a `{{secret:...}}`
+                // in either field (`SecretInLogPath`), which leaves
+                // `{{instance}}` and `{{name}}`; a survivor's own `instance`
+                // is untouched by a scale and its name cannot move. Note it
+                // is `normalize` that narrows this and not `render`, which
+                // resolves secret references too.
                 slot.entry.spec = stored.clone();
                 match &mut slot.entry.pending {
                     // A slot already owed a config keeps it, with the count

--- a/crates/shep-daemon/src/supervisor.rs
+++ b/crates/shep-daemon/src/supervisor.rs
@@ -19850,6 +19850,46 @@ mod tests {
         );
     }
 
+    /// The mirror case: a load parks a moved `out_file`/`err_file`, but the
+    /// child has not respawned yet and is still appending to the old path.
+    /// Reporting the parked path early would be this same bug pointed the
+    /// other way, naming a file nothing writes to yet.
+    #[tokio::test(start_paused = true)]
+    async fn a_parked_log_path_change_does_not_reach_the_listing_before_a_restart() {
+        let dir = tempfile::tempdir().unwrap();
+        let (mut actor, _enforcer) = actor_over(&dir, &[app_with("web", |_| {})]);
+        let logs = actor.paths.logs.clone();
+
+        let mut file = AppConfig::minimal("web", "./srv");
+        file.out_file = Some("/var/log/moved-out.log".to_string());
+        file.err_file = Some("/var/log/moved-err.log".to_string());
+        apply_config(
+            &mut actor,
+            vec![declared_app(
+                file,
+                &["name", "script", "out_file", "err_file"],
+            )],
+            ResetDepth::None,
+        )
+        .await;
+        assert!(
+            actor.sheep[&0].entry.pending.is_some(),
+            "the fixture must really park the change, or this case proves nothing"
+        );
+
+        let still_reported = to_info(&actor.sheep[&0].entry, &actor.smits);
+        assert_eq!(
+            still_reported.out_file.as_deref(),
+            logs.join("web-0-out.log").to_str(),
+            "the child is still writing to the old path until it respawns"
+        );
+        assert_eq!(
+            still_reported.err_file.as_deref(),
+            logs.join("web-0-err.log").to_str(),
+            "and the same for stderr"
+        );
+    }
+
     /// A pending field an operator cannot see is a silent divergence.
     #[tokio::test(start_paused = true)]
     async fn to_info_reports_the_pending_fields_names_only() {


### PR DESCRIPTION
- `respawn()` rebuilds a fresh spec on restart but never wrote its `out_file`/`err_file` back onto the entry. A moved log path never showed up in `shep describe`, `shep flock`, or the lookout until the whole daemon restarted. Fixed: it copies them over now, alongside the other post-spawn fields
- Added a regression test that reproduces it, plus a second one pinning the opposite case: a parked but not-yet-promoted path stays unreported until the restart actually happens
- Swept the other three spots that write `slot.entry.spec` in place. Only `respawn` had the bug: `apply_one`/`handle_set_sheep_field` already park `NeedsRespawn` fields instead of writing them straight through, and `handle_scale` only ever touches `instances`, which no log-path template reads. Left a comment there explaining why, since it looked like the same exposure at a glance
- Didn't touch `web/`. No flag, verb, config key, or JSON shape changed, just already-documented behavior working correctly. Overrule me if you'd rather it be called out there anyway

Full local gate passes: fmt, clippy `-D warnings`, `cargo test --workspace --all-features`, rustdoc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Log paths now update in status and process details after a restarted process begins using newly configured output or error log locations.
  * Pending log-path changes remain reported with the current paths until the process is restarted and the changes take effect.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->