### PR TITLE
feat(cli): shep flock --follow, with a host line above the listing

### DIFF
--- a/crates/shep-cli/Cargo.toml
+++ b/crates/shep-cli/Cargo.toml
@@ -85,10 +85,17 @@ shep-core = { workspace = true, features = ["schema"] }
 # dependency edge.
 shep-daemon.workspace = true
 shep-client.workspace = true
-# `dog::metrics`'s host reading (`shep_host_*`). Adds zero crates: the same
-# workspace-pinned version shep-daemon already carries for its tree sampler
-# (`limits/sample.rs`).
-sysinfo.workspace = true
+# `dog::metrics`'s host reading (`shep_host_*`) and `host`'s own line above a
+# followed listing. Adds zero crates: the same workspace-pinned version
+# shep-daemon already carries for its tree sampler (`limits/sample.rs`).
+#
+# # Option: `disk` and `network`
+# The two rates on `shep flock --follow`'s host line. Named here rather than
+# at the workspace root because only this crate reads them, and both are
+# additive: `disk` and `network` pull no crate `system` has not already
+# pulled on macOS, Linux or Windows, only more of the `windows` crate's own
+# feature surface.
+sysinfo = { workspace = true, features = ["disk", "network"] }
 # `serve`'s basic-auth comparison, through `hmac::sign`/`hmac::verify`, not
 # `ring::constant_time`: that module is `deprecated_constant_time` under an
 # alias in 0.17.14, and its own doc disclaims side-channel guarantees for

--- a/crates/shep-cli/src/cli.rs
+++ b/crates/shep-cli/src/cli.rs
@@ -385,7 +385,7 @@ pub enum Commands {
     Stock(StockArgs),
     /// List the flock.
     #[command(visible_aliases = ["list", "ls"])]
-    Flock,
+    Flock(FlockArgs),
     /// List the dogs, and nothing else. `--available` lists the community
     /// index of dogs you could adopt instead of the ones this shepherd is
     /// running.
@@ -899,6 +899,43 @@ pub struct SelectorArgs {
     /// `web.1` is the sheep called `web.1`.
     #[arg(required = true, num_args = 1..)]
     pub selectors: Vec<String>,
+}
+
+/// Arguments to `shep flock`.
+///
+/// A listing is a moment, and this moment drifts: a sheep that started
+/// after the list printed, one restarting. `--follow` keeps the moment
+/// current.
+#[derive(Debug, clap::Args)]
+pub struct FlockArgs {
+    /// Keep the listing current: redraw it in place until Ctrl+C
+    ///
+    /// One listing to start, then a fresh one every `--interval` seconds
+    /// while the shepherd stays reachable, each one painted over the last.
+    /// A summary of the machine rides above the tables. Ctrl+C leaves an
+    /// exit of zero, a stopped shepherd leaves the code its refusal
+    /// carries: an interrupted follow and a dead shepherd must not read as
+    /// the same thing.
+    ///
+    /// Needs a live shepherd: a saved roll is a single moment, and a
+    /// follow's whole reason is the moments after it. Needs a terminal
+    /// too, and refuses `--format json`, since neither has anywhere to put
+    /// a redraw.
+    #[arg(long, action = clap::ArgAction::SetTrue)]
+    pub follow: bool,
+    /// Seconds between redraws, with `--follow`
+    ///
+    /// The floor is one second, which is also the default. Below it the
+    /// listing costs the shepherd more than it tells the operator, and
+    /// `sysinfo` reports no CPU at all over a window that short.
+    #[arg(
+        long,
+        default_value_t = 1,
+        value_name = "SECONDS",
+        value_parser = clap::value_parser!(u64).range(1..),
+        requires = "follow"
+    )]
+    pub interval: u64,
 }
 
 /// Arguments to `shep stock`.
@@ -2229,9 +2266,48 @@ mod tests {
         for argv in [["shep", "flock"], ["shep", "list"], ["shep", "ls"]] {
             assert!(matches!(
                 Cli::try_parse_from(argv).unwrap().command,
-                Commands::Flock
+                Commands::Flock(_)
             ));
         }
+    }
+
+    /// Pins the three facts `flock`'s own arguments settle: a bare listing
+    /// does not follow, the interval defaults to the floor, and an interval
+    /// without a follow is a usage error rather than a silent no-op.
+    #[test]
+    fn flock_follows_only_when_asked_and_defaults_to_a_one_second_interval() {
+        use clap::Parser;
+
+        let Commands::Flock(args) = Cli::try_parse_from(["shep", "flock"]).unwrap().command else {
+            panic!("expected flock")
+        };
+        assert!(!args.follow, "a bare listing is still one moment");
+        assert_eq!(args.interval, 1);
+
+        let Commands::Flock(args) =
+            Cli::try_parse_from(["shep", "flock", "--follow", "--interval", "5"])
+                .unwrap()
+                .command
+        else {
+            panic!("expected flock")
+        };
+        assert!(args.follow);
+        assert_eq!(args.interval, 5);
+
+        assert!(
+            Cli::try_parse_from(["shep", "flock", "--interval", "5"]).is_err(),
+            "an interval with nothing to pace is a usage error"
+        );
+    }
+
+    /// fails if the floor is dropped from `--interval`. Zero would spin the
+    /// redraw against the shepherd as fast as the socket answers, and
+    /// `sysinfo` reports no CPU at all over a window under 200 ms.
+    #[test]
+    fn a_zero_interval_is_refused() {
+        use clap::Parser;
+
+        assert!(Cli::try_parse_from(["shep", "flock", "--follow", "--interval", "0"]).is_err());
     }
 
     #[test]

--- a/crates/shep-cli/src/cli.rs
+++ b/crates/shep-cli/src/cli.rs
@@ -901,6 +901,21 @@ pub struct SelectorArgs {
     pub selectors: Vec<String>,
 }
 
+/// The floor and the default for `shep flock --follow`'s `--interval`, in
+/// seconds.
+///
+/// One second, from two measurements rather than taste. `sysinfo` reports no
+/// CPU at all over a window shorter than its own
+/// `MINIMUM_CPU_UPDATE_INTERVAL`, which is 200 ms, so a faster cadence buys
+/// a column of dashes. And one redraw costs the shepherd a
+/// `Request::ListFlock` plus a host sample measured at 5.6 ms a tick on
+/// macOS (`crate::host`'s own module doc): 0.6% of a core at this floor, and
+/// 5.6% of one at the 100 ms somebody would otherwise reach for.
+///
+/// Seconds rather than milliseconds because the operator types it, and
+/// nothing between 200 ms and 1 s is worth the unit confusion.
+pub(crate) const FOLLOW_INTERVAL_FLOOR_SECONDS: u64 = 1;
+
 /// Arguments to `shep flock`.
 ///
 /// A listing is a moment, and this moment drifts: a sheep that started
@@ -930,9 +945,9 @@ pub struct FlockArgs {
     /// `sysinfo` reports no CPU at all over a window that short.
     #[arg(
         long,
-        default_value_t = 1,
+        default_value_t = FOLLOW_INTERVAL_FLOOR_SECONDS,
         value_name = "SECONDS",
-        value_parser = clap::value_parser!(u64).range(1..),
+        value_parser = clap::value_parser!(u64).range(FOLLOW_INTERVAL_FLOOR_SECONDS..),
         requires = "follow"
     )]
     pub interval: u64,
@@ -2282,7 +2297,7 @@ mod tests {
             panic!("expected flock")
         };
         assert!(!args.follow, "a bare listing is still one moment");
-        assert_eq!(args.interval, 1);
+        assert_eq!(args.interval, FOLLOW_INTERVAL_FLOOR_SECONDS);
 
         let Commands::Flock(args) =
             Cli::try_parse_from(["shep", "flock", "--follow", "--interval", "5"])

--- a/crates/shep-cli/src/commands/query.rs
+++ b/crates/shep-cli/src/commands/query.rs
@@ -447,7 +447,10 @@ fn fit_rows(frame: &str, columns: u16, rows: u16) -> String {
 /// once at its widest to reserve the rows, and once with the count it settled
 /// on.
 fn notice(dropped: usize) -> String {
-    format!("{dropped} more lines than this terminal shows")
+    // Singular is reachable: `dropped` is at least one wherever the notice
+    // prints at all, and a follow redraws this once a second.
+    let lines = if dropped == 1 { "line" } else { "lines" };
+    format!("{dropped} more {lines} than this terminal shows")
 }
 
 /// How many terminal rows `line` occupies once it wraps at `columns`.
@@ -737,6 +740,26 @@ mod tests {
                 );
             }
         }
+    }
+
+    /// fails if the notice goes back to one spelling. Dropping exactly one
+    /// line is the common case on a window one row short, and it redraws
+    /// every second.
+    #[test]
+    fn the_notice_counts_one_dropped_line_in_the_singular() {
+        let frame = "one\ntwo\nthree\n";
+
+        // Four rows: one held for the cursor, one for the notice, two for
+        // content, so exactly one line drops and the word is singular.
+        assert_eq!(
+            fit_rows(frame, 80, 4),
+            "one\ntwo\n1 more line than this terminal shows\n"
+        );
+        // Three rows leaves one for content, so two drop and it is plural.
+        assert_eq!(
+            fit_rows(frame, 80, 3),
+            "one\n2 more lines than this terminal shows\n"
+        );
     }
 
     #[test]

--- a/crates/shep-cli/src/commands/query.rs
+++ b/crates/shep-cli/src/commands/query.rs
@@ -362,11 +362,28 @@ pub(crate) async fn flock_follow(
             // whole. Scrolling beats hiding a sheep.
             Err(_unmeasured) => frame,
         };
-        let _ = streams.out.queue(MoveTo(0, 0));
-        let _ = streams.out.queue(Clear(ClearType::FromCursorDown));
-        let _ = write!(streams.out, "{frame}");
-        let _ = streams.out.flush();
+        // Not discarded. A follow whose terminal has gone (the emulator
+        // closed, an ssh session dropped) writes into a dead descriptor
+        // forever otherwise, and keeps asking the shepherd for a listing it
+        // cannot paint. `write_outcome` keeps a broken pipe at
+        // `ExitCode::Success`, which is the reader leaving rather than a
+        // failure.
+        let painted = paint(streams.out, &frame);
+        if painted.is_err() {
+            return write_outcome(painted);
+        }
     }
+}
+
+/// One redraw's four writes, as one `io::Result`.
+///
+/// Separate so the loop above reads as "paint, and stop if that failed"
+/// rather than four discarded results in a row.
+fn paint(out: &mut dyn io::Write, frame: &str) -> io::Result<()> {
+    out.queue(MoveTo(0, 0))?;
+    out.queue(Clear(ClearType::FromCursorDown))?;
+    write!(out, "{frame}")?;
+    out.flush()
 }
 
 /// One redraw's worth of text: the host line, then the tables [`flock`]
@@ -436,9 +453,31 @@ fn fit_rows(frame: &str, columns: u16, rows: u16) -> String {
     if kept > 0 {
         fitted.push('\n');
     }
-    fitted.push_str(&notice(lines.len() - kept));
+    // `budget - used` rather than the whole notice: a window too narrow to
+    // hold it is the one case the reservation above cannot satisfy, and
+    // printing it whole overruns the budget and scrolls the screen, which is
+    // the single thing this function exists to prevent. Clipped, the frame
+    // stays inside its rows and the operator still reads the leading digits,
+    // which is the part that says how much is missing.
+    fitted.push_str(&clip_rows(
+        &notice(lines.len() - kept),
+        columns,
+        budget.saturating_sub(used),
+    ));
     fitted.push('\n');
     fitted
+}
+
+/// `text` cut to at most `rows` rows at `columns` wide.
+///
+/// Only [`fit_rows`]'s notice reaches this, and only on a window too narrow
+/// to print it whole.
+fn clip_rows(text: &str, columns: usize, rows: usize) -> String {
+    let ceiling = rows.saturating_mul(columns);
+    if width::visible_width(text) <= ceiling {
+        return text.to_owned();
+    }
+    text.chars().take(ceiling).collect()
 }
 
 /// What a trimmed frame says in place of the lines it dropped.
@@ -716,8 +755,9 @@ mod tests {
     /// kept line back" reservation bought one. Measured overruns before the
     /// fix: 12x3, 12x5, 16x3, 20x3, 24x3 and 30x3.
     ///
-    /// A window too narrow to hold even the notice is the one case that
-    /// cannot be satisfied, and it reads as the notice alone.
+    /// Including the window too narrow to hold the notice whole, which is
+    /// the case that used to be skipped here: it is clipped now rather than
+    /// allowed to overrun.
     #[test]
     fn a_trimmed_frame_never_overruns_the_rows_it_was_given() {
         let frame: String = (0..40)
@@ -731,9 +771,6 @@ mod tests {
                     .map(|line| line_rows(line, usize::from(columns)))
                     .sum();
                 let budget = usize::from(rows).saturating_sub(1);
-                if out.lines().count() == 1 {
-                    continue; // the notice alone, which is all that fits
-                }
                 assert!(
                     used <= budget,
                     "{columns}x{rows}: used {used} rows against a budget of {budget}"

--- a/crates/shep-cli/src/commands/query.rs
+++ b/crates/shep-cli/src/commands/query.rs
@@ -32,6 +32,7 @@ use crate::dog_index::{self, AvailableDog, DogSourceKind};
 use crate::exit::ExitCode;
 use crate::fetch;
 use crate::flourish;
+use crate::host::{HostSample, HostWatch};
 use crate::lookout::term;
 use crate::output::width;
 use crate::output::{
@@ -334,6 +335,7 @@ pub(crate) async fn flock_follow(
     });
     let _ = streams.out.queue(Hide);
 
+    let mut host = HostWatch::install();
     let mut ticker = tokio::time::interval(interval);
     // A shepherd slower to answer than the interval would otherwise bank
     // every tick it missed and redraw them back to back the moment it
@@ -356,7 +358,7 @@ pub(crate) async fn flock_follow(
             Ok(_unrecognised) => return unexpected_response(streams),
             Err(err) => return client_error(streams, &err),
         };
-        let frame = follow_frame(procs, streams.style);
+        let frame = follow_frame(procs, streams.style, host.as_mut().map(HostWatch::sample));
         let frame = match crossterm::terminal::size() {
             Ok((columns, rows)) => fit_rows(&frame, columns, rows),
             // A terminal that will not say how big it is gets the frame
@@ -370,14 +372,22 @@ pub(crate) async fn flock_follow(
     }
 }
 
-/// One redraw's worth of text: the tables [`flock`] would have printed.
+/// One redraw's worth of text: the host line, then the tables [`flock`]
+/// would have printed.
 ///
-/// Rendered into a buffer rather than straight onto the terminal, so the
-/// caller can measure the frame before painting it and so the clear and the
-/// frame reach the terminal as one write.
-fn follow_frame(listing: Vec<ProcessInfo>, style: Presentation) -> String {
+/// The host line goes above rather than below so it holds still while the
+/// tables under it change length, and so it is the last thing [`fit_rows`]
+/// gives up.
+fn follow_frame(
+    listing: Vec<ProcessInfo>,
+    style: Presentation,
+    host: Option<HostSample>,
+) -> String {
     let mut frame = Vec::new();
-    // Writing to a `Vec` cannot fail.
+    if let Some(host) = host {
+        // Writing to a `Vec` cannot fail, here or below.
+        let _ = writeln!(frame, "{}\n", host.line());
+    }
     let _ = emit_flock(&mut frame, Format::Table, "flock", listing, style);
     String::from_utf8_lossy(&frame).into_owned()
 }
@@ -740,11 +750,42 @@ mod tests {
         );
     }
 
+    /// fails if the host line stops leading the frame. It has to be first:
+    /// it holds still while the tables under it change length, and it is
+    /// what survives a window too short for the rest.
+    #[test]
+    fn a_followed_frame_leads_with_the_host_line() {
+        let host = HostSample {
+            cpu_percent: Some(11.0),
+            memory_used_bytes: 39_963_869_184,
+            memory_total_bytes: 51_539_607_552,
+            disk_bytes_per_second: Some((0, 0)),
+            network_bytes_per_second: Some((0, 0)),
+        };
+
+        let frame = follow_frame(vec![sample_info()], Presentation::BARE, Some(host));
+
+        let mut lines = frame.lines();
+        assert!(lines.next().unwrap().starts_with("host  cpu 11%"));
+        assert_eq!(lines.next().unwrap(), "");
+        assert!(frame.contains("web"), "the table still follows: {frame}");
+    }
+
+    /// fails if a target `sysinfo` cannot read starts printing a blank host
+    /// line instead of no host line.
+    #[test]
+    fn a_frame_without_a_host_sample_is_the_tables_alone() {
+        let frame = follow_frame(vec![sample_info()], Presentation::BARE, None);
+
+        assert!(!frame.contains("host  cpu"), "{frame}");
+        assert!(frame.contains("web"), "{frame}");
+    }
+
     /// fails if the flourish comes back into a followed frame. It is art
     /// above an empty flock, and a redraw every second turns it into noise.
     #[test]
     fn a_followed_frame_of_an_empty_flock_carries_no_flourish() {
-        let frame = follow_frame(Vec::new(), Presentation::BARE);
+        let frame = follow_frame(Vec::new(), Presentation::BARE, None);
 
         assert!(!frame.contains("no sheep in the flock yet"), "{frame}");
     }

--- a/crates/shep-cli/src/commands/query.rs
+++ b/crates/shep-cli/src/commands/query.rs
@@ -10,7 +10,12 @@
 //! still issues `Request::Ping` as the liveness check.
 
 use std::collections::BTreeMap;
+use std::io::{self, Write as _};
+use std::time::Duration;
 
+use crossterm::QueueableCommand as _;
+use crossterm::cursor::{Hide, MoveTo, Show};
+use crossterm::terminal::{Clear, ClearType};
 use shep_client::Client;
 use shep_core::paths::ShepPaths;
 use shep_core::protocol::{ProcessInfo, Request, Response, SelectorSpec};
@@ -27,10 +32,14 @@ use crate::dog_index::{self, AvailableDog, DogSourceKind};
 use crate::exit::ExitCode;
 use crate::fetch;
 use crate::flourish;
+use crate::lookout::term;
+use crate::output::width;
 use crate::output::{
     AvailableDogRows, DescribedSecret, DogRows, RolledSheep, RolledSheepRows, SecretStatus,
     Streams, emit, emit_described, emit_flock, write_outcome,
 };
+use crate::shutdown::Interrupt;
+use crate::style::Presentation;
 
 /// `describe` and `fold`'s shared body: one `Request::Describe` against
 /// `selector`, rendered through [`emit_described`] as the sheep table and
@@ -284,6 +293,144 @@ fn sheep_flourish(listing: &[ProcessInfo]) -> Option<String> {
         .then(|| flourish::all_asleep(sheep.len()))
 }
 
+/// `shep flock --follow`: the same listing, painted over itself every
+/// `interval` until the operator interrupts it or the shepherd goes.
+///
+/// Each redraw is one `Request::ListFlock` rendered into a buffer and then
+/// written over the screen in a single write. Rendering before clearing is
+/// what keeps the terminal from sitting blank for the length of the round
+/// trip, which is what a clear issued ahead of the request would do.
+///
+/// The main screen, not the alternate one: a follow that took the alternate
+/// screen would hand back a terminal with no trace of what the flock looked
+/// like, and the last frame is the thing an operator reads after stopping.
+///
+/// No flourish. It is art above an empty flock, and art redrawn every second
+/// is noise.
+///
+/// A shepherd that goes away mid-follow ends the follow carrying its
+/// refusal's own exit code; an interrupt ends it at [`ExitCode::Success`].
+/// The two must not read as the same thing.
+pub(crate) async fn flock_follow(
+    client: &Client,
+    streams: &mut Streams<'_>,
+    interval: Duration,
+) -> ExitCode {
+    let mut interrupt = match Interrupt::install() {
+        Ok(interrupt) => interrupt,
+        Err(err) => {
+            let message = format!("listening for an interrupt: {err}");
+            return streams.fail(ExitCode::Failure, &message);
+        }
+    };
+    // The hook covers a panic, the guard covers every other way out of this
+    // function, and `term::restore` is documented idempotent because a panic
+    // fires both. The guard shows the cursor and stops there: hiding it is
+    // the only change this verb makes to the terminal, where `lookout` also
+    // takes raw mode and the alternate screen.
+    term::install_panic_hook();
+    let _cursor = term::RestoreGuard::with_action(|| {
+        let _ = crossterm::execute!(io::stdout(), Show);
+    });
+    let _ = streams.out.queue(Hide);
+
+    let mut ticker = tokio::time::interval(interval);
+    // A shepherd slower to answer than the interval would otherwise bank
+    // every tick it missed and redraw them back to back the moment it
+    // answered. `Delay` measures the next interval from the redraw that just
+    // finished, so a slow shepherd slows the cadence instead of bursting it.
+    ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+    loop {
+        tokio::select! {
+            _ = ticker.tick() => {}
+            _ = interrupt.recv() => return ExitCode::Success,
+        }
+        // The request is raced too, so a shepherd that stops answering does
+        // not hold the terminal until it does.
+        let listing = tokio::select! {
+            listing = client.request(Request::ListFlock) => listing,
+            _ = interrupt.recv() => return ExitCode::Success,
+        };
+        let procs = match listing {
+            Ok(Response::Flock(procs)) => procs,
+            Ok(_unrecognised) => return unexpected_response(streams),
+            Err(err) => return client_error(streams, &err),
+        };
+        let frame = follow_frame(procs, streams.style);
+        let frame = match crossterm::terminal::size() {
+            Ok((columns, rows)) => fit_rows(&frame, columns, rows),
+            // A terminal that will not say how big it is gets the frame
+            // whole. Scrolling beats hiding a sheep.
+            Err(_unmeasured) => frame,
+        };
+        let _ = streams.out.queue(MoveTo(0, 0));
+        let _ = streams.out.queue(Clear(ClearType::FromCursorDown));
+        let _ = write!(streams.out, "{frame}");
+        let _ = streams.out.flush();
+    }
+}
+
+/// One redraw's worth of text: the tables [`flock`] would have printed.
+///
+/// Rendered into a buffer rather than straight onto the terminal, so the
+/// caller can measure the frame before painting it and so the clear and the
+/// frame reach the terminal as one write.
+fn follow_frame(listing: Vec<ProcessInfo>, style: Presentation) -> String {
+    let mut frame = Vec::new();
+    // Writing to a `Vec` cannot fail.
+    let _ = emit_flock(&mut frame, Format::Table, "flock", listing, style);
+    String::from_utf8_lossy(&frame).into_owned()
+}
+
+/// Trims `frame` to what a terminal `columns` wide and `rows` tall shows,
+/// saying how much it dropped.
+///
+/// Rows, not lines: a line wider than the terminal wraps onto more than one
+/// of them, so counting lines would overrun a narrow window and leave every
+/// redraw scrolling. One row is held back for the cursor the redraw leaves
+/// behind, and one more for the notice whenever there is a notice to print.
+///
+/// A size of nothing is not a window of nothing. A pty that has never been
+/// told how big it is reports zero, and `script(1)` hands `--follow` exactly
+/// that: measured 2026-09-12, where trimming to it printed the notice alone,
+/// every second, and no flock at all. Sizes that leave no room to trim get
+/// the frame whole, the same answer a terminal that will not measure gets.
+fn fit_rows(frame: &str, columns: u16, rows: u16) -> String {
+    let (columns, budget) = (usize::from(columns), usize::from(rows).saturating_sub(1));
+    if columns == 0 || budget == 0 {
+        return frame.to_owned();
+    }
+    let lines: Vec<&str> = frame.lines().collect();
+    let mut used = 0;
+    let mut kept = 0;
+    for line in &lines {
+        let height = line_rows(line, columns);
+        if used + height > budget {
+            break;
+        }
+        used += height;
+        kept += 1;
+    }
+    if kept == lines.len() {
+        return frame.to_owned();
+    }
+    // One kept line goes back, so the notice has a row of its own.
+    let kept = kept.saturating_sub(1);
+    let dropped = lines.len() - kept;
+    let mut fitted = lines[..kept].join("\n");
+    fitted.push_str(&format!(
+        "\n{dropped} more lines than this terminal shows\n"
+    ));
+    fitted
+}
+
+/// How many terminal rows `line` occupies once it wraps at `columns`.
+///
+/// An empty line still occupies one.
+fn line_rows(line: &str, columns: usize) -> usize {
+    width::visible_width(line).div_ceil(columns).max(1)
+}
+
 /// Lists the dogs and nothing else: the same `Request::ListFlock` [`flock`]
 /// sends, filtered to the entries carrying a `dog` marker
 ///
@@ -531,6 +678,76 @@ mod tests {
     /// Bounds every `envelopes.recv()` here: a verb that never reaches the
     /// wire must fail by assertion, not by hanging the job.
     const RECV_TIMEOUT: Duration = Duration::from_secs(5);
+
+    /// fails if a frame that fits gets trimmed anyway. Three lines in a
+    /// window with rows to spare come back byte-identical, trailing newline
+    /// and all.
+    #[test]
+    fn a_frame_that_fits_is_left_alone() {
+        let frame = "one\ntwo\nthree\n";
+
+        assert_eq!(fit_rows(frame, 80, 24), frame);
+    }
+
+    /// fails if the fit counts lines instead of rows. Four lines is four
+    /// lines, but at ten columns each of these wraps onto three, so twelve
+    /// rows of content do not go into a window of eight.
+    #[test]
+    fn a_wrapped_line_costs_more_than_one_row() {
+        let wide = "0123456789012345678901234";
+        let frame = format!("{wide}\n{wide}\n{wide}\n{wide}\n");
+
+        let fitted = fit_rows(&frame, 10, 8);
+
+        assert_eq!(
+            fitted, "0123456789012345678901234\n3 more lines than this terminal shows\n",
+            "two lines of three rows fit a budget of seven; one goes back for the notice"
+        );
+    }
+
+    /// fails if the notice steals the row of a line it is reporting, or if
+    /// the count goes wrong. Ten lines into a window six rows tall keeps
+    /// four and says so.
+    #[test]
+    fn a_frame_too_tall_says_how_much_it_dropped() {
+        let frame = (0..10)
+            .map(|n| n.to_string())
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        let fitted = fit_rows(&frame, 80, 6);
+
+        assert_eq!(
+            fitted,
+            "0\n1\n2\n3\n6 more lines than this terminal shows\n"
+        );
+    }
+
+    /// fails if a pty that has never been told its size swallows the flock.
+    /// `script(1)` reports zero rows and zero columns, and trimming to that
+    /// left nothing on screen but the notice, once a second.
+    #[test]
+    fn a_terminal_reporting_no_size_gets_the_frame_whole() {
+        let frame = "a\nb\nc\n";
+
+        assert_eq!(fit_rows(frame, 0, 0), frame, "no size at all");
+        assert_eq!(fit_rows(frame, 80, 0), frame, "no rows");
+        assert_eq!(fit_rows(frame, 0, 24), frame, "no columns");
+        assert_eq!(
+            fit_rows(frame, 80, 1),
+            frame,
+            "one row leaves nothing to trim to once the cursor has its own"
+        );
+    }
+
+    /// fails if the flourish comes back into a followed frame. It is art
+    /// above an empty flock, and a redraw every second turns it into noise.
+    #[test]
+    fn a_followed_frame_of_an_empty_flock_carries_no_flourish() {
+        let frame = follow_frame(Vec::new(), Presentation::BARE);
+
+        assert!(!frame.contains("no sheep in the flock yet"), "{frame}");
+    }
 
     #[tokio::test]
     async fn flock_asks_the_daemon_to_list_the_whole_flock() {

--- a/crates/shep-cli/src/commands/query.rs
+++ b/crates/shep-cli/src/commands/query.rs
@@ -758,7 +758,8 @@ mod tests {
 
         assert_eq!(
             fitted, "0123456789012345678901234\n3 more lines than this terminal shows\n",
-            "two lines of three rows fit a budget of seven; one goes back for the notice"
+            "the notice reserves its own four rows at ten columns, leaving three of the seven \
+             for content, which is one wrapped line"
         );
     }
 

--- a/crates/shep-cli/src/commands/query.rs
+++ b/crates/shep-cli/src/commands/query.rs
@@ -300,18 +300,15 @@ fn sheep_flourish(listing: &[ProcessInfo]) -> Option<String> {
 /// Each redraw is one `Request::ListFlock` rendered into a buffer and then
 /// written over the screen in a single write. Rendering before clearing is
 /// what keeps the terminal from sitting blank for the length of the round
-/// trip, which is what a clear issued ahead of the request would do.
+/// trip. The main screen, not the alternate one, so the last frame is still
+/// there afterwards. No flourish, which redrawn every second is noise.
 ///
-/// The main screen, not the alternate one: a follow that took the alternate
-/// screen would hand back a terminal with no trace of what the flock looked
-/// like, and the last frame is the thing an operator reads after stopping.
+/// An interrupt ends the follow at [`ExitCode::Success`], a shepherd that
+/// goes away mid-follow ends it carrying that refusal's own code. The two
+/// must not read as the same thing.
 ///
-/// No flourish. It is art above an empty flock, and art redrawn every second
-/// is noise.
-///
-/// A shepherd that goes away mid-follow ends the follow carrying its
-/// refusal's own exit code; an interrupt ends it at [`ExitCode::Success`].
-/// The two must not read as the same thing.
+/// Why each of those beat its alternative: `docs/decisions.md`, "Following
+/// the flock".
 pub(crate) async fn flock_follow(
     client: &Client,
     streams: &mut Streams<'_>,

--- a/crates/shep-cli/src/commands/query.rs
+++ b/crates/shep-cli/src/commands/query.rs
@@ -395,7 +395,15 @@ fn follow_frame(
 /// Rows, not lines: a line wider than the terminal wraps onto more than one
 /// of them, so counting lines would overrun a narrow window and leave every
 /// redraw scrolling. One row is held back for the cursor the redraw leaves
-/// behind, and one more for the notice whenever there is a notice to print.
+/// behind, and the notice's own height for the notice.
+///
+/// The notice wraps like anything else, which is why its height is measured
+/// rather than assumed to be one. Giving a kept line back to make room was
+/// the earlier answer and it does not hold: at 30 columns the notice takes
+/// two rows and the line handed back was worth one, so the frame overran by
+/// one row and the window scrolled on every redraw. Measured at 12, 16, 20,
+/// 24 and 30 columns. Reserving the worst case, every line dropped, costs at
+/// most one row more than the final count needs, and no circularity.
 ///
 /// A size of nothing is not a window of nothing. A pty that has never been
 /// told how big it is reports zero, and `script(1)` hands `--follow` exactly
@@ -408,11 +416,14 @@ fn fit_rows(frame: &str, columns: u16, rows: u16) -> String {
         return frame.to_owned();
     }
     let lines: Vec<&str> = frame.lines().collect();
+    // Widest the notice can get, since more dropped lines means more digits.
+    let reserve = line_rows(&notice(lines.len()), columns);
+    let fill = budget.saturating_sub(reserve);
     let mut used = 0;
     let mut kept = 0;
     for line in &lines {
         let height = line_rows(line, columns);
-        if used + height > budget {
+        if used + height > fill {
             break;
         }
         used += height;
@@ -421,14 +432,22 @@ fn fit_rows(frame: &str, columns: u16, rows: u16) -> String {
     if kept == lines.len() {
         return frame.to_owned();
     }
-    // One kept line goes back, so the notice has a row of its own.
-    let kept = kept.saturating_sub(1);
-    let dropped = lines.len() - kept;
     let mut fitted = lines[..kept].join("\n");
-    fitted.push_str(&format!(
-        "\n{dropped} more lines than this terminal shows\n"
-    ));
+    if kept > 0 {
+        fitted.push('\n');
+    }
+    fitted.push_str(&notice(lines.len() - kept));
+    fitted.push('\n');
     fitted
+}
+
+/// What a trimmed frame says in place of the lines it dropped.
+///
+/// A function rather than a literal because [`fit_rows`] measures this twice:
+/// once at its widest to reserve the rows, and once with the count it settled
+/// on.
+fn notice(dropped: usize) -> String {
+    format!("{dropped} more lines than this terminal shows")
 }
 
 /// How many terminal rows `line` occupies once it wraps at `columns`.
@@ -689,6 +708,37 @@ mod tests {
     /// fails if a frame that fits gets trimmed anyway. Three lines in a
     /// window with rows to spare come back byte-identical, trailing newline
     /// and all.
+    /// fails if the notice's own height stops being reserved. It wraps like
+    /// any other line, so at 30 columns it is two rows and the old "hand one
+    /// kept line back" reservation bought one. Measured overruns before the
+    /// fix: 12x3, 12x5, 16x3, 20x3, 24x3 and 30x3.
+    ///
+    /// A window too narrow to hold even the notice is the one case that
+    /// cannot be satisfied, and it reads as the notice alone.
+    #[test]
+    fn a_trimmed_frame_never_overruns_the_rows_it_was_given() {
+        let frame: String = (0..40)
+            .map(|n| format!("sheep-{n:02}  online  1234  0.5%  12.3 MB  0d 0h 1m\n"))
+            .collect();
+        for columns in [12u16, 16, 20, 24, 30, 38, 40, 60, 80, 120] {
+            for rows in [3u16, 4, 5, 8, 12, 24, 40] {
+                let out = fit_rows(&frame, columns, rows);
+                let used: usize = out
+                    .lines()
+                    .map(|line| line_rows(line, usize::from(columns)))
+                    .sum();
+                let budget = usize::from(rows).saturating_sub(1);
+                if out.lines().count() == 1 {
+                    continue; // the notice alone, which is all that fits
+                }
+                assert!(
+                    used <= budget,
+                    "{columns}x{rows}: used {used} rows against a budget of {budget}"
+                );
+            }
+        }
+    }
+
     #[test]
     fn a_frame_that_fits_is_left_alone() {
         let frame = "one\ntwo\nthree\n";

--- a/crates/shep-cli/src/host.rs
+++ b/crates/shep-cli/src/host.rs
@@ -1,0 +1,350 @@
+//! The machine the flock runs on, as one line above a followed listing.
+//!
+//! Three of the four numbers are rates, so none of them exists in a single
+//! moment: CPU, disk traffic and network traffic are all differences between
+//! two samples. [`HostWatch`] holds the earlier sample between redraws, which
+//! is the only reason `shep flock --follow` can show them and a one-shot
+//! `shep flock` cannot.
+//!
+//! Cost is the constraint. `lookout`'s own sampler carries a comment saying a
+//! process walk is what makes `dog::metrics` expensive, and this runs on the
+//! same cadence, so nothing here refreshes anything that is not printed: no
+//! process table, no swap, no disk capacity, no component temperatures.
+//! Measured on macOS at 5.6 ms a tick, against a floor of one second between
+//! ticks.
+
+use std::collections::BTreeSet;
+use std::time::{Duration, Instant};
+
+use sysinfo::{
+    CpuRefreshKind, DiskRefreshKind, Disks, MemoryRefreshKind, NetworkData, Networks, RefreshKind,
+    System,
+};
+
+use crate::output::human_bytes;
+
+/// What one redraw reads off the machine.
+///
+/// Every rate is `Option`: the window between two samples can be too short to
+/// divide by, and on the first redraw it always is.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(crate) struct HostSample {
+    /// Every core's usage, as one percentage of one whole machine.
+    pub cpu_percent: Option<f32>,
+    /// Memory in use, as the platform reports it.
+    pub memory_used_bytes: u64,
+    /// Total physical memory.
+    pub memory_total_bytes: u64,
+    /// Bytes a second the block devices read and wrote over the window.
+    pub disk_bytes_per_second: Option<(u64, u64)>,
+    /// Bytes a second the non-loopback interfaces received and transmitted
+    /// over the window.
+    pub network_bytes_per_second: Option<(u64, u64)>,
+}
+
+impl HostSample {
+    /// The one line that sits above a followed listing.
+    ///
+    /// Rates that have no window yet render as `-` rather than as zero: a
+    /// machine doing nothing and a machine not yet measured are different
+    /// claims, and the first redraw is always the second one.
+    pub(crate) fn line(&self) -> String {
+        let cpu = match self.cpu_percent {
+            Some(percent) => format!("{percent:.0}%"),
+            None => "-".to_owned(),
+        };
+        let (disk_read, disk_write) = rate_pair(self.disk_bytes_per_second);
+        let (received, transmitted) = rate_pair(self.network_bytes_per_second);
+        format!(
+            "host  cpu {cpu}  mem {}/{}  disk r {disk_read} w {disk_write}  net rx {received} tx {transmitted}",
+            human_bytes(self.memory_used_bytes),
+            human_bytes(self.memory_total_bytes),
+        )
+    }
+}
+
+/// One rate pair rendered, or a pair of dashes where there is no window.
+fn rate_pair(rate: Option<(u64, u64)>) -> (String, String) {
+    match rate {
+        Some((first, second)) => (
+            format!("{}/s", human_bytes(first)),
+            format!("{}/s", human_bytes(second)),
+        ),
+        None => ("-".to_owned(), "-".to_owned()),
+    }
+}
+
+/// Bytes one block device moved: what it has moved since boot, and what it
+/// moved over the last window.
+///
+/// The lifetime pair is not displayed. It is the device's identity, for
+/// [`distinct_disk_io`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct DiskIo {
+    /// Bytes read and written since boot.
+    pub lifetime: (u64, u64),
+    /// Bytes read and written since the previous refresh.
+    pub window: (u64, u64),
+}
+
+/// Totals `entries` over distinct devices, counting each one once.
+///
+/// The entries are mount points, and several of them can sit on one device.
+/// macOS is where this bites: `sysinfo` walks each APFS volume up to the
+/// `IOBlockStorageDriver` behind it, so `/` and `/System/Volumes/Data` report
+/// the same counters and a plain sum doubles every number. Measured 12 times
+/// out of 12 under a 4 GB write, both volumes byte-identical every round.
+///
+/// Lifetime counters are the identity because `sysinfo` exposes no device
+/// name to group by. Two genuinely separate devices agreeing on both 64-bit
+/// counters would collapse into one, which is only reachable at boot with
+/// both at zero, where they contribute nothing either way.
+fn distinct_disk_io(entries: impl IntoIterator<Item = DiskIo>) -> (u64, u64) {
+    let mut seen = BTreeSet::new();
+    let mut read = 0u64;
+    let mut written = 0u64;
+    for entry in entries {
+        if seen.insert(entry.lifetime) {
+            read = read.saturating_add(entry.window.0);
+            written = written.saturating_add(entry.window.1);
+        }
+    }
+    (read, written)
+}
+
+/// Whether every address on `interface` is a loopback address.
+///
+/// A followed listing counts what left the machine. On a box where a sheep
+/// answers a local proxy, loopback carries every request twice and swamps the
+/// interface an operator is actually watching. Judged by address rather than
+/// by name, since `lo` and `lo0` are two spellings of a set with no promised
+/// end. An interface with no addresses at all is not loopback; it also moves
+/// no bytes.
+fn is_loopback(interface: &NetworkData) -> bool {
+    let addresses = interface.ip_networks();
+    !addresses.is_empty() && addresses.iter().all(|network| network.addr.is_loopback())
+}
+
+/// `bytes` over `window`, as bytes a second.
+///
+/// `u128` throughout: a window of a few milliseconds against a large delta
+/// overflows `u64` on the multiply long before the divide brings it back.
+fn per_second(bytes: u64, window: Duration) -> u64 {
+    let millis = window.as_millis().max(1);
+    u64::try_from(u128::from(bytes) * 1000 / millis).unwrap_or(u64::MAX)
+}
+
+/// The earlier sample, held between redraws.
+///
+/// Not `Default` and not `new()`: [`HostWatch::install`] answers `None` on a
+/// target `sysinfo` cannot read, which is a real state a caller has to render
+/// rather than an error (`dog::metrics::sample_host` makes the same call).
+#[derive(Debug)]
+pub(crate) struct HostWatch {
+    system: System,
+    disks: Disks,
+    networks: Networks,
+    sampled_at: Instant,
+}
+
+impl HostWatch {
+    /// Takes the first sample, or answers `None` where `sysinfo` reads
+    /// nothing.
+    ///
+    /// The sample taken here is never displayed. It is the anchor the first
+    /// displayed sample subtracts from.
+    pub(crate) fn install() -> Option<Self> {
+        if !sysinfo::IS_SUPPORTED_SYSTEM {
+            return None;
+        }
+        Some(Self {
+            system: System::new_with_specifics(Self::refresh()),
+            disks: Disks::new_with_refreshed_list_specifics(Self::disk_refresh()),
+            networks: Networks::new_with_refreshed_list(),
+            sampled_at: Instant::now(),
+        })
+    }
+
+    /// CPU usage and memory in use, and nothing else `System` can be asked
+    /// for.
+    ///
+    /// `with_ram()` rather than `MemoryRefreshKind::everything()`, which the
+    /// two older samplers use: swap is not on this line.
+    fn refresh() -> RefreshKind {
+        RefreshKind::nothing()
+            .with_cpu(CpuRefreshKind::nothing().with_cpu_usage())
+            .with_memory(MemoryRefreshKind::nothing().with_ram())
+    }
+
+    /// Bytes moved, and not capacity: `total_space` costs a `statvfs` per
+    /// mount point and appears nowhere on the line.
+    fn disk_refresh() -> DiskRefreshKind {
+        DiskRefreshKind::nothing().with_io_usage()
+    }
+
+    /// Refreshes every source and reports the window since the last refresh.
+    ///
+    /// Refreshing always, reporting conditionally: a refresh that is skipped
+    /// leaves the next window measuring from the wrong instant, so the short
+    /// window is spent rather than avoided. What a short window suppresses is
+    /// the arithmetic, not the sample.
+    ///
+    /// `MINIMUM_CPU_UPDATE_INTERVAL` is the floor for all three rates, not
+    /// only for CPU. It is the shortest window `sysinfo` promises a CPU
+    /// reading over, and dividing a handful of bytes by a handful of
+    /// milliseconds is no more honest for the other two.
+    pub(crate) fn sample(&mut self) -> HostSample {
+        let now = Instant::now();
+        let window = now.saturating_duration_since(self.sampled_at);
+        self.sampled_at = now;
+
+        self.system.refresh_specifics(Self::refresh());
+        self.disks.refresh_specifics(false, Self::disk_refresh());
+        self.networks.refresh(false);
+
+        let measured = window >= sysinfo::MINIMUM_CPU_UPDATE_INTERVAL;
+        let disk = measured.then(|| {
+            let (read, written) = distinct_disk_io(self.disks.list().iter().map(|disk| {
+                let usage = disk.usage();
+                DiskIo {
+                    lifetime: (usage.total_read_bytes, usage.total_written_bytes),
+                    window: (usage.read_bytes, usage.written_bytes),
+                }
+            }));
+            (per_second(read, window), per_second(written, window))
+        });
+        let network = measured.then(|| {
+            let (received, transmitted) = self
+                .networks
+                .list()
+                .values()
+                .filter(|interface| !is_loopback(interface))
+                .fold((0u64, 0u64), |(received, transmitted), interface| {
+                    (
+                        received.saturating_add(interface.received()),
+                        transmitted.saturating_add(interface.transmitted()),
+                    )
+                });
+            (
+                per_second(received, window),
+                per_second(transmitted, window),
+            )
+        });
+
+        HostSample {
+            cpu_percent: measured.then(|| self.system.global_cpu_usage()),
+            memory_used_bytes: self.system.used_memory(),
+            memory_total_bytes: self.system.total_memory(),
+            disk_bytes_per_second: disk,
+            network_bytes_per_second: network,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn io(lifetime: (u64, u64), window: (u64, u64)) -> DiskIo {
+        DiskIo { lifetime, window }
+    }
+
+    /// fails if the macOS double-count comes back: two mount points on one
+    /// device carry one device's counters, and summing them reports twice
+    /// the traffic the machine did.
+    #[test]
+    fn two_mount_points_on_one_device_are_counted_once() {
+        let volumes = [
+            io((1_089_321_177_088, 1_750_606_974_976), (2_641_920, 4_096)),
+            io((1_089_321_177_088, 1_750_606_974_976), (2_625_536, 4_096)),
+        ];
+
+        assert_eq!(distinct_disk_io(volumes), (2_641_920, 4_096));
+    }
+
+    /// fails if the dedupe over-reaches: two devices really are two devices,
+    /// and Linux reports each partition's own `/proc/diskstats` line.
+    #[test]
+    fn two_devices_are_counted_twice() {
+        let devices = [io((100, 200), (10, 20)), io((300, 400), (30, 40))];
+
+        assert_eq!(distinct_disk_io(devices), (40, 60));
+    }
+
+    /// fails if an empty list panics rather than reporting nothing moved.
+    #[test]
+    fn no_devices_move_no_bytes() {
+        assert_eq!(distinct_disk_io([]), (0, 0));
+    }
+
+    /// fails if the rate arithmetic overflows instead of scaling. A tenth of
+    /// a second holding 100 MiB is 1000 MiB a second.
+    #[test]
+    fn a_rate_scales_a_window_up_to_a_second() {
+        assert_eq!(
+            per_second(100 * 1024 * 1024, Duration::from_millis(100)),
+            1000 * 1024 * 1024
+        );
+        assert_eq!(per_second(u64::MAX, Duration::from_millis(1)), u64::MAX);
+        assert_eq!(per_second(512, Duration::from_secs(2)), 256);
+    }
+
+    /// fails if a zero window divides by zero.
+    #[test]
+    fn a_window_of_no_time_does_not_divide_by_zero() {
+        assert_eq!(per_second(4, Duration::ZERO), 4000);
+    }
+
+    /// fails if the first redraw starts printing zeroes. A rate with no
+    /// window is absent, and absent is not idle.
+    #[test]
+    fn a_sample_with_no_window_dashes_every_rate_and_still_prints_memory() {
+        let sample = HostSample {
+            cpu_percent: None,
+            memory_used_bytes: 39_963_869_184,
+            memory_total_bytes: 51_539_607_552,
+            disk_bytes_per_second: None,
+            network_bytes_per_second: None,
+        };
+
+        assert_eq!(
+            sample.line(),
+            "host  cpu -  mem 37.2G/48.0G  disk r - w -  net rx - tx -"
+        );
+    }
+
+    /// fails if the measured line loses a unit or a number.
+    #[test]
+    fn a_measured_sample_names_all_four() {
+        let sample = HostSample {
+            cpu_percent: Some(11.459_433),
+            memory_used_bytes: 39_963_869_184,
+            memory_total_bytes: 51_539_607_552,
+            disk_bytes_per_second: Some((1_258_291, 491_520)),
+            network_bytes_per_second: Some((24_594, 9_260)),
+        };
+
+        assert_eq!(
+            sample.line(),
+            "host  cpu 11%  mem 37.2G/48.0G  disk r 1.2M/s w 480.0K/s  net rx 24.0K/s tx 9.0K/s"
+        );
+    }
+
+    /// fails if the real sampler stops reading this machine's memory. The
+    /// rates are not asserted: the window here is microseconds, which is the
+    /// case that has to report nothing.
+    #[test]
+    fn the_first_sample_reads_memory_and_no_rate() {
+        let Some(mut watch) = HostWatch::install() else {
+            return;
+        };
+
+        let sample = watch.sample();
+
+        assert!(sample.memory_total_bytes > 0, "a machine has memory");
+        assert!(sample.memory_used_bytes > 0);
+        assert_eq!(sample.cpu_percent, None, "no window, no rate");
+        assert_eq!(sample.disk_bytes_per_second, None);
+        assert_eq!(sample.network_bytes_per_second, None);
+    }
+}

--- a/crates/shep-cli/src/host.rs
+++ b/crates/shep-cli/src/host.rs
@@ -125,6 +125,16 @@ fn is_loopback(interface: &NetworkData) -> bool {
     !addresses.is_empty() && addresses.iter().all(|network| network.addr.is_loopback())
 }
 
+/// Whether `window` is long enough to report a rate over.
+///
+/// `MINIMUM_CPU_UPDATE_INTERVAL` is the floor for all three rates, not only
+/// for CPU. It is the shortest window `sysinfo` promises a CPU reading over,
+/// and dividing a handful of bytes by a handful of milliseconds is no more
+/// honest for the other two.
+fn is_measurable(window: Duration) -> bool {
+    window >= sysinfo::MINIMUM_CPU_UPDATE_INTERVAL
+}
+
 /// `bytes` over `window`, as bytes a second.
 ///
 /// `u128` throughout: a window of a few milliseconds against a large delta
@@ -186,13 +196,8 @@ impl HostWatch {
     ///
     /// Refreshing always, reporting conditionally: a refresh that is skipped
     /// leaves the next window measuring from the wrong instant, so the short
-    /// window is spent rather than avoided. What a short window suppresses is
-    /// the arithmetic, not the sample.
-    ///
-    /// `MINIMUM_CPU_UPDATE_INTERVAL` is the floor for all three rates, not
-    /// only for CPU. It is the shortest window `sysinfo` promises a CPU
-    /// reading over, and dividing a handful of bytes by a handful of
-    /// milliseconds is no more honest for the other two.
+    /// window is spent rather than avoided. What [`is_measurable`] suppresses
+    /// is the arithmetic, not the sample.
     pub(crate) fn sample(&mut self) -> HostSample {
         let now = Instant::now();
         let window = now.saturating_duration_since(self.sampled_at);
@@ -202,7 +207,7 @@ impl HostWatch {
         self.disks.refresh_specifics(false, Self::disk_refresh());
         self.networks.refresh(false);
 
-        let measured = window >= sysinfo::MINIMUM_CPU_UPDATE_INTERVAL;
+        let measured = is_measurable(window);
         let disk = measured.then(|| {
             let (read, written) = distinct_disk_io(self.disks.list().iter().map(|disk| {
                 let usage = disk.usage();
@@ -330,11 +335,28 @@ mod tests {
         );
     }
 
-    /// fails if the real sampler stops reading this machine's memory. The
-    /// rates are not asserted: the window here is microseconds, which is the
-    /// case that has to report nothing.
+    /// fails if the first redraw starts reporting rates over a window too
+    /// short to divide by, or if the floor drifts off `sysinfo`'s own.
+    ///
+    /// A pure function rather than a real sample, deliberately: asserting
+    /// that `HostWatch::install` and the sample after it fall inside 200 ms
+    /// would be asserting that a CI runner never deschedules a thread, and
+    /// the rule under test has nothing to do with how fast the machine is.
     #[test]
-    fn the_first_sample_reads_memory_and_no_rate() {
+    fn a_window_under_sysinfos_own_floor_carries_no_rate() {
+        assert!(!is_measurable(Duration::ZERO));
+        assert!(!is_measurable(Duration::from_millis(5)));
+        assert!(!is_measurable(
+            sysinfo::MINIMUM_CPU_UPDATE_INTERVAL - Duration::from_nanos(1)
+        ));
+        assert!(is_measurable(sysinfo::MINIMUM_CPU_UPDATE_INTERVAL));
+        assert!(is_measurable(Duration::from_secs(1)), "the interval floor");
+    }
+
+    /// fails if the real sampler stops reading this machine's memory. Memory
+    /// is not a rate, so it is the one number a first sample must carry.
+    #[test]
+    fn a_real_sample_reads_this_machines_memory() {
         let Some(mut watch) = HostWatch::install() else {
             return;
         };
@@ -343,8 +365,5 @@ mod tests {
 
         assert!(sample.memory_total_bytes > 0, "a machine has memory");
         assert!(sample.memory_used_bytes > 0);
-        assert_eq!(sample.cpu_percent, None, "no window, no rate");
-        assert_eq!(sample.disk_bytes_per_second, None);
-        assert_eq!(sample.network_bytes_per_second, None);
     }
 }

--- a/crates/shep-cli/src/host.rs
+++ b/crates/shep-cli/src/host.rs
@@ -17,8 +17,8 @@ use std::collections::BTreeSet;
 use std::time::{Duration, Instant};
 
 use sysinfo::{
-    CpuRefreshKind, DiskRefreshKind, Disks, MemoryRefreshKind, NetworkData, Networks, RefreshKind,
-    System,
+    CpuRefreshKind, DiskRefreshKind, Disks, IpNetwork, MemoryRefreshKind, NetworkData, Networks,
+    RefreshKind, System,
 };
 
 use crate::output::human_bytes;
@@ -121,7 +121,16 @@ fn distinct_disk_io(entries: impl IntoIterator<Item = DiskIo>) -> (u64, u64) {
 /// end. An interface with no addresses at all is not loopback; it also moves
 /// no bytes.
 fn is_loopback(interface: &NetworkData) -> bool {
-    let addresses = interface.ip_networks();
+    addresses_are_loopback(interface.ip_networks())
+}
+
+/// The judgement [`is_loopback`] makes, over the addresses alone.
+///
+/// Split out because `sysinfo::NetworkData` has no public constructor, so the
+/// rule above it is untestable while it is wired to one. It decides which
+/// interfaces reach the network rate at all, and a regression would inflate
+/// or deflate every number on the host line without failing anything.
+fn addresses_are_loopback(addresses: &[IpNetwork]) -> bool {
     !addresses.is_empty() && addresses.iter().all(|network| network.addr.is_loopback())
 }
 
@@ -365,5 +374,34 @@ mod tests {
 
         assert!(sample.memory_total_bytes > 0, "a machine has memory");
         assert!(sample.memory_used_bytes > 0);
+    }
+
+    fn net(addr: &str) -> IpNetwork {
+        IpNetwork {
+            addr: addr.parse().expect("a literal address"),
+            prefix: 8,
+        }
+    }
+
+    /// fails if loopback stops being judged by address. Judging by name was
+    /// the alternative, and `lo` and `lo0` are two spellings of a set with no
+    /// promised end.
+    #[test]
+    fn an_interface_is_loopback_only_when_every_address_is() {
+        assert!(addresses_are_loopback(&[net("127.0.0.1")]));
+        assert!(addresses_are_loopback(&[net("127.0.0.1"), net("::1")]));
+        assert!(!addresses_are_loopback(&[net("192.168.1.4")]));
+        assert!(
+            !addresses_are_loopback(&[net("127.0.0.1"), net("192.168.1.4")]),
+            "one routable address is enough to make an interface count"
+        );
+    }
+
+    /// The empty case the doc comment claims and nothing checked. An
+    /// interface with no addresses is not loopback, so it stays in the total;
+    /// it also moves no bytes, so it contributes nothing either way.
+    #[test]
+    fn an_interface_with_no_addresses_is_not_loopback() {
+        assert!(!addresses_are_loopback(&[]));
     }
 }

--- a/crates/shep-cli/src/lib.rs
+++ b/crates/shep-cli/src/lib.rs
@@ -34,6 +34,7 @@ use std::ffi::OsString;
 use std::io::{IsTerminal, Write};
 use std::path::Path;
 use std::path::PathBuf;
+use std::time::Duration;
 
 use clap::Parser;
 
@@ -948,7 +949,7 @@ async fn run(
         },
         // Falls back to the muster roll rather than refusing: looking at the
         // flock must not be a dead end on a machine that just rebooted.
-        Commands::Flock => flock_command(&mut streams, &paths, guard).await,
+        Commands::Flock(ref args) => flock_command(&mut streams, &paths, guard, args).await,
         // The guard arm is what makes `--available` work with no shepherd
         // running: it never reaches `connect_client`.
         Commands::Dogs(ref args) if args.available => {
@@ -1395,7 +1396,11 @@ async fn flock_command(
     streams: &mut Streams<'_>,
     paths: &ShepPaths,
     guard: VersionGuard,
+    args: &cli::FlockArgs,
 ) -> ExitCode {
+    if args.follow {
+        return follow_flock_command(streams, paths, guard, args).await;
+    }
     match Client::connect(&paths.socket).await {
         Ok(client) => match refuse_version_skew(streams, &client, guard) {
             Ok(()) => query::flock(&client, streams).await,
@@ -1417,6 +1422,44 @@ async fn flock_command(
             let code = ExitCode::from(&err);
             streams.fail(code, &flock_connect_refusal_message(&err))
         }
+    }
+}
+
+/// `shep flock --follow`'s own dispatch: two refusals, then
+/// [`connect_client`] and the redraw loop.
+///
+/// [`connect_client`], not [`flock_command`]'s hand-rolled connect, because
+/// this path has no roll to fall back to. A saved roll is one moment, and a
+/// follow exists for the moments after it, so a shepherd that is not running
+/// is a refusal here rather than a listing.
+///
+/// Both refusals are usage errors rather than degradations. A follow written
+/// into a file would be a file of escape sequences, and a follow that quietly
+/// printed once instead would exit zero having done something else than what
+/// was asked.
+async fn follow_flock_command(
+    streams: &mut Streams<'_>,
+    paths: &ShepPaths,
+    guard: VersionGuard,
+    args: &cli::FlockArgs,
+) -> ExitCode {
+    if streams.fmt == Format::Json {
+        return streams.fail(
+            ExitCode::Usage,
+            "`--follow` redraws a table; `--format json` has no follow form",
+        );
+    }
+    if !std::io::stdout().is_terminal() {
+        return streams.fail(
+            ExitCode::Usage,
+            "`--follow` needs a terminal; stdout is not one",
+        );
+    }
+    match connect_client(streams, paths, guard).await {
+        Ok(client) => {
+            query::flock_follow(&client, streams, Duration::from_secs(args.interval)).await
+        }
+        Err(code) => code,
     }
 }
 
@@ -2458,7 +2501,7 @@ mod tests {
         let mut err = Vec::new();
         let code = {
             let mut streams = buffered_streams(&mut out, &mut err);
-            flock_command(&mut streams, &paths, VersionGuard::Enforce).await
+            flock_command(&mut streams, &paths, VersionGuard::Enforce, &flock_args()).await
         };
 
         assert_ne!(code, ExitCode::Success);
@@ -2481,7 +2524,7 @@ mod tests {
         let mut err = Vec::new();
         let code = {
             let mut streams = buffered_streams(&mut out, &mut err);
-            flock_command(&mut streams, &paths, VersionGuard::Enforce).await
+            flock_command(&mut streams, &paths, VersionGuard::Enforce, &flock_args()).await
         };
 
         assert_eq!(code, ExitCode::DaemonUnreachable);
@@ -2535,6 +2578,14 @@ mod tests {
         }
     }
 
+    /// A [`cli::FlockArgs`] that does not follow: the bare `shep flock`.
+    fn flock_args() -> cli::FlockArgs {
+        cli::FlockArgs {
+            follow: false,
+            interval: 1,
+        }
+    }
+
     /// A [`DaemonArgs`] carrying `cmd` and nothing else, for asking which
     /// guard the `daemon` verb's two shapes get.
     fn daemon_args(cmd: Option<cli::DaemonCmd>) -> DaemonArgs {
@@ -2576,9 +2627,9 @@ mod tests {
             VersionGuard::for_command(&Commands::Daemon(daemon_args(None))),
             VersionGuard::Enforce
         );
-        assert_eq!(recovery_verb(&Commands::Flock), None);
+        assert_eq!(recovery_verb(&Commands::Flock(flock_args())), None);
         assert_eq!(
-            VersionGuard::for_command(&Commands::Flock),
+            VersionGuard::for_command(&Commands::Flock(flock_args())),
             VersionGuard::Enforce
         );
         assert_eq!(

--- a/crates/shep-cli/src/lib.rs
+++ b/crates/shep-cli/src/lib.rs
@@ -2533,6 +2533,58 @@ mod tests {
         assert!(text.contains("no shepherd running"), "{text}");
     }
 
+    /// Both of `--follow`'s refusals carry `ExitCode::Usage`, so the code
+    /// alone cannot tell them apart: delete either guard and a test asserting
+    /// only the code still passes. Each is pinned by its own message instead.
+    ///
+    /// Neither arm needs a fixture. The `--format json` case proves the first
+    /// guard answered rather than the second, since a table-format follow
+    /// under a pipe would have refused too, with different words.
+    #[tokio::test]
+    async fn follow_refuses_json_and_a_pipe_for_different_reasons() {
+        let dir = tempfile::tempdir().unwrap();
+        let paths = ShepPaths::resolve(&|_| None, dir.path());
+        let args = cli::FlockArgs {
+            follow: true,
+            interval: 1,
+        };
+
+        let mut out = Vec::new();
+        let mut err = Vec::new();
+        let code = {
+            let mut streams = buffered_streams(&mut out, &mut err);
+            streams.fmt = Format::Json;
+            flock_command(&mut streams, &paths, VersionGuard::Enforce, &args).await
+        };
+        assert_eq!(code, ExitCode::Usage);
+        let text = String::from_utf8(err).unwrap();
+        assert!(
+            text.contains("no follow form"),
+            "the json guard answers before the terminal one: {text}"
+        );
+
+        // `cargo test` captures stdout, so the terminal guard fires on its
+        // own. Under `--nocapture` on a real terminal it cannot, and there is
+        // nothing to pin rather than something to fail.
+        if std::io::stdout().is_terminal() {
+            return;
+        }
+        let mut out = Vec::new();
+        let mut err = Vec::new();
+        let code = {
+            let mut streams = buffered_streams(&mut out, &mut err);
+            flock_command(&mut streams, &paths, VersionGuard::Enforce, &args).await
+        };
+        assert_eq!(code, ExitCode::Usage);
+        let text = String::from_utf8(err).unwrap();
+        assert!(text.contains("needs a terminal"), "{text}");
+        assert!(
+            out.is_empty(),
+            "a refused follow prints no listing: {}",
+            String::from_utf8_lossy(&out)
+        );
+    }
+
     #[tokio::test]
     async fn a_matching_version_passes_without_a_word() {
         let dir = tempfile::tempdir().unwrap();

--- a/crates/shep-cli/src/lib.rs
+++ b/crates/shep-cli/src/lib.rs
@@ -16,6 +16,7 @@ mod dog_index;
 mod exit;
 mod fetch;
 mod flourish;
+mod host;
 mod http;
 mod launch;
 mod lookout;

--- a/crates/shep-cli/src/lib.rs
+++ b/crates/shep-cli/src/lib.rs
@@ -2635,7 +2635,7 @@ mod tests {
     fn flock_args() -> cli::FlockArgs {
         cli::FlockArgs {
             follow: false,
-            interval: 1,
+            interval: cli::FOLLOW_INTERVAL_FLOOR_SECONDS,
         }
     }
 

--- a/crates/shep-cli/src/shutdown.rs
+++ b/crates/shep-cli/src/shutdown.rs
@@ -64,9 +64,13 @@ impl Terminate {
 
     /// Resolves when the OS asks this process to stop.
     ///
-    /// `Option<()>` rather than `()`, so the unix arm passes through
-    /// `Signal::recv`'s own `None` unchanged, keeping every call site's
-    /// `while ... .is_some()` unchanged too.
+    /// `Option<()>` rather than `()`, because that is what
+    /// `tokio::signal::unix::Signal::recv` answers and the unix arm is a
+    /// straight pass-through of it. Every call site ignores the value: each
+    /// one is a `select!` arm binding `_`, or an awaited `recv()` whose
+    /// result is discarded. So the type is tokio's shape surviving rather
+    /// than anything a caller reads, and narrowing it to `()` would be
+    /// correct at every call site today.
     ///
     /// # Cancellation safety
     /// Safe on both platforms: each underlying stream is documented

--- a/crates/shep-cli/src/shutdown.rs
+++ b/crates/shep-cli/src/shutdown.rs
@@ -90,6 +90,68 @@ impl Terminate {
     }
 }
 
+/// A listener for the operator's own Ctrl+C.
+///
+/// Distinct from [`Terminate`], which is the OS asking a long-running
+/// process to stop. This is a person ending something they started at a
+/// keyboard, and a verb that has changed the terminal has to put it back
+/// before it goes.
+///
+/// Installed rather than awaited through `tokio::signal::ctrl_c()`, which
+/// registers its handler on the first poll: an interrupt arriving before
+/// that poll reaches the default disposition and kills the process outright,
+/// leaving whatever the verb did to the terminal in place.
+pub(crate) struct Interrupt {
+    #[cfg(unix)]
+    signal: tokio::signal::unix::Signal,
+    #[cfg(windows)]
+    ctrl_c: tokio::signal::windows::CtrlC,
+}
+
+impl core::fmt::Debug for Interrupt {
+    /// Hand-written for the reason [`Terminate`]'s is.
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("Interrupt").finish_non_exhaustive()
+    }
+}
+
+impl Interrupt {
+    /// Installs the listener.
+    ///
+    /// # Errors
+    ///
+    /// [`io::Error`] if the OS refuses to register a handler.
+    pub(crate) fn install() -> io::Result<Self> {
+        #[cfg(unix)]
+        {
+            Ok(Self {
+                signal: tokio::signal::unix::signal(tokio::signal::unix::SignalKind::interrupt())?,
+            })
+        }
+        #[cfg(windows)]
+        {
+            Ok(Self {
+                ctrl_c: tokio::signal::windows::ctrl_c()?,
+            })
+        }
+    }
+
+    /// Resolves when the operator interrupts this process.
+    ///
+    /// # Cancellation safety
+    /// Safe on both platforms, for the reason [`Terminate::recv`] is.
+    pub(crate) async fn recv(&mut self) -> Option<()> {
+        #[cfg(unix)]
+        {
+            self.signal.recv().await
+        }
+        #[cfg(windows)]
+        {
+            self.ctrl_c.recv().await
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -115,5 +177,23 @@ mod tests {
             early.is_err(),
             "recv() must park until the OS actually asks us to stop"
         );
+    }
+
+    /// fails if the interrupt listener cannot be installed here. Raises no
+    /// real `SIGINT`, for the reason its `Terminate` twin raises no
+    /// `SIGTERM`.
+    #[tokio::test]
+    async fn an_interrupt_listener_installs_on_this_platform() {
+        let listener = Interrupt::install().expect("installing an interrupt listener must work");
+        assert!(format!("{listener:?}").contains("Interrupt"));
+    }
+
+    /// fails if a followed listing would exit the instant it started.
+    #[tokio::test]
+    async fn an_uninterrupted_listener_does_not_resolve() {
+        let mut listener = Interrupt::install().unwrap();
+        let early =
+            tokio::time::timeout(std::time::Duration::from_millis(150), listener.recv()).await;
+        assert!(early.is_err(), "recv() must park until Ctrl+C arrives");
     }
 }

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -40,6 +40,7 @@ go for the full argument. The commit that removed them names itself.
 - [CI and releases](#ci-and-releases) (2)
 - [Config pane writes](#config-pane-writes) (1)
 - [Boot ordering](#boot-ordering) (6)
+- [Following the flock](#following-the-flock) (3)
 
 ## Core types and the daemon's shape
 
@@ -2103,3 +2104,86 @@ than a solved problem, and it is written down here so nobody later reads the
 emitter as the whole of what was designed.
 
 `verified docs/brainstorming/specs/2026-09-02-shep-client-libraries-design.md (The generator)`
+
+## Following the flock
+
+### `--follow` rather than `--watch`, and no second TUI
+
+`shep flock` grew `--follow` and `--interval`, redrawing the listing in place
+on the main screen.
+
+**Why the name:** `watch` already means something on this surface. It is the
+Flockfile field that restarts a sheep when its files change, so a flag reading
+"the flock, watched" next to an app setting reading "watch the filesystem" is
+one word carrying two meanings. `--follow` is the spelling `shep bleats`
+already uses for keeping a stream open. The uncommitted work this was built
+from used `--watch`; that is the only part of it that was overruled outright.
+
+**Why the main screen:** the alternate screen hands back a terminal with no
+trace of what the flock looked like, and the last frame is what an operator
+reads after stopping. A cursor-up-and-overwrite count was rejected separately,
+because a wrapped line makes the count wrong.
+
+**Why the frame is rendered before anything is cleared:** a clear issued ahead
+of the list request leaves the terminal blank for the length of the round trip.
+This is also why the uncommitted `flock_with_list_hook` seam was dropped rather
+than used: it existed so the clear could happen inside the same call as the
+request, and buffering removes the need for the seam and the blank screen at
+once.
+
+Both refusals are usage errors rather than degradations. Not a terminal, and
+`--format json`. A follow printed once into a redirect would exit zero having
+done something other than what was asked, and `shep lookout` already refuses a
+redirected stdout for the same reason.
+
+`verified crates/shep-cli/src/cli.rs (FlockArgs), crates/shep-cli/src/commands/query.rs (flock_follow, follow_frame, fit_rows), crates/shep-cli/src/lib.rs (follow_flock_command)`
+
+### The host line rides with a follow, and not with the one-shot listing
+
+A followed listing carries a line of host numbers above the tables. A bare
+`shep flock` carries nothing new, and its JSON envelope is unchanged.
+
+**Why:** three of the four numbers are rates, and a rate is a difference
+between two samples. A listing that prints once and exits has only ever taken
+one. `HostWatch` holds the earlier sample between redraws, which is the whole
+reason the follow can show them.
+
+The structural note, since it is the call most likely to want revisiting: pm2's
+own analogue splits the same way. `pm2 monit` is per-process, and host-level
+CPU, memory, disk and network is `pm2-server-monit`, a separately installed
+module. That is the shape of a dog here, not of a verb, so extending the
+metrics dog would be the closer match. Pulling the host line is a small revert
+if that is the call: nothing outside the follow path changed, and
+`SCHEMA_VERSION` does not move.
+
+`verified crates/shep-cli/src/host.rs, crates/shep-cli/src/commands/query.rs (follow_frame)`
+
+### Disk traffic sums over distinct devices, keyed on lifetime counters
+
+`sysinfo::Disks` lists mount points, and several of them can sit on one device.
+`host::distinct_disk_io` counts each device once.
+
+**Why:** on macOS sysinfo walks each APFS volume up to the
+`IOBlockStorageDriver` behind it, so `/` and `/System/Volumes/Data` report the
+same counters and a plain sum doubles every number. Measured 2026-09-12:
+byte-identical lifetime counters on both volumes, 12 rounds out of 12, under a
+4 GB write. The lifetime pair is the identity because sysinfo exposes no device
+name to group by, and two separate devices agreeing on both 64-bit counters is
+only reachable at boot with both at zero, where they contribute nothing either
+way. Linux is unaffected: its backend keys `/proc/diskstats` by the partition,
+so two partitions are two devices with different counters.
+
+The rejected alternative was to ship three numbers and say the fourth could not
+be had. It stays the fallback if the dedupe ever proves wrong on a platform
+this was not measured on.
+
+Network excludes loopback, judged by address rather than by interface name. On
+a box where a sheep answers a local proxy, loopback carries every request twice
+and swamps the interface being watched; `lo` and `lo0` are two spellings of a
+set with no promised end.
+
+`disk` and `network` are enabled on shep-cli alone rather than at the workspace
+root, since nothing else reads them. Neither adds a crate on any of the three
+platforms.
+
+`verified crates/shep-cli/src/host.rs (distinct_disk_io, is_loopback), crates/shep-cli/Cargo.toml (the sysinfo entry)`

--- a/web/src/data/cli-reference.generated.txt
+++ b/web/src/data/cli-reference.generated.txt
@@ -806,6 +806,18 @@ List the flock
 Usage: shep flock [OPTIONS]
 
 Options:
+      --follow
+          Keep the listing current: redraw it in place until Ctrl+C
+          
+          One listing to start, then a fresh one every `--interval` seconds while the shepherd stays
+          reachable, each one painted over the last. A summary of the machine rides above the
+          tables. Ctrl+C leaves an exit of zero, a stopped shepherd leaves the code its refusal
+          carries: an interrupted follow and a dead shepherd must not read as the same thing.
+          
+          Needs a live shepherd: a saved roll is a single moment, and a follow's whole reason is the
+          moments after it. Needs a terminal too, and refuses `--format json`, since neither has
+          anywhere to put a redraw.
+
       --format <FORMAT>
           Output format
 
@@ -814,6 +826,15 @@ Options:
           - json:  A versioned JSON envelope, one object per invocation
           
           [default: table]
+
+      --interval <SECONDS>
+          Seconds between redraws, with `--follow`
+          
+          The floor is one second, which is also the default. Below it the listing costs the
+          shepherd more than it tells the operator, and `sysinfo` reports no CPU at all over a
+          window that short.
+          
+          [default: 1]
 
   -q, --quiet
           Suppress non-essential output

--- a/web/src/pages/docs/from-pm2.astro
+++ b/web/src/pages/docs/from-pm2.astro
@@ -78,7 +78,12 @@ const verbTable: { pm2: string; shep: string; note?: string }[] = [
   {
     pm2: "pm2 monit",
     shep: "shep lookout",
-    note: "alias: dash (a fuller dashboard, not a straight swap)",
+    note: "alias: dash (a fuller dashboard, not a straight swap). shep flock --follow redraws the same table in place, if that is all you want",
+  },
+  {
+    pm2: "pm2-server-monit",
+    shep: "shep flock --follow",
+    note: "a separately installed pm2 module. In shep the host line comes with the followed listing",
   },
   { pm2: "-", shep: "shep enable / disable / adopt / rehome", note: "dogs have no pm2 analogue" },
   { pm2: "-", shep: "shep set / get / unset", note: "the KV store; nothing in pm2 does this" },

--- a/web/src/pages/docs/lookout.astro
+++ b/web/src/pages/docs/lookout.astro
@@ -402,6 +402,14 @@ esc/S close   ←/→ tab   z collapse   v reveal for 10s   ↵ set a value   D 
       sequences somewhere nobody will read them.
     </Callout>
 
+    <Callout variant="note">
+      If all you want is the flock table kept current, <code
+        >shep flock --follow</code
+      > redraws it in place with no panes and no action gate. Covered under <a
+        href="/docs/output">terminal output</a
+      >.
+    </Callout>
+
     <h2>Start it</h2>
     <CodeBlock>{startCmds}</CodeBlock>
     <p class="fine">

--- a/web/src/pages/docs/output.astro
+++ b/web/src/pages/docs/output.astro
@@ -463,6 +463,44 @@ notice[style]: full (from $SHEP_STYLE)`}</CodeBlock>
       service is simply wrong.
     </Callout>
 
+    <h2>Following the flock</h2>
+    <p>
+      <code>shep flock --follow</code> keeps the table on screen and paints a
+      fresh one over it every second. <code>--interval</code> changes the
+      cadence. One second is the default and the floor.
+    </p>
+    <CodeBlock
+      label="shep flock --follow, 100 columns"
+    >{`host  cpu 63%  mem 32.7G/48.0G  disk r 58.4M/s w 177.0M/s  net rx 10.4M/s tx 10.6M/s
+
+┌────┬────────┬────────┬───────┬──────────┬──────┬─────┬──────┬──────┬─────────┬──────┬──────┐
+│ ID │ NAME   │ STATUS │ PID   │ RESTARTS │ EXIT │ CFG │ CPU  │ MEM  │ UPTIME  │ FOLD │ SMIT │
+├────┼────────┼────────┼───────┼──────────┼──────┼─────┼──────┼──────┼─────────┼──────┼──────┤
+│ 0  │ web    │ online │ 26932 │ 0        │ -    │ -   │ 0.0% │ 3.1M │ 17m 39s │ -    │ -    │
+│ 1  │ worker │ online │ 27395 │ 0        │ -    │ -   │ 0.1% │ 3.1M │ 17m 31s │ -    │ -    │
+└────┴────────┴────────┴───────┴──────────┴──────┴─────┴──────┴──────┴─────────┴──────┴──────┘`}</CodeBlock>
+    <p>
+      The top line is the machine, not the flock: CPU across every core, memory
+      in use against memory installed, and what the disks and the network moved
+      over the last interval. Loopback traffic is left out of the network
+      figures.
+    </p>
+    <Callout variant="note">
+      Three of those four are rates, so the first frame has nothing to divide
+      and prints <code>-</code> for each. They fill in on the next redraw.
+    </Callout>
+    <p>
+      A follow needs a live shepherd and a real terminal. A saved roll is one
+      moment, and a follow is about the moments after it. With stdout redirected
+      it refuses outright rather than writing escape sequences into a file, and{
+        " "
+      }<code>--format json</code> gets the same refusal.
+    </p>
+    <p class="fine">
+      A flock taller than the window is cut at the bottom, with a line saying how
+      many it dropped. <code>shep lookout</code> scrolls. This does not.
+    </p>
+
     <h2>Following logs</h2>
     <p>
       <code>shep bleats</code> prints the tail of each log before it starts


### PR DESCRIPTION
`shep flock` answers one moment, and the moment drifts. `--follow` keeps asking and paints each listing over the last, with a line of host numbers above it.

```
host  cpu 63%  mem 32.7G/48.0G  disk r 58.4M/s w 177.0M/s  net rx 10.4M/s tx 10.6M/s

┌────┬────────┬────────┬───────┬──────────┬──────┬─────┬──────┬──────┬─────────┬──────┬──────┐
│ ID │ NAME   │ STATUS │ PID   │ RESTARTS │ EXIT │ CFG │ CPU  │ MEM  │ UPTIME  │ FOLD │ SMIT │
├────┼────────┼────────┼───────┼──────────┼──────┼─────┼──────┼──────┼─────────┼──────┼──────┤
│ 0  │ web    │ online │ 26932 │ 0        │ -    │ -   │ 0.0% │ 3.1M │ 17m 39s │ -    │ -    │
│ 1  │ worker │ online │ 27395 │ 0        │ -    │ -   │ 0.1% │ 3.1M │ 17m 31s │ -    │ -    │
└────┴────────┴────────┴───────┴──────────┴──────┴─────┴──────┴──────┴─────────┴──────┴──────┘
```

- `shep flock --follow` redraws in place on the main screen. Not a TUI, `shep lookout` is the TUI.
- `--interval <SECONDS>`, default 1, floor 1, `requires = "follow"`.
- A host line above the tables: CPU, memory, disk read and write, network in and out.
- `shutdown::Interrupt` beside the existing `Terminate`, so Ctrl+C shows the cursor again and exits zero.
- Docs: the generated CLI reference, plus `output`, `lookout` and `from-pm2`.

Longer body than usual because the design calls are all mine and you had no chance to weigh in on any of them.

## Started from the uncommitted `--watch`

The half-finished work in the worktree is the base, not a rewrite. Its `FlockArgs` and the reasoning in its doc comment are kept, including the two things it already settled: Ctrl+C exits zero while a stopped shepherd keeps its refusal's code, and a follow needs a live shepherd because a saved roll is one moment.

Its `flock_with_list_hook` seam is gone. The seam existed so a screen clear could happen inside the same call as the list request. Rendering the frame into a buffer first removes the need for it, and removes the blank screen a clear-before-request would have left for the length of the round trip.

## Calls, all of them yours to overrule

| Call | What I did | What it could have been |
|---|---|---|
| Flag name | `--follow`, matching `shep bleats` | `--watch`, as the WIP had it. Rejected: `watch` is already the Flockfile field for filesystem restarts, so one word would mean two things on one surface |
| Interval | whole seconds, `u64`, default and floor of 1, enforced by clap | sub-second, or a duration string. Nobody needs sub-second for a process listing, and under 200 ms sysinfo reports no CPU at all |
| Redraw | cursor home, clear from cursor down, main screen | the alternate screen. Rejected: it hands back a terminal with no trace of what the flock looked like |
| Not a terminal | refuse, exit 2 | print once and exit zero. Rejected: that exits zero having done something other than what was asked. `shep lookout` already refuses |
| `--format json` | refuse, exit 2 | a document per tick, which is a different feature |
| Flourish | suppressed under a follow | first frame only, which the next clear would wipe a second later |
| Host line | only under `--follow` | on the one-shot listing too. Three of its four numbers are rates, and a listing that prints once has taken one sample |
| Too-tall flock | cut at the bottom, with a count of what went | scroll, which is `lookout`'s job |

## Which of the four host numbers I could actually get

All four, on all three platforms, but only after a correction on disk.

| Number | Source | Catch |
|---|---|---|
| CPU | `System::global_cpu_usage` | needs two samples 200 ms apart. The one second interval floor guarantees it, so only the first redraw prints `-` |
| Memory | `total_memory` / `used_memory` | none. RAM only, not swap |
| Network | `Networks::refresh`, then `received`/`transmitted` | already per-refresh deltas. Loopback excluded by address rather than by interface name |
| Disk | `Disk::usage()` with `DiskRefreshKind::with_io_usage` | `Disks` lists mount points, and on macOS several volumes report one device |

On the disk catch: sysinfo walks each APFS volume up to the `IOBlockStorageDriver` behind it, so `/` and `/System/Volumes/Data` carry the same counters and a plain sum doubles every number. Measured here: byte-identical lifetime counters on both volumes, 12 rounds out of 12, under a 4 GB write. `distinct_disk_io` totals over distinct devices, keyed on those lifetime counters, since sysinfo exposes no device name to group by. Linux is unaffected either way, its backend keys `/proc/diskstats` by partition so two partitions differ. Windows takes the same dedupe and is a no-op if it does not need it.

The fallback if that dedupe ever proves wrong somewhere I could not test: drop the disk column and ship three. Two separate devices agreeing on both 64-bit counters is only reachable at boot with both at zero, where they contribute nothing anyway.

`disk` and `network` are enabled for shep-cli alone, not at the workspace root. Neither adds a crate: `cargo tree -p shep --all-features` is byte-identical before and after on macOS, and the feature table resolves both to `windows` crate features on Windows and to nothing on Linux. The 0.38 pin is untouched.

## What a pipe or a redirect gets

A usage error on stderr, nothing on stdout, and no escape sequences anywhere.

```
$ shep flock --follow > out.txt
error[usage]: `--follow` needs a terminal; stdout is not one
$ echo $?
2
$ wc -c out.txt
       0 out.txt
```

`--format json --follow` is the same refusal in an envelope, whether or not stdout is a terminal.

## The pm2 premise, checked

`pm2 monit` is a terminal dashboard of per-process CPU and memory. Host level CPU, memory, disk and network is `pm2-server-monit`, a separately installed pm2 module, which is the analogue of a shep dog rather than of `pm2 list`.

So the structurally closer match would be extending the metrics dog, not the `flock` verb. I built what was asked, but a host summary printed by a verb that talks to the shepherd is a new kind of thing for that verb to do, and it is the one call here I would most expect you to want back. Nothing outside the follow path changed, so pulling it is a small revert: the one-shot listing and its JSON envelope are untouched, and `SCHEMA_VERSION` does not move.

## Verified by looking at the screen, not the diff

`tui-screen-capture` against a real shepherd with two sheep, at 120x30, 100x24 and 70x8.

It found a bug a green suite did not. `script(1)` hands a pty that has never been told its size, so `crossterm::terminal::size()` reported zero rows, and trimming to that printed the notice alone, once a second, with no flock at all. Sizes with no room to trim now get the frame whole, same as a terminal that will not measure.

Gate: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`, `cargo test --workspace --all-features`, `RUSTDOCFLAGS="-D warnings" cargo doc`, `cargo deny check` for the feature change, and `npx astro build` plus `npx astro check` in `web/`.

Not covered locally: Linux and Windows. Read CI before calling this green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added `shep flock --follow` to continuously refresh the process table in place.
  - Added configurable refresh timing with `--interval` (default: 1 second).
  - Followed listings now show CPU, memory, disk, and network activity metrics.
  - Long listings are trimmed to fit the terminal, with dropped-row counts displayed.
  - Added graceful interruption with Ctrl+C.

- **Bug Fixes**
  - Prevented invalid zero-second intervals.
  - Follow mode is unavailable for redirected output and JSON formatting.

- **Documentation**
  - Added usage guidance and migration notes for follow mode and host metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->