### PR TITLE
fix(daemon)!: anchor a relative out_file/err_file at the app's cwd

### DIFF
--- a/crates/shep-daemon/src/assemble.rs
+++ b/crates/shep-daemon/src/assemble.rs
@@ -17,7 +17,7 @@
 use core::convert::Infallible;
 use core::fmt;
 use std::collections::BTreeMap;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use shep_core::config::ResolvedApp;
 use shep_core::config::template::{self, RenderError};
@@ -182,7 +182,8 @@ impl core::error::Error for AssembleError {
 /// Explicit `out_file`/`err_file` win over the default log path and render
 /// `{{instance}}` and `{{name}}` the way `env` and `args` do; normalize
 /// refuses a `{{secret:...}}` in either, and a path that collides across
-/// instances unless `merge_logs` asked for it.
+/// instances unless `merge_logs` asked for it. A relative one is anchored at
+/// the app's `cwd`.
 /// `SpawnSpec::stdin` carries `config.stdin` straight through: unlike
 /// `channel`, nothing else turns it on.
 ///
@@ -326,12 +327,12 @@ fn build<E>(
     };
 
     let out_file = match &config.out_file {
-        Some(explicit) => PathBuf::from(render(explicit, "out_file")?),
+        Some(explicit) => anchor_log_path(render(explicit, "out_file")?, cwd.as_deref()),
         None => paths.logs.join(format!("{}out.log", log_stem)),
     };
 
     let err_file = match &config.err_file {
-        Some(explicit) => PathBuf::from(render(explicit, "err_file")?),
+        Some(explicit) => anchor_log_path(render(explicit, "err_file")?, cwd.as_deref()),
         None => paths.logs.join(format!("{}err.log", log_stem)),
     };
 
@@ -352,6 +353,22 @@ fn build<E>(
         stdin: config.stdin,
         credentials,
     })
+}
+
+/// Anchors an explicit log path at the sheep's `cwd` when it is relative.
+///
+/// The shepherd opens these files itself, so a bare relative path resolves
+/// against the shepherd's directory rather than the sheep's: the same config
+/// names one file under the shepherd a handover started from and another
+/// under its successor, and `shep bleats` reads a third under the CLI's.
+///
+/// A sheep with no `cwd` already runs in the shepherd's own directory.
+fn anchor_log_path(rendered: String, cwd: Option<&Path>) -> PathBuf {
+    let path = PathBuf::from(rendered);
+    match cwd {
+        Some(cwd) if path.is_relative() => cwd.join(path),
+        _ => path,
+    }
 }
 
 #[cfg(test)]
@@ -543,6 +560,92 @@ mod tests {
         assert_eq!(
             spec.err_file,
             PathBuf::from("/home/ada/.shep/logs/app-0-err.log")
+        );
+    }
+
+    #[test]
+    fn a_relative_log_path_is_anchored_at_the_app_cwd() {
+        let app_config = AppConfig {
+            name: "app".to_string(),
+            script: "app".to_string(),
+            args: vec![],
+            cwd: Some("/srv/app".to_string()),
+            out_file: Some("logs/out.log".to_string()),
+            err_file: Some("logs/{{name}}-err.log".to_string()),
+            ..Default::default()
+        };
+        let app = normalize(app_config).unwrap();
+        let paths = test_paths();
+
+        let spec = assemble(&app, 0, &paths, None, &no_secrets()).unwrap();
+
+        assert_eq!(spec.out_file, PathBuf::from("/srv/app/logs/out.log"));
+        assert_eq!(spec.err_file, PathBuf::from("/srv/app/logs/app-err.log"));
+    }
+
+    #[test]
+    fn an_absolute_log_path_ignores_the_app_cwd() {
+        // A leading separator is not absolute on Windows, so the literal
+        // has to carry a drive letter there to be the case under test.
+        let absolute = if cfg!(windows) {
+            r"C:\var\log\myapp.log"
+        } else {
+            "/var/log/myapp.log"
+        };
+        let app_config = AppConfig {
+            name: "app".to_string(),
+            script: "app".to_string(),
+            args: vec![],
+            cwd: Some("/srv/app".to_string()),
+            out_file: Some(absolute.to_string()),
+            ..Default::default()
+        };
+        let app = normalize(app_config).unwrap();
+        let paths = test_paths();
+
+        let spec = assemble(&app, 0, &paths, None, &no_secrets()).unwrap();
+
+        assert_eq!(spec.out_file, PathBuf::from(absolute));
+    }
+
+    /// A sheep with no `cwd` runs where the shepherd does, so a relative
+    /// path already resolves there and gains nothing from an anchor.
+    #[test]
+    fn a_relative_log_path_without_a_cwd_is_left_alone() {
+        let app_config = AppConfig {
+            name: "app".to_string(),
+            script: "app".to_string(),
+            args: vec![],
+            cwd: None,
+            out_file: Some("logs/out.log".to_string()),
+            ..Default::default()
+        };
+        let app = normalize(app_config).unwrap();
+        let paths = test_paths();
+
+        let spec = assemble(&app, 0, &paths, None, &no_secrets()).unwrap();
+
+        assert_eq!(spec.out_file, PathBuf::from("logs/out.log"));
+    }
+
+    /// The default log path is `$SHEP_HOME/logs`, which no `cwd` moves.
+    #[test]
+    fn a_defaulted_log_path_ignores_the_app_cwd() {
+        let app_config = AppConfig {
+            name: "app".to_string(),
+            script: "app".to_string(),
+            args: vec![],
+            cwd: Some("/srv/app".to_string()),
+            ..Default::default()
+        };
+        let app = normalize(app_config).unwrap();
+        let paths = test_paths();
+
+        let spec = assemble(&app, 0, &paths, None, &no_secrets()).unwrap();
+
+        assert_eq!(
+            spec.out_file,
+            PathBuf::from("/home/ada/.shep/logs/app-0-out.log")
         );
     }
 

--- a/crates/shep-daemon/tests/real_runner.rs
+++ b/crates/shep-daemon/tests/real_runner.rs
@@ -848,6 +848,54 @@ async fn a_bare_interpreter_resolves_via_the_seeded_path() {
     assert_eq!(outcome.code, Some(0));
 }
 
+/// The shepherd opens a sheep's log files itself, so a relative `out_file`
+/// has to be anchored at the sheep's `cwd` before that open.
+///
+/// This test process stands somewhere else entirely, which is the case: an
+/// unanchored path would create the file under the test binary's own
+/// directory and leave the one asserted here missing.
+#[tokio::test]
+async fn a_relative_log_path_lands_under_the_sheep_cwd() {
+    use shep_core::config::{AppConfig, normalize};
+    use shep_core::paths::ShepPaths;
+    use shep_core::secrets::SecretView;
+    use shep_daemon::assemble::assemble;
+
+    let dir = tempfile::tempdir().unwrap();
+    let app_dir = dir.path().join("app");
+    fs::create_dir_all(&app_dir).unwrap();
+    let paths = ShepPaths::resolve(
+        &|key| (key == "SHEP_HOME").then(|| dir.path().to_string_lossy().into_owned()),
+        Path::new("/unused-by-this-fixture"),
+    );
+
+    let app_config = AppConfig {
+        name: "anchored".to_string(),
+        script: "/bin/sh".to_string(),
+        interpreter: Some("none".to_string()),
+        args: vec!["-c".to_string(), "echo anchored-ok".to_string()],
+        cwd: Some(app_dir.to_string_lossy().into_owned()),
+        out_file: Some("logs/out.log".to_string()),
+        err_file: Some("logs/err.log".to_string()),
+        ..Default::default()
+    };
+    let app = normalize(app_config).unwrap();
+    let spec = assemble(
+        &app,
+        0,
+        &paths,
+        None,
+        &SecretView::empty("production".to_string()),
+    )
+    .expect("this fixture carries no secret to resolve");
+    assert_eq!(spec.out_file, app_dir.join("logs").join("out.log"));
+
+    let runner = TokioRunner::new();
+    let (mut proc, _io) = runner.spawn(&spec).unwrap();
+    assert_eq!(proc.wait().await.code, Some(0));
+    await_file_contents(&app_dir.join("logs").join("out.log"), "anchored-ok\n").await;
+}
+
 /// A real pipe on a real fd 0. `cat` echoes what is written to it, so a
 /// line on stdout proves the whole path worked: created, mapped to fd 0,
 /// written, flushed, and read by the child.

--- a/web/src/pages/docs/first-flockfile.astro
+++ b/web/src/pages/docs/first-flockfile.astro
@@ -133,8 +133,8 @@ const fieldGroups: FieldGroup[] = [
   {
     title: "Logs",
     fields: [
-      { name: "out_file", type: "string?", default: "logs/<name>-<i>-out.log", does: "Stdout log file path override; supports {{instance}} and {{name}}. With instances > 1, an explicit path needs {{instance}} or merge_logs, or it's refused: {{name}} renders the same for every instance, so a path carrying only that one still collides." },
-      { name: "err_file", type: "string?", default: "logs/<name>-<i>-err.log", does: "Stderr log file path override; supports {{instance}} and {{name}}. With instances > 1, an explicit path needs {{instance}} or merge_logs, or it's refused: {{name}} renders the same for every instance, so a path carrying only that one still collides." },
+      { name: "out_file", type: "string?", default: "$SHEP_HOME/logs/<name>-<i>-out.log", does: "Stdout log file path override; supports {{instance}} and {{name}}, and a relative path lands under the app's cwd. With instances > 1, an explicit path needs {{instance}} or merge_logs, or it's refused: {{name}} renders the same for every instance, so a path carrying only that one still collides." },
+      { name: "err_file", type: "string?", default: "$SHEP_HOME/logs/<name>-<i>-err.log", does: "Stderr log file path override; supports {{instance}} and {{name}}, and a relative path lands under the app's cwd. With instances > 1, an explicit path needs {{instance}} or merge_logs, or it's refused: {{name}} renders the same for every instance, so a path carrying only that one still collides." },
       { name: "merge_logs", type: "bool", default: "false", does: "Collapse every instance's logs into one file pair." },
     ],
   },

--- a/web/src/pages/docs/logs.astro
+++ b/web/src/pages/docs/logs.astro
@@ -86,8 +86,10 @@ stderr  /tmp/shepdocs/home/logs/shepd.err.log  emptied`;
       <code>&lt;name&gt;-&lt;instance&gt;-err.log</code>. An app can point either
       somewhere else with{" "}
       <code>out_file</code> and <code>err_file</code>, or fold both streams
-      into one file with <code>merge_logs</code>. A clustered app gets one
-      pair per instance unless it says otherwise, which is why an explicit{" "}
+      into one file with <code>merge_logs</code>. A relative path in either
+      lands under the app's <code>cwd</code>, so a Flockfile can keep its logs
+      beside the app it runs. A clustered app gets one pair per instance
+      unless it says otherwise, which is why an explicit{" "}
       <code>out_file</code> on a multi-instance app is refused unless it
       carries <code>{"{{instance}}"}</code> or the app sets{" "}
       <code>merge_logs</code>: without one of those, every instance would be


### PR DESCRIPTION
`out_file` and `err_file` have always been documented as following `cwd` when relative. They did not. `assemble` built both with `PathBuf::from(render(...))` and joined nothing, and the shepherd is the process that opens them, so a relative path resolved against whatever directory the shepherd was launched from.

Reproduced against a real flock with `cwd = <dir>/b` and `out_file = "rel-out.log"`, loaded from `<dir>/a`:

- the sheep reported running in `<dir>/b`, its log landed in `<dir>/a`
- restarting the same Flockfile from `<dir>/c` moved the logs to `<dir>/c`, config unchanged
- `shep bleats relog --no-follow` from `<dir>/c` printed nothing, since the CLI opens the recorded path against its own directory

Either the join or the docs had to move. Went with the join: `lifecycle.rs` already states the rule for the sibling field, "the daemon resolves against its own cwd, so what crosses must be absolute", and `script` is absolutised by the CLI for exactly that reason. The log paths were the pair that never got it. Doing it in `assemble` rather than the CLI covers `shep set` and the override store too.

An app with no `cwd` runs in the shepherd's own directory, so a relative path there already resolves where the sheep runs and is left alone. That keeps `assemble` pure, with no `current_dir()` read.

Breaking: an app that set a relative `out_file` and a `cwd` will find its next log under the `cwd`.

- tests: four in `assemble.rs` for anchored, absolute, no-cwd and defaulted paths, plus one in `real_runner.rs` that spawns a real child and reads the line back out of the file under the app's `cwd`. Reverting the join fails that one.
- docs: `logs.astro` and the Flockfile reference now say where a relative path lands, and that reference's `out_file`/`err_file` defaults gained the `$SHEP_HOME` prefix they were missing. The generated CLI reference and `flockfile.schema.json` both regenerate unchanged.
- follow-up, not in this PR: with no `cwd` at all the recorded path stays relative, and `shep bleats` prints nothing rather than naming the file it could not open.
- worth a look on #220: `log_path_advisory` stats the raw config value, so whichever of the two lands second should hand it the anchored path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Relative application log paths now resolve under the app’s configured working directory.
  - Absolute log paths and applications without a working directory continue to behave as before.

- **Documentation**
  - Updated log configuration guidance to clarify path resolution.
  - Documented the default locations for standard output and error logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->