### PR TITLE
fix(cli): name the log file a read could not find

### DIFF
--- a/crates/shep-cli/src/commands/bleats.rs
+++ b/crates/shep-cli/src/commands/bleats.rs
@@ -1965,7 +1965,7 @@ mod tests {
 
         let (client, daemon) = fake_client_with_push(&sock).await;
         let mut ghost = info(1, "ghost");
-        ghost.out_file = Some(missing_path);
+        ghost.out_file = Some(missing_path.clone());
         let mut real = info(2, "web");
         real.out_file = Some(real_path);
         daemon.reply_to_list(vec![ghost, real]);
@@ -1995,8 +1995,10 @@ mod tests {
         assert!(String::from_utf8(out).unwrap().contains("still-here"));
         let stderr = String::from_utf8(err).unwrap();
         assert!(
-            stderr.contains("log_missing") && stderr.contains("never-written.log"),
-            "the notice must name the file that was not there: {stderr}"
+            stderr.contains(&format!(
+                "notice[log_missing]: ghost: no out log at {missing_path} yet"
+            )),
+            "the notice must name the sheep, the stream and the file: {stderr}"
         );
     }
 

--- a/crates/shep-cli/src/commands/bleats.rs
+++ b/crates/shep-cli/src/commands/bleats.rs
@@ -236,6 +236,23 @@ pub(crate) fn read_tail(path: &Path, limit: usize) -> io::Result<(Vec<String>, b
     Ok((lines, truncated))
 }
 
+/// Why a log file is not there, naming the path this process tried.
+///
+/// `stream` is `"out"` or `"err"`. Each process resolves a relative
+/// `out_file`/`err_file` against its own directory, so the absolute form is
+/// what shows that the shepherd is writing a different file.
+pub(crate) fn missing_log_note(stream: &str, path: &Path) -> String {
+    if !path.is_relative() {
+        return format!("no {stream} log at {} yet", path.display());
+    }
+    let tried = std::path::absolute(path).unwrap_or_else(|_| path.to_path_buf());
+    format!(
+        "no {stream} log at {}; {stream}_file is relative, so the shepherd \
+         resolves it against its own directory instead",
+        tried.display()
+    )
+}
+
 /// Renders the selected files of every sheep the selector admits, in flock
 /// order, and returns the exit code that reports how that went.
 ///
@@ -245,9 +262,10 @@ pub(crate) fn read_tail(path: &Path, limit: usize) -> io::Result<(Vec<String>, b
 ///
 /// A `None` path (a shepherd predating
 /// [`shep_core::protocol::ProcessInfo::out_file`]) is a `log_path_unknown`
-/// notice. A missing file is silent, since the daemon creates both at
-/// spawn. Any other read failure is a `log_unreadable` notice and sets
-/// [`ExitCode::Failure`]; the rest of the flock still prints.
+/// notice. A file that is not there is a `log_missing` notice and leaves
+/// the exit code alone. Any other read failure is a `log_unreadable`
+/// notice and sets [`ExitCode::Failure`]; the rest of the flock still
+/// prints.
 fn tail_log_files(
     streams: &mut Streams<'_>,
     quiet: bool,
@@ -348,10 +366,15 @@ fn tail_log_files(
                             }
                         }
                         Err(err) if err.kind() == io::ErrorKind::NotFound => {
-                            // Silent: the daemon creates both files at spawn,
-                            // so a missing file means this sheep has never
-                            // run in this $SHEP_HOME. A notice per quiet
-                            // sheep would spam stderr on a fresh flock.
+                            write_notice(
+                                streams,
+                                quiet,
+                                "log_missing",
+                                &format!(
+                                    "{name}: {}",
+                                    missing_log_note(stream_name, Path::new(path))
+                                ),
+                            );
                         }
                         Err(err) => {
                             failure = true;
@@ -1926,10 +1949,10 @@ mod tests {
     }
 
     /// The daemon creates both files at spawn, so a missing one means this
-    /// sheep has never run in this `$SHEP_HOME`, not a fault worth a
-    /// notice.
+    /// sheep has never run in this `$SHEP_HOME`. Said rather than exited on:
+    /// an empty tail and an empty log read the same on a terminal.
     #[tokio::test]
-    async fn a_missing_file_is_silent_and_the_rest_still_print() {
+    async fn a_missing_file_is_noticed_and_the_rest_still_print() {
         let dir = tempfile::tempdir().unwrap();
         let sock = shep_client::testing::control_address(dir.path());
         let real_path = write_log(dir.path(), "web-out.log", "still-here\n");
@@ -1964,12 +1987,62 @@ mod tests {
             .expect("--no-follow never subscribes, so it must terminate on its own")
         };
 
-        assert_eq!(code, ExitCode::Success);
+        assert_eq!(
+            code,
+            ExitCode::Success,
+            "a sheep that has never run is not a failed run"
+        );
         assert!(String::from_utf8(out).unwrap().contains("still-here"));
+        let stderr = String::from_utf8(err).unwrap();
         assert!(
-            err.is_empty(),
-            "a missing file is silent, not a notice: {}",
-            String::from_utf8_lossy(&err)
+            stderr.contains("log_missing") && stderr.contains("never-written.log"),
+            "the notice must name the file that was not there: {stderr}"
+        );
+    }
+
+    /// A relative `out_file` is resolved against the shepherd's directory
+    /// by the shepherd and against this one here, so the two name different
+    /// files and the silent read was of the wrong one.
+    #[tokio::test]
+    async fn a_relative_path_names_the_file_this_process_actually_tried() {
+        let dir = tempfile::tempdir().unwrap();
+        let sock = shep_client::testing::control_address(dir.path());
+
+        let (client, daemon) = fake_client_with_push(&sock).await;
+        let mut sheep = info(1, "web");
+        sheep.out_file = Some("logs/out.log".to_string());
+        daemon.reply_to_list(vec![sheep]);
+
+        let mut out = Vec::new();
+        let mut err = Vec::new();
+        let code = {
+            let mut streams = Streams {
+                out: &mut out,
+                err: &mut err,
+                style: crate::style::Presentation::BARE,
+                fmt: Format::Table,
+            };
+            tokio::time::timeout(
+                RUN_TIMEOUT,
+                bleats(&client, &mut streams, false, &no_follow_args_out("all")),
+            )
+            .await
+            .expect("--no-follow never subscribes, so it must terminate on its own")
+        };
+
+        assert_eq!(code, ExitCode::Success);
+        assert!(out.is_empty());
+        let stderr = String::from_utf8(err).unwrap();
+        // Asserted against the un-resolved spelling rather than against a
+        // second `absolute` call: a sibling test moves the process cwd, so
+        // the expected string cannot be recomputed here.
+        assert!(
+            stderr.contains("out.log") && !stderr.contains("at logs"),
+            "the notice must name the absolute path this process read: {stderr}"
+        );
+        assert!(
+            stderr.contains("out_file is relative"),
+            "the notice must say why the shepherd's file is a different one: {stderr}"
         );
     }
 

--- a/crates/shep-cli/src/whistle/facts.rs
+++ b/crates/shep-cli/src/whistle/facts.rs
@@ -348,6 +348,13 @@ pub struct BleatTail {
     /// A model that cannot tell "this is all of it" from "this is the last
     /// 50" will draw the wrong conclusion from a quiet log.
     pub truncated: bool,
+    /// One entry per stream whose file this process could not find, naming
+    /// the path it tried. Empty when both files were read.
+    ///
+    /// An empty `out` alone cannot tell a sheep that has written nothing
+    /// from a path that resolves to a different file here than it does
+    /// under the shepherd.
+    pub notes: Vec<String>,
 }
 
 #[cfg(test)]

--- a/crates/shep-cli/src/whistle/read.rs
+++ b/crates/shep-cli/src/whistle/read.rs
@@ -406,6 +406,12 @@ mod tests {
             result.0.err.is_empty(),
             "no err_file means an empty tail, not an error"
         );
+        // Both files read, so the key is still on the wire and still empty:
+        // a model told nothing and a model told nothing is wrong differ.
+        assert_eq!(
+            serde_json::to_value(&result.0).unwrap()["notes"],
+            serde_json::json!([])
+        );
 
         served.await.expect("the fake daemon task must not panic");
     }
@@ -451,6 +457,11 @@ mod tests {
             result.0.notes[0].contains("out_file is relative"),
             "the note must say why the shepherd's file is a different one: {:?}",
             result.0.notes
+        );
+        assert_eq!(
+            serde_json::to_value(&result.0).unwrap()["notes"],
+            serde_json::json!([result.0.notes[0]]),
+            "the note has to reach `structuredContent`, not just the struct"
         );
 
         served.await.expect("the fake daemon task must not panic");

--- a/crates/shep-cli/src/whistle/read.rs
+++ b/crates/shep-cli/src/whistle/read.rs
@@ -22,7 +22,7 @@ use super::facts::{
     BarkListing, BarkRow, BleatTail, FlockListing, HostRow, MetricsReading, SheepRow,
 };
 use super::shepherd;
-use crate::commands::bleats::read_tail;
+use crate::commands::bleats::{missing_log_note, read_tail};
 use crate::dog::metrics::sample_host;
 
 /// The argument every sheep-scoped tool takes.
@@ -143,14 +143,15 @@ impl Whistle {
         let Some(info) = flock.first() else {
             return Err(unexpected_response());
         };
-        let (out, out_truncated) = tail_stream(info.out_file.as_deref(), limit)?;
-        let (err, err_truncated) = tail_stream(info.err_file.as_deref(), limit)?;
+        let out = tail_stream(info.out_file.as_deref(), limit, "out")?;
+        let err = tail_stream(info.err_file.as_deref(), limit, "err")?;
         Ok(Json(BleatTail {
             name: info.name.clone(),
             id: info.id,
-            out,
-            err,
-            truncated: out_truncated || err_truncated,
+            truncated: out.truncated || err.truncated,
+            notes: [out.note, err.note].into_iter().flatten().collect(),
+            out: out.lines,
+            err: err.lines,
         }))
     }
 
@@ -175,17 +176,51 @@ impl Whistle {
     }
 }
 
-/// One sheep's log tail for one stream (`out` or `err`).
+/// What one stream's tail yielded.
 ///
-/// A `None` path or a missing file both read as an empty, non-truncated
-/// tail. Any other I/O failure is a refusal naming the path.
-fn tail_stream(path: Option<&str>, limit: usize) -> Result<(Vec<String>, bool), CallToolResult> {
+/// A struct rather than a tuple: two of the three are what a model reads to
+/// decide whether an empty `lines` means anything.
+struct StreamTail {
+    /// The lines that survived both of `read_tail`'s bounds, oldest first.
+    lines: Vec<String>,
+    /// Whether either bound cut them short.
+    truncated: bool,
+    /// Why there are no lines, when the file was not there.
+    note: Option<String>,
+}
+
+/// One sheep's log tail for one stream, `stream` being `"out"` or `"err"`.
+///
+/// A `None` path reads as an empty tail with nothing to say: the shepherd
+/// reported no path at all. A file that is not there carries a note naming
+/// the path this process tried. Any other I/O failure is a refusal.
+///
+/// # Errors
+/// The file could be named but not read: a permission refusal, a directory
+/// where a file was expected, an I/O fault mid-read.
+fn tail_stream(
+    path: Option<&str>,
+    limit: usize,
+    stream: &str,
+) -> Result<StreamTail, CallToolResult> {
     let Some(path) = path else {
-        return Ok((Vec::new(), false));
+        return Ok(StreamTail {
+            lines: Vec::new(),
+            truncated: false,
+            note: None,
+        });
     };
     match read_tail(Path::new(path), limit) {
-        Ok(result) => Ok(result),
-        Err(err) if err.kind() == io::ErrorKind::NotFound => Ok((Vec::new(), false)),
+        Ok((lines, truncated)) => Ok(StreamTail {
+            lines,
+            truncated,
+            note: None,
+        }),
+        Err(err) if err.kind() == io::ErrorKind::NotFound => Ok(StreamTail {
+            lines: Vec::new(),
+            truncated: false,
+            note: Some(missing_log_note(stream, Path::new(path))),
+        }),
         Err(err) => Err(shepherd::own_refusal(
             "log_unreadable",
             format!("failed to read {path}: {err}"),
@@ -370,6 +405,52 @@ mod tests {
         assert!(
             result.0.err.is_empty(),
             "no err_file means an empty tail, not an error"
+        );
+
+        served.await.expect("the fake daemon task must not panic");
+    }
+
+    /// A model reading `out: []` has to be able to tell a quiet sheep from
+    /// a path that resolves elsewhere under the shepherd than it does here.
+    #[tokio::test]
+    async fn tail_bleats_says_which_file_it_could_not_find() {
+        let dir = tempfile::tempdir().unwrap();
+        let socket = shep_client::testing::control_address(dir.path());
+
+        let mut info = shep_client::testing::sample_info();
+        info.out_file = Some("logs/out.log".to_string());
+        info.err_file = None;
+
+        let served = shep_client::testing::serve_one_request(
+            &socket,
+            matching_ack(),
+            Response::Described(vec![info]),
+        )
+        .await;
+
+        let whistle = whistle_at(socket, dir.path().join("barks.jsonl"));
+        let result = tokio::time::timeout(
+            TEST_TIMEOUT,
+            whistle.tail_bleats(Parameters(TailParams {
+                name: "web".to_string(),
+                lines: None,
+            })),
+        )
+        .await
+        .expect("tail_bleats must return within the test timeout")
+        .expect("a file that is not there is not a tool error");
+
+        assert!(result.0.out.is_empty());
+        assert_eq!(
+            result.0.notes.len(),
+            1,
+            "one note for the one stream with a path: {:?}",
+            result.0.notes
+        );
+        assert!(
+            result.0.notes[0].contains("out_file is relative"),
+            "the note must say why the shepherd's file is a different one: {:?}",
+            result.0.notes
         );
 
         served.await.expect("the fake daemon task must not panic");

--- a/web/src/pages/docs/logs.astro
+++ b/web/src/pages/docs/logs.astro
@@ -158,6 +158,13 @@ stderr  /tmp/shepdocs/home/logs/shepd.err.log  emptied`;
       shep's would silently lose half the output of that redirect and make{" "}
       <code>--err</code> produce an empty file.
     </p>
+    <p>
+      A log file that is not there is named on stderr rather than read as an
+      empty tail, and the notice carries the path this command resolved. That
+      matters most when <code>out_file</code> is relative: the shepherd
+      resolves it against its own directory and <code>shep bleats</code>{" "}
+      against yours, so the two are different files.
+    </p>
     <Callout variant="note">
       <code>--no-follow</code> reads files and <code>--follow</code> reads
       the bus, and the difference shows up twice. A stopped sheep still has


### PR DESCRIPTION
`shep bleats` and `tail_bleats` swallowed `NotFound` on a log file, so a file they could not open printed as an empty tail. An empty tail and an empty log read the same on a terminal.

- A missing file is now a `log_missing` notice naming the path, on stderr, silenced by `--quiet`
- A relative `out_file` reports the absolute path this process tried, and says the shepherd resolves it against its own directory instead
- `tail_bleats` gains a `notes` field with the same text
- Exit code unchanged, `log_unreadable` keeps sole ownership of `ExitCode::Failure`
- `lookout/tail.rs` already did this, so only two of the three readers were silent

Daemon side untouched: an app with no `cwd` still records a relative path, so the shepherd and the CLI still open different files. Anchoring that needs the shepherd's own directory inside `assemble`, which is either a new parameter across 44 call sites and a break in `shep-daemon`'s public `assemble`, or a field on `ShepPaths`, whose module doc is "On-disk layout of $SHEP_HOME". Related: #224

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - `shep bleats --no-follow` and backlog reads now report missing log files on stderr.
  - Diagnostics include the attempted absolute path and clarify how relative paths are resolved.
  - Missing logs no longer appear as unexplained empty output, while successful commands retain their existing exit status.

- **Documentation**
  - Updated log documentation to explain missing-file notices and the difference between shepherd and CLI resolution of relative `out_file` paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->