### PR TITLE
perf(cli): compile the bleats match axis once, and share its chip suffix

### DIFF
--- a/crates/shep-cli/src/lookout/app.rs
+++ b/crates/shep-cli/src/lookout/app.rs
@@ -4039,7 +4039,7 @@ impl App {
             KeyPress::MatchPrev => {
                 let stepping = self
                     .sheep_pane()
-                    .is_some_and(|pane| pane.feed().filters().matcher.is_some());
+                    .is_some_and(|pane| pane.feed().filters().match_text().is_some());
                 if stepping && let Some(feed) = self.sheep_feed_mut() {
                     feed.scroll_up(1);
                 }
@@ -4210,7 +4210,7 @@ impl App {
             KeyPress::MatchPrev => {
                 let stepping = self
                     .bleats_pane()
-                    .is_some_and(|pane| pane.filters().matcher.is_some());
+                    .is_some_and(|pane| pane.filters().match_text().is_some());
                 if stepping {
                     self.scroll_bleats_back(1);
                 }
@@ -4272,7 +4272,7 @@ impl App {
             KeyPress::Quit => Effect::Quit,
             KeyPress::TextChar(typed) => {
                 if let Some(pane) = self.bleats_pane_mut() {
-                    let mut text = pane.filters().matcher.clone().unwrap_or_default();
+                    let mut text = pane.filters().match_text().unwrap_or_default().to_string();
                     text.push(typed);
                     pane.set_match(text);
                 }
@@ -4280,7 +4280,7 @@ impl App {
             }
             KeyPress::TextBackspace => {
                 if let Some(pane) = self.bleats_pane_mut() {
-                    let mut text = pane.filters().matcher.clone().unwrap_or_default();
+                    let mut text = pane.filters().match_text().unwrap_or_default().to_string();
                     text.pop();
                     pane.set_match(text);
                 }
@@ -4314,7 +4314,7 @@ impl App {
             KeyPress::Quit => Effect::Quit,
             KeyPress::TextChar(typed) => {
                 if let Some(feed) = self.sheep_feed_mut() {
-                    let mut text = feed.filters().matcher.clone().unwrap_or_default();
+                    let mut text = feed.filters().match_text().unwrap_or_default().to_string();
                     text.push(typed);
                     feed.set_match(text);
                 }
@@ -4322,7 +4322,7 @@ impl App {
             }
             KeyPress::TextBackspace => {
                 if let Some(feed) = self.sheep_feed_mut() {
-                    let mut text = feed.filters().matcher.clone().unwrap_or_default();
+                    let mut text = feed.filters().match_text().unwrap_or_default().to_string();
                     text.pop();
                     feed.set_match(text);
                 }
@@ -13018,21 +13018,13 @@ mod tests {
         let _ = app.update(Msg::Key(KeyPress::TextChar('p')));
         let _ = app.update(Msg::Key(KeyPress::TextChar('o')));
         assert_eq!(
-            app.bleats_pane()
-                .expect("open")
-                .filters()
-                .matcher
-                .as_deref(),
+            app.bleats_pane().expect("open").filters().match_text(),
             Some("po")
         );
         let _ = app.update(Msg::Key(KeyPress::TextApply));
         assert_eq!(app.mode(), InputMode::Normal);
         assert_eq!(
-            app.bleats_pane()
-                .expect("open")
-                .filters()
-                .matcher
-                .as_deref(),
+            app.bleats_pane().expect("open").filters().match_text(),
             Some("po"),
             "TextApply keeps what was already applied live"
         );
@@ -13053,22 +13045,14 @@ mod tests {
         let _ = app.update(Msg::Key(KeyPress::FilterStart));
         let _ = app.update(Msg::Key(KeyPress::TextChar('x')));
         assert_eq!(
-            app.bleats_pane()
-                .expect("open")
-                .filters()
-                .matcher
-                .as_deref(),
+            app.bleats_pane().expect("open").filters().match_text(),
             Some("poolx"),
             "typing narrowed live"
         );
         let _ = app.update(Msg::Key(KeyPress::TextAbandon));
         assert_eq!(app.mode(), InputMode::Normal);
         assert_eq!(
-            app.bleats_pane()
-                .expect("open")
-                .filters()
-                .matcher
-                .as_deref(),
+            app.bleats_pane().expect("open").filters().match_text(),
             Some("pool"),
             "abandon restores what the axis held before the edit"
         );

--- a/crates/shep-cli/src/lookout/pane_bleats.rs
+++ b/crates/shep-cli/src/lookout/pane_bleats.rs
@@ -715,10 +715,8 @@ mod tests {
         assert_eq!(pane.filters().match_kind(), Some(MatchKind::Literal));
     }
 
-    /// The three suffixes, exact. Both panes that draw a filter chip word
-    /// them through here, and a render assertion reading `match pool` would
-    /// pass with a suffix appended too, so the empty one is pinned here
-    /// rather than only there.
+    /// The three suffixes, exact. This pins the wording itself; each
+    /// pane's own test pins that its call site adds nothing to it.
     #[test]
     fn only_the_two_regex_states_carry_a_chip_suffix() {
         assert_eq!(MatchKind::Literal.chip_suffix(), "");

--- a/crates/shep-cli/src/lookout/pane_bleats.rs
+++ b/crates/shep-cli/src/lookout/pane_bleats.rs
@@ -341,9 +341,12 @@ pub struct BleatsPane {
     scroll_offset: usize,
     /// Whether the view stays pinned to the newest surviving line as new
     /// ones arrive. `true` on open: an operator who has not scrolled wants
-    /// the live tail. Any backward movement clears it;
-    /// [`Self::jump_to_end`] and [`Self::toggle_follow`] (turning it on) both
-    /// restore it and reset [`Self::scroll_offset`] to `0`.
+    /// the live tail. A deliberate move off the tail clears it: every
+    /// backward step, and [`Self::match_next`], which steps toward the newest
+    /// line and clears it anyway. [`Self::scroll_down`] is the one that does
+    /// not, walking back toward a tail an earlier step left rather than away
+    /// from one. [`Self::jump_to_end`] and [`Self::toggle_follow`] (turning it
+    /// on) both restore it and reset [`Self::scroll_offset`] to `0`.
     following: bool,
     /// The body rows available to page by, set from
     /// [`super::app::App::note_body_rows`]. `0` until the first draw.
@@ -385,7 +388,7 @@ impl BleatsPane {
 
     /// The match axis's current text, or `None` when it is not set.
     ///
-    /// A thin alias for `filters().matcher.as_deref()`, `#[cfg(test)]` like
+    /// A thin alias for [`Filters::match_text`], `#[cfg(test)]` like
     /// [`super::app::App::bleats_pane_mut_for_tests`]: nothing in production
     /// reads a promoted pane's carried filter back out once `b` has set it,
     /// only `crate::lookout::app`'s own
@@ -595,10 +598,10 @@ impl BleatsPane {
     /// [`Filters::keeps`] already dropped every non-matching line out of
     /// [`Self::visible`], so every surviving line *is* a match, and
     /// stepping between matches is stepping between the lines already on
-    /// screen. Clears the follow flag either way, like any other backward
-    /// movement — `n` moves toward the newest line, not away from it, but
-    /// the design still calls it a deliberate jump the next refresh must
-    /// not undo.
+    /// screen. Clears the follow flag whenever it steps: `n` moves toward
+    /// the newest line rather than away from it, but the design still calls
+    /// it a deliberate jump the next refresh must not undo. The guard above clears nothing, so an `n` pressed with no
+    /// axis set leaves a followed view following.
     pub fn match_next(&mut self) {
         if self.filters.match_text().is_none() {
             return;
@@ -1008,5 +1011,30 @@ mod tests {
             3,
             "the axis is gone, so `n` did nothing"
         );
+    }
+
+    /// Whitespace is a needle like any other: only a genuinely empty string
+    /// clears the axis. Worth pinning because the chip for it renders as a
+    /// near-blank `match   `, which reads like the empty-clears rule having
+    /// misfired rather than like a filter doing what it was asked.
+    #[test]
+    fn whitespace_only_match_text_is_a_needle_not_a_cleared_axis() {
+        let mut pane = BleatsPane::new(RowKey::Sheep(9));
+        pane.set_match("  ".to_string());
+
+        assert_eq!(pane.filters().match_kind(), Some(MatchKind::Literal));
+        assert_eq!(pane.filters().match_text(), Some("  "));
+        assert!(!pane.filters().is_empty(), "the axis is set, not cleared");
+
+        let lines = vec![
+            line(Stream::Out, "pool  exhausted"),
+            line(Stream::Out, "kennel"),
+        ];
+        let kept: Vec<&str> = pane
+            .visible(&lines, &Classifier::new(&[]))
+            .iter()
+            .map(|l| l.text.as_str())
+            .collect();
+        assert_eq!(kept, vec!["pool  exhausted"]);
     }
 }

--- a/crates/shep-cli/src/lookout/pane_bleats.rs
+++ b/crates/shep-cli/src/lookout/pane_bleats.rs
@@ -971,4 +971,42 @@ mod tests {
         assert!(pane.filters().match_ranges("pool").is_empty());
         assert!(!pane.drop_newest_chip(), "nothing left to drop");
     }
+
+    /// `n` steps toward the newest matching line only while the match axis
+    /// is set. With it clear there is no "matching line" to step between, so
+    /// the key must not quietly become a line-movement key.
+    ///
+    /// The guard reads the axis, so it is the match-axis state machine's
+    /// last untested door: nothing else exercised the `None` arm.
+    #[test]
+    fn n_steps_only_while_the_match_axis_is_set() {
+        let mut pane = BleatsPane::new(RowKey::Sheep(9));
+
+        pane.match_next();
+        assert!(pane.following(), "no axis set, so `n` spent no follow flag");
+        assert_eq!(pane.scroll_offset(), 0, "and moved nothing");
+
+        pane.scroll_up(3);
+        pane.set_match("/po+l/".to_string());
+        pane.match_next();
+        assert_eq!(pane.scroll_offset(), 2, "the axis is set, so `n` stepped");
+        assert!(!pane.following(), "a deliberate jump clears follow");
+    }
+
+    /// The axis dropping mid-session closes that door again, rather than
+    /// leaving `n` live off a matcher that is gone.
+    #[test]
+    fn n_stops_stepping_once_the_match_chip_is_dropped() {
+        let mut pane = BleatsPane::new(RowKey::Sheep(9));
+        pane.set_match("/po+l/".to_string());
+        pane.scroll_up(3);
+        assert!(pane.drop_newest_chip());
+
+        pane.match_next();
+        assert_eq!(
+            pane.scroll_offset(),
+            3,
+            "the axis is gone, so `n` did nothing"
+        );
+    }
 }

--- a/crates/shep-cli/src/lookout/pane_bleats.rs
+++ b/crates/shep-cli/src/lookout/pane_bleats.rs
@@ -1047,4 +1047,52 @@ mod tests {
             .collect();
         assert_eq!(kept, vec!["pool  exhausted"]);
     }
+
+    /// `Matcher` hand-writes `Debug`, and that impl is half of why holding a
+    /// compiled regex on `Filters` was possible at all: a derived one prints
+    /// the compiled half as `Regex(Regex("po+l"))`, so an operator's search
+    /// text would appear twice in every `Filters` dump.
+    ///
+    /// Exact-string, because nothing else pins it. `pane_sheep`'s own
+    /// `Debug` test only ever sees `matcher: None`, so a later derive here
+    /// would change this output and fail nothing.
+    #[test]
+    fn a_matcher_debug_names_its_kind_and_prints_its_text_once() {
+        let mut pane = BleatsPane::new(RowKey::Sheep(9));
+
+        pane.set_match("/po+l/".to_string());
+        assert_eq!(
+            format!("{:?}", pane.filters()),
+            r#"Filters { stream: None, min_level: None, matcher: Some(Matcher { text: "/po+l/", kind: Regex }), order: [Match] }"#
+        );
+
+        pane.set_match("/pool(/".to_string());
+        assert_eq!(
+            format!("{:?}", pane.filters()),
+            r#"Filters { stream: None, min_level: None, matcher: Some(Matcher { text: "/pool(/", kind: Invalid }), order: [Match] }"#
+        );
+    }
+
+    /// The other half: `PartialEq` reads the typed text, since `regex::Regex`
+    /// implements neither `PartialEq` nor `Eq` and the compiled form is a
+    /// pure function of the text anyway.
+    ///
+    /// Worth pinning because an impl answering `true` unconditionally would
+    /// also compile, and would make every `Filters` comparison in the suite
+    /// pass while comparing nothing.
+    #[test]
+    fn filter_sets_compare_by_their_match_text() {
+        let mut one = BleatsPane::new(RowKey::Sheep(9));
+        let mut two = BleatsPane::new(RowKey::Sheep(9));
+        one.set_match("/po+l/".to_string());
+        two.set_match("/po+l/".to_string());
+        assert_eq!(one.filters(), two.filters(), "same text, same axis");
+
+        two.set_match("/po+ls/".to_string());
+        assert_ne!(
+            one.filters(),
+            two.filters(),
+            "different text, different axis"
+        );
+    }
 }

--- a/crates/shep-cli/src/lookout/pane_bleats.rs
+++ b/crates/shep-cli/src/lookout/pane_bleats.rs
@@ -1,6 +1,8 @@
 //! The full-screen bleats pane's own state: which sheep it is pinned to, and
 //! the three filters an operator can stack over the feed it reads.
 
+use core::fmt;
+
 use regex::Regex;
 
 use super::app::RowKey;
@@ -38,7 +40,7 @@ enum Axis {
 /// characters and never reinterprets a search an operator meant literally.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum MatchKind {
-    /// Plain substring search: `Filters::matcher`'s text, verbatim.
+    /// Plain substring search: [`Filters::match_text`], verbatim.
     Literal,
     /// `/…/`-delimited text that compiled.
     Regex,
@@ -49,73 +51,130 @@ pub enum MatchKind {
     Invalid,
 }
 
-/// How `Filters::matcher`'s typed text is actually matched against a line.
+/// The match axis's typed text, together with what it compiled to.
 ///
-/// Parsed fresh from [`Filters::matcher`] wherever it is needed
-/// ([`Filters::keeps`] through [`Filters::visible`], and the filter row's
-/// highlighting) rather than cached on `Filters` itself: `regex::Regex`
-/// implements neither `PartialEq` nor `Eq`, so storing a compiled one on
-/// `Filters` would force a hand-written `PartialEq` (or dropping it, which
-/// every existing test compares `Filters` by), and it implements `Debug` by
-/// printing its source pattern, which is a worse `Debug` for `Filters` than
-/// the plain string already there. Recompiling costs one small regex
-/// compile per redraw at most, against a window capped at
-/// [`super::tail::FEED_TAIL_LINES`] lines; nothing here is hot enough for
-/// that to matter.
-enum Matcher {
+/// One value rather than a string beside a cached regex, because the two
+/// have to agree and a single constructor is what makes disagreeing
+/// impossible. [`Filters::set_match`] is the only way to build one.
+///
+/// Compiling at set time rather than at match time is the point:
+/// [`Filters::match_ranges`] runs once per rendered line, so a matcher
+/// parsed on demand recompiled the same pattern once per line on every
+/// frame. Measured over a full 80-line feed at 160x50, `/\w+@\w+\.\w+/`
+/// cost 27.0 ms a redraw that way, against [`super::MIN_REDRAW`]'s 33 ms
+/// frame budget. Compiled once at set time it is 24.8 us, within noise of
+/// the 21.1 us a literal axis costs: a redraw compiles nothing at all.
+#[derive(Clone)]
+struct Matcher {
+    /// The text exactly as typed, delimiters and all. Also the needle a
+    /// [`Compiled::Literal`] search runs with.
+    text: String,
+    /// What [`Self::text`] compiled to.
+    compiled: Compiled,
+}
+
+/// What a [`Matcher`]'s text compiled to.
+///
+/// [`Self::Literal`] carries nothing: its needle is [`Matcher::text`]
+/// itself, and a second copy of it could only ever drift.
+#[derive(Clone)]
+enum Compiled {
     /// Plain substring search.
-    Literal(String),
+    Literal,
     /// A compiled `/…/`-delimited regex.
     Regex(Regex),
     /// A `/…/`-delimited pattern that failed to compile.
     Invalid,
 }
 
+#[cfg(test)]
+thread_local! {
+    /// How many matchers this thread has built, for the tests that pin a
+    /// redraw compiling none.
+    ///
+    /// Thread-local, not a global counter: the test harness gives each test
+    /// its own thread, and a global one would count every other test's
+    /// matchers alongside the one under test.
+    static COMPILES: core::cell::Cell<usize> = const { core::cell::Cell::new(0) };
+}
+
+/// How many matchers this thread has built so far. Tests assert on the
+/// difference between two readings, never on the value itself.
+#[cfg(test)]
+pub(crate) fn compiles() -> usize {
+    COMPILES.with(core::cell::Cell::get)
+}
+
 impl Matcher {
-    /// Parses `text` per [`MatchKind`]'s rule.
-    fn parse(text: &str) -> Self {
-        match delimited_regex(text) {
-            Some(pattern) => Regex::new(pattern).map_or(Self::Invalid, Self::Regex),
-            None => Self::Literal(text.to_string()),
-        }
+    /// Compiles `text` per [`MatchKind`]'s rule.
+    fn new(text: String) -> Self {
+        #[cfg(test)]
+        COMPILES.with(|count| count.set(count.get() + 1));
+        let compiled = match delimited_regex(&text) {
+            Some(pattern) => Regex::new(pattern).map_or(Compiled::Invalid, Compiled::Regex),
+            None => Compiled::Literal,
+        };
+        Self { text, compiled }
     }
 
     /// This matcher's [`MatchKind`].
     fn kind(&self) -> MatchKind {
-        match self {
-            Self::Literal(_) => MatchKind::Literal,
-            Self::Regex(_) => MatchKind::Regex,
-            Self::Invalid => MatchKind::Invalid,
+        match self.compiled {
+            Compiled::Literal => MatchKind::Literal,
+            Compiled::Regex(_) => MatchKind::Regex,
+            Compiled::Invalid => MatchKind::Invalid,
         }
     }
 
     /// Whether `haystack` matches at all.
     fn is_match(&self, haystack: &str) -> bool {
-        match self {
-            Self::Literal(pattern) => haystack.contains(pattern.as_str()),
-            Self::Regex(re) => re.is_match(haystack),
-            Self::Invalid => false,
+        match &self.compiled {
+            Compiled::Literal => haystack.contains(self.text.as_str()),
+            Compiled::Regex(re) => re.is_match(haystack),
+            Compiled::Invalid => false,
         }
     }
 
     /// Every byte range in `haystack` this matcher hits, oldest first, for
-    /// highlighting. Empty for [`Self::Invalid`], which matches nothing, and
-    /// for an empty literal pattern, which `str::match_indices` would
+    /// highlighting. Empty for [`Compiled::Invalid`], which matches nothing,
+    /// and for an empty literal pattern, which `str::match_indices` would
     /// otherwise report at every byte boundary.
     fn ranges(&self, haystack: &str) -> Vec<(usize, usize)> {
-        match self {
-            Self::Literal(pattern) if !pattern.is_empty() => haystack
-                .match_indices(pattern.as_str())
+        match &self.compiled {
+            Compiled::Literal if !self.text.is_empty() => haystack
+                .match_indices(self.text.as_str())
                 .map(|(start, matched)| (start, start + matched.len()))
                 .collect(),
-            Self::Literal(_) | Self::Invalid => Vec::new(),
-            Self::Regex(re) => re
+            Compiled::Literal | Compiled::Invalid => Vec::new(),
+            Compiled::Regex(re) => re
                 .find_iter(haystack)
                 .map(|m| (m.start(), m.end()))
                 .collect(),
         }
     }
 }
+
+/// Names the typed text and what it compiled to, never the compiled regex:
+/// `regex::Regex` implements `Debug` by reprinting its own pattern, which
+/// would print an operator's search text twice.
+impl fmt::Debug for Matcher {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Matcher")
+            .field("text", &self.text)
+            .field("kind", &self.kind())
+            .finish()
+    }
+}
+
+/// The typed text alone. [`Matcher::compiled`] is a pure function of it, and
+/// `regex::Regex` implements neither `PartialEq` nor `Eq`.
+impl PartialEq for Matcher {
+    fn eq(&self, other: &Self) -> bool {
+        self.text == other.text
+    }
+}
+
+impl Eq for Matcher {}
 
 /// `text` if it is `/`-delimited on both ends with at least one byte between
 /// them, stripped of both delimiters; `None` otherwise.
@@ -137,11 +196,16 @@ pub struct Filters {
     /// A line with no detectable level always passes regardless of this
     /// field: see [`Filters::keeps`].
     pub min_level: Option<Level>,
-    /// Keep only lines this text matches: a plain substring, or a
+    /// Keep only lines this matcher hits: a plain substring, or a
     /// `/…/`-delimited regex. See [`MatchKind`] for exactly how the two are
-    /// told apart, and [`Filters::match_kind`]/[`Filters::match_ranges`] for
-    /// reading the result back.
-    pub matcher: Option<String>,
+    /// told apart.
+    ///
+    /// Private, unlike the two axes above, because it carries a compiled
+    /// regex that has to stay in step with the text it came from:
+    /// [`Self::set_match`] and [`Self::clear_match`] are the only writers,
+    /// and [`Self::match_text`], [`Self::match_kind`] and
+    /// [`Self::match_ranges`] read it back.
+    matcher: Option<Matcher>,
     /// The axes currently set, oldest first, so the newest is the last
     /// element.
     order: Vec<Axis>,
@@ -169,13 +233,35 @@ impl Filters {
         self.stream.is_none() && self.min_level.is_none() && self.matcher.is_none()
     }
 
-    /// What the match axis's typed text resolves to, or `None` when the
+    /// Sets the match axis to `text`, compiling it once, here, rather than
+    /// once per line the pane later draws. An empty `text` clears the axis;
+    /// see [`BleatsPane::set_match`] for why.
+    fn set_match(&mut self, text: String) {
+        let matcher = (!text.is_empty()).then(|| Matcher::new(text));
+        self.note_axis(Axis::Match, matcher.is_some());
+        self.matcher = matcher;
+    }
+
+    /// Clears the match axis, leaving [`Self::order`] to the caller.
+    ///
+    /// [`BleatsPane::drop_newest_chip`] has already popped the axis out of
+    /// the order it is walking, so this must not touch it again.
+    fn clear_match(&mut self) {
+        self.matcher = None;
+    }
+
+    /// The match axis's text exactly as typed, delimiters and all, or `None`
+    /// when the axis is not set.
+    #[must_use]
+    pub fn match_text(&self) -> Option<&str> {
+        self.matcher.as_ref().map(|matcher| matcher.text.as_str())
+    }
+
+    /// What the match axis's typed text resolved to, or `None` when the
     /// axis is not set.
     #[must_use]
     pub fn match_kind(&self) -> Option<MatchKind> {
-        self.matcher
-            .as_deref()
-            .map(|text| Matcher::parse(text).kind())
+        self.matcher.as_ref().map(Matcher::kind)
     }
 
     /// Every byte range in `haystack` the match axis hits, for highlighting
@@ -184,20 +270,19 @@ impl Filters {
     #[must_use]
     pub fn match_ranges(&self, haystack: &str) -> Vec<(usize, usize)> {
         self.matcher
-            .as_deref()
-            .map(|text| Matcher::parse(text).ranges(haystack))
-            .unwrap_or_default()
+            .as_ref()
+            .map_or_else(Vec::new, |matcher| matcher.ranges(haystack))
     }
 
     /// Whether `line` survives every axis currently set.
     ///
     /// Each axis short-circuits the line out the moment it fails; an axis
     /// left `None` holds automatically, which is how the three compose
-    /// with AND rather than needing a combinator. `matcher` is the match
-    /// axis's typed text, and `levels` this sheep's own reading of a level,
-    /// both built once by the caller ([`Self::visible`]) rather than per
-    /// line.
-    fn keeps(&self, line: &TailLine, matcher: Option<&Matcher>, levels: &Classifier) -> bool {
+    /// with AND rather than needing a combinator. `levels` is this sheep's
+    /// own reading of a level, built once by the caller ([`Self::visible`])
+    /// rather than per line; the match axis needs no such hoist, holding a
+    /// matcher already compiled.
+    fn keeps(&self, line: &TailLine, levels: &Classifier) -> bool {
         if let Some(stream) = self.stream
             && line.stream != stream
         {
@@ -218,7 +303,7 @@ impl Filters {
                 return false;
             }
         }
-        if let Some(matcher) = matcher
+        if let Some(matcher) = &self.matcher
             && !matcher.is_match(&line.text)
         {
             return false;
@@ -309,7 +394,7 @@ impl BleatsPane {
     #[cfg(test)]
     #[must_use]
     pub(crate) fn match_filter(&self) -> Option<&str> {
-        self.filters.matcher.as_deref()
+        self.filters.match_text()
     }
 
     /// The filters currently stacked on this pane's feed.
@@ -342,15 +427,13 @@ impl BleatsPane {
     /// typed yet", so an empty search box behaves as if the axis were
     /// never set.
     pub fn set_match(&mut self, text: String) {
-        let matcher = (!text.is_empty()).then_some(text);
-        self.filters.note_axis(Axis::Match, matcher.is_some());
-        self.filters.matcher = matcher;
+        self.filters.set_match(text);
     }
 
     /// Opens the match box, remembering the match axis's current text so
     /// [`Self::abandon_match_edit`] can restore it.
     pub fn begin_match_edit(&mut self) {
-        self.match_snapshot = Some(self.filters.matcher.clone());
+        self.match_snapshot = Some(self.filters.match_text().map(str::to_string));
     }
 
     /// The match box's live buffer while it is open, or `None` when it is
@@ -363,7 +446,7 @@ impl BleatsPane {
     pub fn match_editing(&self) -> Option<&str> {
         self.match_snapshot
             .as_ref()
-            .map(|_| self.filters.matcher.as_deref().unwrap_or(""))
+            .map(|_| self.filters.match_text().unwrap_or(""))
     }
 
     /// Ends the match box, keeping whatever [`Self::set_match`] already
@@ -393,10 +476,9 @@ impl BleatsPane {
     /// builds it from the row the feed came from.
     #[must_use]
     pub fn visible<'a>(&self, lines: &'a [TailLine], levels: &Classifier) -> Vec<&'a TailLine> {
-        let matcher = self.filters.matcher.as_deref().map(Matcher::parse);
         lines
             .iter()
-            .filter(|line| self.filters.keeps(line, matcher.as_ref(), levels))
+            .filter(|line| self.filters.keeps(line, levels))
             .collect()
     }
 
@@ -518,7 +600,7 @@ impl BleatsPane {
     /// the design still calls it a deliberate jump the next refresh must
     /// not undo.
     pub fn match_next(&mut self) {
-        if self.filters.matcher.is_none() {
+        if self.filters.match_text().is_none() {
             return;
         }
         self.scroll_down(1);
@@ -539,7 +621,7 @@ impl BleatsPane {
         match axis {
             Axis::Stream => self.filters.stream = None,
             Axis::Level => self.filters.min_level = None,
-            Axis::Match => self.filters.matcher = None,
+            Axis::Match => self.filters.clear_match(),
         }
         true
     }
@@ -710,5 +792,183 @@ mod tests {
             .map(|&(start, end)| &"pool then pol then pooool"[start..end])
             .collect();
         assert_eq!(hits, vec!["pool", "pol", "pooool"]);
+    }
+
+    /// The axis compiles its text once, when it is set, and never again:
+    /// every read afterwards runs off the matcher already there.
+    ///
+    /// This is the whole point of holding a compiled matcher rather than
+    /// parsing per call. `match_ranges` runs once per rendered line, so a
+    /// matcher parsed on demand recompiled the same pattern once per line on
+    /// every frame.
+    #[test]
+    fn setting_the_axis_compiles_once_and_reading_it_back_compiles_never() {
+        let mut pane = BleatsPane::new(RowKey::Sheep(9));
+
+        let before = compiles();
+        pane.set_match("/po+l/".to_string());
+        assert_eq!(compiles() - before, 1, "one compile, at set time");
+
+        let after_set = compiles();
+        let lines: Vec<TailLine> = (0..80)
+            .map(|i| line(Stream::Out, &format!("pool acquire {i}")))
+            .collect();
+        for feed_line in pane.visible(&lines, &Classifier::new(&[])) {
+            let _ = pane.filters().match_ranges(&feed_line.text);
+            let _ = pane.filters().match_kind();
+            let _ = pane.filters().match_text();
+        }
+        assert_eq!(
+            compiles(),
+            after_set,
+            "reading the axis back over a full feed compiles nothing"
+        );
+    }
+
+    /// Replacing a regex with a literal must not leave the regex behind:
+    /// the new text is what matches, and it matches literally.
+    #[test]
+    fn replacing_a_regex_axis_with_a_literal_drops_the_compiled_regex() {
+        let mut pane = BleatsPane::new(RowKey::Sheep(9));
+        pane.set_match("/po+l/".to_string());
+        pane.set_match("po+l".to_string());
+
+        assert_eq!(pane.filters().match_kind(), Some(MatchKind::Literal));
+        let lines = vec![line(Stream::Out, "pool"), line(Stream::Out, "po+l")];
+        let kept: Vec<&str> = pane
+            .visible(&lines, &Classifier::new(&[]))
+            .iter()
+            .map(|l| l.text.as_str())
+            .collect();
+        assert_eq!(
+            kept,
+            vec!["po+l"],
+            "the literal matches, the regex does not"
+        );
+    }
+
+    /// The mirror: a literal replaced by a regex compiles the new text.
+    #[test]
+    fn replacing_a_literal_axis_with_a_regex_compiles_the_new_text() {
+        let mut pane = BleatsPane::new(RowKey::Sheep(9));
+        pane.set_match("pool".to_string());
+        pane.set_match("/po+l/".to_string());
+
+        assert_eq!(pane.filters().match_kind(), Some(MatchKind::Regex));
+        let lines = vec![line(Stream::Out, "pol"), line(Stream::Out, "kennel")];
+        assert_eq!(
+            pane.visible(&lines, &Classifier::new(&[])).len(),
+            1,
+            "the regex matches `pol`"
+        );
+    }
+
+    /// An empty string clears the axis outright, matcher and all, rather
+    /// than leaving the previous one in place behind an unset chip.
+    #[test]
+    fn setting_the_axis_to_nothing_clears_the_matcher_it_held() {
+        let mut pane = BleatsPane::new(RowKey::Sheep(9));
+        pane.set_match("/po+l/".to_string());
+        pane.set_match(String::new());
+
+        assert_eq!(pane.filters().match_kind(), None);
+        assert_eq!(pane.filters().match_text(), None);
+        assert!(pane.filters().match_ranges("pool").is_empty());
+        assert!(pane.filters().is_empty(), "no axis is set");
+    }
+
+    /// Abandoning an edit restores what the axis held before it, compiled:
+    /// the regex that was there has to work again, not merely have its text
+    /// back.
+    #[test]
+    fn abandoning_an_edit_restores_the_earlier_matcher_compiled() {
+        let mut pane = BleatsPane::new(RowKey::Sheep(9));
+        pane.set_match("/po+l/".to_string());
+
+        pane.begin_match_edit();
+        pane.set_match("kennel".to_string());
+        assert_eq!(pane.filters().match_kind(), Some(MatchKind::Literal));
+
+        pane.abandon_match_edit();
+        assert_eq!(pane.filters().match_kind(), Some(MatchKind::Regex));
+        assert_eq!(pane.filters().match_text(), Some("/po+l/"));
+        assert_eq!(
+            pane.filters().match_ranges("pol and pool"),
+            vec![(0, 3), (8, 12)],
+            "the restored regex matches, rather than being a dead string"
+        );
+    }
+
+    /// The mirror, and the one a stale matcher survives: abandoning back to
+    /// a literal must not leave the regex typed during the edit compiled and
+    /// still matching.
+    #[test]
+    fn abandoning_an_edit_back_to_a_literal_drops_the_regex_typed_during_it() {
+        let mut pane = BleatsPane::new(RowKey::Sheep(9));
+        pane.set_match("po+l".to_string());
+
+        pane.begin_match_edit();
+        pane.set_match("/po+l/".to_string());
+        pane.abandon_match_edit();
+
+        assert_eq!(pane.filters().match_kind(), Some(MatchKind::Literal));
+        assert!(
+            pane.filters().match_ranges("pool").is_empty(),
+            "the abandoned regex must not still be matching"
+        );
+        assert_eq!(pane.filters().match_ranges("po+l"), vec![(0, 4)]);
+    }
+
+    /// Abandoning an edit that began with no axis set clears it again,
+    /// rather than keeping whatever was typed before the escape.
+    #[test]
+    fn abandoning_an_edit_that_began_unset_leaves_the_axis_unset() {
+        let mut pane = BleatsPane::new(RowKey::Sheep(9));
+        pane.begin_match_edit();
+        pane.set_match("/po+l/".to_string());
+        pane.abandon_match_edit();
+
+        assert_eq!(pane.filters().match_text(), None);
+        assert!(pane.filters().is_empty());
+    }
+
+    /// Abandon with no edit open is a no-op: the axis keeps what it has.
+    #[test]
+    fn abandoning_with_no_edit_open_leaves_the_axis_alone() {
+        let mut pane = BleatsPane::new(RowKey::Sheep(9));
+        pane.set_match("/po+l/".to_string());
+        pane.abandon_match_edit();
+
+        assert_eq!(pane.filters().match_kind(), Some(MatchKind::Regex));
+        assert_eq!(pane.filters().match_ranges("pool"), vec![(0, 4)]);
+    }
+
+    /// Committing keeps what was typed during the edit, compiled as its own
+    /// text rather than as the text the edit started from.
+    #[test]
+    fn committing_an_edit_keeps_the_matcher_typed_during_it() {
+        let mut pane = BleatsPane::new(RowKey::Sheep(9));
+        pane.set_match("pool".to_string());
+
+        pane.begin_match_edit();
+        pane.set_match("/po+l/".to_string());
+        pane.commit_match_edit();
+
+        assert_eq!(pane.filters().match_kind(), Some(MatchKind::Regex));
+        assert_eq!(pane.filters().match_ranges("pol"), vec![(0, 3)]);
+        assert_eq!(pane.match_editing(), None, "the box is closed");
+    }
+
+    /// esc spending the match chip clears the matcher, not only the chip:
+    /// a dropped axis highlights nothing.
+    #[test]
+    fn dropping_the_match_chip_clears_the_matcher_it_held() {
+        let mut pane = BleatsPane::new(RowKey::Sheep(9));
+        pane.set_match("/po+l/".to_string());
+
+        assert!(pane.drop_newest_chip(), "the match chip was newest");
+        assert_eq!(pane.filters().match_kind(), None);
+        assert!(pane.filters().match_ranges("pool").is_empty());
+        assert!(!pane.drop_newest_chip(), "nothing left to drop");
     }
 }

--- a/crates/shep-cli/src/lookout/pane_bleats.rs
+++ b/crates/shep-cli/src/lookout/pane_bleats.rs
@@ -49,6 +49,23 @@ pub enum MatchKind {
     Invalid,
 }
 
+impl MatchKind {
+    /// What a filter chip appends after the matcher's own text.
+    ///
+    /// Shared by both panes that draw a chip, so the regex states are
+    /// worded in one place. Only the suffix is shared: `view::sheep`'s
+    /// embedded feed words the stream and level axes shorter than
+    /// `view::bleats_full` does, on purpose.
+    #[must_use]
+    pub fn chip_suffix(self) -> &'static str {
+        match self {
+            Self::Literal => "",
+            Self::Regex => " (regex)",
+            Self::Invalid => " (invalid regex, matches nothing)",
+        }
+    }
+}
+
 /// How `Filters::matcher`'s typed text is actually matched against a line.
 ///
 /// Parsed fresh from [`Filters::matcher`] wherever it is needed
@@ -696,6 +713,20 @@ mod tests {
             .collect();
         assert_eq!(kept, vec!["GET get index.html 200"]);
         assert_eq!(pane.filters().match_kind(), Some(MatchKind::Literal));
+    }
+
+    /// The three suffixes, exact. Both panes that draw a filter chip word
+    /// them through here, and a render assertion reading `match pool` would
+    /// pass with a suffix appended too, so the empty one is pinned here
+    /// rather than only there.
+    #[test]
+    fn only_the_two_regex_states_carry_a_chip_suffix() {
+        assert_eq!(MatchKind::Literal.chip_suffix(), "");
+        assert_eq!(MatchKind::Regex.chip_suffix(), " (regex)");
+        assert_eq!(
+            MatchKind::Invalid.chip_suffix(),
+            " (invalid regex, matches nothing)"
+        );
     }
 
     /// The ranges a regex matcher reports are what the filter row highlights;

--- a/crates/shep-cli/src/lookout/pane_bleats.rs
+++ b/crates/shep-cli/src/lookout/pane_bleats.rs
@@ -106,15 +106,27 @@ pub(crate) fn compiles() -> usize {
 }
 
 impl Matcher {
-    /// Compiles `text` per [`MatchKind`]'s rule.
-    fn new(text: String) -> Self {
+    /// Compiles `text` per [`MatchKind`]'s rule, or `None` for an empty
+    /// `text`, which is an unset axis rather than a matcher hitting every
+    /// line.
+    ///
+    /// The refusal lives here rather than in [`Filters::set_match`] because
+    /// [`Self::is_match`] and [`Self::ranges`] disagree on an empty needle:
+    /// `str::contains` answers true for one, and `str::match_indices`
+    /// reports a hit at every byte boundary. A matcher that cannot hold
+    /// empty text is one guard instead of two, and neither method has to
+    /// know about it.
+    fn new(text: String) -> Option<Self> {
+        if text.is_empty() {
+            return None;
+        }
         #[cfg(test)]
         COMPILES.with(|count| count.set(count.get() + 1));
         let compiled = match delimited_regex(&text) {
             Some(pattern) => Regex::new(pattern).map_or(Compiled::Invalid, Compiled::Regex),
             None => Compiled::Literal,
         };
-        Self { text, compiled }
+        Some(Self { text, compiled })
     }
 
     /// This matcher's [`MatchKind`].
@@ -136,16 +148,14 @@ impl Matcher {
     }
 
     /// Every byte range in `haystack` this matcher hits, oldest first, for
-    /// highlighting. Empty for [`Compiled::Invalid`], which matches nothing,
-    /// and for an empty literal pattern, which `str::match_indices` would
-    /// otherwise report at every byte boundary.
+    /// highlighting. Empty for [`Compiled::Invalid`], which matches nothing.
     fn ranges(&self, haystack: &str) -> Vec<(usize, usize)> {
         match &self.compiled {
-            Compiled::Literal if !self.text.is_empty() => haystack
+            Compiled::Literal => haystack
                 .match_indices(self.text.as_str())
                 .map(|(start, matched)| (start, start + matched.len()))
                 .collect(),
-            Compiled::Literal | Compiled::Invalid => Vec::new(),
+            Compiled::Invalid => Vec::new(),
             Compiled::Regex(re) => re
                 .find_iter(haystack)
                 .map(|m| (m.start(), m.end()))
@@ -237,7 +247,7 @@ impl Filters {
     /// once per line the pane later draws. An empty `text` clears the axis;
     /// see [`BleatsPane::set_match`] for why.
     fn set_match(&mut self, text: String) {
-        let matcher = (!text.is_empty()).then(|| Matcher::new(text));
+        let matcher = Matcher::new(text);
         self.note_axis(Axis::Match, matcher.is_some());
         self.matcher = matcher;
     }

--- a/crates/shep-cli/src/lookout/pane_bleats.rs
+++ b/crates/shep-cli/src/lookout/pane_bleats.rs
@@ -57,7 +57,7 @@ impl MatchKind {
     /// embedded feed words the stream and level axes shorter than
     /// `view::bleats_full` does, on purpose.
     #[must_use]
-    pub fn chip_suffix(self) -> &'static str {
+    pub const fn chip_suffix(self) -> &'static str {
         match self {
             Self::Literal => "",
             Self::Regex => " (regex)",

--- a/crates/shep-cli/src/lookout/view/bleats_full.rs
+++ b/crates/shep-cli/src/lookout/view/bleats_full.rs
@@ -491,7 +491,7 @@ fn chip_labels(filters: &Filters) -> Vec<String> {
     if let Some(min) = filters.min_level {
         chips.push(format!("level ≥ {min}"));
     }
-    if let Some(text) = &filters.matcher {
+    if let Some(text) = filters.match_text() {
         let suffix = match filters.match_kind() {
             Some(MatchKind::Literal) | None => String::new(),
             Some(MatchKind::Regex) => " (regex)".to_string(),
@@ -580,7 +580,7 @@ mod tests {
     use super::super::super::app::{KeyPress, Msg};
     use super::super::super::frames::render_text;
     use super::super::super::level::Level;
-    use super::super::super::pane_bleats::MatchKind;
+    use super::super::super::pane_bleats::{MatchKind, compiles};
     use super::super::super::tail::{Stream, Tail, TailLine};
     use super::super::fixtures::{
         bleats_pane_with_filters, full_app, render_all, rendered, with_feed, with_no_selection,
@@ -1025,5 +1025,58 @@ mod tests {
                 }
             }
         }
+    }
+
+    /// A redraw compiles the match axis's pattern no times at all.
+    ///
+    /// `highlighted` runs once per rendered line, so this used to be one
+    /// `Regex::new` per line per frame. Measured over this feed at 160x50,
+    /// `/\w+@\w+\.\w+/` cost 27.0 ms a redraw that way, against
+    /// `lookout::MIN_REDRAW`'s 33 ms frame budget; it is 24.8 us now. The
+    /// count is what pins it: a timing assertion would be flaky, and a test
+    /// asserting only that the highlight renders passes just as well over a
+    /// version that recompiles every line.
+    #[test]
+    fn a_redraw_compiles_the_match_axis_no_times() {
+        let mut app = with_selection(ProcessInfo::builder(9, "web", ProcStatus::Online).build());
+        app.update(Msg::Bleats {
+            tail: Tail {
+                lines: (0..80)
+                    .map(|i| TailLine {
+                        stream: if i % 2 == 0 { Stream::Out } else { Stream::Err },
+                        text: format!("worker[{i}] pool acquire ok user=ops{i}@example.com"),
+                    })
+                    .collect(),
+                missed_lines: 0,
+                missed_bytes: 0,
+                read_bytes: 65_536,
+                note: None,
+            },
+        });
+        app.update(Msg::Key(KeyPress::Bleats));
+        app.bleats_pane_mut_for_tests()
+            .expect("the key above opened the pane")
+            .set_match(r"/\w+@\w+\.\w+/".to_string());
+
+        let before = compiles();
+        let drawn = draw_lines(&app, 160, 50);
+        assert_eq!(compiles(), before, "a redraw compiles nothing");
+
+        // Without these the count above would hold over a pane drawing no
+        // lines at all, which is how two of the first measurements of this
+        // looked cheap: a matcher that survives no line is never run. The
+        // span count is the second half: a body row whose match was
+        // highlighted is split into more spans than the stream tag plus one
+        // run of plain text.
+        assert_eq!(
+            drawn.len(),
+            50,
+            "the title, the filter row and 48 body rows"
+        );
+        let body = &drawn[2..];
+        assert!(
+            body.iter().all(|line| line.spans.len() > 2),
+            "every body row split its hit into its own span"
+        );
     }
 }

--- a/crates/shep-cli/src/lookout/view/bleats_full.rs
+++ b/crates/shep-cli/src/lookout/view/bleats_full.rs
@@ -1064,16 +1064,17 @@ mod tests {
 
         // Without these the count above would hold over a pane drawing no
         // lines at all, which is how two of the first measurements of this
-        // looked cheap: a matcher that survives no line is never run. The
-        // span count is the second half: a body row whose match was
-        // highlighted is split into more spans than the stream tag plus one
-        // run of plain text.
-        assert_eq!(
-            drawn.len(),
-            50,
-            "the title, the filter row and 48 body rows"
-        );
-        let body = &drawn[2..];
+        // looked cheap: a matcher that survives no line is never run. Body
+        // rows are picked out by their own text rather than by skipping a
+        // header count, which would quietly review the wrong rows if the
+        // pane ever grew another header. The span count is the second half:
+        // a row whose match was highlighted is split into more spans than
+        // the stream tag plus one run of plain text.
+        let body: Vec<_> = drawn
+            .iter()
+            .filter(|line| render_all(std::slice::from_ref(*line)).contains("@example.com"))
+            .collect();
+        assert_eq!(body.len(), 48, "the feed filled every body row");
         assert!(
             body.iter().all(|line| line.spans.len() > 2),
             "every body row split its hit into its own span"

--- a/crates/shep-cli/src/lookout/view/bleats_full.rs
+++ b/crates/shep-cli/src/lookout/view/bleats_full.rs
@@ -492,11 +492,7 @@ fn chip_labels(filters: &Filters) -> Vec<String> {
         chips.push(format!("level ≥ {min}"));
     }
     if let Some(text) = &filters.matcher {
-        let suffix = match filters.match_kind() {
-            Some(MatchKind::Literal) | None => String::new(),
-            Some(MatchKind::Regex) => " (regex)".to_string(),
-            Some(MatchKind::Invalid) => " (invalid regex, matches nothing)".to_string(),
-        };
+        let suffix = filters.match_kind().map_or("", MatchKind::chip_suffix);
         chips.push(format!("match {text}{suffix}"));
     }
     chips

--- a/crates/shep-cli/src/lookout/view/bleats_full.rs
+++ b/crates/shep-cli/src/lookout/view/bleats_full.rs
@@ -803,6 +803,29 @@ mod tests {
         assert!(text.contains("match pool"), "got {text}");
     }
 
+    /// A literal matcher's chip is the typed text and nothing after it. The
+    /// assertion above reads `match pool` out of the whole row, which a
+    /// chip carrying a suffix satisfies just as well, so this one compares
+    /// the chip's own span: `chip_labels` writes the text and
+    /// `filter_row_line` pads it, and anything appended in either breaks
+    /// the comparison.
+    #[test]
+    fn a_literal_matcher_chip_carries_nothing_after_the_typed_text() {
+        let mut app = with_selection(ProcessInfo::builder(9, "web", ProcStatus::Online).build());
+        app.update(Msg::Key(KeyPress::Bleats));
+        app.bleats_pane_mut_for_tests()
+            .expect("the key above opened the pane")
+            .set_match("pool".to_string());
+        let lines = draw_lines(&app, 160, 40);
+        let chips: Vec<&str> = lines
+            .iter()
+            .flat_map(|line| line.spans.iter())
+            .map(|span| span.content.as_ref())
+            .filter(|text| text.contains("match pool"))
+            .collect();
+        assert_eq!(chips, vec![" match pool "]);
+    }
+
     /// A `/…/`-delimited matcher's chip says it is a regex.
     #[test]
     fn a_regex_matcher_chip_names_itself_a_regex() {

--- a/crates/shep-cli/src/lookout/view/bleats_full.rs
+++ b/crates/shep-cli/src/lookout/view/bleats_full.rs
@@ -1059,7 +1059,7 @@ mod tests {
             .set_match(r"/\w+@\w+\.\w+/".to_string());
 
         let before = compiles();
-        let drawn = draw_lines(&app, 160, 50);
+        let drawn_rows = draw_lines(&app, 160, 50);
         assert_eq!(compiles(), before, "a redraw compiles nothing");
 
         // Without these the count above would hold over a pane drawing no
@@ -1070,7 +1070,7 @@ mod tests {
         // pane ever grew another header. The span count is the second half:
         // a row whose match was highlighted is split into more spans than
         // the stream tag plus one run of plain text.
-        let body: Vec<_> = drawn
+        let body: Vec<_> = drawn_rows
             .iter()
             .filter(|line| render_all(std::slice::from_ref(*line)).contains("@example.com"))
             .collect();

--- a/crates/shep-cli/src/lookout/view/sheep.rs
+++ b/crates/shep-cli/src/lookout/view/sheep.rs
@@ -1771,6 +1771,19 @@ mod tests {
         assert!(text.contains("match /po+l/ (regex)"), "got {text:?}");
     }
 
+    /// A literal matcher's chip is the typed text and nothing after it.
+    /// The two assertions around this one read a suffix they expect, so
+    /// neither can see a suffix that should not be there; this one anchors
+    /// on the brackets `feed_header_text` draws around each chip, which
+    /// anything appended would fall outside of.
+    #[test]
+    fn the_headers_match_chip_carries_nothing_after_a_literal() {
+        let mut feed = BleatsPane::new(RowKey::Sheep(1));
+        feed.set_match("pool".to_string());
+        let text = feed_header_text(&feed, 0);
+        assert!(text.contains("[match pool]"), "got {text:?}");
+    }
+
     /// A pattern that fails to compile says so on the chip, rather than the
     /// embedded feed just going quiet with no explanation until the
     /// operator presses `b` to reach the full-screen pane's own chip.

--- a/crates/shep-cli/src/lookout/view/sheep.rs
+++ b/crates/shep-cli/src/lookout/view/sheep.rs
@@ -467,7 +467,8 @@ fn feed_header_text(feed: &BleatsPane, hidden: usize) -> String {
 /// One chip's text per filter axis currently set on the embedded feed, in
 /// field order. Deliberately its own, smaller vocabulary rather than
 /// `view::bleats_full`'s private `chip_labels`: this row has 83 cells for
-/// the whole sentence, not a dedicated filter row underneath it.
+/// the whole sentence, not a dedicated filter row underneath it. The match
+/// axis's suffix is the one exception, shared as [`MatchKind::chip_suffix`].
 fn feed_chip_labels(filters: &Filters) -> Vec<String> {
     let mut chips = Vec::new();
     if let Some(stream) = filters.stream {
@@ -480,11 +481,7 @@ fn feed_chip_labels(filters: &Filters) -> Vec<String> {
         chips.push(format!("level\u{2265}{min}"));
     }
     if let Some(text) = &filters.matcher {
-        let suffix = match filters.match_kind() {
-            Some(MatchKind::Literal) | None => "",
-            Some(MatchKind::Regex) => " (regex)",
-            Some(MatchKind::Invalid) => " (invalid regex, matches nothing)",
-        };
+        let suffix = filters.match_kind().map_or("", MatchKind::chip_suffix);
         chips.push(format!("match {text}{suffix}"));
     }
     chips

--- a/crates/shep-cli/src/lookout/view/sheep.rs
+++ b/crates/shep-cli/src/lookout/view/sheep.rs
@@ -479,7 +479,7 @@ fn feed_chip_labels(filters: &Filters) -> Vec<String> {
     if let Some(min) = filters.min_level {
         chips.push(format!("level\u{2265}{min}"));
     }
-    if let Some(text) = &filters.matcher {
+    if let Some(text) = filters.match_text() {
         let suffix = match filters.match_kind() {
             Some(MatchKind::Literal) | None => "",
             Some(MatchKind::Regex) => " (regex)",


### PR DESCRIPTION
Two changes to the lookout's match filter, folded together because they conflicted in all three files they share. #231 is merged in here rather than landing separately, which saves a CodeRabbit read and the rebase it owed this branch.

## The recompile

`Filters::match_ranges` parsed the match axis on every call, and `highlighted` calls it once per rendered line, so a bleats pane with a regex axis ran `Regex::new` on the same pattern once per line per frame.

Measured before changing anything, release profile, 80-line feed at 160x50, 48 body rows drawn:

| match axis | before | after | one `Regex::new` |
|---|---|---|---|
| literal `pool` | 21.9 us | 21.1 us | |
| `/pool\|ERROR/` | 599 us | ~25 us | 11.5 us |
| `/conn=[0-9]+/` | 1.0 ms | 26.4 us | 20.6 us |
| `/\d+\.\d+ms/` | 2.7 ms | 23.2 us | 43.6 us |
| `/\w+@\w+\.\w+/` | 27.0 ms | 24.8 us | 505.8 us |

`MIN_REDRAW` is 33 ms, so that last row spent 82% of a frame budget compiling one pattern 48 times, and typing it into the match box redraws once per keystroke. Compile cost scales with the pattern and the pattern is whatever an operator types, so the bound was theirs rather than ours.

- `Filters::matcher` is now `Option<Matcher>`, private, holding the typed text beside what it compiled to
- one field and one constructor, so a stale regex has nowhere to survive: not a replaced axis, not an abandoned edit, not a dropped chip
- `Matcher::new` returns `Option<Self>` and refuses empty text itself, because `is_match` and `ranges` disagreed about an empty needle and the guard was being held in three places
- `Matcher` hand-writes `Debug` (text and kind, since `Regex`'s own `Debug` reprints the pattern) and `PartialEq`/`Eq` (text alone), which is what the old comment gave as the reason not to cache
- callers read the axis through `Filters::match_text`
- an invalid regex still matches nothing and still never panics

Two of my first measurements looked cheap for the wrong reason: a matcher that survives no line is never highlighted, so `/(?i)error/` over a feed of INFO lines reported 83.8 us with zero rows drawn. Every number above is over a feed the pattern actually matches.

## The shared chip suffix, from #231

The three-arm suffix labelling a match chip as a regex or an invalid regex was written out once per pane, so the wording had to change in both places to stay in step. It is now `MatchKind::chip_suffix`, a `const fn` both call sites read. Only the suffix is shared: the embedded feed in `view::sheep` words its stream and level chips shorter on purpose.

Three conflicts on the merge, all the same shape, since #231 moved both panes to the helper in the same lines this branch made `Filters::matcher` private. Resolved by keeping their helper and reading it through `match_text`.

Ran #231's own mutation check against the resolution rather than only its tests, since this branch changes 58 lines in `bleats_full.rs` and their assertion compares a chip's own span. Setting `chip_suffix`'s `Literal` arm to `" (literal)"` fails all three of their tests, both pane ones included.

## Tests

`Matcher::new` increments a `#[cfg(test)]` thread-local counter. Two tests read it: setting the axis compiles once and reading it back over 80 lines compiles nothing, and a full redraw compiles nothing. Both confirmed to fail with the per-call compile put back, at 81 against 1 and 49 against 1, exactly the per-line counts. The redraw test also pins 48 body rows drawn and every one span-split, since the count alone passes over a pane drawing nothing.

The match-edit state machine had no coverage at all. It has ten now, covering every path that writes the axis, plus the `n` key's guard, whitespace-only text, and both hand-written impls. Each asserts the restored matcher still matches, not just that its text came back.

## Verification

Ten qwen rounds. Q raised 12 findings: 7 real and fixed, 5 dismissed, four of those on measured magnitude and one on a `thread_local` the chunked round could not see. My own rounds found 5 Q missed. Every counter and guard test was re-checked red against its own reversion.

Gate green: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`, `cargo test --workspace --all-features` (3875 passed), `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features`, all exit 0.

No operator-visible change, so `web/` needs nothing. `lookout` is a private module in this crate's lib.rs, so the field going private is not a public API change.

Closes #231

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Match filters now process typed search text more efficiently, reducing repeated work during filtering and screen redraws.
  - Filtering behavior remains consistent while editing, applying, abandoning, and navigating match filters.
  - Match indicators now display consistent, clearer labels across the bleats and sheep views.
  - Empty match text is handled cleanly without producing an unnecessary literal match condition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->