### PR TITLE
refactor(cli): word a match chip's regex suffix in one place

### DIFF
--- a/crates/shep-cli/src/lookout/pane_bleats.rs
+++ b/crates/shep-cli/src/lookout/pane_bleats.rs
@@ -715,10 +715,8 @@ mod tests {
         assert_eq!(pane.filters().match_kind(), Some(MatchKind::Literal));
     }
 
-    /// The three suffixes, exact. Both panes that draw a filter chip word
-    /// them through here, and a render assertion reading `match pool` would
-    /// pass with a suffix appended too, so the empty one is pinned here
-    /// rather than only there.
+    /// The three suffixes, exact. This pins the wording itself; each
+    /// pane's own test pins that its call site adds nothing to it.
     #[test]
     fn only_the_two_regex_states_carry_a_chip_suffix() {
         assert_eq!(MatchKind::Literal.chip_suffix(), "");

--- a/crates/shep-cli/src/lookout/pane_bleats.rs
+++ b/crates/shep-cli/src/lookout/pane_bleats.rs
@@ -49,6 +49,23 @@ pub enum MatchKind {
     Invalid,
 }
 
+impl MatchKind {
+    /// What a filter chip appends after the matcher's own text.
+    ///
+    /// Shared by both panes that draw a chip, so the regex states are
+    /// worded in one place. Only the suffix is shared: `view::sheep`'s
+    /// embedded feed words the stream and level axes shorter than
+    /// `view::bleats_full` does, on purpose.
+    #[must_use]
+    pub fn chip_suffix(self) -> &'static str {
+        match self {
+            Self::Literal => "",
+            Self::Regex => " (regex)",
+            Self::Invalid => " (invalid regex, matches nothing)",
+        }
+    }
+}
+
 /// How `Filters::matcher`'s typed text is actually matched against a line.
 ///
 /// Parsed fresh from [`Filters::matcher`] wherever it is needed
@@ -696,6 +713,20 @@ mod tests {
             .collect();
         assert_eq!(kept, vec!["GET get index.html 200"]);
         assert_eq!(pane.filters().match_kind(), Some(MatchKind::Literal));
+    }
+
+    /// The three suffixes, exact. Both panes that draw a filter chip word
+    /// them through here, and a render assertion reading `match pool` would
+    /// pass with a suffix appended too, so the empty one is pinned here
+    /// rather than only there.
+    #[test]
+    fn only_the_two_regex_states_carry_a_chip_suffix() {
+        assert_eq!(MatchKind::Literal.chip_suffix(), "");
+        assert_eq!(MatchKind::Regex.chip_suffix(), " (regex)");
+        assert_eq!(
+            MatchKind::Invalid.chip_suffix(),
+            " (invalid regex, matches nothing)"
+        );
     }
 
     /// The ranges a regex matcher reports are what the filter row highlights;

--- a/crates/shep-cli/src/lookout/pane_bleats.rs
+++ b/crates/shep-cli/src/lookout/pane_bleats.rs
@@ -57,7 +57,7 @@ impl MatchKind {
     /// embedded feed words the stream and level axes shorter than
     /// `view::bleats_full` does, on purpose.
     #[must_use]
-    pub fn chip_suffix(self) -> &'static str {
+    pub const fn chip_suffix(self) -> &'static str {
         match self {
             Self::Literal => "",
             Self::Regex => " (regex)",

--- a/crates/shep-cli/src/lookout/view/bleats_full.rs
+++ b/crates/shep-cli/src/lookout/view/bleats_full.rs
@@ -492,11 +492,7 @@ fn chip_labels(filters: &Filters) -> Vec<String> {
         chips.push(format!("level ≥ {min}"));
     }
     if let Some(text) = &filters.matcher {
-        let suffix = match filters.match_kind() {
-            Some(MatchKind::Literal) | None => String::new(),
-            Some(MatchKind::Regex) => " (regex)".to_string(),
-            Some(MatchKind::Invalid) => " (invalid regex, matches nothing)".to_string(),
-        };
+        let suffix = filters.match_kind().map_or("", MatchKind::chip_suffix);
         chips.push(format!("match {text}{suffix}"));
     }
     chips

--- a/crates/shep-cli/src/lookout/view/bleats_full.rs
+++ b/crates/shep-cli/src/lookout/view/bleats_full.rs
@@ -803,6 +803,29 @@ mod tests {
         assert!(text.contains("match pool"), "got {text}");
     }
 
+    /// A literal matcher's chip is the typed text and nothing after it. The
+    /// assertion above reads `match pool` out of the whole row, which a
+    /// chip carrying a suffix satisfies just as well, so this one compares
+    /// the chip's own span: `chip_labels` writes the text and
+    /// `filter_row_line` pads it, and anything appended in either breaks
+    /// the comparison.
+    #[test]
+    fn a_literal_matcher_chip_carries_nothing_after_the_typed_text() {
+        let mut app = with_selection(ProcessInfo::builder(9, "web", ProcStatus::Online).build());
+        app.update(Msg::Key(KeyPress::Bleats));
+        app.bleats_pane_mut_for_tests()
+            .expect("the key above opened the pane")
+            .set_match("pool".to_string());
+        let lines = draw_lines(&app, 160, 40);
+        let chips: Vec<&str> = lines
+            .iter()
+            .flat_map(|line| line.spans.iter())
+            .map(|span| span.content.as_ref())
+            .filter(|text| text.contains("match pool"))
+            .collect();
+        assert_eq!(chips, vec![" match pool "]);
+    }
+
     /// A `/…/`-delimited matcher's chip says it is a regex.
     #[test]
     fn a_regex_matcher_chip_names_itself_a_regex() {

--- a/crates/shep-cli/src/lookout/view/sheep.rs
+++ b/crates/shep-cli/src/lookout/view/sheep.rs
@@ -1771,6 +1771,19 @@ mod tests {
         assert!(text.contains("match /po+l/ (regex)"), "got {text:?}");
     }
 
+    /// A literal matcher's chip is the typed text and nothing after it.
+    /// The two assertions around this one read a suffix they expect, so
+    /// neither can see a suffix that should not be there; this one anchors
+    /// on the brackets `feed_header_text` draws around each chip, which
+    /// anything appended would fall outside of.
+    #[test]
+    fn the_headers_match_chip_carries_nothing_after_a_literal() {
+        let mut feed = BleatsPane::new(RowKey::Sheep(1));
+        feed.set_match("pool".to_string());
+        let text = feed_header_text(&feed, 0);
+        assert!(text.contains("[match pool]"), "got {text:?}");
+    }
+
     /// A pattern that fails to compile says so on the chip, rather than the
     /// embedded feed just going quiet with no explanation until the
     /// operator presses `b` to reach the full-screen pane's own chip.

--- a/crates/shep-cli/src/lookout/view/sheep.rs
+++ b/crates/shep-cli/src/lookout/view/sheep.rs
@@ -467,7 +467,8 @@ fn feed_header_text(feed: &BleatsPane, hidden: usize) -> String {
 /// One chip's text per filter axis currently set on the embedded feed, in
 /// field order. Deliberately its own, smaller vocabulary rather than
 /// `view::bleats_full`'s private `chip_labels`: this row has 83 cells for
-/// the whole sentence, not a dedicated filter row underneath it.
+/// the whole sentence, not a dedicated filter row underneath it. The match
+/// axis's suffix is the one exception, shared as [`MatchKind::chip_suffix`].
 fn feed_chip_labels(filters: &Filters) -> Vec<String> {
     let mut chips = Vec::new();
     if let Some(stream) = filters.stream {
@@ -480,11 +481,7 @@ fn feed_chip_labels(filters: &Filters) -> Vec<String> {
         chips.push(format!("level\u{2265}{min}"));
     }
     if let Some(text) = &filters.matcher {
-        let suffix = match filters.match_kind() {
-            Some(MatchKind::Literal) | None => "",
-            Some(MatchKind::Regex) => " (regex)",
-            Some(MatchKind::Invalid) => " (invalid regex, matches nothing)",
-        };
+        let suffix = filters.match_kind().map_or("", MatchKind::chip_suffix);
         chips.push(format!("match {text}{suffix}"));
     }
     chips


### PR DESCRIPTION
Both lookout chip builders carried the same three-arm match over `MatchKind`, differing only in whether the arms built a `String` or a `&str`, so the regex wording lived in two places.

- `MatchKind::chip_suffix` in `pane_bleats.rs` holds the three suffixes now
- `view::bleats_full::chip_labels` and `view::sheep::feed_chip_labels` both read it as `match_kind().map_or("", MatchKind::chip_suffix)`
- Only the suffix is shared. The stream and level chips differ on purpose (`stream err` / `level ≥ warn` against `err only` / `level≥warn`) and `feed_chip_labels` already explained why, so it just names the exception now
- Exact-string test on the three suffixes, plus one per pane pinning a literal chip at the call site: `bleats_full` compares the chip's own span to `" match pool "`, `sheep` reads the `[match pool]` brackets `feed_header_text` draws
- The literal case is why the second commit exists. The old row assertions read `match pool`, which a chip carrying a suffix passes too, so the refactor's riskiest case was the one nothing exercised

Checked the new tests fail when the defect is present: with `chip_suffix`'s `Literal` arm returning `" (literal)"` both come back FAILED, exit 101.

No operator-visible change and the rendered chip text is identical, so `web/` needed nothing. Found while reviewing https://github.com/shep-pm/shep/pull/230, predates it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
