### PR TITLE
fix(cli)!: refuse a relative $SHEP_HOME

### DIFF
--- a/crates/shep-cli/src/cli.rs
+++ b/crates/shep-cli/src/cli.rs
@@ -174,7 +174,8 @@ pub struct GlobalArgs {
     /// Talk to a different shepherd
     ///
     /// Mostly plumbing: `shep dev` sessions, a system-wide flock, tests. You
-    /// almost certainly want the default, ~/.shep.
+    /// almost certainly want the default, ~/.shep. Must be an absolute path:
+    /// a relative one would name a different flock from every directory.
     // Declared last on purpose. It was the first global option anyone read,
     // which announced it as a choice when it is really the daemon's
     // data-root. `{options}` renders in declaration order and ignores

--- a/crates/shep-cli/src/commands/dev.rs
+++ b/crates/shep-cli/src/commands/dev.rs
@@ -28,6 +28,49 @@ const UNRESOLVED_DEV_HOME: &str =
 const UNRESOLVED_DEV_HOME: &str =
     "neither %SHEP_DEV_HOME% nor %USERPROFILE% resolves a root directory for shep dev";
 
+/// How an operator on this platform spells the variable, for a refusal that
+/// names it mid-sentence.
+#[cfg(not(windows))]
+const DEV_HOME_VAR: &str = "$SHEP_DEV_HOME";
+
+/// How an operator on this platform spells the variable, for a refusal that
+/// names it mid-sentence.
+#[cfg(windows)]
+const DEV_HOME_VAR: &str = "%SHEP_DEV_HOME%";
+
+/// Why [`dev_home`] would not name a root for this session.
+///
+/// `shep dev`'s own refusals, not [`crate::HomeRefusal`]'s: both messages
+/// have to name `$SHEP_DEV_HOME`, which is the one variable this verb reads
+/// and the one an operator can act on.
+#[derive(Debug)]
+enum DevHomeRefusal {
+    /// Neither `$SHEP_DEV_HOME` nor a home directory resolved a root.
+    Unresolved,
+    /// `$SHEP_DEV_HOME` named a path with no root.
+    Relative {
+        /// The path as the operator spelled it.
+        given: PathBuf,
+        /// The same path joined onto this process's directory, for the
+        /// remedy line. `None` when that directory could not be read.
+        absolute: Option<PathBuf>,
+    },
+}
+
+impl core::fmt::Display for DevHomeRefusal {
+    /// The operator-facing message, remedy included.
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::Unresolved => f.write_str(UNRESOLVED_DEV_HOME),
+            Self::Relative { given, absolute } => {
+                crate::write_relative_refusal(f, DEV_HOME_VAR, given, absolute.as_deref())
+            }
+        }
+    }
+}
+
+impl core::error::Error for DevHomeRefusal {}
+
 /// Where a dev flock lives: `$SHEP_DEV_HOME`, else `~/.shep-dev`.
 ///
 /// `--home` and `$SHEP_HOME` are ignored: sharing a real flock's home would
@@ -40,14 +83,35 @@ const UNRESOLVED_DEV_HOME: &str =
 ///
 /// `home_dir` is read for the `~/.shep-dev` fallback alone, so `None` (no
 /// passwd home, no `$HOME`) is answerable as long as `$SHEP_DEV_HOME` names
-/// somewhere. `None` back means neither did.
-fn dev_home(env: &impl Fn(&str) -> Option<String>, home_dir: Option<&Path>) -> Option<ShepPaths> {
+/// somewhere.
+///
+/// # Errors
+///
+/// - [`DevHomeRefusal::Relative`] if `$SHEP_DEV_HOME` named a path with no
+///   root. Gated here rather than in [`dev`], so the rule travels with the
+///   resolver that reads the variable.
+/// - [`DevHomeRefusal::Unresolved`] if neither named a root.
+fn dev_home(
+    env: &impl Fn(&str) -> Option<String>,
+    home_dir: Option<&Path>,
+) -> Result<ShepPaths, DevHomeRefusal> {
     let home = match env("SHEP_DEV_HOME") {
-        Some(dir) => PathBuf::from(dir),
-        None => home_dir?.join(".shep-dev"),
+        Some(dir) => {
+            let named = PathBuf::from(dir);
+            if named.is_relative() {
+                return Err(DevHomeRefusal::Relative {
+                    absolute: crate::absolute_form(&named),
+                    given: named,
+                });
+            }
+            named
+        }
+        None => home_dir
+            .ok_or(DevHomeRefusal::Unresolved)?
+            .join(".shep-dev"),
     };
     let inject = |key: &str| (key == "SHEP_HOME").then(|| home.to_string_lossy().into_owned());
-    Some(ShepPaths::resolve(&inject, &home))
+    Ok(ShepPaths::resolve(&inject, &home))
 }
 
 /// Sets `watch = true` on every app, in place: rebuilding each [`AppConfig`]
@@ -139,8 +203,9 @@ pub async fn dev(
         }
     };
     let home_dir = user_home(&|key| std::env::var_os(key));
-    let Some(paths) = dev_home(&env, home_dir.as_deref()) else {
-        return streams.fail(ExitCode::Usage, UNRESOLVED_DEV_HOME);
+    let paths = match dev_home(&env, home_dir.as_deref()) {
+        Ok(paths) => paths,
+        Err(refusal) => return streams.fail(ExitCode::Usage, &refusal.to_string()),
     };
 
     let options = ForegroundOptions {
@@ -168,24 +233,59 @@ mod tests {
 
         let env = |key: &str| match key {
             "SHEP_HOME" => Some("/srv/production".to_string()),
-            "SHEP_DEV_HOME" => Some("/tmp/t1".to_string()),
+            "SHEP_DEV_HOME" => Some(ABSOLUTE_DEV_HOME.to_string()),
             _ => None,
         };
         assert_eq!(
             dev_home(&env, Some(Path::new("/home/ada"))).unwrap().home,
-            Path::new("/tmp/t1")
+            Path::new(ABSOLUTE_DEV_HOME)
         );
 
         // No passwd home and no `$HOME`: `$SHEP_DEV_HOME` alone still
         // answers, and without it there is nowhere to put a dev flock.
         assert_eq!(
             dev_home(&env, None).unwrap().home,
-            Path::new("/tmp/t1"),
+            Path::new(ABSOLUTE_DEV_HOME),
             "`$SHEP_DEV_HOME` names the home outright, so no fallback is needed"
         );
         let no_dev_home = |key: &str| (key == "SHEP_HOME").then(|| "/srv/production".to_string());
-        assert!(dev_home(&no_dev_home, None).is_none());
+        assert!(matches!(
+            dev_home(&no_dev_home, None),
+            Err(DevHomeRefusal::Unresolved)
+        ));
     }
+
+    /// The same rule `resolve_paths` holds for `$SHEP_HOME`: a home with no
+    /// root would put the dev flock under whatever directory `shep dev` was
+    /// run from, and its logs under a second one.
+    #[test]
+    fn a_relative_dev_home_is_refused_and_the_absolute_form_named() {
+        let env = |key: &str| (key == "SHEP_DEV_HOME").then(|| "scratch/.shep-dev".to_string());
+        let Err(refusal) = dev_home(&env, Some(Path::new("/home/ada"))) else {
+            panic!("a relative $SHEP_DEV_HOME must not resolve a layout");
+        };
+        assert!(matches!(refusal, DevHomeRefusal::Relative { .. }));
+
+        let rendered = refusal.to_string();
+        assert!(
+            rendered.contains("scratch/.shep-dev"),
+            "the refusal must quote the path as typed: {rendered}"
+        );
+        let cwd = std::env::current_dir().expect("a current directory");
+        assert!(
+            rendered.contains(&cwd.join("scratch/.shep-dev").display().to_string()),
+            "the remedy must name the absolute form of what was typed: {rendered}"
+        );
+    }
+
+    /// A rooted path on the platform running the test: `Path::is_relative`
+    /// answers yes to `/tmp/t1` on Windows, which has no drive prefix.
+    #[cfg(not(windows))]
+    const ABSOLUTE_DEV_HOME: &str = "/tmp/t1";
+
+    /// A rooted path on the platform running the test.
+    #[cfg(windows)]
+    const ABSOLUTE_DEV_HOME: &str = r"C:\tmp\t1";
 
     #[test]
     fn every_app_gets_watch_and_keeps_everything_else() {

--- a/crates/shep-cli/src/lib.rs
+++ b/crates/shep-cli/src/lib.rs
@@ -323,23 +323,81 @@ async fn print_shepherd_status(argv: &[OsString]) {
 ///
 /// # Errors
 ///
-/// [`ExitCode::Usage`] if neither `--home`/`$SHEP_HOME` nor a home directory
-/// resolves a root. The home directory is read only as that fallback, so a
-/// `--home` invocation still works with none at all.
-fn resolve_paths(global: &GlobalArgs) -> Result<ShepPaths, ExitCode> {
+/// - [`HomeRefusal::Relative`] if whichever of the two supplied the root
+///   named a path without one. Decided here rather than in
+///   [`ShepPaths::resolve`], which promises to touch no filesystem: the
+///   absolute form of a relative path is a read of this process's own
+///   directory.
+/// - [`HomeRefusal::Unresolved`] if neither `--home`/`$SHEP_HOME` nor a home
+///   directory resolves a root. The home directory is read only as that
+///   fallback, so a `--home` invocation still works with none at all.
+fn resolve_paths(global: &GlobalArgs) -> Result<ShepPaths, HomeRefusal> {
+    resolve_paths_in(global, &|key| std::env::var_os(key))
+}
+
+/// [`resolve_paths`] with the environment injected, so the home-directory
+/// arm can be pinned without mutating this process's own.
+///
+/// # Errors
+///
+/// [`resolve_paths`]'s, unchanged.
+fn resolve_paths_in(
+    global: &GlobalArgs,
+    var: &dyn Fn(&str) -> Option<OsString>,
+) -> Result<ShepPaths, HomeRefusal> {
+    if let Some(named) = global.home.as_ref() {
+        require_absolute(HOME_KNOB, named)?;
+    }
     let env = |key: &str| match key {
         "SHEP_HOME" => global
             .home
             .as_ref()
             .map(|p| p.to_string_lossy().into_owned()),
-        other => std::env::var(other).ok(),
+        other => var(other).map(|value| value.to_string_lossy().into_owned()),
     };
-    let home_dir = match (user_home(&|key| std::env::var_os(key)), env("SHEP_HOME")) {
+    let home_dir = match (user_home(var), env("SHEP_HOME")) {
         (Some(dir), _) => dir,
         (None, Some(_)) => PathBuf::new(),
-        (None, None) => return Err(ExitCode::Usage),
+        (None, None) => return Err(HomeRefusal::Unresolved),
     };
+    // Only when the home directory is what `resolve` will join `.shep` onto:
+    // an absolute `--home` above has already won, and the empty placeholder
+    // this arm can carry goes unread in that case.
+    if global.home.is_none() {
+        require_absolute(HOME_DIR_VAR, &home_dir)?;
+    }
     Ok(ShepPaths::resolve(&env, &home_dir))
+}
+
+/// Refuses `candidate` when it has no root, naming `knob` as the spelling to
+/// fix.
+///
+/// Every path in a [`ShepPaths`] is `$SHEP_HOME` plus a fixed tail, the
+/// control socket included, so one rootless home is a whole flock that
+/// answers from one directory and reports nothing from the next.
+///
+/// # Errors
+///
+/// [`HomeRefusal::Relative`], carrying `candidate` as typed and its absolute
+/// form when this process's own directory could be read.
+fn require_absolute(knob: &'static str, candidate: &Path) -> Result<(), HomeRefusal> {
+    if candidate.is_absolute() {
+        return Ok(());
+    }
+    Err(HomeRefusal::Relative {
+        knob,
+        absolute: absolute_form(candidate),
+        given: candidate.to_path_buf(),
+    })
+}
+
+/// What a rootless `candidate` would have meant from here, for a refusal's
+/// remedy line. `None` when this process's directory could not be read.
+///
+/// Shared with `commands::dev`, so the two refusals suggest the same path
+/// for the same typed one.
+pub(crate) fn absolute_form(candidate: &Path) -> Option<PathBuf> {
+    std::env::current_dir().ok().map(|cwd| cwd.join(candidate))
 }
 
 /// Parses `shep.toml`'s `[interpreters]` table into an extension to
@@ -420,15 +478,28 @@ fn must_render_bare(stdout_is_terminal: bool, fmt: cli::Format) -> bool {
     !stdout_is_terminal || fmt == cli::Format::Json
 }
 
-/// Why [`ensure_home`] would not hand back a layout.
+/// Why [`resolve_paths`] or [`ensure_home`] would not hand back a layout.
 ///
-/// A type rather than a bare [`ExitCode`]: two of the three carry the path
+/// A type rather than a bare [`ExitCode`]: three of the four carry the path
 /// they are about, and an operator cannot act on a refusal that omits it.
 #[derive(Debug)]
 pub(crate) enum HomeRefusal {
     /// None of `--home`, `$SHEP_HOME` or the user's home directory
     /// resolved a root directory.
     Unresolved,
+    /// Something named a path with no root, so every path derived from it
+    /// would resolve against whatever directory the process happens to be
+    /// in.
+    Relative {
+        /// The spelling an operator has to fix: `--home`/`$SHEP_HOME`, or
+        /// the home-directory variable when that is what supplied the root.
+        knob: &'static str,
+        /// The path as it was spelled.
+        given: PathBuf,
+        /// The same path joined onto this process's directory, for the
+        /// remedy line. `None` when that directory could not be read.
+        absolute: Option<PathBuf>,
+    },
     /// `--home`/`$SHEP_HOME` named a directory that is not there. Never
     /// created: a named path is not a path shep may invent.
     Missing(PathBuf),
@@ -446,6 +517,11 @@ impl core::fmt::Display for HomeRefusal {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
             Self::Unresolved => f.write_str(UNRESOLVED_HOME),
+            Self::Relative {
+                knob,
+                given,
+                absolute,
+            } => write_relative_refusal(f, knob, given, absolute.as_deref()),
             Self::Missing(path) => write!(
                 f,
                 "no flock at {path}\n  \
@@ -463,7 +539,7 @@ impl core::fmt::Display for HomeRefusal {
 impl core::error::Error for HomeRefusal {
     fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
         match self {
-            Self::Unresolved | Self::Missing(_) => None,
+            Self::Unresolved | Self::Relative { .. } | Self::Missing(_) => None,
             Self::Io { source, .. } => Some(source),
         }
     }
@@ -476,7 +552,7 @@ impl HomeRefusal {
     /// something reasonable and shep failed at it.
     pub(crate) fn code(&self) -> ExitCode {
         match self {
-            Self::Unresolved | Self::Missing(_) => ExitCode::Usage,
+            Self::Unresolved | Self::Relative { .. } | Self::Missing(_) => ExitCode::Usage,
             Self::Io { .. } => ExitCode::Internal,
         }
     }
@@ -489,7 +565,7 @@ impl HomeRefusal {
 ///
 /// Every variant of [`HomeRefusal`]; see [`ensure_home_at`].
 fn ensure_home(global: &GlobalArgs) -> Result<(ShepPaths, bool), HomeRefusal> {
-    let paths = resolve_paths(global).map_err(|_| HomeRefusal::Unresolved)?;
+    let paths = resolve_paths(global)?;
     ensure_home_at(paths, global.home.is_some())
 }
 
@@ -636,8 +712,9 @@ async fn run(
             if let Some(cli::DaemonCmd::Reload) = args.cmd {
                 let paths = match resolve_paths(&cli.global) {
                     Ok(paths) => paths,
-                    Err(code) => {
-                        emit_error_locked(fmt, code, UNRESOLVED_HOME);
+                    Err(refusal) => {
+                        let code = refusal.code();
+                        emit_error_locked(fmt, code, &refusal.to_string());
                         return code;
                     }
                 };
@@ -1059,11 +1136,11 @@ async fn run(
     }
 }
 
-/// What both [`resolve_paths`] call sites report when nothing resolves a root.
+/// What [`HomeRefusal::Unresolved`] reports.
 #[cfg(not(windows))]
 const UNRESOLVED_HOME: &str = "none of --home, $SHEP_HOME, or $HOME resolves a root directory";
 
-/// What both [`resolve_paths`] call sites report when nothing resolves a root.
+/// What [`HomeRefusal::Unresolved`] reports.
 ///
 /// Names `%USERPROFILE%`, not `$HOME`: a Windows session sets no `HOME`, so
 /// naming it sends an operator looking for a variable that was never going
@@ -1071,6 +1148,55 @@ const UNRESOLVED_HOME: &str = "none of --home, $SHEP_HOME, or $HOME resolves a r
 #[cfg(windows)]
 const UNRESOLVED_HOME: &str =
     "none of --home, %SHEP_HOME%, or %USERPROFILE% resolves a root directory";
+
+/// How an operator on this platform names the home directly, for a refusal
+/// that has to say what to fix.
+#[cfg(not(windows))]
+const HOME_KNOB: &str = "--home/$SHEP_HOME";
+
+/// How an operator on this platform names the home directly, for a refusal
+/// that has to say what to fix.
+#[cfg(windows)]
+const HOME_KNOB: &str = "--home/%SHEP_HOME%";
+
+/// The variable behind the default home, named by the refusal for a root
+/// that came from there rather than from [`HOME_KNOB`].
+#[cfg(not(windows))]
+const HOME_DIR_VAR: &str = "$HOME";
+
+/// The variable behind the default home, named by the refusal for a root
+/// that came from there rather than from [`HOME_KNOB`].
+///
+/// Names `%USERPROFILE%` for the same reason [`UNRESOLVED_HOME`] does: a
+/// Windows session sets no `HOME`, so although [`user_home`] reads that
+/// first, `%USERPROFILE%` is the first of the three that answers.
+#[cfg(windows)]
+const HOME_DIR_VAR: &str = "%USERPROFILE%";
+
+/// The one refusal shep gives for a home with no root, whichever knob named
+/// it: `knob` is the spelling to fix, `absolute` the same path against this
+/// process's directory when that could be read.
+///
+/// Shared with `commands::dev`, which gates `$SHEP_DEV_HOME` on the same
+/// rule and owes an operator the same sentence.
+pub(crate) fn write_relative_refusal(
+    f: &mut core::fmt::Formatter<'_>,
+    knob: &str,
+    given: &Path,
+    absolute: Option<&Path>,
+) -> core::fmt::Result {
+    write!(
+        f,
+        "{knob} must be an absolute path, not {given}\n  \
+         a relative home is read against whatever directory shep runs in, so the flock it \
+         names is reachable from that one directory and nowhere else",
+        given = given.display(),
+    )?;
+    match absolute {
+        Some(absolute) => write!(f, "\n  did you mean:  {}", absolute.display()),
+        None => Ok(()),
+    }
+}
 
 /// Emits one error envelope to stderr under a lock taken for just that write.
 ///
@@ -1481,8 +1607,9 @@ fn flock_connect_refusal_message(err: &shep_client::ConnectError) -> String {
 async fn run_daemon_command(fmt: Format, global: &GlobalArgs, args: &DaemonArgs) -> ExitCode {
     let paths = match resolve_paths(global) {
         Ok(paths) => paths,
-        Err(code) => {
-            emit_error_locked(fmt, code, UNRESOLVED_HOME);
+        Err(refusal) => {
+            let code = refusal.code();
+            emit_error_locked(fmt, code, &refusal.to_string());
             return code;
         }
     };
@@ -2145,19 +2272,23 @@ mod tests {
         );
     }
 
+    /// A rooted path on the platform running the test. `/tmp/explicit` has
+    /// no drive prefix, so Windows reads it as relative and the gate in
+    /// `resolve_paths` refuses it.
+    #[cfg(not(windows))]
+    const EXPLICIT_HOME: &str = "/tmp/explicit";
+
+    /// A rooted path on the platform running the test.
+    #[cfg(windows)]
+    const EXPLICIT_HOME: &str = r"C:\tmp\explicit";
+
     /// Pins `resolve_paths`'s folding of an already-populated
     /// `GlobalArgs::home` only. `$SHEP_HOME` reaches that field through clap,
     /// and is pinned in `cli.rs`.
     #[test]
     fn explicit_home_field_resolves_to_the_expected_shep_paths() {
-        let global = cli::GlobalArgs {
-            home: Some("/tmp/explicit".into()),
-            format: cli::Format::Table,
-            quiet: false,
-            style: None,
-        };
-        let paths = resolve_paths(&global).unwrap();
-        assert_eq!(paths.home, std::path::Path::new("/tmp/explicit"));
+        let paths = resolve_paths(&global_with_home(Some(EXPLICIT_HOME))).unwrap();
+        assert_eq!(paths.home, std::path::Path::new(EXPLICIT_HOME));
         // The control address is a socket file on unix and a named-pipe name
         // on Windows, so `--home` is asserted to reach both derivations.
         #[cfg(unix)]
@@ -2167,6 +2298,96 @@ mod tests {
         );
         #[cfg(windows)]
         assert_eq!(paths.socket, std::path::Path::new(&paths.pipe_name()));
+    }
+
+    fn global_with_home(home: Option<&str>) -> cli::GlobalArgs {
+        cli::GlobalArgs {
+            home: home.map(Into::into),
+            format: cli::Format::Table,
+            quiet: false,
+            style: None,
+        }
+    }
+
+    /// The whole point of the gate: a home with no root puts the control
+    /// socket at `rel-home/run/shep.sock`, which names one flock from the
+    /// directory it was started in and a different, absent one from
+    /// anywhere else.
+    #[test]
+    fn a_relative_home_is_refused_before_any_path_is_derived() {
+        let Err(refusal) = resolve_paths(&global_with_home(Some("rel-home"))) else {
+            panic!("a relative --home must not resolve a layout");
+        };
+        assert_eq!(
+            refusal.code(),
+            ExitCode::Usage,
+            "a path shep cannot act on is the operator's to fix"
+        );
+
+        let rendered = refusal.to_string();
+        assert!(
+            rendered.contains("rel-home"),
+            "the refusal must quote the path as typed: {rendered}"
+        );
+        assert!(
+            rendered.contains(HOME_KNOB),
+            "the refusal must name the spelling to fix: {rendered}"
+        );
+        let cwd = std::env::current_dir().expect("a current directory");
+        assert!(
+            rendered.contains(&cwd.join("rel-home").display().to_string()),
+            "the remedy must name the absolute form of what was typed: {rendered}"
+        );
+    }
+
+    /// Windows reads a path with no drive prefix as relative, so `\shep`
+    /// carries the same defect as `rel-home` and has to be refused with it.
+    #[cfg(windows)]
+    #[test]
+    fn a_drive_relative_home_is_refused_on_windows() {
+        assert!(
+            resolve_paths(&global_with_home(Some(r"\shep"))).is_err(),
+            r"`\shep` resolves against whichever drive is current"
+        );
+    }
+
+    /// The gate is on the resolved root, not on `--home` alone: with no
+    /// `--home`, the default home is the home directory plus `.shep`, and a
+    /// rootless home directory is the same defect one door over.
+    #[test]
+    fn a_relative_home_directory_is_refused_and_names_its_own_variable() {
+        // Every variable `user_home` reads on either platform, so the arm
+        // under test is the one that answered rather than a fallback.
+        let rootless = |key: &str| {
+            matches!(key, "HOME" | "USERPROFILE" | "HOMEDRIVE" | "HOMEPATH")
+                .then(|| OsString::from("ada"))
+        };
+        let Err(refusal) = resolve_paths_in(&global_with_home(None), &rootless) else {
+            panic!("a rootless home directory must not resolve a layout");
+        };
+        let rendered = refusal.to_string();
+        assert!(
+            rendered.contains(HOME_DIR_VAR),
+            "an operator cannot fix `--home` when `--home` is not what said it: {rendered}"
+        );
+        assert!(
+            !rendered.contains(HOME_KNOB),
+            "naming a knob the operator did not touch sends them to the wrong fix: {rendered}"
+        );
+    }
+
+    /// The gate must not refuse the ordinary case it sits in front of.
+    #[test]
+    fn an_absolute_home_directory_still_resolves_the_default_home() {
+        let rooted = |key: &str| (key == "HOME").then(|| OsString::from(EXPLICIT_HOME));
+        // Windows reads `HOME` only after `USERPROFILE`, which this closure
+        // leaves unset, so one absolute answer serves both platforms.
+        let paths = resolve_paths_in(&global_with_home(None), &rooted)
+            .expect("an absolute home directory resolves the default home");
+        assert_eq!(
+            paths.home,
+            std::path::Path::new(EXPLICIT_HOME).join(".shep")
+        );
     }
 
     #[test]

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -33,7 +33,7 @@ go for the full argument. The commit that removed them names itself.
 - [whistle](#whistle) (18)
 - [Config and packaging](#config-and-packaging) (5)
 - [serve, dev and runtime](#serve-dev-and-runtime) (8)
-- [Output and first run](#output-and-first-run) (7)
+- [Output and first run](#output-and-first-run) (8)
 - [Config overrides](#config-overrides) (9)
 - [Dog config store](#dog-config-store) (1)
 - [CI flakes, and the log line a stop could lose](#ci-flakes-and-the-log-line-a-stop-could-lose) (4)
@@ -1691,6 +1691,34 @@ ensure_home_at creates ~/.shep silently on first use, but a --home/$SHEP_HOME pa
 **Why:** ~/.shep is a name shep chose, so shep may conjure it; an operator-typed path is more likely a typo than intent, and silently creating it would produce a second, empty, invisible flock whose bug report reads as "shep lost all my processes" when the truth is "you're looking at a different flock". Uses DirBuilder::new().mode(DIR_MODE) at creation, not create_dir_all+chmod, to avoid a window where the directory exists world-readable.
 
 `docs/writing-plans/plans/2026-08-17-first-run-experience.md:178`
+
+### A relative home is refused, never absolutized
+
+`resolve_paths` requires a rooted home before any path is derived from it, and
+`dev_home` holds the same line for `$SHEP_DEV_HOME`. The refusal quotes the path
+as typed and names its absolute form.
+
+**Why:** The two candidate fixes were refusing and absolutizing, and only one of
+them reaches the defect. A relative home names a different directory from every
+cwd, so absolutizing at each invocation leaves the flock reachable from the one
+directory it was started in; it makes the wrong answer internally consistent
+rather than fixing it. Measured 2026-09-13 against the release binary: a
+shepherd started under `SHEP_HOME=rel-home` in one directory answers
+`shep flock` there and reports "no shepherd running" from the next, while still
+supervising every process it was given. That is the bug report the
+missing-home entry above exists to prevent, reached with no typo at all.
+Absolutizing inside `ShepPaths::resolve` was ruled out separately: its doc
+promises to touch no filesystem, and the absolute form of a relative path is a
+read of this process's own directory, so the gate belongs in the CLI.
+
+The gate is on the resolved root rather than on `--home` alone. A rootless home
+directory reaches `ShepPaths` through the default-home fallback and carries the
+same defect, so it is refused by the same rule and named by its own variable
+instead of a flag the operator never typed. Windows reads a path with no drive
+prefix as relative, so `\shep` is refused there for the same reason `rel-home`
+is everywhere.
+
+`verified crates/shep-cli/src/lib.rs (resolve_paths, require_absolute), crates/shep-cli/src/commands/dev.rs (dev_home)`
 
 ### Sheep decoration never appears on error output or after a destructive verb
 

--- a/web/src/data/cli-reference.generated.txt
+++ b/web/src/data/cli-reference.generated.txt
@@ -54,7 +54,8 @@ Upgrading        cargo install shep replaces the binary, not the running shepher
           Talk to a different shepherd
           
           Mostly plumbing: `shep dev` sessions, a system-wide flock, tests. You almost certainly
-          want the default, ~/.shep.
+          want the default, ~/.shep. Must be an absolute path: a relative one would name a different
+          flock from every directory.
           
           [env: SHEP_HOME=]
 
@@ -148,7 +149,8 @@ Options:
           Talk to a different shepherd
           
           Mostly plumbing: `shep dev` sessions, a system-wide flock, tests. You almost certainly
-          want the default, ~/.shep.
+          want the default, ~/.shep. Must be an absolute path: a relative one would name a different
+          flock from every directory.
           
           [env: SHEP_HOME=]
 
@@ -284,7 +286,8 @@ Options:
           Talk to a different shepherd
           
           Mostly plumbing: `shep dev` sessions, a system-wide flock, tests. You almost certainly
-          want the default, ~/.shep.
+          want the default, ~/.shep. Must be an absolute path: a relative one would name a different
+          flock from every directory.
           
           [env: SHEP_HOME=]
 
@@ -401,7 +404,8 @@ Options:
           Talk to a different shepherd
           
           Mostly plumbing: `shep dev` sessions, a system-wide flock, tests. You almost certainly
-          want the default, ~/.shep.
+          want the default, ~/.shep. Must be an absolute path: a relative one would name a different
+          flock from every directory.
           
           [env: SHEP_HOME=]
 
@@ -486,7 +490,8 @@ Options:
           Talk to a different shepherd
           
           Mostly plumbing: `shep dev` sessions, a system-wide flock, tests. You almost certainly
-          want the default, ~/.shep.
+          want the default, ~/.shep. Must be an absolute path: a relative one would name a different
+          flock from every directory.
           
           [env: SHEP_HOME=]
 
@@ -565,7 +570,8 @@ Options:
           Talk to a different shepherd
           
           Mostly plumbing: `shep dev` sessions, a system-wide flock, tests. You almost certainly
-          want the default, ~/.shep.
+          want the default, ~/.shep. Must be an absolute path: a relative one would name a different
+          flock from every directory.
           
           [env: SHEP_HOME=]
 
@@ -667,7 +673,8 @@ Options:
           Talk to a different shepherd
           
           Mostly plumbing: `shep dev` sessions, a system-wide flock, tests. You almost certainly
-          want the default, ~/.shep.
+          want the default, ~/.shep. Must be an absolute path: a relative one would name a different
+          flock from every directory.
           
           [env: SHEP_HOME=]
 
@@ -725,7 +732,8 @@ Options:
           Talk to a different shepherd
           
           Mostly plumbing: `shep dev` sessions, a system-wide flock, tests. You almost certainly
-          want the default, ~/.shep.
+          want the default, ~/.shep. Must be an absolute path: a relative one would name a different
+          flock from every directory.
           
           [env: SHEP_HOME=]
 
@@ -791,7 +799,8 @@ Options:
           Talk to a different shepherd
           
           Mostly plumbing: `shep dev` sessions, a system-wide flock, tests. You almost certainly
-          want the default, ~/.shep.
+          want the default, ~/.shep. Must be an absolute path: a relative one would name a different
+          flock from every directory.
           
           [env: SHEP_HOME=]
 
@@ -858,7 +867,8 @@ Options:
           Talk to a different shepherd
           
           Mostly plumbing: `shep dev` sessions, a system-wide flock, tests. You almost certainly
-          want the default, ~/.shep.
+          want the default, ~/.shep. Must be an absolute path: a relative one would name a different
+          flock from every directory.
           
           [env: SHEP_HOME=]
 
@@ -914,7 +924,8 @@ Options:
           Talk to a different shepherd
           
           Mostly plumbing: `shep dev` sessions, a system-wide flock, tests. You almost certainly
-          want the default, ~/.shep.
+          want the default, ~/.shep. Must be an absolute path: a relative one would name a different
+          flock from every directory.
           
           [env: SHEP_HOME=]
 
@@ -968,7 +979,8 @@ Options:
           Talk to a different shepherd
           
           Mostly plumbing: `shep dev` sessions, a system-wide flock, tests. You almost certainly
-          want the default, ~/.shep.
+          want the default, ~/.shep. Must be an absolute path: a relative one would name a different
+          flock from every directory.
           
           [env: SHEP_HOME=]
 
@@ -1022,7 +1034,8 @@ Options:
           Talk to a different shepherd
           
           Mostly plumbing: `shep dev` sessions, a system-wide flock, tests. You almost certainly
-          want the default, ~/.shep.
+          want the default, ~/.shep. Must be an absolute path: a relative one would name a different
+          flock from every directory.
           
           [env: SHEP_HOME=]
 
@@ -1087,7 +1100,8 @@ Options:
           Talk to a different shepherd
           
           Mostly plumbing: `shep dev` sessions, a system-wide flock, tests. You almost certainly
-          want the default, ~/.shep.
+          want the default, ~/.shep. Must be an absolute path: a relative one would name a different
+          flock from every directory.
           
           [env: SHEP_HOME=]
 
@@ -1141,7 +1155,8 @@ Options:
           Talk to a different shepherd
           
           Mostly plumbing: `shep dev` sessions, a system-wide flock, tests. You almost certainly
-          want the default, ~/.shep.
+          want the default, ~/.shep. Must be an absolute path: a relative one would name a different
+          flock from every directory.
           
           [env: SHEP_HOME=]
 
@@ -1205,7 +1220,8 @@ Options:
           Talk to a different shepherd
           
           Mostly plumbing: `shep dev` sessions, a system-wide flock, tests. You almost certainly
-          want the default, ~/.shep.
+          want the default, ~/.shep. Must be an absolute path: a relative one would name a different
+          flock from every directory.
           
           [env: SHEP_HOME=]
 
@@ -1269,7 +1285,8 @@ Options:
           Talk to a different shepherd
           
           Mostly plumbing: `shep dev` sessions, a system-wide flock, tests. You almost certainly
-          want the default, ~/.shep.
+          want the default, ~/.shep. Must be an absolute path: a relative one would name a different
+          flock from every directory.
           
           [env: SHEP_HOME=]
 
@@ -1333,7 +1350,8 @@ Options:
           Talk to a different shepherd
           
           Mostly plumbing: `shep dev` sessions, a system-wide flock, tests. You almost certainly
-          want the default, ~/.shep.
+          want the default, ~/.shep. Must be an absolute path: a relative one would name a different
+          flock from every directory.
           
           [env: SHEP_HOME=]
 
@@ -1397,7 +1415,8 @@ Options:
           Talk to a different shepherd
           
           Mostly plumbing: `shep dev` sessions, a system-wide flock, tests. You almost certainly
-          want the default, ~/.shep.
+          want the default, ~/.shep. Must be an absolute path: a relative one would name a different
+          flock from every directory.
           
           [env: SHEP_HOME=]
 
@@ -1447,7 +1466,8 @@ Options:
           Talk to a different shepherd
           
           Mostly plumbing: `shep dev` sessions, a system-wide flock, tests. You almost certainly
-          want the default, ~/.shep.
+          want the default, ~/.shep. Must be an absolute path: a relative one would name a different
+          flock from every directory.
           
           [env: SHEP_HOME=]
 
@@ -1519,7 +1539,8 @@ Options:
           Talk to a different shepherd
           
           Mostly plumbing: `shep dev` sessions, a system-wide flock, tests. You almost certainly
-          want the default, ~/.shep.
+          want the default, ~/.shep. Must be an absolute path: a relative one would name a different
+          flock from every directory.
           
           [env: SHEP_HOME=]
 
@@ -1589,7 +1610,8 @@ Options:
           Talk to a different shepherd
           
           Mostly plumbing: `shep dev` sessions, a system-wide flock, tests. You almost certainly
-          want the default, ~/.shep.
+          want the default, ~/.shep. Must be an absolute path: a relative one would name a different
+          flock from every directory.
           
           [env: SHEP_HOME=]
 
@@ -1647,7 +1669,8 @@ Options:
           Talk to a different shepherd
           
           Mostly plumbing: `shep dev` sessions, a system-wide flock, tests. You almost certainly
-          want the default, ~/.shep.
+          want the default, ~/.shep. Must be an absolute path: a relative one would name a different
+          flock from every directory.
           
           [env: SHEP_HOME=]
 
@@ -1699,7 +1722,8 @@ Options:
           Talk to a different shepherd
           
           Mostly plumbing: `shep dev` sessions, a system-wide flock, tests. You almost certainly
-          want the default, ~/.shep.
+          want the default, ~/.shep. Must be an absolute path: a relative one would name a different
+          flock from every directory.
           
           [env: SHEP_HOME=]
 
@@ -1752,7 +1776,8 @@ Options:
           Talk to a different shepherd
           
           Mostly plumbing: `shep dev` sessions, a system-wide flock, tests. You almost certainly
-          want the default, ~/.shep.
+          want the default, ~/.shep. Must be an absolute path: a relative one would name a different
+          flock from every directory.
           
           [env: SHEP_HOME=]
 
@@ -1805,7 +1830,8 @@ Options:
           Talk to a different shepherd
           
           Mostly plumbing: `shep dev` sessions, a system-wide flock, tests. You almost certainly
-          want the default, ~/.shep.
+          want the default, ~/.shep. Must be an absolute path: a relative one would name a different
+          flock from every directory.
           
           [env: SHEP_HOME=]
 
@@ -1865,7 +1891,8 @@ Options:
           Talk to a different shepherd
           
           Mostly plumbing: `shep dev` sessions, a system-wide flock, tests. You almost certainly
-          want the default, ~/.shep.
+          want the default, ~/.shep. Must be an absolute path: a relative one would name a different
+          flock from every directory.
           
           [env: SHEP_HOME=]
 
@@ -1915,7 +1942,8 @@ Options:
           Talk to a different shepherd
           
           Mostly plumbing: `shep dev` sessions, a system-wide flock, tests. You almost certainly
-          want the default, ~/.shep.
+          want the default, ~/.shep. Must be an absolute path: a relative one would name a different
+          flock from every directory.
           
           [env: SHEP_HOME=]
 
@@ -1968,7 +1996,8 @@ Options:
           Talk to a different shepherd
           
           Mostly plumbing: `shep dev` sessions, a system-wide flock, tests. You almost certainly
-          want the default, ~/.shep.
+          want the default, ~/.shep. Must be an absolute path: a relative one would name a different
+          flock from every directory.
           
           [env: SHEP_HOME=]
 
@@ -2034,7 +2063,8 @@ Options:
           Talk to a different shepherd
           
           Mostly plumbing: `shep dev` sessions, a system-wide flock, tests. You almost certainly
-          want the default, ~/.shep.
+          want the default, ~/.shep. Must be an absolute path: a relative one would name a different
+          flock from every directory.
           
           [env: SHEP_HOME=]
 
@@ -2080,7 +2110,8 @@ Options:
           Talk to a different shepherd
           
           Mostly plumbing: `shep dev` sessions, a system-wide flock, tests. You almost certainly
-          want the default, ~/.shep.
+          want the default, ~/.shep. Must be an absolute path: a relative one would name a different
+          flock from every directory.
           
           [env: SHEP_HOME=]
 
@@ -2126,7 +2157,8 @@ Options:
           Talk to a different shepherd
           
           Mostly plumbing: `shep dev` sessions, a system-wide flock, tests. You almost certainly
-          want the default, ~/.shep.
+          want the default, ~/.shep. Must be an absolute path: a relative one would name a different
+          flock from every directory.
           
           [env: SHEP_HOME=]
 
@@ -2172,7 +2204,8 @@ Options:
           Talk to a different shepherd
           
           Mostly plumbing: `shep dev` sessions, a system-wide flock, tests. You almost certainly
-          want the default, ~/.shep.
+          want the default, ~/.shep. Must be an absolute path: a relative one would name a different
+          flock from every directory.
           
           [env: SHEP_HOME=]
 
@@ -2218,7 +2251,8 @@ Options:
           Talk to a different shepherd
           
           Mostly plumbing: `shep dev` sessions, a system-wide flock, tests. You almost certainly
-          want the default, ~/.shep.
+          want the default, ~/.shep. Must be an absolute path: a relative one would name a different
+          flock from every directory.
           
           [env: SHEP_HOME=]
 
@@ -2284,7 +2318,8 @@ Options:
           Talk to a different shepherd
           
           Mostly plumbing: `shep dev` sessions, a system-wide flock, tests. You almost certainly
-          want the default, ~/.shep.
+          want the default, ~/.shep. Must be an absolute path: a relative one would name a different
+          flock from every directory.
           
           [env: SHEP_HOME=]
 
@@ -2347,7 +2382,8 @@ Options:
           Talk to a different shepherd
           
           Mostly plumbing: `shep dev` sessions, a system-wide flock, tests. You almost certainly
-          want the default, ~/.shep.
+          want the default, ~/.shep. Must be an absolute path: a relative one would name a different
+          flock from every directory.
           
           [env: SHEP_HOME=]
 
@@ -2398,7 +2434,8 @@ Options:
           Talk to a different shepherd
           
           Mostly plumbing: `shep dev` sessions, a system-wide flock, tests. You almost certainly
-          want the default, ~/.shep.
+          want the default, ~/.shep. Must be an absolute path: a relative one would name a different
+          flock from every directory.
           
           [env: SHEP_HOME=]
 
@@ -2462,7 +2499,8 @@ Options:
           Talk to a different shepherd
           
           Mostly plumbing: `shep dev` sessions, a system-wide flock, tests. You almost certainly
-          want the default, ~/.shep.
+          want the default, ~/.shep. Must be an absolute path: a relative one would name a different
+          flock from every directory.
           
           [env: SHEP_HOME=]
 
@@ -2550,7 +2588,8 @@ Options:
           Talk to a different shepherd
           
           Mostly plumbing: `shep dev` sessions, a system-wide flock, tests. You almost certainly
-          want the default, ~/.shep.
+          want the default, ~/.shep. Must be an absolute path: a relative one would name a different
+          flock from every directory.
           
           [env: SHEP_HOME=]
 
@@ -2635,7 +2674,8 @@ Options:
           Talk to a different shepherd
           
           Mostly plumbing: `shep dev` sessions, a system-wide flock, tests. You almost certainly
-          want the default, ~/.shep.
+          want the default, ~/.shep. Must be an absolute path: a relative one would name a different
+          flock from every directory.
           
           [env: SHEP_HOME=]
 
@@ -2702,7 +2742,8 @@ Options:
           Talk to a different shepherd
           
           Mostly plumbing: `shep dev` sessions, a system-wide flock, tests. You almost certainly
-          want the default, ~/.shep.
+          want the default, ~/.shep. Must be an absolute path: a relative one would name a different
+          flock from every directory.
           
           [env: SHEP_HOME=]
 
@@ -2756,7 +2797,8 @@ Options:
           Talk to a different shepherd
           
           Mostly plumbing: `shep dev` sessions, a system-wide flock, tests. You almost certainly
-          want the default, ~/.shep.
+          want the default, ~/.shep. Must be an absolute path: a relative one would name a different
+          flock from every directory.
           
           [env: SHEP_HOME=]
 
@@ -2813,7 +2855,8 @@ Options:
           Talk to a different shepherd
           
           Mostly plumbing: `shep dev` sessions, a system-wide flock, tests. You almost certainly
-          want the default, ~/.shep.
+          want the default, ~/.shep. Must be an absolute path: a relative one would name a different
+          flock from every directory.
           
           [env: SHEP_HOME=]
 
@@ -2874,7 +2917,8 @@ Options:
           Talk to a different shepherd
           
           Mostly plumbing: `shep dev` sessions, a system-wide flock, tests. You almost certainly
-          want the default, ~/.shep.
+          want the default, ~/.shep. Must be an absolute path: a relative one would name a different
+          flock from every directory.
           
           [env: SHEP_HOME=]
 
@@ -2923,7 +2967,8 @@ Options:
           Talk to a different shepherd
           
           Mostly plumbing: `shep dev` sessions, a system-wide flock, tests. You almost certainly
-          want the default, ~/.shep.
+          want the default, ~/.shep. Must be an absolute path: a relative one would name a different
+          flock from every directory.
           
           [env: SHEP_HOME=]
 

--- a/web/src/pages/docs/cli.astro
+++ b/web/src/pages/docs/cli.astro
@@ -130,7 +130,10 @@ if (coveredCount !== cliReference.verbs.length) {
       <code>--home</code>, <code>--format table|json</code> and <code>-q</code>/<code>--quiet</code>{" "}
       work on every verb on this page. They're global flags, flattened onto each
       subcommand rather than repeated in the prose below. See the full dump under
-      "Every verb, at a glance" for exactly how they render on each one.
+      "Every verb, at a glance" for exactly how they render on each one.{" "}
+      <code>--home</code> takes an absolute path, and so does{" "}
+      <code>$SHEP_HOME</code>. A relative one would mean a different flock from
+      every directory, so shep refuses it and prints the absolute form instead.
     </Callout>
 
     <Callout variant="note">


### PR DESCRIPTION
A relative `$SHEP_HOME` was accepted and then read against whatever directory shep ran in, `socket` included, so the flock it named was reachable from that one directory and nowhere else.

Measured 2026-09-13 against the release binary: a shepherd started under `SHEP_HOME=rel-home` answers `shep flock` where it was started, reports "no shepherd running" from the next directory over, and keeps supervising everything either way.

- `--home`, `$SHEP_HOME` and `$SHEP_DEV_HOME` now require an absolute path
- the refusal quotes the path as typed and names the absolute form it would have meant, exit 2
- gated on the resolved root, not on `--home` alone, so a rootless home directory is refused too and names its own variable
- `resolve_paths` returns `HomeRefusal` instead of `ExitCode`, so callers print the real refusal rather than the generic unresolved-home text
- Windows reads a path with no drive prefix as relative, so `\shep` is refused there too
- decisions.md entry, `--home` help text, CLI reference regenerated

Refusing rather than absolutizing: a relative home means a different directory from every cwd, so absolutizing per invocation leaves the flock unreachable from anywhere else and only makes the wrong answer internally consistent. Nothing documented relative homes as supported, and neither `docs/decisions.md` nor goals.md had a recorded call on it.

This also kills the `{{SHEP_HOME}}` log-anchor symptom in #227 at the root. With the home always absolute, a rendered `{{SHEP_HOME}}/logs/out.log` is absolute and `anchor_log_path` leaves it alone, so nothing in that PR needs changing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - The CLI now rejects relative paths supplied through `--home`, `$SHEP_HOME`, or `$SHEP_DEV_HOME` instead of resolving them ambiguously.
  - Error messages identify the provided path, show its absolute equivalent, and explain how to correct it.
  - Startup failures for unresolved home locations now provide more specific feedback.

- **Documentation**
  - CLI help and online documentation now state that home paths must be absolute.
  - Added documentation describing how relative home paths are handled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->