### PR TITLE
docs(web): publish every secret subcommand's own flags

### DIFF
--- a/crates/shep-cli/src/cli.rs
+++ b/crates/shep-cli/src/cli.rs
@@ -1761,16 +1761,66 @@ mod tests {
         Cli::command().debug_assert(); // clap's own structural self-check
     }
 
-    /// fails when a visible verb is missing from the docs site's CLI
-    /// reference generator.
+    /// The generator's `VERBS` array, one entry per element, with a quoted
+    /// multi-word entry like `"secret set"` kept whole.
+    fn listed_verb_paths(generator: &str) -> Vec<String> {
+        let (_, rest) = generator
+            .split_once("VERBS=(")
+            .expect("the generator declares a VERBS array");
+        let (block, _) = rest.split_once(')').expect("the VERBS array closes");
+
+        // Splitting on the quote character puts every quoted entry at an odd
+        // index and everything unquoted at an even one.
+        block
+            .split('"')
+            .enumerate()
+            .flat_map(|(i, chunk)| {
+                if i % 2 == 1 {
+                    vec![chunk.to_string()]
+                } else {
+                    chunk.split_whitespace().map(str::to_string).collect()
+                }
+            })
+            .collect()
+    }
+
+    /// Every visible command path, space-joined, parents before children:
+    /// `secret`, `secret set`, `secret get`, and so on.
     ///
-    /// The generator's `VERBS` array is hand-kept, and regenerating the
-    /// reference refreshes only what that array already names -- so a verb
-    /// left out of it is invisible in the published docs and the generator
-    /// reports success. `style` and `welcome` shipped that way, found
-    /// 2026-08-23 when `init` did the same.
+    /// A hidden command takes its whole subtree with it, which is how the
+    /// `daemon` re-exec target and its own `reload` stay out. `help` is
+    /// clap's own at every depth and the other deliberate omission.
+    fn visible_command_paths(command: &clap::Command) -> Vec<String> {
+        fn walk(command: &clap::Command, prefix: &str, found: &mut Vec<String>) {
+            for sub in command.get_subcommands() {
+                if sub.is_hide_set() || sub.get_name() == "help" {
+                    continue;
+                }
+                let path = if prefix.is_empty() {
+                    sub.get_name().to_string()
+                } else {
+                    format!("{prefix} {}", sub.get_name())
+                };
+                found.push(path.clone());
+                walk(sub, &path, found);
+            }
+        }
+
+        let mut found = Vec::new();
+        walk(command, "", &mut found);
+        found
+    }
+
+    /// fails when a visible verb or subcommand is missing from the docs
+    /// site's CLI reference generator.
     ///
-    /// `help` is clap's own subcommand and the one deliberate omission.
+    /// The generator's `VERBS` array is hand-kept and regenerating the
+    /// reference refreshes only what it already names, so a verb left out
+    /// is invisible on the published site while the generator reports
+    /// success. `style` and `welcome` shipped that way, found 2026-08-23
+    /// when `init` did the same. So did every `shep secret` flag: a host's
+    /// own `--help` names its subcommands without their flags, and this
+    /// walk used to stop at the top level.
     ///
     /// Skips outside the workspace checkout -- see
     /// [`read_workspace_web_file`].
@@ -1781,26 +1831,51 @@ mod tests {
         let Some(generator) = read_workspace_web_file("scripts/generate-cli-reference.sh") else {
             return;
         };
-        const NOT_DOCUMENTED: &[&str] = &["help"];
-
-        let (_, rest) = generator
-            .split_once("VERBS=(")
-            .expect("the generator declares a VERBS array");
-        let (block, _) = rest.split_once(')').expect("the VERBS array closes");
-        let listed: Vec<&str> = block.split_whitespace().collect();
+        let listed = listed_verb_paths(&generator);
 
         let command = Cli::command();
-        let missing: Vec<&str> = command
-            .get_subcommands()
-            .filter(|verb| !verb.is_hide_set())
-            .map(clap::Command::get_name)
-            .filter(|name| !NOT_DOCUMENTED.contains(name) && !listed.contains(name))
+        let missing: Vec<String> = visible_command_paths(&command)
+            .into_iter()
+            .filter(|path| !listed.contains(path))
             .collect();
 
         assert!(
             missing.is_empty(),
             "these verbs would be missing from the published CLI reference: {missing:?}\n\
              add them to VERBS in web/scripts/generate-cli-reference.sh and re-run it"
+        );
+    }
+
+    /// fails when the committed CLI reference has no block for something
+    /// the generator's `VERBS` array names.
+    ///
+    /// The array and the generated file are two separate edits and only the
+    /// first one is typing, so a stale file is the ordinary way this drifts.
+    /// `web/src/data/cliReference.ts` reads its verb list off the
+    /// `@@VERB:...@@` markers rather than keeping a second copy of the
+    /// array, which leaves an entry with no block as a verb the site
+    /// quietly does not have.
+    ///
+    /// Skips outside the workspace checkout -- see
+    /// [`read_workspace_web_file`].
+    #[test]
+    fn every_listed_verb_has_a_block_in_the_committed_reference() {
+        let (Some(generator), Some(reference)) = (
+            read_workspace_web_file("scripts/generate-cli-reference.sh"),
+            read_workspace_web_file("src/data/cli-reference.generated.txt"),
+        ) else {
+            return;
+        };
+
+        let missing: Vec<String> = listed_verb_paths(&generator)
+            .into_iter()
+            .filter(|path| !reference.contains(&format!("\n@@VERB:{path}@@\n")))
+            .collect();
+
+        assert!(
+            missing.is_empty(),
+            "the committed CLI reference has no block for {missing:?}\n\
+             run 'cargo build --release' then ./web/scripts/generate-cli-reference.sh"
         );
     }
 

--- a/web/scripts/generate-cli-reference.sh
+++ b/web/scripts/generate-cli-reference.sh
@@ -36,18 +36,25 @@ fi
 # Verb order matches the Commands enum's declaration order. `resurrect`, a
 # hidden alias of `muster` (clap `alias`, not `visible_alias`), stays out on
 # purpose so it doesn't appear in generated docs. `help` is clap's own and
-# is the other deliberate omission. `import pm2` and `import env` sit right
-# after `import` itself: `import` is a subcommand host now, so `shep import
-# --help` only lists them, and each entry's own flags need their own block.
+# is the other deliberate omission.
+#
+# A quoted multi-word entry is a path into the tree, and every subcommand of
+# a subcommand host needs one. A host's own `--help` prints its subcommands
+# as one-line summaries and none of their flags, so `secret set --stdin` --
+# there so a credential stays out of `ps` and shell history -- reaches the
+# published reference only through `"secret set"` below.
 #
 # `every_visible_verb_reaches_the_docs_site_generator` in cli.rs checks this
-# list against the binary's own visible subcommands, so a new verb fails a
-# test rather than going undocumented.
+# list against the binary's own command tree, at every depth, so a new verb
+# or subcommand fails a test rather than going undocumented. Its sibling
+# `every_listed_verb_has_a_block_in_the_committed_reference` fails when this
+# array has grown and nobody re-ran this script.
 VERBS=(
   start add serve stop restart reload delete stock flock dogs enable disable
   adopt rehome describe trigger signal whisper fold bleats lookout whistle
-  reopen flush barks set get unset secret ping kill save muster runtime dev
-  import "import pm2" "import env" startup unstartup completions init style
+  reopen flush barks set get unset secret "secret set" "secret get"
+  "secret unset" "secret list" ping kill save muster runtime dev import
+  "import pm2" "import env" startup unstartup completions init style
   welcome
 )
 

--- a/web/src/data/cli-reference.generated.txt
+++ b/web/src/data/cli-reference.generated.txt
@@ -2043,6 +2043,221 @@ Options:
 
   -V, --version
           Print version
+@@VERB:secret set@@
+Store a value
+
+The value is a positional argument by default, so it is visible in `ps` and in this shell's history
+for as long as the command runs. Pass `--stdin` to keep it out of both.
+
+Usage: shep secret set [OPTIONS] <KEY> [VALUE]
+
+Arguments:
+  <KEY>
+          The key
+
+  [VALUE]
+          The value; required unless --stdin is given
+
+Options:
+      --env <ENV>
+          Which environment; omit for every environment
+
+      --format <FORMAT>
+          Output format
+
+          Possible values:
+          - table: Human-readable columns (the default)
+          - json:  A versioned JSON envelope, one object per invocation
+          
+          [default: table]
+
+  -q, --quiet
+          Suppress non-essential output
+          
+          Currently narrows `bleats`' own notices (a dropped-events count, a daemon-shutdown notice,
+          ...): diagnostics distinct from a sheep's own line or a real error, both of which still
+          print regardless.
+
+      --stdin
+          Read the value from stdin; the positional form is visible in `ps` and in shell history
+
+      --style <STYLE>
+          How much this invocation dresses up its output: `full`, `plain`, or `bare`
+          
+          Wins over `$SHEP_STYLE` and `shep.toml`'s `[style] level`. Omit to let those decide; `shep
+          style` reports which one answered.
+
+          Possible values:
+          - full:  Sheep, boxes and colour
+          - plain: Boxes and colour, no sheep
+          - bare:  Exactly what shep printed before any of this, and exactly what a pipe gets
+
+      --home <HOME>
+          Talk to a different shepherd
+          
+          Mostly plumbing: `shep dev` sessions, a system-wide flock, tests. You almost certainly
+          want the default, ~/.shep.
+          
+          [env: SHEP_HOME=]
+
+  -h, --help
+          Print help (see a summary with '-h')
+
+  -V, --version
+          Print version
+@@VERB:secret get@@
+Print a value back, if `[secrets] allow_read` is on
+
+Usage: shep secret get [OPTIONS] <KEY>
+
+Arguments:
+  <KEY>
+          The key
+
+Options:
+      --env <ENV>
+          Which environment; omit to use `[daemon] environment`'s default, which an app's own
+          environment may override
+
+      --format <FORMAT>
+          Output format
+
+          Possible values:
+          - table: Human-readable columns (the default)
+          - json:  A versioned JSON envelope, one object per invocation
+          
+          [default: table]
+
+  -q, --quiet
+          Suppress non-essential output
+          
+          Currently narrows `bleats`' own notices (a dropped-events count, a daemon-shutdown notice,
+          ...): diagnostics distinct from a sheep's own line or a real error, both of which still
+          print regardless.
+
+      --style <STYLE>
+          How much this invocation dresses up its output: `full`, `plain`, or `bare`
+          
+          Wins over `$SHEP_STYLE` and `shep.toml`'s `[style] level`. Omit to let those decide; `shep
+          style` reports which one answered.
+
+          Possible values:
+          - full:  Sheep, boxes and colour
+          - plain: Boxes and colour, no sheep
+          - bare:  Exactly what shep printed before any of this, and exactly what a pipe gets
+
+      --home <HOME>
+          Talk to a different shepherd
+          
+          Mostly plumbing: `shep dev` sessions, a system-wide flock, tests. You almost certainly
+          want the default, ~/.shep.
+          
+          [env: SHEP_HOME=]
+
+  -h, --help
+          Print help (see a summary with '-h')
+
+  -V, --version
+          Print version
+@@VERB:secret unset@@
+Remove a value
+
+Usage: shep secret unset [OPTIONS] <KEY>
+
+Arguments:
+  <KEY>
+          The key
+
+Options:
+      --env <ENV>
+          Which environment; omit for the every-environment slot
+
+      --format <FORMAT>
+          Output format
+
+          Possible values:
+          - table: Human-readable columns (the default)
+          - json:  A versioned JSON envelope, one object per invocation
+          
+          [default: table]
+
+  -q, --quiet
+          Suppress non-essential output
+          
+          Currently narrows `bleats`' own notices (a dropped-events count, a daemon-shutdown notice,
+          ...): diagnostics distinct from a sheep's own line or a real error, both of which still
+          print regardless.
+
+      --style <STYLE>
+          How much this invocation dresses up its output: `full`, `plain`, or `bare`
+          
+          Wins over `$SHEP_STYLE` and `shep.toml`'s `[style] level`. Omit to let those decide; `shep
+          style` reports which one answered.
+
+          Possible values:
+          - full:  Sheep, boxes and colour
+          - plain: Boxes and colour, no sheep
+          - bare:  Exactly what shep printed before any of this, and exactly what a pipe gets
+
+      --home <HOME>
+          Talk to a different shepherd
+          
+          Mostly plumbing: `shep dev` sessions, a system-wide flock, tests. You almost certainly
+          want the default, ~/.shep.
+          
+          [env: SHEP_HOME=]
+
+  -h, --help
+          Print help (see a summary with '-h')
+
+  -V, --version
+          Print version
+@@VERB:secret list@@
+List keys and the environments each has a value for
+
+Usage: shep secret list [OPTIONS]
+
+Options:
+      --format <FORMAT>
+          Output format
+
+          Possible values:
+          - table: Human-readable columns (the default)
+          - json:  A versioned JSON envelope, one object per invocation
+          
+          [default: table]
+
+  -q, --quiet
+          Suppress non-essential output
+          
+          Currently narrows `bleats`' own notices (a dropped-events count, a daemon-shutdown notice,
+          ...): diagnostics distinct from a sheep's own line or a real error, both of which still
+          print regardless.
+
+      --style <STYLE>
+          How much this invocation dresses up its output: `full`, `plain`, or `bare`
+          
+          Wins over `$SHEP_STYLE` and `shep.toml`'s `[style] level`. Omit to let those decide; `shep
+          style` reports which one answered.
+
+          Possible values:
+          - full:  Sheep, boxes and colour
+          - plain: Boxes and colour, no sheep
+          - bare:  Exactly what shep printed before any of this, and exactly what a pipe gets
+
+      --home <HOME>
+          Talk to a different shepherd
+          
+          Mostly plumbing: `shep dev` sessions, a system-wide flock, tests. You almost certainly
+          want the default, ~/.shep.
+          
+          [env: SHEP_HOME=]
+
+  -h, --help
+          Print help (see a summary with '-h')
+
+  -V, --version
+          Print version
 @@VERB:ping@@
 Check whether the shepherd answers
 

--- a/web/src/data/cliReference.ts
+++ b/web/src/data/cliReference.ts
@@ -34,69 +34,22 @@ export interface CliReferenceData {
   verbs: CliVerb[];
 }
 
-// The verb order the generator script runs in — also the declaration order
-// in the Commands enum, and the order `shep --help` itself lists them.
-// Kept here (rather than re-derived from the generated file) so a missing
-// or misspelled `@@VERB:...@@` marker is a loud parse error, not a silently
-// short verb list.
+// Splits the generated file into its `@@VERB:<name>@@` blocks, in the order
+// the generator wrote them: the declaration order of the Commands enum, and
+// the order `shep --help` itself lists them. A quoted entry in the
+// generator's `VERBS` array is a path into the command tree, so a name here
+// can be two words. "secret set" is its own block, with its own flags.
 //
-// It was silently short by three anyway, from whenever `init`, `style` and
-// `welcome` shipped until 2026-09-03. Nothing caught it: this list is what
-// the page renders FROM, so a verb absent here is a verb the reference
-// simply does not have, and `cli.astro`'s own count check compares the
-// groups against this list rather than against the generated file, so the
-// two agreed with each other while both disagreed with the binary. The
-// generator's `VERBS` array has a Rust test holding it to the real command
-// tree (`every_visible_verb_reaches_the_docs_site_generator` in
-// crates/shep-cli/src/cli.rs); this list has nothing, and
-// the only thing standing between it and the same drift is the build error
-// you get when the groups and this list disagree.
-const VERB_NAMES = [
-  "start",
-  "add",
-  "serve",
-  "stop",
-  "restart",
-  "reload",
-  "delete",
-  "stock",
-  "flock",
-  "dogs",
-  "enable",
-  "disable",
-  "adopt",
-  "rehome",
-  "describe",
-  "trigger",
-  "signal",
-  "whisper",
-  "fold",
-  "bleats",
-  "lookout",
-  "whistle",
-  "reopen",
-  "flush",
-  "barks",
-  "set",
-  "get",
-  "unset",
-  "secret",
-  "ping",
-  "kill",
-  "save",
-  "muster",
-  "runtime",
-  "dev",
-  "import",
-  "import pm2",
-  "import env",
-  "startup",
-  "unstartup",
-  "completions",
-  "init",
-  "style",
-  "welcome",
-] as const;
+// The verb list is derived from these markers rather than kept here as a
+// second copy of that array. The copy agreed with the generator only by
+// hand, and for months it did not: short by three from whenever `init`,
+// `style` and `welcome` shipped until 2026-09-03, caught by nothing,
+// because this list is what the page renders FROM. Two Rust tests hold the
+// chain now. `every_visible_verb_reaches_the_docs_site_generator` walks the
+// binary's command tree against the generator's array, and
+// `every_listed_verb_has_a_block_in_the_committed_reference` fails when that
+// array names something the generated text below does not carry.
+const VERB_MARKER = /^@@VERB:(.+)@@$/m;
 
 function fail(message: string): never {
   throw new Error(`web/src/data/cliReference.ts: ${message}`);
@@ -130,13 +83,6 @@ function unwrapParagraphs(block: string): string[] {
         .join(" "),
     )
     .filter(Boolean);
-}
-
-/** Extracts the `[alias: x]` / `[aliases: x, y]` suffix clap prints on a Commands: entry, if any. */
-function parseAliases(entryText: string): string[] {
-  const match = entryText.match(/\[alias(?:es)?:\s*([^\]]+)]\s*$/);
-  if (!match) return [];
-  return match[1].split(",").map((s) => s.trim());
 }
 
 function parseVerbBlock(name: string, block: string): CliVerb {
@@ -217,29 +163,26 @@ function parse(source: string): CliReferenceData {
     fail("does not open with the @@TOPLEVEL@@ marker — re-run generate-cli-reference.sh.");
   }
 
-  const firstVerbMarker = `\n@@VERB:${VERB_NAMES[0]}@@\n`;
-  const firstVerbIndex = source.indexOf(firstVerbMarker);
-  if (firstVerbIndex === -1) {
-    fail(`missing marker for the first verb "${VERB_NAMES[0]}" — re-run generate-cli-reference.sh.`);
+  // Splitting on a pattern with one capture group interleaves the captures
+  // with the text between them, so this is [before, name, block, name, ...].
+  const [topLevelSection, ...sections] = source.split(VERB_MARKER);
+  if (sections.length === 0) {
+    fail("has no @@VERB:...@@ markers — re-run generate-cli-reference.sh.");
   }
-  const topLevelHelp = source.slice(TOP_LEVEL_MARKER.length, firstVerbIndex).trim();
+  const topLevelHelp = topLevelSection.slice(TOP_LEVEL_MARKER.length).trim();
 
-  const aliasesByVerb = parseAliasesFromTopLevel(topLevelHelp, VERB_NAMES);
+  const verbs: CliVerb[] = [];
+  for (let i = 0; i < sections.length; i += 2) {
+    verbs.push(parseVerbBlock(sections[i], sections[i + 1] ?? ""));
+  }
 
-  const verbs: CliVerb[] = VERB_NAMES.map((name, i) => {
-    const marker = `\n@@VERB:${name}@@\n`;
-    const start = source.indexOf(marker);
-    if (start === -1) {
-      fail(`missing marker for verb "${name}" — re-run generate-cli-reference.sh.`);
-    }
-    const blockStart = start + marker.length;
-    const nextName = VERB_NAMES[i + 1];
-    const end = nextName ? source.indexOf(`\n@@VERB:${nextName}@@\n`) : source.length;
-    const block = source.slice(blockStart, end === -1 ? source.length : end);
-    const verb = parseVerbBlock(name, block);
-    verb.aliases = aliasesByVerb.get(name) ?? [];
-    return verb;
-  });
+  const aliasesByVerb = parseAliasesFromTopLevel(
+    topLevelHelp,
+    verbs.map((v) => v.name),
+  );
+  for (const verb of verbs) {
+    verb.aliases = aliasesByVerb.get(verb.name) ?? [];
+  }
 
   return { topLevelHelp, verbs };
 }

--- a/web/src/pages/docs/cli.astro
+++ b/web/src/pages/docs/cli.astro
@@ -73,7 +73,7 @@ const groups = [
   },
   {
     title: "Secrets",
-    verbs: ["secret"],
+    verbs: ["secret", "secret set", "secret get", "secret unset", "secret list"],
   },
   {
     title: "Interfaces",


### PR DESCRIPTION
`shep secret --help` lists `set`, `get`, `unset` and `list` without their flags, so none of those flags reached the published reference. `--stdin` is the one that matters: it exists so a credential stays out of `ps` and shell history.

- Four quoted `VERBS` entries for the secret subcommands, the same treatment `import pm2` and `import env` got
- Regenerated the reference, 44 blocks to 48, and added the four to the Secrets group in `cli.astro`
- `every_visible_verb_reaches_the_docs_site_generator` walks the whole command tree now, not just the top level
- New `every_listed_verb_has_a_block_in_the_committed_reference` catches a stale generated file
- Dropped `VERB_NAMES`, 44 hand-kept lines. `cliReference.ts` reads its verb list off the `@@VERB:` markers instead
- Dropped `parseAliases`, dead code `astro check` flagged on every run
- Replaced the page's group count check with a by-name one, after the review found the count passes when a name is filed twice and another goes missing

`secret` and `import` are the only visible subcommand hosts. `dogs` takes flags rather than subcommands, so its own help already had them. `dog` and `daemon` are hidden and stay undocumented.

Every build-time check here is mutation checked, because a guard that passes either way is decoration:

| mutation | fails with |
| --- | --- |
| drop `"secret set"` from `VERBS` | `these verbs would be missing: ["secret set"]` |
| delete the `secret list` block from the reference | `the committed CLI reference has no block for ["secret list"]` |
| file `"secret set"` twice, drop `"secret get"` | `Missing: ["secret get"] ... Filed twice: ["secret set"]` |
| duplicate the `secret list` block | `Carried twice by the reference itself: ["secret list"]` |

The last two both passed before this PR.

Green on fmt, clippy, `cargo test --workspace --all-features`, rustdoc, `astro check` (0 errors, 0 warnings, 0 hints) and `astro build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Expanded the CLI reference to include individual `secret` and `import` subcommands.
  - Improved CLI help organization and coverage for nested commands.
  - Updated the Secrets documentation section to list all available subcommands.

- **Bug Fixes**
  - Strengthened validation to detect missing, unknown, duplicate, or incomplete CLI reference entries.
  - Improved consistency between the available CLI commands and the committed documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->